### PR TITLE
OCPBUGS-11364:  images: pin yq version to 3.1.1

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -60,7 +60,7 @@ RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
-RUN python3 -m pip install yq
+RUN python3 -m pip install 'yq<3.2.0'
 
 ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -29,7 +29,7 @@ RUN yum update -y && \
     python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq && \
     yum clean all && rm -rf /var/cache/yum/*
 
-RUN python -m pip install yq
+RUN python -m pip install 'yq<3.2.0'
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
The latest version 3.2.0 depends on tomlkit>=0.11.7 which requires python >= 3.7. Our builder images are still on python 3.6.8