### PR TITLE
OCPBUGS-9982: bootstrap-pivot: skip pivot in SCOS Live ISO

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
@@ -1,6 +1,16 @@
 {{if .IsOKD -}}
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Exit early if pivot is attempted on SCOS Live ISO
+{{if .IsSCOS -}}
+source /etc/os-release
+if [[ ! $(touch /usr/.test) ]] && [[ ${ID} =~ ^(centos)$ ]]; then
+  touch /opt/openshift/.pivot-done
+  exit 0
+fi
+{{end -}}
+
 # Rebase to OKD's OSTree container image.
 # This is required in OKD as the node is first provisioned with plain Fedora CoreOS.
 


### PR DESCRIPTION
If bootstrap is running in a Live ISO of SCOS `rpm-ostree pivot` will fail as /usr is not writable. Live ISO is used in assisted-installer flow and it doesn't need to pivot machine-os-content during bootstrap (it would write SCOS image on disk and run pivot via machine-config-daemon-pivot service). 

This change unblocks OKD Stream isntall using assisted-installer