### PR TITLE
OCPBUGS-11479: Upgrade libnmstate version used

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -74,7 +74,7 @@ func (a *AgentImage) fetchAgentTuiFiles(releaseImage string, pullSecret string, 
 		Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay},
 		releaseImage, pullSecret, mirrorConfig)
 
-	agentTuiFilenames := []string{"/usr/bin/agent-tui", "/usr/lib64/libnmstate.so.1.3.3"}
+	agentTuiFilenames := []string{"/usr/bin/agent-tui", "/usr/lib64/libnmstate.so.*"}
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {


### PR DESCRIPTION
The version of libnmstate in the release image changed from 1.x to 2.x. Use a wildcard match to handle the upgrade which can be used in a generic way with other libraries.

Tested with both libnmstate.so.1.3.3 (currently 4.14 until a CI release passes) and 2.2.9 (4.13)

$ ls -al /home/stack/.cache/agent/files_cache/
total 15592
drwxr-xr-x. 2 stack stack      73 Apr 10 13:40 .
drwxr-xr-x. 4 stack stack      44 Apr  6 09:05 ..
-r-xr-xr-x. 1 stack stack 9284768 Mar 30 16:29 agent-tui
lrwxrwxrwx. 1 stack stack      19 Aug 15  2022 libnmstate.so.1 -> libnmstate.so.1.3.3
-r-xr-xr-x. 1 stack stack 6678840 Aug 15  2022 libnmstate.so.1.3.3

$ ls -al /home/stack/.cache/agent/files_cache
total 16872
drwxr-xr-x. 2 stack stack      73 Apr 10 12:33 .
drwxr-xr-x. 4 stack stack      44 Apr  6 09:05 ..
-r-xr-xr-x. 1 stack stack 9284472 Apr  5 17:40 agent-tui
lrwxrwxrwx. 1 stack stack      19 Apr  5 11:07 libnmstate.so.2 -> libnmstate.so.2.2.9
-r-xr-xr-x. 1 stack stack 7990432 Apr  5 11:08 libnmstate.so.2.2.9
