### PR TITLE
gcp: add confidential compute support for boostrap TF

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -113,6 +113,27 @@ resource "google_compute_instance" "bootstrap" {
     network_ip = local.public_endpoints ? null : google_compute_address.bootstrap.address
   }
 
+  dynamic "shielded_instance_config" {
+    for_each = var.gcp_master_secure_boot != "" ? [1] : []
+    content {
+      enable_secure_boot = var.gcp_master_secure_boot == "Enabled"
+    }
+  }
+
+  dynamic "confidential_instance_config" {
+    for_each = var.gcp_master_confidential_compute != "" ? [1] : []
+    content {
+      enable_confidential_compute = var.gcp_master_confidential_compute == "Enabled"
+    }
+  }
+
+  dynamic "scheduling" {
+    for_each = var.gcp_master_on_host_maintenance != "" ? [1] : []
+    content {
+      on_host_maintenance = var.gcp_master_on_host_maintenance
+    }
+  }
+
   metadata = {
     user-data = data.ignition_config.redirect.rendered
   }


### PR DESCRIPTION
This change adds the [confidential compute configuration options](https://github.com/openshift/installer/pull/6799) for the GCP bootstrap machine as well.

The confidential compute configuration options for the bootstrap instance are defined by the respective control-plane instance options.

The scheduling and confidential_instance_config options are defined as dynamic blocks and they will be applied when the user specifies the respective config options. This allows us to respect the cloud provider defaults, when the user does not provide any values. At the same time, it does not require code updates when the cloud provider defaults change.

Feature link: https://issues.redhat.com/browse/OCPBU-142

/cc @eranco74 