### PR TITLE
openstack: Bump CI base image to v4.14

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,14 +1,14 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/origin/4.12:cli AS cli
+FROM registry.ci.openshift.org/ocp/4.14:cli AS cli
 
-FROM registry.ci.openshift.org/origin/4.12:base
+FROM registry.ci.openshift.org/ocp/4.14:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi/openstack /var/lib/openshift-install/upi


### PR DESCRIPTION
Note: these are rhel-8 images for 4.14.

cf https://github.com/openshift/installer/blob/master/images/installer/Dockerfile.ci