### PR TITLE
OCPBUGS-5931: destroy/gcp: Disk names are filtered using kubernetes name format

### DIFF
--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -44,7 +44,7 @@ func (o *ClusterUninstaller) storageLabelOrClusterIDFilter() string {
 }
 
 func (o *ClusterUninstaller) listDisks() ([]cloudResource, error) {
-	return o.listDisksWithFilter("items/*/disks(name,zone,type,sizeGb),nextPageToken", o.clusterLabelOrClusterIDFilter(), nil)
+	return o.listDisksWithFilter("items/*/disks(name,zone,type,sizeGb),nextPageToken", o.storageLabelOrClusterIDFilter(), nil)
 }
 
 // listDisksWithFilter lists disks in the project that satisfy the filter criteria.


### PR DESCRIPTION
** Disks are now ALSO filtered using the kubernetes name format which currently can be found https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/util.go function GenerateVolumeName(). The max name length comes out to be 22 characters as the kubernetes volume name or pv name appears to take 40 characters. Search for disks matching the similar name structure in the project on GCP.

Removed labels from returned types

** Altering var to const for the variables as they are not altered during execution