### PR TITLE
OCPBUGS-10570: openstack: No master primarySubnet control-plane if portTarget is set

### DIFF
--- a/scripts/openstack/manifest-tests/failure-domains/install-config.yaml
+++ b/scripts/openstack/manifest-tests/failure-domains/install-config.yaml
@@ -77,4 +77,5 @@ platform:
     cloud: ${OS_CLOUD}
     externalNetwork: ${EXTERNAL_NETWORK}
     lbFloatingIP: ${API_FIP}
+    machinesSubnet: 198.51.100.0/24
 pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/failure-domains/test_machines.py
+++ b/scripts/openstack/manifest-tests/failure-domains/test_machines.py
@@ -122,6 +122,13 @@ class FailureDomainsMachines(unittest.TestCase):
             # availability zones have matching names in the test-case install-config
             self.assertEqual(compute_zone[-1], storage_zone[-1])
 
+
+    def test_no_primarySubnet_if_control_plane_portTarget(self):
+        """Since install-config sets a control-plane portTarget, assert that primarySubnet is empty."""
+        for machine in self.machines:
+            self.assertIsNone(machine["spec"]["providerSpec"]["value"].get("primarySubnet"))
+
+
 if __name__ == '__main__':
     ASSETS_DIR = sys.argv.pop()
     with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:


### PR DESCRIPTION
When a "control-plane" portTarget is set, masters should not have the machinesSubnet in the "primarySubnet" field of their Machine ProviderSpec.

I don’t want to change any behaviour unrelated to failure domains in this PR, but in a follow-up we could and should stop setting primarySubnet in all cases.