### PR TITLE
OCPBUGS-8353: Disable 'create pxe-files' command

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -69,6 +69,7 @@ var (
 		},
 	}
 
+	//nolint:varcheck,deadcode
 	agentPXEFilesTarget = target{
 		name: "Agent PXE Files",
 		command: &cobra.Command{
@@ -83,7 +84,7 @@ var (
 		},
 	}
 
-	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget}
+	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget}
 )
 
 func newAgentCreateCmd() *cobra.Command {

--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
@@ -1,5 +1,7 @@
 # Verify a default configuration for the SNO topology
 
+skip 'pxe-files generation is disabled'
+
 exec openshift-install agent create pxe-files --dir $WORK
 
 stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'


### PR DESCRIPTION
This feature has only partly landed, and is likely to be in a broken state. Disable the command that has landed, so that we can defer to a future release.