### PR TITLE
GCP: add europe-west12 region to the survey as supported region

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -37,6 +37,7 @@ var (
 		"europe-west6":            "Zürich, Switzerland",
 		"europe-west8":            "Milan, Italy",
 		"europe-west9":            "Paris, France",
+		"europe-west12":           "Turin, Italy",
 		"europe-southwest1":       "Madrid, Spain",
 		"me-west1":                "Tel Aviv, Israel",
 		"northamerica-northeast1": "Montréal, Québec, Canada",


### PR DESCRIPTION
Add the europe-west12 GCP region that was not previously listed as a supported region for the installer to use.

[CORS-2593](https://issues.redhat.com/browse/CORS-2593)