### PR TITLE
terraform: don't run zip if building provider binary failed

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -34,7 +34,7 @@ $(GO_BUILD_TARGETS): go-build.%: bin/$(TARGET_OS_ARCH)/terraform-provider-%.zip
 $(TERRAFORM_PROVIDER_TARGETS): bin/$(TARGET_OS_ARCH)/terraform-provider-%.zip: providers/%/go.mod
 	cd providers/$*; \
 	if [ -f main.go ]; then path="."; else path=./vendor/`grep _ tools.go|awk '{ print $$2 }'|sed 's|"||g'`; fi; \
-	go build -gcflags $(GCFLAGS) -ldflags $(LDFLAGS) -o ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$* "$$path"; \
+	go build -gcflags $(GCFLAGS) -ldflags $(LDFLAGS) -o ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$* "$$path" && \
 	zip -1j ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$*.zip ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$*;
 
 .PHONY: go-build-terraform


### PR DESCRIPTION
If we build the terraform provider binaries, then change one of them so that it fails to build and try running `make -C terraform` without running `make -C clean` we might miss the build failure.

For example:
```
make: Entering directory '/home/rfonseca/prjs/upstream/openshift/installer/terraform'
cd providers/google; \
if [ -f main.go ]; then path="."; else path=./vendor/`grep _ tools.go|awk '{ print $2 }'|sed 's|"||g'`; fi; \
go build -gcflags "" -ldflags "-s -w" -o ../../bin/linux_amd64/terraform-provider-google "$path"; \
zip -1j ../../bin/linux_amd64/terraform-provider-google.zip ../../bin/linux_amd64/terraform-provider-google;
vendor/github.com/hashicorp/terraform-provider-google/google/resource_storage_bucket.go:1063:37: cannot convert condition.Age (variable of type *int64) to type int
vendor/github.com/hashicorp/terraform-provider-google/google/resource_storage_bucket.go:1226:21: cannot use int64(v.(int)) (value of type int64) as type *int64 in assignment
updating: terraform-provider-google (deflated 66%)
make: Leaving directory '/home/rfonseca/prjs/upstream/openshift/installer/terraform'
+ copy_terraform_to_mirror
```

That is not a problem in CI since we always build with a blank slate:
```
 # github.com/hashicorp/terraform-provider-google/google
vendor/github.com/hashicorp/terraform-provider-google/google/resource_storage_bucket.go:1063:37: cannot convert condition.Age (variable of type *int64) to type int
vendor/github.com/hashicorp/terraform-provider-google/google/resource_storage_bucket.go:1226:21: cannot use int64(v.(int)) (value of type int64) as type *int64 in assignment
	zip warning: name not matched: ../../bin/linux_amd64/terraform-provider-google
zip error: Nothing to do! (../../bin/linux_amd64/terraform-provider-google.zip)
```
but it can happen locally as we move branches and rebuild the project since an old binary might still exist. Instead of just using a list of commands with the `;` bash operator, let's use a conditional `&&` so that `zip` won't execute unless the build is successful.