### PR TITLE
OCPBUGS-11658: Handle libnmstate version in integration tests

### DIFF
--- a/cmd/openshift-install/agent_internal_integration_test.go
+++ b/cmd/openshift-install/agent_internal_integration_test.go
@@ -322,7 +322,8 @@ func checkFileFromInitrdImg(isoPath string, fileName string) error {
 
 			// check if the current cpio files match the required ones
 			for _, f := range files {
-				if f == fileName {
+				matched, err := filepath.Match(fileName, f)
+				if matched && err == nil {
 					return nil
 				}
 			}

--- a/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
@@ -6,7 +6,7 @@ exists $WORK/agent.x86_64.iso
 
 ignitionImgContains agent.x86_64.iso config.ign
 initrdImgContains agent.x86_64.iso /agent-files/agent-tui
-initrdImgContains agent.x86_64.iso /agent-files/libnmstate.so.1.3.3
+initrdImgContains agent.x86_64.iso /agent-files/libnmstate.so.*
 initrdImgContains agent.x86_64.iso /usr/lib/dracut/hooks/pre-pivot/99-agent-copy-files.sh
 
 -- install-config.yaml --


### PR DESCRIPTION
Use a wildcard to handle the libnmstate version in integration tests as its just been upgraded from 1 to 2.