### PR TITLE
OCPBUGS-9404: azure: skip LB creation when not needed

### DIFF
--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -53,6 +53,7 @@ data "azurerm_public_ip" "cluster_public_ip_v6" {
 }
 
 resource "azurerm_lb" "public" {
+  count               = local.need_public_ipv4 ? 1 : 0
   sku                 = "Standard"
   name                = var.cluster_id
   resource_group_name = data.azurerm_resource_group.main.name
@@ -100,14 +101,14 @@ resource "azurerm_lb" "public" {
 resource "azurerm_lb_backend_address_pool" "public_lb_pool_v4" {
   count = local.need_public_ipv4 ? 1 : 0
 
-  loadbalancer_id = azurerm_lb.public.id
+  loadbalancer_id = azurerm_lb.public[0].id
   name            = var.cluster_id
 }
 
 resource "azurerm_lb_backend_address_pool" "public_lb_pool_v6" {
   count = local.need_public_ipv6 ? 1 : 0
 
-  loadbalancer_id = azurerm_lb.public.id
+  loadbalancer_id = azurerm_lb.public[0].id
   name            = "${var.cluster_id}-IPv6"
 }
 
@@ -117,7 +118,7 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v4" {
   name                           = "api-internal-v4"
   protocol                       = "Tcp"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id]
-  loadbalancer_id                = azurerm_lb.public.id
+  loadbalancer_id                = azurerm_lb.public[0].id
   frontend_port                  = 6443
   backend_port                   = 6443
   frontend_ip_configuration_name = local.public_lb_frontend_ip_v4_configuration_name
@@ -133,7 +134,7 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v6" {
   name                           = "api-internal-v6"
   protocol                       = "Tcp"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id]
-  loadbalancer_id                = azurerm_lb.public.id
+  loadbalancer_id                = azurerm_lb.public[0].id
   frontend_port                  = 6443
   backend_port                   = 6443
   frontend_ip_configuration_name = local.public_lb_frontend_ip_v6_configuration_name
@@ -147,7 +148,7 @@ resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v4" {
   count = var.use_ipv4 && var.azure_private && ! var.azure_outbound_user_defined_routing ? 1 : 0
 
   name                    = "outbound-rule-v4"
-  loadbalancer_id         = azurerm_lb.public.id
+  loadbalancer_id         = azurerm_lb.public[0].id
   backend_address_pool_id = azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id
   protocol                = "All"
 
@@ -160,7 +161,7 @@ resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v6" {
   count = var.use_ipv6 && var.azure_private && ! var.azure_outbound_user_defined_routing ? 1 : 0
 
   name                    = "outbound-rule-v6"
-  loadbalancer_id         = azurerm_lb.public.id
+  loadbalancer_id         = azurerm_lb.public[0].id
   backend_address_pool_id = azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id
   protocol                = "All"
 
@@ -175,7 +176,7 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
   name                = "api-internal-probe"
   interval_in_seconds = 5
   number_of_probes    = 2
-  loadbalancer_id     = azurerm_lb.public.id
+  loadbalancer_id     = azurerm_lb.public[0].id
   port                = 6443
   protocol            = "Https"
   request_path        = "/readyz"


### PR DESCRIPTION
When one creates an IPI Azure cluster with an `internal` publishing method, it creates a standard load balancer with an empty definition. This load balancer doesn't serve a purpose since the configuration is completely empty. Because it doesn't have a public IP address and backend pools it's not providing any outbound connectivity, and there are no frontend IP configurations for ingress connectivity to the cluster.