### PR TITLE
pass featuregate args to config-operator to get rendered featuregates

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -78,6 +78,43 @@ then
     record_service_stage_success
 fi
 
+if [ ! -f config-bootstrap.done ]
+then
+    record_service_stage_start "config-bootstrap"
+	echo "Rendering cluster config manifests..."
+
+	rm --recursive --force config-bootstrap
+
+	ADDITIONAL_FLAGS=()
+	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
+		ADDITIONAL_FLAGS+=("--cloud-provider-config-input-file=/assets/manifests/cloud-provider-config.yaml")
+	fi
+	{{- if .FeatureSet }}
+	ADDITIONAL_FLAGS+=("--feature-set={{.FeatureSet}}")
+	{{- end}}
+  VERSION="$(oc adm release info -o 'jsonpath={.metadata.version}' "${RELEASE_IMAGE_DIGEST}")"
+
+	bootkube_podman_run \
+		--name config-render \
+		--volume "$PWD:/assets:z" \
+		"${CONFIG_OPERATOR_IMAGE}" \
+		/usr/bin/cluster-config-operator render \
+		--cluster-infrastructure-input-file=/assets/manifests/cluster-infrastructure-02-config.yml \
+		--cloud-provider-config-output-file=/assets/config-bootstrap/cloud-provider-config-generated.yaml \
+		--config-output-file=/assets/config-bootstrap/config \
+		--asset-input-dir=/assets/tls \
+		--asset-output-dir=/assets/config-bootstrap \
+		--featuregate-manifest=/assets/manifests/99_feature-gate.yaml \
+		--rendered-manifest-files=/assets/manifests \
+		--payload-version=$VERSION \
+		"${ADDITIONAL_FLAGS[@]}"
+
+	cp config-bootstrap/manifests/* manifests/
+
+	touch config-bootstrap.done
+    record_service_stage_success
+fi
+
 if [ ! -f cvo-bootstrap.done ]
 then
     record_service_stage_start "cvo-bootstrap"
@@ -132,39 +169,6 @@ then
 	cp etcd-bootstrap/tls/* tls/
 
 	touch etcd-bootstrap.done
-    record_service_stage_success
-fi
-
-if [ ! -f config-bootstrap.done ]
-then
-    record_service_stage_start "config-bootstrap"
-	echo "Rendering cluster config manifests..."
-
-	rm --recursive --force config-bootstrap
-
-	ADDITIONAL_FLAGS=()
-	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
-		ADDITIONAL_FLAGS+=("--cloud-provider-config-input-file=/assets/manifests/cloud-provider-config.yaml")
-	fi
-	{{- if .FeatureSet }}
-	ADDITIONAL_FLAGS+=("--feature-set={{.FeatureSet}}")
-	{{- end}}
-
-	bootkube_podman_run \
-		--name config-render \
-		--volume "$PWD:/assets:z" \
-		"${CONFIG_OPERATOR_IMAGE}" \
-		/usr/bin/cluster-config-operator render \
-		--cluster-infrastructure-input-file=/assets/manifests/cluster-infrastructure-02-config.yml \
-		--cloud-provider-config-output-file=/assets/config-bootstrap/cloud-provider-config-generated.yaml \
-		--config-output-file=/assets/config-bootstrap/config \
-		--asset-input-dir=/assets/tls \
-		--asset-output-dir=/assets/config-bootstrap \
-		"${ADDITIONAL_FLAGS[@]}"
-
-	cp config-bootstrap/manifests/* manifests/
-
-	touch config-bootstrap.done
     record_service_stage_success
 fi
 

--- a/pkg/asset/manifests/featuregate.go
+++ b/pkg/asset/manifests/featuregate.go
@@ -40,38 +40,33 @@ func (f *FeatureGate) Generate(dependencies asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	dependencies.Get(installConfig)
 
-	// A FeatureGate could be populated on every install,
-	// even for those using the default feature set, but for
-	// continuity let's only create a cluster feature gate
-	// when non-default feature gates are enabled.
-	if installConfig.Config.FeatureSet != configv1.Default {
-		f.Config = configv1.FeatureGate{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: configv1.SchemeGroupVersion.String(),
-				Kind:       "FeatureGate",
+	f.Config = configv1.FeatureGate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: configv1.SchemeGroupVersion.String(),
+			Kind:       "FeatureGate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.FeatureGateSpec{
+			FeatureGateSelection: configv1.FeatureGateSelection{
+				FeatureSet: installConfig.Config.FeatureSet,
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster",
-			},
-			Spec: configv1.FeatureGateSpec{
-				FeatureGateSelection: configv1.FeatureGateSelection{
-					FeatureSet: installConfig.Config.FeatureSet,
-				},
-			},
-		}
-
-		configData, err := yaml.Marshal(f.Config)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create %s manifests from InstallConfig", f.Name())
-		}
-
-		f.FileList = []*asset.File{
-			{
-				Filename: fgFileName,
-				Data:     configData,
-			},
-		}
+		},
 	}
+
+	configData, err := yaml.Marshal(f.Config)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %s manifests from InstallConfig", f.Name())
+	}
+
+	f.FileList = []*asset.File{
+		{
+			Filename: fgFileName,
+			Data:     configData,
+		},
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For https://github.com/openshift/enhancements/pull/1373

I could probably live with this having to be vendored sometimes, but it would make me sad.

Part 5 of the three step plan to make individual featuregates observable via the API. This was previously avoided because when featuregates get promoted from TechPreview to Default, during an upgrade, an old operator may try to enable a TechPreview variant of a feature.

This builds on https://github.com/openshift/cluster-config-operator/pull/288 with a goal of making the development-time flow

1. update openshift/api with new featuregate
2. vendor into near zero-dep openshfit/cluster-config-operator (automated someday?)
3. done.

with a runtime flow of
1. installer builds the featuregate.yaml with spec completed
2. bootkube passes featuregate.yaml to cluster-config-operator render
3. cluster-config-operator render completes status and overwrites the featuregate.yaml
4. other operator in render receive featuregate.yaml and consume featuregates from that status
5. cluster-bootstrap writes both the spec and status
6. in the running cluster, cluster-config-operator consistently writes the featuregate.status


shortcomings
- [x]  There is some generation I don't know how to do.
- [x]  It relies on https://github.com/openshift/cluster-config-operator/pull/288 to work and that hasn't merged
- [x]  I don't know if I got the filename write
- [x]  I don't know if a file can be overwritten during rendering
- [x]  I don't know where the other input files come from
- [x]  Technically I could leave this after the CVO and get 90% of the benefit.  If we have ordering problems I will do so to get unstuck.
