### PR TITLE
pkg: rhcos: use Errorf instead of Error

### DIFF
--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -14,7 +14,7 @@ import (
 func AMIRegions(architecture types.Architecture) sets.String {
 	stream, err := FetchCoreOSBuild(context.Background())
 	if err != nil {
-		logrus.Error("could not fetch the rhcos stream data: %w", err)
+		logrus.Errorf("could not fetch the rhcos stream data: %v", err)
 		return nil
 	}
 	rpmArch := arch.RpmArch(string(architecture))


### PR DESCRIPTION
Otherwise the log message looks like
```
 time="2023-04-06T17:03:26Z" level=error msg="could not fetch the rhcos stream data: %wfailed to read embedded CoreOS stream metadata: open data/coreos/rhcos.json: no such file or directory"
 ```