### PR TITLE
OCPBUGS-4998: Log additional info when status is pending-user-action

### DIFF
--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -219,6 +219,16 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 
 		czero.PrintInstallStatus(clusterMetadata)
 
+		// If status indicates pending action, log host info to help pinpoint what is missing
+		if (*clusterMetadata.Status != czero.installHistory.RestAPIPreviousClusterStatus) &&
+			(*clusterMetadata.Status == models.ClusterStatusInstallingPendingUserAction) {
+			for _, host := range clusterMetadata.Hosts {
+				if *host.Status == models.ClusterStatusInstallingPendingUserAction {
+					logrus.Debugf("Host %s %s", host.RequestedHostname, *host.StatusInfo)
+				}
+			}
+		}
+
 		if *clusterMetadata.Status == models.ClusterStatusReady {
 			stuck, err := czero.IsClusterStuckInReady()
 			if err != nil {

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -18,7 +18,8 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
 	defer cancel()
 
-	var lastErr error
+	var lastErrOnExit error
+	var lastErrStr string
 	wait.Until(func() {
 		bootstrap, exitOnErr, err := cluster.IsBootstrapComplete()
 		if bootstrap && err == nil {
@@ -28,10 +29,14 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 
 		if err != nil {
 			if exitOnErr {
-				lastErr = err
+				lastErrOnExit = err
 				cancel()
 			} else {
 				logrus.Info(err)
+				if err.Error() != lastErrStr {
+					logrus.Info(err)
+					lastErrStr = err.Error()
+				}
 			}
 		}
 
@@ -47,10 +52,10 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 
 	waitErr := waitContext.Err()
 	if waitErr != nil {
-		if waitErr == context.Canceled && lastErr != nil {
-			return errors.Wrap(lastErr, "bootstrap process returned error")
+		if errors.Is(waitErr, context.Canceled) && lastErrOnExit != nil {
+			return errors.Wrap(lastErrOnExit, "bootstrap process returned error")
 		}
-		if waitErr == context.DeadlineExceeded {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
 			return errors.Wrap(waitErr, "bootstrap process timed out")
 		}
 	}


### PR DESCRIPTION
When the cluster status is installing-pending-user-action the install won't complete. Most likely this is due to an invalid boot disk. In the `wait-for bootstrap-complete` also log the host's status_info for hosts that have this status.  In addition, don't continuously log the same errors in bootstrap such as occurs when this failure happens.

As an example, the `wait-for` output when an invalid boot disk is used is now:
```
level=info msg=Cluster has hosts requiring user input
level=debug msg=Host master-1 Expected the host to boot from disk, but it booted the installation image - please reboot and fix boot order to boot from disk QEMU_HARDDISK drive-scsi0-0-0-0 (sda, /dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0)
level=debug msg=Host master-2 Expected the host to boot from disk, but it booted the installation image - please reboot and fix boot order to boot from disk QEMU_HARDDISK drive-scsi0-0-0-0 (sda, /dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0)
level=info msg=cluster has stopped installing... working to recover installation
```