### PR TITLE
OCPBUGS-11039: remove container-runtime flag from kubelet config

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
@@ -6,7 +6,6 @@
 /usr/bin/hyperkube \
   kubelet \
     --anonymous-auth=false \
-    --container-runtime=remote \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout="${KUBELET_RUNTIME_REQUEST_TIMEOUT}" \
 {{- if .BootstrapNodeIP }}

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -356,7 +356,6 @@ For example:
                     --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
                     --rotate-certificates \
                     --kubeconfig=/var/lib/kubelet/kubeconfig \
-                    --container-runtime=remote \
                     --container-runtime-endpoint=/var/run/crio/crio.sock \
                     --allow-privileged \
                     --node-labels=node-role.kubernetes.io/master \


### PR DESCRIPTION
removes the container-runtime=remote flag to correlate with:

```
CHANGELOG/CHANGELOG-1.27.md
478:- Kubelet: remove deprecated flag `--container-runtime` 
```

ref: https://github.com/kubernetes/kubernetes/pull/114017
