### PR TITLE
OCPBUGS-5140: [Alibaba] update the bandwidth value of EIP

### DIFF
--- a/data/data/alibabacloud/cluster/vpc/eip.tf
+++ b/data/data/alibabacloud/cluster/vpc/eip.tf
@@ -5,6 +5,7 @@ resource "alicloud_eip_address" "eip" {
   address_name         = "${local.prefix}-eip"
   payment_type         = "PayAsYouGo"
   internet_charge_type = "PayByTraffic"
+  bandwidth            = 200
   resource_group_id    = var.resource_group_id
   tags = merge(
     {


### PR DESCRIPTION
Solve the issue of interrupted image downloads from quay.io by increasing the bandwidth value of the EIP bound to the gateway