### PR TITLE
CORS-2525: Azure: remove storage account with bootstrap destroy

### DIFF
--- a/data/data/azure/bootstrap/outputs.tf
+++ b/data/data/azure/bootstrap/outputs.tf
@@ -1,3 +1,4 @@
 output "bootstrap_ip" {
   value = var.azure_private ? azurerm_network_interface.bootstrap.private_ip_address : azurerm_public_ip.bootstrap_public_ip_v4[0].ip_address
 }
+

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -59,12 +59,11 @@ variable "outbound_udr" {
   description = <<EOF
 This determined whether User defined routing will be used for egress to
 Internet.
-When false, Standard LB will be used for egress to the Internet.
 
+When false, Standard LB will be used for egress to the Internet.
 This is required because terraform cannot calculate counts during plan phase
 completely and therefore the `vnet/public-lb.tf`
 conditional need to be recreated. See
 https://github.com/hashicorp/terraform/issues/12570
 EOF
 }
-

--- a/data/data/azure/storage/main.tf
+++ b/data/data/azure/storage/main.tf
@@ -1,0 +1,62 @@
+locals {
+  tags = merge(
+    {
+      "kubernetes.io_cluster.${var.cluster_id}" = "owned"
+    },
+    var.azure_extra_tags,
+  )
+  description = "Created By OpenShift Installer"
+  # At this time min_tls_version is only supported in the Public Cloud and US Government Cloud.
+  environments_with_min_tls_version = ["public", "usgovernment"]
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id             = var.azure_subscription_id
+  client_id                   = var.azure_client_id
+  client_secret               = var.azure_client_secret
+  client_certificate_password = var.azure_certificate_password
+  client_certificate_path     = var.azure_certificate_path
+  tenant_id                   = var.azure_tenant_id
+  environment                 = var.azure_environment
+}
+
+resource "azurerm_resource_group" "main" {
+  count = var.azure_resource_group_name == "" ? 1 : 0
+
+  name     = "${var.cluster_id}-rg"
+  location = var.azure_region
+  tags     = var.azure_extra_tags
+}
+
+data "azurerm_resource_group" "main" {
+  name = var.azure_resource_group_name == "" ? "${var.cluster_id}-rg" : var.azure_resource_group_name
+
+  depends_on = [azurerm_resource_group.main]
+}
+
+resource "azurerm_storage_account" "cluster" {
+  name                            = "cluster${var.random_storage_account_suffix}"
+  resource_group_name             = data.azurerm_resource_group.main.name
+  location                        = var.azure_region
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
+  allow_nested_items_to_be_public = false
+  tags                            = var.azure_extra_tags
+}
+
+# copy over the vhd to cluster resource group and create an image using that
+resource "azurerm_storage_container" "vhd" {
+  name                 = "vhd"
+  storage_account_name = azurerm_storage_account.cluster.name
+}
+
+resource "azurerm_storage_blob" "rhcos_image" {
+  name                   = "rhcos${var.random_storage_account_suffix}.vhd"
+  storage_account_name   = azurerm_storage_account.cluster.name
+  storage_container_name = azurerm_storage_container.vhd.name
+  type                   = "Page"
+  source_uri             = var.azure_image_url
+  metadata               = tomap({ source_uri = var.azure_image_url })
+}

--- a/data/data/azure/storage/outputs.tf
+++ b/data/data/azure/storage/outputs.tf
@@ -1,0 +1,11 @@
+output "resource_group_name" {
+  value = data.azurerm_resource_group.main.name
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.cluster.name
+}
+
+output "rhcos_image_url" {
+  value = azurerm_storage_blob.rhcos_image.url
+}

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -46,9 +46,6 @@ output "worker_subnet_id" {
   value = local.worker_subnet_id
 }
 
-output "resource_group_name" {
-  value = data.azurerm_resource_group.main.name
-}
 
 output "vm_image" {
   value = var.azure_hypervgeneration_version == "V2" ? azurerm_shared_image_version.clustergen2_image_version.id : azurerm_shared_image_version.cluster_image_version.id
@@ -60,10 +57,6 @@ output "identity" {
 
 output "subnet_id" {
   value = local.master_subnet_id
-}
-
-output "storage_account_name" {
-  value = azurerm_storage_account.cluster.name
 }
 
 output "outbound_udr" {

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -1,0 +1,14 @@
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group name for the deployment."
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "the name of the storage account for the cluster. It can be used for boot diagnostics."
+}
+
+variable "rhcos_image_url" {
+  type        = string
+  description = "The external load balancer bakend pool id. used to attach the bootstrap NIC"
+}

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -11,6 +11,12 @@ import (
 var PlatformStages = []terraform.Stage{
 	stages.NewStage(
 		typesazure.Name,
+		"storage",
+		[]providers.Provider{providers.AzureRM},
+		stages.WithNormalBootstrapDestroy(),
+	),
+	stages.NewStage(
+		typesazure.Name,
 		"vnet",
 		[]providers.Provider{providers.AzureRM},
 	),


### PR DESCRIPTION
The work is being done to address the issue of Azure storage accounts being persisted for the life of an OpenShift cluster, which incurs costs and management effort. The goal is to destroy the storage account along with other bootstrap resources during the bootstrap destroy process. Additionally, the default creation of two Azure storage accounts has raised security issues, which the work aims to address by restricting network access using virtual network rules.

Using azurerm_storage_account_network_rules on the storage account did not work as it blocks other resources from using the storage accounts.