### PR TITLE
OCPBUGS-10394: Sort userTags in Machine and Machineset manifests

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -3,6 +3,7 @@ package aws
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -245,11 +246,18 @@ func tagsFromUserTags(clusterID string, usertags map[string]string) ([]machineap
 	for idx := range tags {
 		forbiddenTags.Insert(tags[idx].Name)
 	}
-	for k, v := range usertags {
+
+	userTagKeys := make([]string, 0, len(usertags))
+	for key := range usertags {
+		userTagKeys = append(userTagKeys, key)
+	}
+	sort.Strings(userTagKeys)
+
+	for _, k := range userTagKeys {
 		if forbiddenTags.Has(k) {
 			return nil, fmt.Errorf("user tags may not clobber %s", k)
 		}
-		tags = append(tags, machineapi.TagSpecification{Name: k, Value: v})
+		tags = append(tags, machineapi.TagSpecification{Name: k, Value: usertags[k]})
 	}
 	return tags, nil
 }


### PR DESCRIPTION
Installer inserts AWS userTags provided via install config into Machine and Machineset manifests that it generates. The userTags need to be ordered before adding to AWSMachineProviderConfig. This way when CPMS-operator compares its control plane & worker machines with the Installer generated manifests, it does not flag them as different.