### PR TITLE
OCPBUGS-9081: openstack/destroy: BulkDelete more objects at once

### DIFF
--- a/pkg/destroy/openstack/semaphore.go
+++ b/pkg/destroy/openstack/semaphore.go
@@ -1,0 +1,35 @@
+package openstack
+
+import "sync"
+
+type semaphore struct {
+	semC chan struct{}
+	wg   sync.WaitGroup
+}
+
+// newSemaphore returns a semaphore. A semaphore runs at most maxConcurrency
+// functions concurrently.
+func newSemaphore(maxConcurrency int) *semaphore {
+	return &semaphore{
+		semC: make(chan struct{}, maxConcurrency),
+	}
+}
+
+// Add enqueues the function f to be run in a separate goroutine as soon as
+// there is a free slot. Add returns immediately.
+func (s *semaphore) Add(f func()) {
+	s.wg.Add(1)
+	go func() {
+		s.semC <- struct{}{}
+		defer func() {
+			<-s.semC
+			s.wg.Done()
+		}()
+		f()
+	}()
+}
+
+// Wait returns when the queue is empty and no function is running.
+func (s *semaphore) Wait() {
+	s.wg.Wait()
+}


### PR DESCRIPTION
With this change:
* listing of container object is no longer limited to 50, but left to the default (which is 10000 on a standard Swift configuration);
* the object deletion calls are issued in concurrent goroutines rather than serially, giving Swift a chance to work them in parallel.

The goal of this change is to tackle waiting times on OCP destroy on clusters with massive amounts of data stored in OpenStack object storage.