### PR TITLE
OCPBUGS-7954: openstack: Only check HTTPS certs on public endpoints

### DIFF
--- a/docs/user/openstack/invalid-https-certificates.md
+++ b/docs/user/openstack/invalid-https-certificates.md
@@ -63,7 +63,7 @@ while read -r name interface url; do
 	noschema=${url#"https://"}
 	
 	# If the schema was not HTTPS, error
-	if [[ noschema == "$url" ]]; then
+	if [[ "$noschema" == "$url" ]]; then
 		echo "ERROR (unknown schema): $name $interface $url"
 		exit 2
 	fi

--- a/docs/user/openstack/invalid-https-certificates.md
+++ b/docs/user/openstack/invalid-https-certificates.md
@@ -7,7 +7,7 @@ With OpenShift v4.10, HTTPS certificates not using the `Subject Alternative Name
 A script provided below automates the operation. However, it requires to have a set of tools available (including a relatively recent version of `python3-openstackclient`). To manually check your OpenStack infrastructure:
 
 1. Collect the URL of the OpenStack public endpoints with `openstack catalog list` (HTTP (unsecured) endpoints do not need to be checked)
-2. For each HTTPS endpoint: collect the host (by removing the scheme, the port and the path) and the port
+2. For each public HTTPS endpoint: collect the host (by removing the scheme, the port and the path) and the port
 3. Run this openssl command to extract the SAN field of the certificate:
 
 ```plaintext
@@ -49,7 +49,7 @@ readonly catalog san
 declare invalid=0
 
 openstack catalog list --format json --column Name --column Endpoints \
-	| jq -r '.[] | .Name as $name | .Endpoints[] | [$name, .interface, .url] | join(" ")' \
+	| jq -r '.[] | .Name as $name | .Endpoints[] | select(.interface=="public") | [$name, .interface, .url] | join(" ")' \
 	| sort \
 	> "$catalog"
 


### PR DESCRIPTION
Before this change the validation steps, and the script, assumed that `internal` and `admin` OpenStack endpoints were always reachable. With this change, the manual steps and the script are amended to only check the validity of HTTPS certificates on the `public` endpoints of the OpenStack catalog.

In a separate commit, this PR fixes a syntax issue in the script that could cause it to crash when the OpenStack catalog contained an URL that is not HTTP and not HTTPS.