### PR TITLE
CORS-2572: azure: implement egress via NAT gateway

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -158,7 +158,7 @@ resource "azurerm_network_interface" "bootstrap" {
 resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap_v4" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
-  count = (! var.azure_private || ! var.azure_outbound_user_defined_routing) ? 1 : 0
+  count = (! var.azure_private || var.azure_outbound_routing_type != "UserDefinedRouting") ? 1 : 0
 
   network_interface_id    = azurerm_network_interface.bootstrap.id
   backend_address_pool_id = var.elb_backend_pool_v4_id
@@ -168,7 +168,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "public_lb
 resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap_v6" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
-  count = var.use_ipv6 && (! var.azure_private || ! var.azure_outbound_user_defined_routing) ? 1 : 0
+  count = var.use_ipv6 && (! var.azure_private || var.azure_outbound_routing_type != "UserDefinedRouting") ? 1 : 0
 
   network_interface_id    = azurerm_network_interface.bootstrap.id
   backend_address_pool_id = var.elb_backend_pool_v6_id

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -52,12 +52,12 @@ variable "identity" {
   description = "The user assigned identity id for the vm."
 }
 
-variable "outbound_udr" {
-  type    = bool
-  default = false
+variable "outbound_type" {
+  type    = string
+  default = "Loadbalancer"
 
   description = <<EOF
-This determined whether User defined routing will be used for egress to
+This determined the routing type that will be used for egress to
 Internet.
 When false, Standard LB will be used for egress to the Internet.
 

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -37,7 +37,7 @@ module "master" {
   os_volume_type             = var.azure_master_root_volume_type
   os_volume_size             = var.azure_master_root_volume_size
   private                    = var.azure_private
-  outbound_udr               = var.azure_outbound_user_defined_routing
+  outbound_type              = var.azure_outbound_routing_type
   ultra_ssd_enabled          = var.azure_control_plane_ultra_ssd_enabled
   vm_networking_type         = var.azure_control_plane_vm_networking_type
   azure_extra_tags           = var.azure_extra_tags

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -51,7 +51,7 @@ resource "azurerm_network_interface" "master" {
 resource "azurerm_network_interface_backend_address_pool_association" "master_v4" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
-  count = (! var.private || ! var.outbound_udr) ? var.instance_count : 0
+  count = (! var.private || var.outbound_type != "UserDefinedRouting") ? var.instance_count : 0
 
   network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
   backend_address_pool_id = var.elb_backend_pool_v4_id
@@ -61,7 +61,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "master_v4
 resource "azurerm_network_interface_backend_address_pool_association" "master_v6" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
-  count = var.use_ipv6 && (! var.private || ! var.outbound_udr) ? var.instance_count : 0
+  count = var.use_ipv6 && (! var.private || var.outbound_type != "UserDefinedRouting") ? var.instance_count : 0
 
   network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
   backend_address_pool_id = var.elb_backend_pool_v6_id

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -119,12 +119,12 @@ variable "use_ipv6" {
   description = "This value determines if this is cluster should use IPv6 networking."
 }
 
-variable "outbound_udr" {
-  type = bool
-  default = false
+variable "outbound_type" {
+  type = string
+  default = "Loadbalancer"
 
   description = <<EOF
-This determined whether User defined routing will be used for egress to Internet.
+This determined the routing type that will be used for egress to Internet.
 When false, Standard LB will be used for egress to the Internet.
 
 This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -72,12 +72,12 @@ variable "identity" {
   description = "The user assigned identity id for the vm."
 }
 
-variable "outbound_udr" {
-  type    = bool
-  default = false
+variable "outbound_type" {
+  type    = string
+  default = "Loadbalancer"
 
   description = <<EOF
-This determined whether User defined routing will be used for egress to
+This determined the routing type that will be used for egress to
 Internet.
 When false, Standard LB will be used for egress to the Internet.
 

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -175,13 +175,13 @@ variable "azure_private" {
   description = "This determines if this is a private cluster or not."
 }
 
-variable "azure_outbound_user_defined_routing" {
-  type    = bool
-  default = false
+variable "azure_outbound_routing_type" {
+  type    = string
+  default = "Loadbalancer"
 
   description = <<EOF
-This determined whether User defined routing will be used for egress to Internet.
-When false, Standard LB will be used for egress to the Internet.
+This determined the routing that will be used for egress to Internet.
+When not set, Standard LB will be used for egress to the Internet.
 EOF
 }
 

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -66,6 +66,6 @@ output "storage_account_name" {
   value = azurerm_storage_account.cluster.name
 }
 
-output "outbound_udr" {
-  value = var.azure_outbound_user_defined_routing
+output "outbound_type" {
+  value = var.azure_outbound_routing_type
 }

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -180,3 +180,50 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
   protocol            = "Https"
   request_path        = "/readyz"
 }
+
+resource "azurerm_public_ip" "ngw_public_ip_v4" {
+  count = local.need_public_ipv4 && var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+
+  sku                 = "Standard"
+  location            = var.azure_region
+  name                = "${var.cluster_id}-natgw-pip-v4"
+  resource_group_name = data.azurerm_resource_group.main.name
+  allocation_method   = "Static"
+  tags                = var.azure_extra_tags
+}
+
+resource "azurerm_public_ip" "ngw_public_ip_v6" {
+  count = local.need_public_ipv6 && var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+
+  ip_version          = "IPv6"
+  sku                 = "Standard"
+  location            = var.azure_region
+  name                = "${var.cluster_id}-natgw-pip-v6"
+  resource_group_name = data.azurerm_resource_group.main.name
+  allocation_method   = "Static"
+  tags                = var.azure_extra_tags
+}
+
+resource "azurerm_nat_gateway" "nat_gw" {
+  count                   = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+  name                    = "${var.cluster_id}-natgw"
+  location                = var.azure_region
+  resource_group_name     = data.azurerm_resource_group.main.name
+  sku_name                = "Standard"
+  idle_timeout_in_minutes = 10
+  tags                    = var.azure_extra_tags
+  # By not specifying zones here, we make the NAT non-zonal
+  #zones = ["1"]
+}
+
+data "azurerm_nat_gateway" "nat_gw" {
+  count               = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+  name                = azurerm_nat_gateway.nat_gw[0].name
+  resource_group_name = data.azurerm_resource_group.main.name
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "nat_ip_assoc" {
+  count                = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+  nat_gateway_id       = azurerm_nat_gateway.nat_gw[0].id
+  public_ip_address_id = var.use_ipv6 ? azurerm_public_ip.ngw_public_ip_v6[0].id : azurerm_public_ip.ngw_public_ip_v4[0].id
+}

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -5,9 +5,9 @@ locals {
 
 locals {
   // DEBUG: Azure apparently requires dual stack LB for v6
-  need_public_ipv4 = ! var.azure_private || ! var.azure_outbound_user_defined_routing
+  need_public_ipv4 = ! var.azure_private || var.azure_outbound_routing_type != "UserDefinedRouting"
 
-  need_public_ipv6 = var.use_ipv6 && (! var.azure_private || ! var.azure_outbound_user_defined_routing)
+  need_public_ipv6 = var.use_ipv6 && (! var.azure_private || var.azure_outbound_routing_type != "UserDefinedRouting")
 }
 
 
@@ -144,7 +144,7 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v6" {
 }
 
 resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v4" {
-  count = var.use_ipv4 && var.azure_private && ! var.azure_outbound_user_defined_routing ? 1 : 0
+  count = var.use_ipv4 && var.azure_private && var.azure_outbound_routing_type != "UserDefinedRouting" ? 1 : 0
 
   name                    = "outbound-rule-v4"
   loadbalancer_id         = azurerm_lb.public.id
@@ -157,7 +157,7 @@ resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v4" {
 }
 
 resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v6" {
-  count = var.use_ipv6 && var.azure_private && ! var.azure_outbound_user_defined_routing ? 1 : 0
+  count = var.use_ipv6 && var.azure_private && var.azure_outbound_routing_type != "UserDefinedRouting" ? 1 : 0
 
   name                    = "outbound-rule-v6"
   loadbalancer_id         = azurerm_lb.public.id

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -31,3 +31,15 @@ resource "azurerm_subnet" "worker_subnet" {
   virtual_network_name = local.virtual_network
   name                 = var.azure_compute_subnet
 }
+
+resource "azurerm_subnet_nat_gateway_association" "nat_master_assoc" {
+  count          = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+  subnet_id      = local.master_subnet_id
+  nat_gateway_id = azurerm_nat_gateway.nat_gw[0].id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "nat_worker_assoc" {
+  count          = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
+  subnet_id      = local.worker_subnet_id
+  nat_gateway_id = azurerm_nat_gateway.nat_gw[0].id
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2191,6 +2191,7 @@ spec:
                     enum:
                     - ""
                     - Loadbalancer
+                    - NatGateway
                     - UserDefinedRouting
                     type: string
                   region:

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -215,7 +215,7 @@ func Test_PrintFields(t *testing.T) {
 
     outboundType <string>
       Default: "Loadbalancer"
-      Valid Values: "","Loadbalancer","UserDefinedRouting"
+      Valid Values: "","Loadbalancer","NatGateway","UserDefinedRouting"
       OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
 
     region <string> -required-

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -48,7 +48,7 @@ type config struct {
 	ComputeSubnet                   string            `json:"azure_compute_subnet"`
 	PreexistingNetwork              bool              `json:"azure_preexisting_network"`
 	Private                         bool              `json:"azure_private"`
-	OutboundUDR                     bool              `json:"azure_outbound_user_defined_routing"`
+	OutboundType                    string            `json:"azure_outbound_routing_type"`
 	BootstrapIgnitionStub           string            `json:"azure_bootstrap_ignition_stub"`
 	BootstrapIgnitionURLPlaceholder string            `json:"azure_bootstrap_ignition_url_placeholder"`
 	HyperVGeneration                string            `json:"azure_hypervgeneration_version"`
@@ -131,7 +131,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ImageURL:                        sources.ImageURL,
 		ImageRelease:                    sources.ImageRelease,
 		Private:                         sources.Publish == types.InternalPublishingStrategy,
-		OutboundUDR:                     sources.OutboundType == azure.UserDefinedRoutingOutboundType,
+		OutboundType:                    string(sources.OutboundType),
 		ResourceGroupName:               sources.ResourceGroupName,
 		BaseDomainResourceGroupName:     sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:        masterConfig.NetworkResourceGroup,

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -9,13 +9,17 @@ import (
 var aro bool
 
 // OutboundType is a strategy for how egress from cluster is achieved.
-// +kubebuilder:validation:Enum="";Loadbalancer;UserDefinedRouting
+// +kubebuilder:validation:Enum="";Loadbalancer;NatGateway;UserDefinedRouting
 type OutboundType string
 
 const (
 	// LoadbalancerOutboundType uses Standard loadbalancer for egress from the cluster.
 	// see https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#lb
 	LoadbalancerOutboundType OutboundType = "Loadbalancer"
+
+	// NatGatewayOutboundType uses NAT gateway for egress from the cluster
+	// see https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-gateway-resource
+	NatGatewayOutboundType OutboundType = "NatGateway"
 
 	// UserDefinedRoutingOutboundType uses user defined routing for egress from the cluster.
 	// see https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -88,6 +88,10 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	if p.OutboundType == azure.UserDefinedRoutingOutboundType && p.VirtualNetwork == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is only allowed when installing to pre-existing network", azure.UserDefinedRoutingOutboundType)))
 	}
+	if p.OutboundType == azure.NatGatewayOutboundType && p.VirtualNetwork != "" {
+		// For now, BYO network and NAT gateways are not compatible
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is not allowed when installing to pre-existing network", azure.NatGatewayOutboundType)))
+	}
 
 	// support for Azure user-defined tags made available through
 	// RFE-2017 is for AzurePublicCloud only.

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -185,6 +185,7 @@ func findDuplicateTagKeys(tagSet map[string]string) error {
 var (
 	validOutboundTypes = map[azure.OutboundType]struct{}{
 		azure.LoadbalancerOutboundType:       {},
+		azure.NatGatewayOutboundType:         {},
 		azure.UserDefinedRoutingOutboundType: {},
 	}
 

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -140,7 +140,7 @@ func TestValidatePlatform(t *testing.T) {
 				p.OutboundType = "random-egress"
 				return p
 			}(),
-			expected: `^test-path\.outboundType: Unsupported value: "random-egress": supported values: "Loadbalancer", "UserDefinedRouting"$`,
+			expected: `^test-path\.outboundType: Unsupported value: "random-egress": supported values: "Loadbalancer", "NatGateway", "UserDefinedRouting"$`,
 		},
 		{
 			name: "invalid user defined type",


### PR DESCRIPTION
Provide the ability to the Installer to deploy clusters with a NAT Gateway for outbound traffic as the AKS installer already does. This will be useful for customers facing SNAT port exhaustion issues with the default LB outbound.