### PR TITLE
OCPBUGS-10638: Properly handle invalid agent command

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -92,7 +92,6 @@ func newAgentCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Commands for generating agent installation artifacts",
-		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
This fixes the behavior when an unexpected string is passed to the `agent create` command and it generates an unexpected error message instead of help.

Current:
```
$ openshift-install agent create foo
FATA[0000] Error executing openshift-install: accepts 0 arg(s), received 1
```

Fix:
```
$ openshift-install agent create foo
Commands for generating agent installation artifacts

Usage:
  openshift-install agent create [flags]
  openshift-install agent create [command]

Available Commands:
  agent-config-template Generates a template of the agent config manifest used by the agent installer
  cluster-manifests     Generates the cluster definition manifests used by the agent installer
  image                 Generates a bootable image containing all the information needed to deploy a cluster

<rest of help output>
```