### PR TITLE
OCPBUGS-8035: IBMCloud: Fix SSH Private bootstrap

### DIFF
--- a/data/data/ibmcloud/bootstrap/variables.tf
+++ b/data/data/ibmcloud/bootstrap/variables.tf
@@ -15,6 +15,10 @@ variable "control_plane_subnet_id_list" {
   type = list(string)
 }
 
+variable "compute_subnet_id_list" {
+  type = list(string)
+}
+
 variable "control_plane_subnet_zone_list" {
   type = list(string)
 }

--- a/data/data/ibmcloud/network/outputs.tf
+++ b/data/data/ibmcloud/network/outputs.tf
@@ -18,6 +18,10 @@ output "control_plane_subnet_zone_list" {
   value = module.vpc.control_plane_subnet_zone_list
 }
 
+output "compute_subnet_id_list" {
+  value = module.vpc.compute_subnet_id_list
+}
+
 output "cos_resource_instance_crn" {
   value = ibm_resource_instance.cos.crn
 }

--- a/data/data/ibmcloud/network/vpc/outputs.tf
+++ b/data/data/ibmcloud/network/vpc/outputs.tf
@@ -19,6 +19,10 @@ output "control_plane_subnet_zone_list" {
   value = local.control_plane_subnets[*].zone
 }
 
+output "compute_subnet_id_list" {
+  value = local.compute_subnets[*].id
+}
+
 output "lb_kubernetes_api_public_hostname" {
   value = var.public_endpoints ? ibm_is_lb.kubernetes_api_public.0.hostname : ""
 }

--- a/data/data/ibmcloud/network/vpc/security-groups.tf
+++ b/data/data/ibmcloud/network/vpc/security-groups.tf
@@ -18,9 +18,11 @@ resource "ibm_is_security_group" "cluster_wide" {
 
 # SSH
 resource "ibm_is_security_group_rule" "cluster_wide_ssh_inbound" {
+  count = length(local.subnet_cidr_blocks)
+
   group     = ibm_is_security_group.cluster_wide.id
   direction = "inbound"
-  remote    = ibm_is_security_group.cluster_wide.id
+  remote    = local.subnet_cidr_blocks[count.index]
   tcp {
     port_min = 22
     port_max = 22


### PR DESCRIPTION
Fix IBM Cloud SecurityGroupRule for the bootstrap node, to allow SSH access to the node from any node within the private network, across all VPC availability zone subnets (10.x), such as a bastion host running IPI.

Related: https://issues.redhat.com/browse/OCPBUGS-8035