### PR TITLE
OCPBUGS-8258: Specify filename for default registries.conf

### DIFF
--- a/pkg/asset/agent/mirror/registriesconf.go
+++ b/pkg/asset/agent/mirror/registriesconf.go
@@ -248,7 +248,8 @@ func (i *RegistriesConf) validateReleaseImageIsSameInRegistriesConf(releaseImage
 
 func (i *RegistriesConf) generateDefaultRegistriesConf() error {
 	i.File = &asset.File{
-		Data: []byte(defaultRegistriesConf),
+		Filename: RegistriesConfFilename,
+		Data:     []byte(defaultRegistriesConf),
 	}
 	registriesConf := &sysregistriesv2.V2RegistriesConf{}
 	if err := toml.Unmarshal([]byte(defaultRegistriesConf), registriesConf); err != nil {


### PR DESCRIPTION
This was accidentally broken by
d3856aa7c6a9630dd7e401efe73e69d0591cd510, resulting in errors when writing the asset to disk (i.e. the 'agent create cluster-manifests' command would fail).