### PR TITLE
data: libvirt: increase volume size to 32GB

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -32,7 +32,7 @@ resource "libvirt_volume" "bootstrap" {
   base_volume_id = libvirt_volume.bootstrap-base.id
   # Keep this in sync with the main libvirt size in
   # data/data/libvirt/bootstrap/main.tf
-  size = "21474836480"
+  size = "34359738368"
 }
 
 resource "libvirt_ignition" "bootstrap" {

--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -7,7 +7,7 @@ resource "libvirt_volume" "bootstrap" {
   base_volume_id = var.base_volume_id
   pool           = var.pool
   # Bump this so it works for OKD/FCOS too
-  size = "21474836480"
+  size = "34359738368"
 }
 
 resource "libvirt_ignition" "bootstrap" {


### PR DESCRIPTION
The storage volume of the bootstrap VM with a max size of 20GB seems to be too small for OKD 4.13 with SCOS and 3 redfish-virtualmedia boot isos. Let's increase it to 32GB.

Fixes #6891