### PR TITLE
OCPBUGS-10207: Do not always output warning msg when releaseImage is digest

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -145,7 +144,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	publicContainerRegistries := getPublicContainerRegistries(registriesConfig)
 
-	releaseImageMirror := getMirrorFromRelease(agentManifests.ClusterImageSet.Spec.ReleaseImage, registriesConfig)
+	releaseImageMirror := mirror.GetMirrorFromRelease(agentManifests.ClusterImageSet.Spec.ReleaseImage, registriesConfig)
 
 	infraEnvID := uuid.New().String()
 	logrus.Debug("Generated random infra-env id ", infraEnvID)
@@ -490,23 +489,6 @@ func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 		err = errors.New("missing rendezvousIP in agent-config or at least one NMStateConfig manifest")
 	}
 	return rendezvousIP, err
-}
-
-func getMirrorFromRelease(releaseImage string, registriesConfig *mirror.RegistriesConf) string {
-	source := regexp.MustCompile(`^(.+?)(@sha256)?:(.+)`).FindStringSubmatch(releaseImage)
-	for _, config := range registriesConfig.MirrorConfig {
-		if config.Location == source[1] {
-			// include the tag with the build release image
-			if len(source) == 4 {
-				// Has Sha256
-				return fmt.Sprintf("%s%s:%s", config.Mirror, source[2], source[3])
-			} else if len(source) == 3 {
-				return fmt.Sprintf("%s:%s", config.Mirror, source[2])
-			}
-		}
-	}
-
-	return ""
 }
 
 func getPublicContainerRegistries(registriesConfig *mirror.RegistriesConf) string {

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -669,7 +669,7 @@ func TestIgnition_getMirrorFromRelease(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			mirror := getMirrorFromRelease(tc.release, &tc.registriesConf)
+			mirror := mirror.GetMirrorFromRelease(tc.release, &tc.registriesConf)
 
 			assert.Equal(t, tc.expectedMirror, mirror)
 

--- a/pkg/asset/agent/mirror/registriesconf.go
+++ b/pkg/asset/agent/mirror/registriesconf.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/pelletier/go-toml"
@@ -162,9 +162,8 @@ func (i *RegistriesConf) Generate(dependencies asset.Parents) error {
 	i.Config = registries
 	i.setMirrorConfig(i.Config)
 
-	releaseImagePath := strings.Split(releaseImage.PullSpec, ":")[0]
-	if found := i.validateReleaseImageIsSameInRegistriesConf(releaseImagePath); !found {
-		logrus.Warnf(fmt.Sprintf("The ImageContentSources configuration in install-config.yaml should have at-least one source field matching the releaseImage value %s", releaseImagePath))
+	if !i.releaseImageIsSameInRegistriesConf(releaseImage.PullSpec) {
+		logrus.Warnf(fmt.Sprintf("The ImageContentSources configuration in install-config.yaml should have at least one source field matching the releaseImage value %s", releaseImage.PullSpec))
 	}
 
 	registriesData, err := toml.Marshal(registries)
@@ -211,10 +210,9 @@ func (i *RegistriesConf) Load(f asset.FileFetcher) (bool, error) {
 	i.setMirrorConfig(i.Config)
 
 	if string(i.File.Data) != defaultRegistriesConf {
-		if valid := i.validateRegistriesConf(); valid {
-			releaseImagePath := strings.Split(releaseImage.PullSpec, ":")[0]
-			if found := i.validateReleaseImageIsSameInRegistriesConf(releaseImagePath); !found {
-				logrus.Warnf(fmt.Sprintf("%s should have an entry matching the releaseImage %s", RegistriesConfFilename, releaseImagePath))
+		if i.validateRegistriesConf() {
+			if !i.releaseImageIsSameInRegistriesConf(releaseImage.PullSpec) {
+				logrus.Warnf(fmt.Sprintf("%s should have an entry matching the releaseImage %s", RegistriesConfFilename, releaseImage.PullSpec))
 			}
 		}
 	}
@@ -232,18 +230,8 @@ func (i *RegistriesConf) validateRegistriesConf() bool {
 	return true
 }
 
-func (i *RegistriesConf) validateReleaseImageIsSameInRegistriesConf(releaseImagePath string) bool {
-
-	var found bool
-
-	for _, registry := range i.Config.Registries {
-		source := registry.Endpoint.Location
-		if source == releaseImagePath {
-			found = true
-			break
-		}
-	}
-	return found
+func (i *RegistriesConf) releaseImageIsSameInRegistriesConf(releaseImage string) bool {
+	return GetMirrorFromRelease(releaseImage, i) != ""
 }
 
 func (i *RegistriesConf) generateDefaultRegistriesConf() error {
@@ -268,4 +256,23 @@ func (i *RegistriesConf) setMirrorConfig(registriesConf *sysregistriesv2.V2Regis
 		}
 	}
 	i.MirrorConfig = mirrorConfig
+}
+
+// GetMirrorFromRelease gets the matching mirror configured for the releaseImage.
+func GetMirrorFromRelease(releaseImage string, registriesConfig *RegistriesConf) string {
+	source := regexp.MustCompile(`^(.+?)(@sha256)?:(.+)`).FindStringSubmatch(releaseImage)
+	for _, config := range registriesConfig.MirrorConfig {
+		if config.Location == source[1] {
+			// include the tag with the build release image
+			switch len(source) {
+			case 4:
+				// Has Sha256
+				return fmt.Sprintf("%s%s:%s", config.Mirror, source[2], source[3])
+			case 3:
+				return fmt.Sprintf("%s:%s", config.Mirror, source[2])
+			}
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
A warning message about missing entry in ImageContentSources is always generated when the releaseImage is a digest. Fix to handle all cases of the image format and reuse a common function for this, along with some minor code cleanup.