### PR TITLE
OCPBUGS-7015: vsphere, nutanix survey: relax vip in machine cidr

### DIFF
--- a/pkg/asset/installconfig/nutanix/nutanix.go
+++ b/pkg/asset/installconfig/nutanix/nutanix.go
@@ -14,11 +14,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/defaults"
 	"github.com/openshift/installer/pkg/types/nutanix"
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
-	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
 
@@ -269,14 +266,6 @@ func getSubnet(ctx context.Context, client *nutanixclientv3.Client, peUUID strin
 func getVIPs() (string, string, error) {
 	var apiVIP, ingressVIP string
 
-	defaultMachineNetwork := &types.Networking{
-		MachineNetwork: []types.MachineNetworkEntry{
-			{
-				CIDR: *defaults.DefaultMachineCIDR,
-			},
-		},
-	}
-
 	//TODO: Add support to specify multiple VIPs (-> dual-stack)
 	if err := survey.Ask([]*survey.Question{
 		{
@@ -285,11 +274,7 @@ func getVIPs() (string, string, error) {
 				Help:    "The VIP to be used for the OpenShift API.",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				err := validate.IP((ans).(string))
-				if err != nil {
-					return err
-				}
-				return validation.ValidateIPinMachineCIDR((ans).(string), defaultMachineNetwork)
+				return validate.IP((ans).(string))
 			}),
 		},
 	}, &apiVIP); err != nil {
@@ -306,11 +291,7 @@ func getVIPs() (string, string, error) {
 				if apiVIP == (ans.(string)) {
 					return fmt.Errorf("%q should not be equal to the Virtual IP address for the API", ans.(string))
 				}
-				err := validate.IP((ans).(string))
-				if err != nil {
-					return err
-				}
-				return validation.ValidateIPinMachineCIDR((ans).(string), defaultMachineNetwork)
+				return validate.IP((ans).(string))
 			}),
 		},
 	}, &ingressVIP); err != nil {

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -15,9 +15,6 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/defaults"
-	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/types/vsphere"
 	"github.com/openshift/installer/pkg/validate"
 )
@@ -365,14 +362,6 @@ func getNetwork(ctx context.Context, datacenter string, cluster string, finder F
 func getVIPs() (string, string, error) {
 	var apiVIP, ingressVIP string
 
-	defaultMachineNetwork := &types.Networking{
-		MachineNetwork: []types.MachineNetworkEntry{
-			{
-				CIDR: *defaults.DefaultMachineCIDR,
-			},
-		},
-	}
-
 	if err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
@@ -380,11 +369,7 @@ func getVIPs() (string, string, error) {
 				Help:    "The VIP to be used for the OpenShift API.",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				err := validate.IP((ans).(string))
-				if err != nil {
-					return err
-				}
-				return validation.ValidateIPinMachineCIDR((ans).(string), defaultMachineNetwork)
+				return validate.IP((ans).(string))
 			}),
 		},
 	}, &apiVIP); err != nil {
@@ -401,11 +386,7 @@ func getVIPs() (string, string, error) {
 				if apiVIP == (ans.(string)) {
 					return fmt.Errorf("%q should not be equal to the Virtual IP address for the API", ans.(string))
 				}
-				err := validate.IP((ans).(string))
-				if err != nil {
-					return err
-				}
-				return validation.ValidateIPinMachineCIDR((ans).(string), defaultMachineNetwork)
+				return validate.IP((ans).(string))
 			}),
 		},
 	}, &ingressVIP); err != nil {


### PR DESCRIPTION
This commit removes validation to ensure the ingress and API vips are in the default machine network cidr. This validation was added to all on-prem platforms. Installs have worked without this validation since the release of openshift 4 and the new requirements seems to be causing user issues. So we are relaxing the validation to be consistent with previous releases and because there is not a clear need for the validation.