### PR TITLE
OCPBUGS-12869: fix nmstate related unit tests

### DIFF
--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -152,7 +152,7 @@ func TestIgnition_addStaticNetworkConfig(t *testing.T) {
 					NetworkYaml: "interfaces:\n- ipv4:\n    address:\n    - ip: bad-ip\n      prefix-length: 24\n    enabled: true\n  mac-address: 52:54:01:aa:aa:a1\n  name: eth0\n  state: up\n  type: ethernet\n",
 				},
 			},
-			expectedError:    "'bad-ip' does not appear to be an IPv4 or IPv6 address",
+			expectedError:    "invalid IP address syntax",
 			expectedFileList: nil,
 		},
 	}

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -345,32 +345,34 @@ spec:
 			expectedError:      "staticNetwork configuration is not valid",
 		},
 
-		{
-			name: "invalid-address-for-type",
-			data: `
-metadata:
-  name: mynmstateconfig
-  namespace: spoke-cluster
-  labels:
-    cluster0-nmstate-label-name: cluster0-nmstate-label-value
-spec:
-  config:
-    interfaces:
-      - name: eth0
-        type: ethernet
-        state: up
-        mac-address: 52:54:01:aa:aa:a1
-        ipv6:
-          enabled: true
-          address:
-            - ip: 192.168.122.21
-              prefix-length: 24
-  interfaces:
-    - name: "eth0"
-      macAddress: "52:54:01:aa:aa:a1"`,
-			requiresNmstatectl: true,
-			expectedError:      "staticNetwork configuration is not valid",
-		},
+		// This test case currently does not work for libnmstate 2.2.9,
+		// due a regression that will be fixed in https://github.com/nmstate/nmstate/issues/2311
+		// 		{
+		// 			name: "invalid-address-for-type",
+		// 			data: `
+		// metadata:
+		//   name: mynmstateconfig
+		//   namespace: spoke-cluster
+		//   labels:
+		//     cluster0-nmstate-label-name: cluster0-nmstate-label-value
+		// spec:
+		//   config:
+		//     interfaces:
+		//       - name: eth0
+		//         type: ethernet
+		//         state: up
+		//         mac-address: 52:54:01:aa:aa:a1
+		//         ipv6:
+		//           enabled: true
+		//           address:
+		//             - ip: 192.168.122.21
+		//               prefix-length: 24
+		//   interfaces:
+		//     - name: "eth0"
+		//       macAddress: "52:54:01:aa:aa:a1"`,
+		// 			requiresNmstatectl: true,
+		// 			expectedError:      "staticNetwork configuration is not valid",
+		// 		},
 
 		{
 			name: "missing-label",


### PR DESCRIPTION
Due to a CI configuration issue (lack of nmstatectl in the image), the current CI [unit-test job](https://github.com/openshift/release/blob/a8a9d08406fc099a421b89b51a317c7ebfe92610/ci-operator/config/openshift/installer/openshift-installer-master.yaml#L205-L211) skips silently those unit tests requiring nmstatectl.
This patch thus:
1) Fixes the old test issues that have been silently ignored
2) Fixes a new test issue due the introduction of a newer nmstate version

*Note:* in the current PR these changes will continue to be skipped. Once merged, another PR https://github.com/openshift/release/pull/38290 will enable them

In addition, a test case has been temporarily disabled due a regression in nmstate 2.2.9