### PR TITLE
OCPBUGS-5201: Error message should be more user-friendly when "openshift-install create cluster" fails due to unexpected VMware configuration

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -673,12 +673,11 @@ func validateClusterComputeResourceHasHosts(cluster string, hosts []*object.Host
 // users know what to address.  This only returns an error if unable to verify or if no ComputeResources
 // are found.  This method is used mostly from interactive installation to make sure ClusterComputeResource
 // has HostSystems to select a network.
-func validateClusterComputeResourceHasHostsWithLookup(ctx context.Context, datacenter string, cluster string, finder Finder) error {
+func validateClusterComputeResourceHasHostsWithLookup(ctx context.Context, cluster string, finder Finder) error {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	path := fmt.Sprintf("/%s/host/%s", datacenter, cluster)
-	ccr, err := finder.ClusterComputeResource(ctx, path)
+	ccr, err := finder.ClusterComputeResource(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -726,7 +726,6 @@ func Test_validateCheckClusterComputeResource(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// err := validateClusterComputeResourceHasHosts(ctx, test.dataCenter, test.cluster, validationCtx.Finder)
 			err := validateClusterComputeResources(validationCtx, fmt.Sprintf("/%v/host/%v", test.dataCenter, test.cluster), vSphereFldPath, computeClusterFldPath, false, false).ToAggregate()
 			if test.expectErr == "" {
 				assert.NoError(t, err)

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -57,6 +57,13 @@ func Platform() (*vsphere.Platform, error) {
 		return nil, err
 	}
 
+	// Check for ComputeResources under the ClusterComputeResource.  If none, then getNetwork
+	// will fail.  Return helpful error message for installer user
+	err = validateClusterComputeResourceHasHosts(ctx, dc, cluster, finder)
+	if err != nil {
+		return nil, err
+	}
+
 	datastore, err := getDataStore(ctx, dcPath, finder, vCenter.Client)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -59,7 +59,7 @@ func Platform() (*vsphere.Platform, error) {
 
 	// Check for ComputeResources under the ClusterComputeResource.  If none, then getNetwork
 	// will fail.  Return helpful error message for installer user
-	err = validateClusterComputeResourceHasHosts(ctx, dc, cluster, finder)
+	err = validateClusterComputeResourceHasHostsWithLookup(ctx, dc, cluster, finder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -59,7 +59,7 @@ func Platform() (*vsphere.Platform, error) {
 
 	// Check for ComputeResources under the ClusterComputeResource.  If none, then getNetwork
 	// will fail.  Return helpful error message for installer user
-	err = validateClusterComputeResourceHasHostsWithLookup(ctx, dc, cluster, finder)
+	err = validateClusterComputeResourceHasHostsWithLookup(ctx, cluster, finder)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enhanced installer for vsphere to verify ComputeResources existed in ComputeClusterResource before progressing to network selection.