### PR TITLE
OpenStack Failure domains

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -602,6 +602,169 @@ spec:
                           items:
                             type: string
                           type: array
+                        failureDomains:
+                          description: FailureDomains is a Tech Preview feature for
+                            resource placement. It is incompatible with zones and
+                            rootVolume zones.
+                          items:
+                            description: 'FailureDomain defines a set of correlated
+                              fault domains across different OpenStack services: compute,
+                              storage, and network.'
+                            properties:
+                              computeAvailabilityZone:
+                                description: ComputeAvailabilityZone is the name of
+                                  a valid nova availability zone. The server will
+                                  be created in this availability zone.
+                                type: string
+                              portTargets:
+                                description: Ports defines a set of port targets which
+                                  can be referenced by machines in this failure domain.
+                                items:
+                                  description: NamedPortTarget includes an ID to characterize
+                                    a PortTarget with its intended purpose. If ID
+                                    is set to "control-plane", then the PortTarget
+                                    will replace the default cluster primary network
+                                    (or the machinesSubnet if defined) as the first
+                                    network for the machine.
+                                  properties:
+                                    fixedIPs:
+                                      description: Specify pairs of subnet and/or
+                                        IP address. These should be subnets of the
+                                        network with the given NetworkID.
+                                      items:
+                                        description: FixedIP defines a subnet.
+                                        properties:
+                                          subnet:
+                                            description: subnetID specifies the ID
+                                              of the subnet where the fixed IP will
+                                              be allocated.
+                                            properties:
+                                              cidr:
+                                                description: cidr filters subnets
+                                                  by CIDR.
+                                                type: string
+                                              description:
+                                                description: description filters subnets
+                                                  by description.
+                                                type: string
+                                              enableDhcp:
+                                                description: 'Deprecated: enableDhcp
+                                                  is silently ignored. It has no replacement.'
+                                                type: boolean
+                                              gateway_ip:
+                                                description: gateway_ip filters subnets
+                                                  by gateway IP.
+                                                type: string
+                                              id:
+                                                description: id is the uuid of a specific
+                                                  subnet to use. If specified, id
+                                                  will not be validated. Instead server
+                                                  creation will fail with an appropriate
+                                                  error.
+                                                type: string
+                                              ipVersion:
+                                                description: ipVersion filters subnets
+                                                  by IP version.
+                                                type: integer
+                                              ipv6AddressMode:
+                                                description: ipv6AddressMode filters
+                                                  subnets by IPv6 address mode.
+                                                type: string
+                                              ipv6RaMode:
+                                                description: ipv6RaMode filters subnets
+                                                  by IPv6 router adversiement mode.
+                                                type: string
+                                              limit:
+                                                description: 'Deprecated: limit is
+                                                  silently ignored. It has no replacement.'
+                                                type: integer
+                                              marker:
+                                                description: 'Deprecated: marker is
+                                                  silently ignored. It has no replacement.'
+                                                type: string
+                                              name:
+                                                description: name filters subnets
+                                                  by name.
+                                                type: string
+                                              networkId:
+                                                description: 'Deprecated: networkId
+                                                  is silently ignored. Set uuid on
+                                                  the containing network definition
+                                                  instead.'
+                                                type: string
+                                              notTags:
+                                                description: notTags filters by subnets
+                                                  which don't match all specified
+                                                  tags. NOT (t1 AND t2...) Multiple
+                                                  tags are comma separated.
+                                                type: string
+                                              notTagsAny:
+                                                description: notTagsAny filters by
+                                                  subnets which don't match any specified
+                                                  tags. NOT (t1 OR t2...) Multiple
+                                                  tags are comma separated.
+                                                type: string
+                                              projectId:
+                                                description: projectId filters subnets
+                                                  by project ID.
+                                                type: string
+                                              sortDir:
+                                                description: 'Deprecated: sortDir
+                                                  is silently ignored. It has no replacement.'
+                                                type: string
+                                              sortKey:
+                                                description: 'Deprecated: sortKey
+                                                  is silently ignored. It has no replacement.'
+                                                type: string
+                                              subnetpoolId:
+                                                description: subnetpoolId filters
+                                                  subnets by subnet pool ID.
+                                                type: string
+                                              tags:
+                                                description: tags filters by subnets
+                                                  containing all specified tags. Multiple
+                                                  tags are comma separated.
+                                                type: string
+                                              tagsAny:
+                                                description: tagsAny filters by subnets
+                                                  containing any specified tags. Multiple
+                                                  tags are comma separated.
+                                                type: string
+                                              tenantId:
+                                                description: 'tenantId filters subnets
+                                                  by tenant ID. Deprecated: use projectId
+                                                  instead. tenantId will be ignored
+                                                  if projectId is set.'
+                                                type: string
+                                            type: object
+                                        required:
+                                        - subnet
+                                        type: object
+                                      type: array
+                                    id:
+                                      type: string
+                                    network:
+                                      description: Network is a query for an openstack
+                                        network that the port will be created or discovered
+                                        on. This will fail if the query returns more
+                                        than one network.
+                                      properties:
+                                        id:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                  required:
+                                  - id
+                                  type: object
+                                type: array
+                              storageAvailabilityZone:
+                                description: StorageAvailabilityZone is the name of
+                                  a valid cinder availability zone. This will be the
+                                  availability zone of the root volume if one is specified.
+                                type: string
+                            type: object
+                          type: array
                         rootVolume:
                           description: RootVolume defines the root volume for instances
                             in the machine pool. The instances use ephemeral disks
@@ -1338,6 +1501,167 @@ spec:
                           in UUID v4 format.
                         items:
                           type: string
+                        type: array
+                      failureDomains:
+                        description: FailureDomains is a Tech Preview feature for
+                          resource placement. It is incompatible with zones and rootVolume
+                          zones.
+                        items:
+                          description: 'FailureDomain defines a set of correlated
+                            fault domains across different OpenStack services: compute,
+                            storage, and network.'
+                          properties:
+                            computeAvailabilityZone:
+                              description: ComputeAvailabilityZone is the name of
+                                a valid nova availability zone. The server will be
+                                created in this availability zone.
+                              type: string
+                            portTargets:
+                              description: Ports defines a set of port targets which
+                                can be referenced by machines in this failure domain.
+                              items:
+                                description: NamedPortTarget includes an ID to characterize
+                                  a PortTarget with its intended purpose. If ID is
+                                  set to "control-plane", then the PortTarget will
+                                  replace the default cluster primary network (or
+                                  the machinesSubnet if defined) as the first network
+                                  for the machine.
+                                properties:
+                                  fixedIPs:
+                                    description: Specify pairs of subnet and/or IP
+                                      address. These should be subnets of the network
+                                      with the given NetworkID.
+                                    items:
+                                      description: FixedIP defines a subnet.
+                                      properties:
+                                        subnet:
+                                          description: subnetID specifies the ID of
+                                            the subnet where the fixed IP will be
+                                            allocated.
+                                          properties:
+                                            cidr:
+                                              description: cidr filters subnets by
+                                                CIDR.
+                                              type: string
+                                            description:
+                                              description: description filters subnets
+                                                by description.
+                                              type: string
+                                            enableDhcp:
+                                              description: 'Deprecated: enableDhcp
+                                                is silently ignored. It has no replacement.'
+                                              type: boolean
+                                            gateway_ip:
+                                              description: gateway_ip filters subnets
+                                                by gateway IP.
+                                              type: string
+                                            id:
+                                              description: id is the uuid of a specific
+                                                subnet to use. If specified, id will
+                                                not be validated. Instead server creation
+                                                will fail with an appropriate error.
+                                              type: string
+                                            ipVersion:
+                                              description: ipVersion filters subnets
+                                                by IP version.
+                                              type: integer
+                                            ipv6AddressMode:
+                                              description: ipv6AddressMode filters
+                                                subnets by IPv6 address mode.
+                                              type: string
+                                            ipv6RaMode:
+                                              description: ipv6RaMode filters subnets
+                                                by IPv6 router adversiement mode.
+                                              type: string
+                                            limit:
+                                              description: 'Deprecated: limit is silently
+                                                ignored. It has no replacement.'
+                                              type: integer
+                                            marker:
+                                              description: 'Deprecated: marker is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            name:
+                                              description: name filters subnets by
+                                                name.
+                                              type: string
+                                            networkId:
+                                              description: 'Deprecated: networkId
+                                                is silently ignored. Set uuid on the
+                                                containing network definition instead.'
+                                              type: string
+                                            notTags:
+                                              description: notTags filters by subnets
+                                                which don't match all specified tags.
+                                                NOT (t1 AND t2...) Multiple tags are
+                                                comma separated.
+                                              type: string
+                                            notTagsAny:
+                                              description: notTagsAny filters by subnets
+                                                which don't match any specified tags.
+                                                NOT (t1 OR t2...) Multiple tags are
+                                                comma separated.
+                                              type: string
+                                            projectId:
+                                              description: projectId filters subnets
+                                                by project ID.
+                                              type: string
+                                            sortDir:
+                                              description: 'Deprecated: sortDir is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            sortKey:
+                                              description: 'Deprecated: sortKey is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            subnetpoolId:
+                                              description: subnetpoolId filters subnets
+                                                by subnet pool ID.
+                                              type: string
+                                            tags:
+                                              description: tags filters by subnets
+                                                containing all specified tags. Multiple
+                                                tags are comma separated.
+                                              type: string
+                                            tagsAny:
+                                              description: tagsAny filters by subnets
+                                                containing any specified tags. Multiple
+                                                tags are comma separated.
+                                              type: string
+                                            tenantId:
+                                              description: 'tenantId filters subnets
+                                                by tenant ID. Deprecated: use projectId
+                                                instead. tenantId will be ignored
+                                                if projectId is set.'
+                                              type: string
+                                          type: object
+                                      required:
+                                      - subnet
+                                      type: object
+                                    type: array
+                                  id:
+                                    type: string
+                                  network:
+                                    description: Network is a query for an openstack
+                                      network that the port will be created or discovered
+                                      on. This will fail if the query returns more
+                                      than one network.
+                                    properties:
+                                      id:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                - id
+                                type: object
+                              type: array
+                            storageAvailabilityZone:
+                              description: StorageAvailabilityZone is the name of
+                                a valid cinder availability zone. This will be the
+                                availability zone of the root volume if one is specified.
+                              type: string
+                          type: object
                         type: array
                       rootVolume:
                         description: RootVolume defines the root volume for instances
@@ -3007,6 +3331,167 @@ spec:
                           in UUID v4 format.
                         items:
                           type: string
+                        type: array
+                      failureDomains:
+                        description: FailureDomains is a Tech Preview feature for
+                          resource placement. It is incompatible with zones and rootVolume
+                          zones.
+                        items:
+                          description: 'FailureDomain defines a set of correlated
+                            fault domains across different OpenStack services: compute,
+                            storage, and network.'
+                          properties:
+                            computeAvailabilityZone:
+                              description: ComputeAvailabilityZone is the name of
+                                a valid nova availability zone. The server will be
+                                created in this availability zone.
+                              type: string
+                            portTargets:
+                              description: Ports defines a set of port targets which
+                                can be referenced by machines in this failure domain.
+                              items:
+                                description: NamedPortTarget includes an ID to characterize
+                                  a PortTarget with its intended purpose. If ID is
+                                  set to "control-plane", then the PortTarget will
+                                  replace the default cluster primary network (or
+                                  the machinesSubnet if defined) as the first network
+                                  for the machine.
+                                properties:
+                                  fixedIPs:
+                                    description: Specify pairs of subnet and/or IP
+                                      address. These should be subnets of the network
+                                      with the given NetworkID.
+                                    items:
+                                      description: FixedIP defines a subnet.
+                                      properties:
+                                        subnet:
+                                          description: subnetID specifies the ID of
+                                            the subnet where the fixed IP will be
+                                            allocated.
+                                          properties:
+                                            cidr:
+                                              description: cidr filters subnets by
+                                                CIDR.
+                                              type: string
+                                            description:
+                                              description: description filters subnets
+                                                by description.
+                                              type: string
+                                            enableDhcp:
+                                              description: 'Deprecated: enableDhcp
+                                                is silently ignored. It has no replacement.'
+                                              type: boolean
+                                            gateway_ip:
+                                              description: gateway_ip filters subnets
+                                                by gateway IP.
+                                              type: string
+                                            id:
+                                              description: id is the uuid of a specific
+                                                subnet to use. If specified, id will
+                                                not be validated. Instead server creation
+                                                will fail with an appropriate error.
+                                              type: string
+                                            ipVersion:
+                                              description: ipVersion filters subnets
+                                                by IP version.
+                                              type: integer
+                                            ipv6AddressMode:
+                                              description: ipv6AddressMode filters
+                                                subnets by IPv6 address mode.
+                                              type: string
+                                            ipv6RaMode:
+                                              description: ipv6RaMode filters subnets
+                                                by IPv6 router adversiement mode.
+                                              type: string
+                                            limit:
+                                              description: 'Deprecated: limit is silently
+                                                ignored. It has no replacement.'
+                                              type: integer
+                                            marker:
+                                              description: 'Deprecated: marker is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            name:
+                                              description: name filters subnets by
+                                                name.
+                                              type: string
+                                            networkId:
+                                              description: 'Deprecated: networkId
+                                                is silently ignored. Set uuid on the
+                                                containing network definition instead.'
+                                              type: string
+                                            notTags:
+                                              description: notTags filters by subnets
+                                                which don't match all specified tags.
+                                                NOT (t1 AND t2...) Multiple tags are
+                                                comma separated.
+                                              type: string
+                                            notTagsAny:
+                                              description: notTagsAny filters by subnets
+                                                which don't match any specified tags.
+                                                NOT (t1 OR t2...) Multiple tags are
+                                                comma separated.
+                                              type: string
+                                            projectId:
+                                              description: projectId filters subnets
+                                                by project ID.
+                                              type: string
+                                            sortDir:
+                                              description: 'Deprecated: sortDir is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            sortKey:
+                                              description: 'Deprecated: sortKey is
+                                                silently ignored. It has no replacement.'
+                                              type: string
+                                            subnetpoolId:
+                                              description: subnetpoolId filters subnets
+                                                by subnet pool ID.
+                                              type: string
+                                            tags:
+                                              description: tags filters by subnets
+                                                containing all specified tags. Multiple
+                                                tags are comma separated.
+                                              type: string
+                                            tagsAny:
+                                              description: tagsAny filters by subnets
+                                                containing any specified tags. Multiple
+                                                tags are comma separated.
+                                              type: string
+                                            tenantId:
+                                              description: 'tenantId filters subnets
+                                                by tenant ID. Deprecated: use projectId
+                                                instead. tenantId will be ignored
+                                                if projectId is set.'
+                                              type: string
+                                          type: object
+                                      required:
+                                      - subnet
+                                      type: object
+                                    type: array
+                                  id:
+                                    type: string
+                                  network:
+                                    description: Network is a query for an openstack
+                                      network that the port will be created or discovered
+                                      on. This will fail if the query returns more
+                                      than one network.
+                                    properties:
+                                      id:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                - id
+                                type: object
+                              type: array
+                            storageAvailabilityZone:
+                              description: StorageAvailabilityZone is the name of
+                                a valid cinder availability zone. This will be the
+                                availability zone of the root volume if one is specified.
+                              type: string
+                          type: object
                         type: array
                       rootVolume:
                         description: RootVolume defines the root volume for instances

--- a/data/data/openstack/masters/outputs.tf
+++ b/data/data/openstack/masters/outputs.tf
@@ -18,9 +18,9 @@ output "master_port_ids" {
 }
 
 output "private_network_id" {
-  value = local.nodes_network_id
+  value = local.nodes_default_port.network_id
 }
 
 output "nodes_subnet_id" {
-  value = local.nodes_subnet_id
+  value = local.nodes_default_port.fixed_ips[0].subnet_id
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -306,6 +306,18 @@ variable "openstack_additional_network_ids" {
   default     = []
 }
 
+variable "openstack_additional_ports" {
+  type = list(list(object({
+    network_id = string
+    fixed_ips = list(object({
+      subnet_id  = string
+      ip_address = string
+    }))
+  })))
+  description = "Additional ports for each master node."
+  default     = [[], [], []]
+}
+
 variable "openstack_master_flavor_name" {
   type        = string
   description = "Instance size for the master node(s). Example: `m1.medium`."
@@ -341,16 +353,28 @@ variable "openstack_master_server_group_policy" {
   description = "Policy of the server group for the master nodes."
 }
 
-variable "openstack_machines_subnet_id" {
-  type        = string
-  default     = ""
-  description = "ID of the subnet to use for cluster machines. If empty, the installer will create a subnet to use as machinesSubnet."
+variable "openstack_default_machines_port" {
+  type = object({
+    network_id = string
+    fixed_ips = list(object({
+      subnet_id  = string
+      ip_address = string
+    }))
+  })
+  default     = null
+  description = "The masters' default control-plane port. If empty, the installer will create a new network."
 }
 
-variable "openstack_machines_network_id" {
-  type        = string
-  default     = ""
-  description = "ID of the network the machines subnet is on. If empty, the installer will create a network to use as machinesNetwork."
+variable "openstack_machines_ports" {
+  type = list(object({
+    network_id = string
+    fixed_ips = list(object({
+      subnet_id  = string
+      ip_address = string
+    }))
+  }))
+  description = "The control-plane port for each machine. If null, the default is used."
+  default     = [null, null, null]
 }
 
 variable "openstack_master_availability_zones" {

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -47,7 +47,19 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int32(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunkSupport, volumeAZs[idx%len(volumeAZs)])
+		provider, err := generateProvider(
+			clusterID,
+			platform,
+			mpool,
+			osImage,
+			role,
+			userDataSecret,
+			trunkSupport,
+			openstack.FailureDomain{
+				ComputeAvailabilityZone: az,
+				StorageAvailabilityZone: volumeAZs[idx%len(volumeAZs)],
+			},
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfvars/openstack/ports.go
+++ b/pkg/tfvars/openstack/ports.go
@@ -1,0 +1,105 @@
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/gophercloud/pagination"
+	network_utils "github.com/gophercloud/utils/openstack/networking/v2/networks"
+
+	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
+	types_openstack "github.com/openshift/installer/pkg/types/openstack"
+)
+
+type terraformFixedIP struct {
+	SubnetID  string `json:"subnet_id"`
+	IPAddress string `json:"ip_address"`
+}
+
+type terraformPort struct {
+	NetworkID string             `json:"network_id"`
+	FixedIP   []terraformFixedIP `json:"fixed_ips"`
+}
+
+func portTargetToTerraformPort(networkClient *gophercloud.ServiceClient, portTarget types_openstack.PortTarget) (terraformPort, error) {
+	networkID := portTarget.Network.ID
+	if networkID == "" && portTarget.Network.Name != "" {
+		var err error
+		networkID, err = network_utils.IDFromName(networkClient, portTarget.Network.Name)
+		if err != nil {
+			return terraformPort{}, fmt.Errorf("failed to resolve network ID for network name %q: %w", portTarget.Network.Name, err)
+		}
+	}
+
+	terraformFixedIPs := make([]terraformFixedIP, len(portTarget.FixedIPs))
+	for i := range terraformFixedIPs {
+		resolvedSubnetID, resolvedNetworkID, err := resolveSubnetFilter(networkClient, networkID, portTarget.FixedIPs[i].Subnet)
+		if err != nil {
+			return terraformPort{}, fmt.Errorf("failed to resolve the subnet filter: %w", err)
+		}
+
+		if networkID == "" {
+			networkID = resolvedNetworkID
+		}
+
+		if networkID != resolvedNetworkID {
+			return terraformPort{}, fmt.Errorf("port target has ports on multiple networks")
+		}
+
+		terraformFixedIPs[i] = terraformFixedIP{
+			SubnetID: resolvedSubnetID,
+		}
+	}
+
+	return terraformPort{
+		NetworkID: networkID,
+		FixedIP:   terraformFixedIPs,
+	}, nil
+}
+
+func resolveSubnetFilter(networkClient *gophercloud.ServiceClient, networkID string, subnetFilter machinev1alpha1.SubnetFilter) (resolvedSubnetID, resolvedNetworkID string, err error) {
+	if subnetFilter.ProjectID != "" {
+		subnetFilter.TenantID = ""
+	}
+	if err = subnets.List(networkClient, subnets.ListOpts{
+		NetworkID:       networkID,
+		Name:            subnetFilter.Name,
+		Description:     subnetFilter.Description,
+		TenantID:        subnetFilter.TenantID,
+		ProjectID:       subnetFilter.ProjectID,
+		IPVersion:       subnetFilter.IPVersion,
+		GatewayIP:       subnetFilter.GatewayIP,
+		CIDR:            subnetFilter.CIDR,
+		IPv6AddressMode: subnetFilter.IPv6AddressMode,
+		IPv6RAMode:      subnetFilter.IPv6RAMode,
+		ID:              subnetFilter.ID,
+		SubnetPoolID:    subnetFilter.SubnetPoolID,
+		Tags:            subnetFilter.Tags,
+		TagsAny:         subnetFilter.TagsAny,
+		NotTags:         subnetFilter.NotTags,
+		NotTagsAny:      subnetFilter.NotTagsAny,
+	}).EachPage(func(page pagination.Page) (bool, error) {
+		returnedSubnets, err := subnets.ExtractSubnets(page)
+		if err != nil {
+			return false, err
+		}
+		for _, subnet := range returnedSubnets {
+			if resolvedSubnetID == "" {
+				resolvedSubnetID = subnet.ID
+				resolvedNetworkID = subnet.NetworkID
+			} else {
+				return false, fmt.Errorf("more than one subnet found")
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return "", "", fmt.Errorf("failed to list subnets: %w", err)
+	}
+
+	if resolvedSubnetID == "" {
+		return "", "", fmt.Errorf("no subnet found")
+	}
+
+	return resolvedSubnetID, resolvedNetworkID, err
+}

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -1,5 +1,7 @@
 package openstack
 
+import machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
+
 // MachinePool stores the configuration for a machine pool installed
 // on OpenStack.
 type MachinePool struct {
@@ -31,6 +33,10 @@ type MachinePool struct {
 	// If no zones are provided, all instances will be deployed on OpenStack Nova default availability zone
 	// +optional
 	Zones []string `json:"zones,omitempty"`
+
+	// FailureDomains is a Tech Preview feature for resource placement. It
+	// is incompatible with zones and rootVolume zones.
+	FailureDomains []FailureDomain `json:"failureDomains,omitempty"`
 }
 
 // Set sets the values from `required` to `o`.
@@ -69,6 +75,10 @@ func (o *MachinePool) Set(required *MachinePool) {
 	if len(required.Zones) > 0 {
 		o.Zones = required.Zones
 	}
+
+	if len(required.FailureDomains) > 0 {
+		o.FailureDomains = required.FailureDomains
+	}
 }
 
 // RootVolume defines the storage for an instance.
@@ -84,4 +94,57 @@ type RootVolume struct {
 	// If no zones are provided, all instances will be deployed on OpenStack Cinder default availability zone
 	// +optional
 	Zones []string `json:"zones,omitempty"`
+}
+
+// -=**
+// FailureDomain and its types are part of a Tech Preview feature, and may change before they're moved to openshift/api
+// **=-
+
+// FailureDomain defines a set of correlated fault domains across different
+// OpenStack services: compute, storage, and network.
+type FailureDomain struct {
+	// ComputeAvailabilityZone is the name of a valid nova availability zone. The server will be created in this availability zone.
+	// +optional
+	ComputeAvailabilityZone string `json:"computeAvailabilityZone"`
+
+	// StorageAvailabilityZone is the name of a valid cinder availability
+	// zone. This will be the availability zone of the root volume if one is
+	// specified.
+	// +optional
+	StorageAvailabilityZone string `json:"storageAvailabilityZone"`
+
+	// Ports defines a set of port targets which can be referenced by machines in this failure domain.
+	//
+	// +optional
+	PortTargets []NamedPortTarget `json:"portTargets"`
+}
+
+// NamedPortTarget includes an ID to characterize a PortTarget with its
+// intended purpose. If ID is set to "control-plane", then the PortTarget will
+// replace the default cluster primary network (or the machinesSubnet if
+// defined) as the first network for the machine.
+type NamedPortTarget struct {
+	ID         string `json:"id"`
+	PortTarget `json:",inline"`
+}
+
+// PortTarget defines, directly or indirectly, one or more subnets where to attach a port.
+type PortTarget struct {
+	// Network is a query for an openstack network that the port will be created or discovered on.
+	// This will fail if the query returns more than one network.
+	Network NetworkFilter `json:"network,omitempty"`
+	// Specify pairs of subnet and/or IP address. These should be subnets of the network with the given NetworkID.
+	FixedIPs []FixedIP `json:"fixedIPs,omitempty"`
+}
+
+// NetworkFilter defines a network either by name or by ID.
+type NetworkFilter struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+// FixedIP defines a subnet.
+type FixedIP struct {
+	// subnetID specifies the ID of the subnet where the fixed IP will be allocated.
+	Subnet machinev1alpha1.SubnetFilter `json:"subnet"`
 }

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -14,7 +14,7 @@ var validServerGroupPolicies = []string{
 }
 
 // ValidateMachinePool validates Control plane and Compute MachinePools
-func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePool, _ string, fldPath *field.Path) field.ErrorList {
+func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePool, role string, fldPath *field.Path) field.ErrorList {
 	if machinePool == nil {
 		return nil
 	}
@@ -24,5 +24,45 @@ func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePo
 	default:
 		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), machinePool.ServerGroupPolicy, validServerGroupPolicies))
 	}
+
+	errs = append(errs, validateFailureDomains(machinePool, role, fldPath)...)
+
+	return errs
+}
+
+func validateFailureDomains(machinePool *openstack.MachinePool, role string, fldPath *field.Path) (errs field.ErrorList) {
+	if len(machinePool.FailureDomains) == 0 {
+		return nil
+	}
+
+	fldPath = fldPath.Child("failureDomains")
+
+	if role != "master" {
+		return append(errs, field.Forbidden(fldPath, "failure domains can only be set on the master machine-pool"))
+	}
+
+	// No failure domains together with zones
+	if len(machinePool.Zones) > 1 || len(machinePool.Zones) > 0 && machinePool.Zones[0] != "" {
+		errs = append(errs, field.Forbidden(fldPath, "failure domains can not be set together with zones"))
+	}
+
+	// No failure domains together with root volume zones
+	if machinePool.RootVolume != nil {
+		if len(machinePool.RootVolume.Zones) > 1 || len(machinePool.RootVolume.Zones) > 0 && machinePool.RootVolume.Zones[0] != "" {
+			errs = append(errs, field.Forbidden(fldPath, "failure domains can not be set together with rootVolume zones"))
+		}
+	}
+
+	// portTarget IDs must be unique
+	for i := range machinePool.FailureDomains {
+		ids := make(map[string]struct{})
+		for _, portTarget := range machinePool.FailureDomains[i].PortTargets {
+			if _, ok := ids[portTarget.ID]; ok {
+				errs = append(errs, field.Duplicate(fldPath.Index(i).Child("id"), portTarget.ID))
+			}
+			ids[portTarget.ID] = struct{}{}
+		}
+	}
+
 	return errs
 }

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -13,6 +13,22 @@ func withServerGroupPolicy(serverGroupPolicy string) func(*openstack.MachinePool
 	return func(mp *openstack.MachinePool) { mp.ServerGroupPolicy = openstack.ServerGroupPolicy(serverGroupPolicy) }
 }
 
+func withZones() func(*openstack.MachinePool) {
+	return func(mp *openstack.MachinePool) { mp.Zones = []string{"one", "two", "three"} }
+}
+
+func withVolumeZones() func(*openstack.MachinePool) {
+	return func(mp *openstack.MachinePool) {
+		mp.RootVolume = &openstack.RootVolume{Zones: []string{"one", "two", "three"}}
+	}
+}
+
+func withFailureDomain(fd openstack.FailureDomain) func(*openstack.MachinePool) {
+	return func(mp *openstack.MachinePool) {
+		mp.FailureDomains = append(mp.FailureDomains, fd)
+	}
+}
+
 func testMachinePool(options ...func(*openstack.MachinePool)) *openstack.MachinePool {
 	var mp openstack.MachinePool
 	for _, apply := range options {
@@ -37,7 +53,7 @@ func TestValidateMachinePool(t *testing.T) {
 	exactlyNErrors := func(want int) checkFunc {
 		return func(errs field.ErrorList) error {
 			if have := len(errs); want != have {
-				return fmt.Errorf("expected %d errors, got %d", want, have)
+				return fmt.Errorf("expected %d errors, got %d: %v", want, have, errs)
 			}
 			return nil
 		}
@@ -47,29 +63,91 @@ func TestValidateMachinePool(t *testing.T) {
 	for _, tc := range [...]struct {
 		name        string
 		machinePool *openstack.MachinePool
+		role        string
 		checks      []checkFunc
 	}{
 		{
 			"empty",
 			testMachinePool(),
+			"default",
 			check(noError),
 		},
 		{
 			"with valid server group policy",
 			testMachinePool(withServerGroupPolicy("anti-affinity")),
+			"default",
 			check(noError),
 		},
 		{
 			"with invalid server group policy",
 			testMachinePool(withServerGroupPolicy("anti-gravity")),
+			"default",
 			check(
 				someErrorType(field.ErrorTypeNotSupported),
 				exactlyNErrors(1),
 			),
 		},
+		{
+			"failure domains",
+			testMachinePool(withFailureDomain(openstack.FailureDomain{
+				PortTargets: []openstack.NamedPortTarget{{ID: "one"}, {ID: "two"}},
+			})),
+			"master",
+			check(noError),
+		},
+		{
+			"failure domains on worker",
+			testMachinePool(withFailureDomain(openstack.FailureDomain{
+				PortTargets: []openstack.NamedPortTarget{{ID: "one"}, {ID: "two"}},
+			})),
+			"worker",
+			check(
+				someErrorType(field.ErrorTypeForbidden),
+				exactlyNErrors(1),
+			),
+		},
+		{
+			"failure domains, duplicate portTarget ID",
+			testMachinePool(withFailureDomain(openstack.FailureDomain{
+				PortTargets: []openstack.NamedPortTarget{{ID: "one"}, {ID: "one"}},
+			})),
+			"master",
+			check(
+				someErrorType(field.ErrorTypeDuplicate),
+				exactlyNErrors(1),
+			),
+		},
+		{
+			"failure domains together with zones",
+			testMachinePool(
+				withZones(),
+				withFailureDomain(openstack.FailureDomain{
+					PortTargets: []openstack.NamedPortTarget{{ID: "one"}, {ID: "two"}},
+				}),
+			),
+			"master",
+			check(
+				someErrorType(field.ErrorTypeForbidden),
+				exactlyNErrors(1),
+			),
+		},
+		{
+			"failure domains together with root volume zones",
+			testMachinePool(
+				withVolumeZones(),
+				withFailureDomain(openstack.FailureDomain{
+					PortTargets: []openstack.NamedPortTarget{{ID: "one"}, {ID: "two"}},
+				}),
+			),
+			"master",
+			check(
+				someErrorType(field.ErrorTypeForbidden),
+				exactlyNErrors(1),
+			),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := ValidateMachinePool(nil, tc.machinePool, "", nil)
+			errs := ValidateMachinePool(nil, tc.machinePool, tc.role, nil)
 			for _, check := range tc.checks {
 				if e := check(errs); e != nil {
 					t.Error(e)

--- a/pkg/types/openstack/validation/techpreview.go
+++ b/pkg/types/openstack/validation/techpreview.go
@@ -9,11 +9,17 @@ import (
 // FilledInTechPreviewFields returns a slice of field paths that were set in
 // install-config, and that are only accepted in the context of a
 // TechPreviewNoUpgrade feature set.
-func FilledInTechPreviewFields(installConfig *types.InstallConfig) []*field.Path {
-	var fields []*field.Path
+func FilledInTechPreviewFields(installConfig *types.InstallConfig) (fields []*field.Path) {
+	if installConfig == nil {
+		return nil
+	}
 
 	if installConfig.OpenStack.LoadBalancer != nil {
 		fields = append(fields, field.NewPath("platform", "openstack", "loadBalancer"))
+	}
+
+	if installConfig.ControlPlane != nil && installConfig.ControlPlane.Platform.OpenStack != nil && len(installConfig.ControlPlane.Platform.OpenStack.FailureDomains) > 0 {
+		fields = append(fields, field.NewPath("controlPlane", "platform", "openstack", "failureDomains"))
 	}
 
 	return fields

--- a/scripts/openstack/manifest-tests/failure-domains/install-config.yaml
+++ b/scripts/openstack/manifest-tests/failure-domains/install-config.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+baseDomain: shiftstack.example.com
+featureSet: TechPreviewNoUpgrade
+controlPlane:
+  hyperthreading: Enabled
+  architecture: amd64
+  name: master
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+      rootVolume:
+        size: 100
+        type: performance
+      failureDomains:
+      - computeAvailabilityZone: computeZone1
+        storageAvailabilityZone: storageZone1
+        portTargets:
+        - id: control-plane
+          network:
+            id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+          fixedIPs:
+          - subnet:
+              id: 11111111-1111-1111-1111-111111111111
+          - subnet:
+              id: 44444444-4444-4444-4444-444444444444
+        - id: storage
+          network:
+            id: dddddddd-dddd-dddd-dddd-dddddddddddd
+      - computeAvailabilityZone: computeZone2
+        storageAvailabilityZone: storageZone2
+        portTargets:
+        - id: control-plane
+          network:
+            id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+          fixedIPs:
+          - subnet:
+              id: 22222222-2222-2222-2222-222222222222
+          - subnet:
+              id: 55555555-5555-5555-5555-555555555555
+        - id: storage
+          network:
+            id: eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee
+      - computeAvailabilityZone: computeZone3
+        storageAvailabilityZone: storageZone3
+        portTargets:
+        - id: storage
+          network:
+            id: ffffffff-ffff-ffff-ffff-ffffffffffff
+        - id: control-plane
+          network:
+            id: cccccccc-cccc-cccc-cccc-cccccccccccc
+          fixedIPs:
+          - subnet:
+              id: 33333333-3333-3333-3333-333333333333
+          - subnet:
+              id: 66666666-6666-6666-6666-666666666666
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+  replicas: 3
+metadata:
+  name: failure-domains-1
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.128.0/17
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  openstack:
+    cloud: ${OS_CLOUD}
+    externalNetwork: ${EXTERNAL_NETWORK}
+    lbFloatingIP: ${API_FIP}
+pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/failure-domains/test_machines.py
+++ b/scripts/openstack/manifest-tests/failure-domains/test_machines.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import os
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+INSTALLCONFIG_PATH = ""
+
+
+class TestMachines(unittest.TestCase):
+    def setUp(self):
+        """Parse the expected values from install-config and collect Machine resources."""
+        self.machines = []
+        for machine_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_master-machines-*.yaml'
+        ):
+            with open(machine_path) as f:
+                self.machines.append(yaml.load(f, Loader=yaml.FullLoader))
+
+        self.expected_failure_domains = []
+        with open(INSTALLCONFIG_PATH) as f:
+            installconfig = yaml.load(f, Loader=yaml.FullLoader)
+            installconfig_failure_domains = installconfig["controlPlane"]["platform"]["openstack"]["failureDomains"]
+            for failure_domain in installconfig_failure_domains:
+                self.expected_failure_domains.append(failure_domain)
+            self.expected_machine_replicas = installconfig["controlPlane"]["replicas"]
+
+
+    def test_total_instance_number(self):
+        """Assert that there are as many Machines as required ControlPlane replicas."""
+        self.assertEqual(len(self.machines), self.expected_machine_replicas)
+
+
+    def test_control_plane_ports(self):
+        """Assert that "control-plane" ports are listed as the first network."""
+
+        # Build a dict of expected networks in the form {network_uuid: [subnet_uuids]}
+        expected_control_plane_networks = {}
+        for failure_domain in self.expected_failure_domains:
+            for portTarget in failure_domain["portTargets"]:
+                if portTarget["id"] == "control-plane":
+                    expected_control_plane_network_uuid = portTarget["network"]["id"]
+                    expected_control_plane_network_subnet_uuids = [fixed_ip["subnet"]["id"] for fixed_ip in portTarget["fixedIPs"]]
+                    expected_control_plane_networks[expected_control_plane_network_uuid] = expected_control_plane_network_subnet_uuids
+
+        # Build a dict of actual networks in the form {network_uuid: [subnet_uuids]}
+        actual_first_networks = {}
+        for machine in self.machines:
+            actual_first_network = machine["spec"]["providerSpec"]["value"]["networks"][0]
+            actual_first_network_uuid = actual_first_network.get("uuid")
+            actual_first_network_subnet_uuids = [fixed_ip.get("filter", {}).get("id") for fixed_ip in actual_first_network.get("subnets", [{}])]
+            actual_first_networks[actual_first_network_uuid] = actual_first_network_subnet_uuids
+
+        # Assert that all expected networks and subnets are represented in machines
+        for expected_control_plane_network, expected_subnet_uuids in expected_control_plane_networks.items():
+            self.assertIn(expected_control_plane_network, actual_first_networks)
+            actual_subnet_uuids = actual_first_networks[expected_control_plane_network]
+            for expected_subnet_uuid in expected_subnet_uuids:
+                self.assertIn(expected_subnet_uuid, actual_subnet_uuids)
+
+        # Assert that all actual networks and subnets were among the expected values
+        for actual_first_network, actual_subnet_uuids in actual_first_networks.items():
+            self.assertIn(actual_first_network, expected_control_plane_networks)
+            expected_subnet_uuids = expected_control_plane_networks[actual_first_network]
+            for actual_subnet_uuid in actual_subnet_uuids:
+                self.assertIn(actual_subnet_uuid, expected_subnet_uuids)
+
+
+    def test_additional_ports(self):
+        """Assert that additional ports are listed in the machines networks."""
+        expected_additional_network_uuid_sets = []
+        for failure_domain in self.expected_failure_domains:
+            expected_additional_network_uuid_sets.append({portTarget["network"]["id"] for portTarget in failure_domain["portTargets"] if portTarget["id"] != "control-plane"})
+
+        actual_additional_network_uuid_sets = []
+        for machine in self.machines:
+            actual_additional_network_uuid_sets.append({network.get("uuid") for network in machine["spec"]["providerSpec"]["value"]["networks"][1:]})
+
+        for actual_additional_network_uuids in actual_additional_network_uuid_sets:
+            self.assertIn(actual_additional_network_uuids, expected_additional_network_uuid_sets)
+
+        for expected_additional_network_uuids in expected_additional_network_uuid_sets:
+            self.assertIn(expected_additional_network_uuids, actual_additional_network_uuid_sets)
+
+
+    def test_computeAvailabilityZone_names(self):
+        """Assert that all machines have one valid compute availability zone."""
+        valid_compute_zones = {failureDomain["computeAvailabilityZone"] for failureDomain in self.expected_failure_domains}
+        for machine in self.machines:
+            zone = machine["spec"]["providerSpec"]["value"]["availabilityZone"]
+            self.assertIn(zone, valid_compute_zones)
+
+
+    def test_replica_distribution(self):
+        """Assert that machines are evenly distributed across compute availability zones."""
+        zones = {}
+        for machine in self.machines:
+            zone = machine["spec"]["providerSpec"]["value"]["availabilityZone"]
+            zones[zone] = zones.get(zone, 0) + 1
+
+        setpoint = 0
+        for replicas in zones.values():
+            if setpoint == 0:
+                setpoint = replicas
+            else:
+                self.assertTrue(-2 < replicas - setpoint < 2)
+
+
+    def test_storage_zone_names(self):
+        """Assert that all machines have one valid storage availability zone that matches the given compute az."""
+        valid_storage_zones = {failureDomain["storageAvailabilityZone"] for failureDomain in self.expected_failure_domains}
+        for machine in self.machines:
+            compute_zone = machine["spec"]["providerSpec"]["value"]["availabilityZone"]
+            storage_zone = machine["spec"]["providerSpec"]["value"]["rootVolume"]["availabilityZone"]
+            self.assertIn(storage_zone, valid_storage_zones)
+            # availability zones have matching names in the test-case install-config
+            self.assertEqual(compute_zone[-1], storage_zone[-1])
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    INSTALLCONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'install-config.yaml')
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Distribute Control plane machines across user-defined failure domains.

This feature is being release under a TechPreviewNoUpgrade FeatureSet.

Failure domains can be defined in the `controlPlane` machine-pool of `install-config.yaml` as follows:

```yaml
controlPlane:
  name: master
  platform:
    openstack:
      type: ${CONTROL_PLANE_FLAVOR}
      failureDomains:
      - computeAvailabilityZone: 'nova-1'
        storageAvailabilityZone: 'cinder-1'
        portTargets:
        - id: storage
          network:
            id: 8db6a48e-375b-4caa-b20b-5b9a7218bfe6
      - computeAvailabilityZone: 'nova-2'
        storageAvailabilityZone: 'cinder-2'
        portTargets:
        - id: storage
          network:
            id: 39a7b82a-a8a4-45a4-ba5a-288569a6edd1
      - computeAvailabilityZone: 'nova-3'
        storageAvailabilityZone: 'cinder-3'
        portTargets:
        - id: storage
          network:
            id: 8e4b4e0d-3865-4a9b-a769-559270271242
```

Each `failureDomains` entry can take an optional `computeAvailabilityZone` string, an optional `storageAvailabilityZone` string, and an optional `portTargets` array.

Each `portTargets` entry requires an arbirtary `id`, which must be unique per `failureDomain`. If `id` is exactly `control-plane`, then that `portTarget` is used instead of the default primary subnet (or instead of `machinesSubnet` if defined) as the first machine network.

Each `portTargets` entry takes an optional `network` object and an optional `fixedIPs` array (not represented in the example).

The `network` object taks an optional `name` string and an optional `id` string. `name` is ignored if `id` is passed.

Each `fixedIPs` entry takes a `subnet` object which syntax is [defined in the `machinev1alpha1` spec as `SubnetFilter`](https://github.com/openshift/api/blob/d170fcdc0fa638b664e4f35f2daf753cb4afe36b/machine/v1alpha1/types_openstack.go#L230-L281).

Note that unless an external load balancer is used, `portTargets` with id `control-plane` must all have one single subnet and must all refer to the same OpenStack subnet. As a consequence, the result will be similar as setting a `machinesSubnet`, except that Compute nodes will not follow.