### PR TITLE
OCPGUS-2363: IBMCloud: Use direct COS endpoint

### DIFF
--- a/data/data/ibmcloud/bootstrap/main.tf
+++ b/data/data/ibmcloud/bootstrap/main.tf
@@ -32,7 +32,7 @@ resource "ibm_is_instance" "bootstrap_node" {
   # terraform-provider-ignition, we should use it instead of this template.
   # https://github.com/community-terraform-providers/terraform-provider-ignition/issues/16
   user_data = templatefile("${path.module}/templates/bootstrap.ign", {
-    HOSTNAME    = ibm_cos_bucket.bootstrap_ignition.s3_endpoint_public
+    HOSTNAME    = ibm_cos_bucket.bootstrap_ignition.s3_endpoint_direct
     BUCKET_NAME = ibm_cos_bucket.bootstrap_ignition.bucket_name
     OBJECT_NAME = ibm_cos_bucket_object.bootstrap_ignition.key
     IAM_TOKEN   = data.ibm_iam_auth_token.iam_token.iam_access_token


### PR DESCRIPTION
Use the direct COS endpoint when managing COS resources on IBM Cloud.

Related: https://issues.redhat.com/browse/OCPBUGS-2363