### PR TITLE
OpenStack: support multiple API and ingress VIPs

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -53,9 +53,9 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
   }
 
   dynamic "allowed_address_pairs" {
-    for_each = var.openstack_user_managed_load_balancer ? [] : [1]
+    for_each = var.openstack_user_managed_load_balancer ? [] : var.openstack_api_int_ips
     content {
-      ip_address = var.openstack_api_int_ip
+      ip_address = allowed_address_pairs.value
     }
   }
 

--- a/data/data/openstack/masters/private-network.tf
+++ b/data/data/openstack/masters/private-network.tf
@@ -71,16 +71,16 @@ resource "openstack_networking_port_v2" "masters" {
   }
 
   dynamic "allowed_address_pairs" {
-    for_each = var.openstack_user_managed_load_balancer ? [] : [1]
+    for_each = var.openstack_user_managed_load_balancer ? [] : var.openstack_api_int_ips
     content {
-      ip_address = var.openstack_api_int_ip
+      ip_address = allowed_address_pairs.value
     }
   }
 
   dynamic "allowed_address_pairs" {
-    for_each = var.openstack_user_managed_load_balancer ? [] : [1]
+    for_each = var.openstack_user_managed_load_balancer ? [] : var.openstack_ingress_ips
     content {
-      ip_address = var.openstack_ingress_ip
+      ip_address = allowed_address_pairs.value
     }
   }
 
@@ -102,7 +102,7 @@ resource "openstack_networking_port_v2" "api_port" {
 
     content {
       subnet_id  = fixed_ip.value["subnet_id"]
-      ip_address = var.openstack_api_int_ip
+      ip_address = var.openstack_api_int_ips[0]
     }
   }
 }
@@ -122,7 +122,7 @@ resource "openstack_networking_port_v2" "ingress_port" {
 
     content {
       subnet_id  = fixed_ip.value["subnet_id"]
-      ip_address = var.openstack_ingress_ip
+      ip_address = var.openstack_ingress_ips[0]
     }
   }
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -284,14 +284,14 @@ EOF
 
 }
 
-variable "openstack_api_int_ip" {
-  type        = string
-  description = "IP on the node subnet reserved for api-int VIP."
+variable "openstack_api_int_ips" {
+  type        = list(string)
+  description = "IPs on the node subnets reserved for api-int VIP."
 }
 
-variable "openstack_ingress_ip" {
-  type        = string
-  description = "IP on the nodes subnet reserved for the ingress VIP."
+variable "openstack_ingress_ips" {
+  type        = list(string)
+  description = "IPs on the nodes subnets reserved for the ingress VIP."
 }
 
 variable "openstack_external_dns" {

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -232,8 +232,8 @@ func TFVars(
 		FlavorName                        string                            `json:"openstack_master_flavor_name,omitempty"`
 		APIFloatingIP                     string                            `json:"openstack_api_floating_ip,omitempty"`
 		IngressFloatingIP                 string                            `json:"openstack_ingress_floating_ip,omitempty"`
-		APIVIP                            string                            `json:"openstack_api_int_ip,omitempty"`
-		IngressVIP                        string                            `json:"openstack_ingress_ip,omitempty"`
+		APIVIPs                           []string                          `json:"openstack_api_int_ips,omitempty"`
+		IngressVIPs                       []string                          `json:"openstack_ingress_ips,omitempty"`
 		TrunkSupport                      bool                              `json:"openstack_trunk_support,omitempty"`
 		OctaviaSupport                    bool                              `json:"openstack_octavia_support,omitempty"`
 		RootVolumeSize                    int                               `json:"openstack_master_root_volume_size,omitempty"`
@@ -259,8 +259,8 @@ func TFVars(
 		FlavorName:                        masterSpecs[0].Flavor,
 		APIFloatingIP:                     installConfig.Config.Platform.OpenStack.APIFloatingIP,
 		IngressFloatingIP:                 installConfig.Config.Platform.OpenStack.IngressFloatingIP,
-		APIVIP:                            installConfig.Config.Platform.OpenStack.APIVIPs[0],
-		IngressVIP:                        installConfig.Config.Platform.OpenStack.IngressVIPs[0],
+		APIVIPs:                           installConfig.Config.Platform.OpenStack.APIVIPs,
+		IngressVIPs:                       installConfig.Config.Platform.OpenStack.IngressVIPs,
 		TrunkSupport:                      masterSpecs[0].Trunk,
 		OctaviaSupport:                    octaviaSupport,
 		RootVolumeSize:                    rootVolumeSize,


### PR DESCRIPTION
This commit enables the usage of more than one API and ingress VIP, which is required by Dual-Stack clusters.