### PR TITLE
OCPBUGS-2130: vSphere - finding networks use full path cluster

### DIFF
--- a/pkg/asset/installconfig/vsphere/client.go
+++ b/pkg/asset/installconfig/vsphere/client.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"time"
 
@@ -95,11 +94,9 @@ func GetClusterNetworks(ctx context.Context, finder Finder, datacenter, cluster 
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	// Get vSphere Cluster resource in the given Datacenter.
-	path := fmt.Sprintf("/%s/host/%s", datacenter, cluster)
-	ccr, err := finder.ClusterComputeResource(context.TODO(), path)
+	ccr, err := finder.ClusterComputeResource(context.TODO(), cluster)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not find vSphere cluster at %s", path)
+		return nil, errors.Wrapf(err, "could not find vSphere cluster at %s", cluster)
 	}
 
 	// Get list of Networks inside vSphere Cluster

--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -165,22 +164,14 @@ func validateFailureDomain(validationCtx *validationContext, failureDomain *vsph
 		checkDatacenterPrivileges = false
 	}
 
-	computeCluster := failureDomain.Topology.ComputeCluster
-	clusterPathRegexp := regexp.MustCompile(`^/(.*?)/host/(.*?)$`)
-	clusterPathParts := clusterPathRegexp.FindStringSubmatch(computeCluster)
-	if len(clusterPathParts) < 3 {
-		return append(allErrs, field.Invalid(topologyField.Child("computeCluster"), computeCluster, "full path of cluster is required"))
-	}
-	computeClusterName := clusterPathParts[2]
-
-	allErrs = append(allErrs, validateESXiVersion(validationCtx, computeCluster, vsphereField, topologyField.Child("computeCluster"))...)
+	allErrs = append(allErrs, validateESXiVersion(validationCtx, failureDomain.Topology.ComputeCluster, vsphereField, topologyField.Child("computeCluster"))...)
 	allErrs = append(allErrs, validateVcenterPrivileges(validationCtx, topologyField.Child("server"))...)
-	allErrs = append(allErrs, computeClusterExists(validationCtx, computeCluster, topologyField.Child("computeCluster"), checkComputeClusterPrivileges, checkTags)...)
+	allErrs = append(allErrs, computeClusterExists(validationCtx, failureDomain.Topology.ComputeCluster, topologyField.Child("computeCluster"), checkComputeClusterPrivileges, checkTags)...)
 	allErrs = append(allErrs, datacenterExists(validationCtx, failureDomain.Topology.Datacenter, topologyField.Child("datacenter"), checkDatacenterPrivileges)...)
 	allErrs = append(allErrs, datastoreExists(validationCtx, failureDomain.Topology.Datacenter, failureDomain.Topology.Datastore, topologyField.Child("datastore"))...)
 
 	for _, network := range failureDomain.Topology.Networks {
-		allErrs = append(allErrs, validateNetwork(validationCtx, failureDomain.Topology.Datacenter, computeClusterName, network, topologyField)...)
+		allErrs = append(allErrs, validateNetwork(validationCtx, failureDomain.Topology.Datacenter, failureDomain.Topology.ComputeCluster, network, topologyField)...)
 	}
 
 	return allErrs

--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -314,7 +314,7 @@ func TestValidateFailureDomains(t *testing.T) {
 			}(),
 			validationMethod: validateFailureDomain,
 			checkTags:        false,
-			expectErr:        `^platform.vsphere.failureDomains.topology.computeCluster: Invalid value: "": full path of cluster is required$`,
+			expectErr:        `[platform.vsphere: Internal error: please specify a datacenter, platform.vsphere.failureDomains.topology.computeCluster: Required value: must specify the cluster]`,
 		},
 		{
 			name: "multi-zone validation - missing datastore",


### PR DESCRIPTION
In previous releases we didn't use full paths for
cluster. Since we are now using full paths generating the path is incorrect. This PR removes that.