### PR TITLE
[azure] update tested instance type on 4.13

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -3,11 +3,12 @@
 * `standardDASv4Family`
 * `standardDASv5Family`
 * `standardDCSv3Family`
-* `standardDCSFamily`
 * `standardDCSv2Family`
 * `standardDDCSv3Family`
 * `standardDDSv4Family`
 * `standardDDSv5Family`
+* `standardDLDSv5Family`
+* `standardDLSv5Family`
 * `standardDSFamily`
 * `standardDSv2Family`
 * `standardDSv2PromoFamily`


### PR DESCRIPTION
Docs update:
1. remove `standardDCSFamily` due to unable to verify it with insufficient quota
2. add two new families `standardDLDSv5Family` `standardDLSv5Family` which are tested passed on 4.13 nightly build.