### PR TITLE
OCPBUGS-14076: PowerVS: Remove ClusterOSImage

### DIFF
--- a/pkg/asset/machines/powervs/machinesets.go
+++ b/pkg/asset/machines/powervs/machinesets.go
@@ -26,9 +26,6 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	mpool := pool.Platform.PowerVS
 	var network string
 	image := fmt.Sprintf("rhcos-%s", clusterID)
-	if platform.ClusterOSImage != "" {
-		image = platform.ClusterOSImage
-	}
 	if platform.PVSNetworkName != "" {
 		network = platform.PVSNetworkName
 	}


### PR DESCRIPTION
Remove changing the image name for a MachineSet if ClusterOSImage is set

Terraform has already created an image bucket based on OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
for us. So worker nodes should not use OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE directly and
instead use the image bucket.