### PR TITLE
OCPBUGS-11662: AWS - Remove ACLs from s3 ign

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -59,16 +59,10 @@ resource "aws_s3_bucket" "ignition" {
   }
 }
 
-resource "aws_s3_bucket_acl" ignition {
-  bucket = aws_s3_bucket.ignition.id
-  acl    = "private"
-}
-
 resource "aws_s3_object" "ignition" {
   bucket = aws_s3_bucket.ignition.id
   key    = "bootstrap.ign"
   source = var.ignition_bootstrap_file
-  acl    = "private"
 
   server_side_encryption = "AES256"
 


### PR DESCRIPTION
AWS has recently disabled ACL support by default. See https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ for further information.

This commit removes our usage of ACLs. By default, S3 buckets will have public access blocked.