### PR TITLE
OCPBUGS-8305: Power VS: Add resourceGroup to infrastructure manifest

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -261,6 +261,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		config.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{
 			Region:         installConfig.Config.Platform.PowerVS.Region,
 			Zone:           installConfig.Config.Platform.PowerVS.Zone,
+			ResourceGroup:  installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
 			CISInstanceCRN: cisInstanceCRN,
 			DNSInstanceCRN: dnsInstanceCRN,
 		}


### PR DESCRIPTION
After https://github.com/openshift/api/commit/925f75a26305c13db2d89c0e993060ab60c267ce ResourceGroup is needed by the machine-config-operator.