### PR TITLE
AGENT-275: Add new agent graph command to output agent internal dependency graph

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -24,6 +24,7 @@ func newAgentCmd() *cobra.Command {
 
 	agentCmd.AddCommand(newAgentCreateCmd())
 	agentCmd.AddCommand(agent.NewWaitForCmd())
+	agentCmd.AddCommand(newAgentGraphCmd())
 	return agentCmd
 }
 
@@ -103,5 +104,19 @@ func newAgentCreateCmd() *cobra.Command {
 		cmd.AddCommand(t.command)
 	}
 
+	return cmd
+}
+
+func newAgentGraphCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Outputs the internal dependency graph for the agent-based installer",
+		Long:  "",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGraphCmd(cmd, args, agentTargets)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&graphOpts.outputFile, "output-file", "", "file where the graph is written, if empty prints the graph to Stdout.")
 	return cmd
 }

--- a/cmd/openshift-install/graph.go
+++ b/cmd/openshift-install/graph.go
@@ -26,13 +26,15 @@ func newGraphCmd() *cobra.Command {
 		Short: "Outputs the internal dependency graph for installer",
 		Long:  "",
 		Args:  cobra.ExactArgs(0),
-		RunE:  runGraphCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGraphCmd(cmd, args, targets)
+		},
 	}
 	cmd.PersistentFlags().StringVar(&graphOpts.outputFile, "output-file", "", "file where the graph is written, if empty prints the graph to Stdout.")
 	return cmd
 }
 
-func runGraphCmd(cmd *cobra.Command, args []string) error {
+func runGraphCmd(cmd *cobra.Command, args []string, cmdTargets []target) error {
 	g := gographviz.NewGraph()
 	g.SetName("G")
 	g.SetDir(true)
@@ -42,7 +44,7 @@ func runGraphCmd(cmd *cobra.Command, args []string) error {
 		string(gographviz.Shape): "box",
 		string(gographviz.Style): "filled",
 	}
-	for _, t := range targets {
+	for _, t := range cmdTargets {
 		name := fmt.Sprintf("%q", fmt.Sprintf("Target %s", t.name))
 		g.AddNode("G", name, tNodeAttr)
 		for _, dep := range t.assets {

--- a/cmd/openshift-install/testdata/agent/graph/graph.txt
+++ b/cmd/openshift-install/testdata/agent/graph/graph.txt
@@ -1,0 +1,5 @@
+# Verify the creation of the agent-based installer graph
+
+exec openshift-install agent graph --output-file $WORK/agent.dot
+
+exists $WORK/agent.dot


### PR DESCRIPTION
This patch adds the equivalent installer `graph`  command for the `agent` specific targets