### PR TITLE
Agent: run shellcheck on start-cluster-installation.sh

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
@@ -18,11 +18,9 @@ done
 
 printf '\nInfra env id is %s\n' "${INFRA_ENV_ID}" 1>&2
 
-required_master_nodes={{.ControlPlaneAgents}}
-required_worker_nodes={{.WorkerAgents}}
-total_required_nodes=$(( ${required_master_nodes}+${required_worker_nodes} ))
-echo "Number of required master nodes: ${required_master_nodes}" 1>&2
-echo "Number of required worker nodes: ${required_worker_nodes}" 1>&2
+total_required_nodes=$(( REQUIRED_MASTER_NODES + REQUIRED_WORKER_NODES ))
+echo "Number of required master nodes: ${REQUIRED_MASTER_NODES}" 1>&2
+echo "Number of required worker nodes: ${REQUIRED_WORKER_NODES}" 1>&2
 echo "Total number of required nodes: ${total_required_nodes}" 1>&2
 
 status_issue="90_start-install"

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -57,14 +57,6 @@ done
 echo "All ${total_required_nodes} hosts are ready." 1>&2
 clear_issue "${status_issue}"
 
-if [[ "${APIVIP}" != "" ]]; then
-    api_vip=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].api_vip)
-    if [ "${api_vip}" == null ]; then
-        echo "Setting api vip" 1>&2
-        curl -s -S -X PATCH "${BASE_URL}/clusters/${cluster_id}" -H "Content-Type: application/json" -d '{"api_vip": "{{.APIVIP}}"}'
-    fi
-fi
-
 while [[ "${cluster_status}" != "installed" ]]
 do
     sleep 5

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -16,7 +16,7 @@ do
     fi
 done
 
-echo -e "\nInfra env id is ${INFRA_ENV_ID}" 1>&2
+printf '\nInfra env id is %s\n' "${INFRA_ENV_ID}" 1>&2
 
 required_master_nodes={{.ControlPlaneAgents}}
 required_worker_nodes={{.WorkerAgents}}

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# shellcheck disable=SC1091
 source issue_status.sh
 
 BASE_URL="${SERVICE_BASE_URL}api/assisted-install/v2"

--- a/data/data/agent/systemd/units/start-cluster-installation.service.template
+++ b/data/data/agent/systemd/units/start-cluster-installation.service.template
@@ -9,6 +9,8 @@ ConditionPathExists=/etc/assisted/node0
 [Service]
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 EnvironmentFile=/etc/assisted/rendezvous-host.env
+Environment=REQUIRED_MASTER_NODES={{.ControlPlaneAgents}}
+Environment=REQUIRED_WORKER_NODES={{.WorkerAgents}}
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
 ExecStart=/usr/local/bin/start-cluster-installation.sh
 

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -52,7 +52,6 @@ type Ignition struct {
 type agentTemplateData struct {
 	ServiceProtocol           string
 	PullSecret                string
-	APIVIP                    string
 	ControlPlaneAgents        int
 	WorkerAgents              int
 	ReleaseImages             string
@@ -271,7 +270,6 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 	return &agentTemplateData{
 		ServiceProtocol:           "http",
 		PullSecret:                pullSecret,
-		APIVIP:                    agentClusterInstall.Spec.APIVIP,
 		ControlPlaneAgents:        agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents,
 		WorkerAgents:              agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents,
 		ReleaseImages:             releaseImageList,

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -90,7 +90,6 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
-	assert.Equal(t, agentClusterInstall.Spec.APIVIP, templateData.APIVIP)
 	assert.Equal(t, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, templateData.ControlPlaneAgents)
 	assert.Equal(t, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, templateData.WorkerAgents)
 	assert.Equal(t, releaseImageList, templateData.ReleaseImages)


### PR DESCRIPTION
Templating in shell scripts makes it impossible for us to run shellcheck
on them. Pass the data we need through environment variables and
template in the systemd unit.