### PR TITLE
OCPBUGS-7973: IBMCloud set dnsrecords offset

### DIFF
--- a/pkg/destroy/ibmcloud/dns.go
+++ b/pkg/destroy/ibmcloud/dns.go
@@ -65,9 +65,10 @@ func (o *ClusterUninstaller) listDNSSvcDNSRecords() (cloudResources, error) {
 
 	result := []cloudResource{}
 	resourceRecordsRemaining := true
-	var viewedResourceRecords int64
+	viewedResourceRecords := int64(0)
 	for resourceRecordsRemaining {
 		options := o.dnsServicesSvc.NewListResourceRecordsOptions(o.DNSInstanceID, o.zoneID)
+		options = options.SetOffset(viewedResourceRecords)
 		resources, _, err := o.dnsServicesSvc.ListResourceRecordsWithContext(ctx, options)
 
 		if err != nil {

--- a/pkg/destroy/ibmcloud/ibmcloud.go
+++ b/pkg/destroy/ibmcloud/ibmcloud.go
@@ -332,13 +332,15 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 
 		zoneID := ""
 		for _, zone := range dzResult.Dnszones {
-			if strings.Contains(o.BaseDomain, *zone.Name) {
+			if o.BaseDomain == *zone.Name {
 				zoneID = *zone.ID
+				break
 			}
 		}
 		if zoneID == "" {
 			return errors.Errorf("Could not determine DNS Services DNS zone ID from base domain %q", o.BaseDomain)
 		}
+		o.Logger.Debugf("Found DNS Services DNS zone ID for base domain %q: %s", o.BaseDomain, zoneID)
 		o.zoneID = zoneID
 	}
 


### PR DESCRIPTION
Set the offset when going through the DNS Services Resource Records for deletion, during destroy, making sure we go through all records.

Related: https://issues.redhat.com/browse/OCPBUGS-7973