### PR TITLE
OCPBUGS-11788: update RHCOS 4.14 bootimage metadata to 414.92.202304131328-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
-  "stream": "rhcos-4.13",
+  "stream": "rhcos-4.14",
   "metadata": {
-    "last-modified": "2023-03-28T21:22:43Z",
-    "generator": "plume cosa2stream 0.15.0+154-g2c151cf83"
+    "last-modified": "2023-04-13T19:23:23Z",
+    "generator": "plume cosa2stream 7a1f61e"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-aws.aarch64.vmdk.gz",
-                "sha256": "845939dad155bf33ba0bc137c40269c2857add0662a73aef437f1bdf905ac1f6",
-                "uncompressed-sha256": "bd56c60d33fccda508ad8c5647cc5e9e86959005830f325bcfebda6cd987435e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-aws.aarch64.vmdk.gz",
+                "sha256": "28bc7034643882a23746e6201c585ba25ab1567d6fc264fabd11feede8c64250",
+                "uncompressed-sha256": "5b6cbea1319b86eda3dd336e7fc824a163e233a183404836e500dee3e375133c"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-azure.aarch64.vhd.gz",
-                "sha256": "b47459a86a668a796ac84d66b633cdaa38b739747332b56790b5d91eb807cbd2",
-                "uncompressed-sha256": "979a075f366d939ec209adee5551515d3600ca6c79846bcd019392f3abec8346"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-azure.aarch64.vhd.gz",
+                "sha256": "93418246d661c8be75a2de893140de666ec932e3ff30eb06272d487a877804d0",
+                "uncompressed-sha256": "95f0b7c4bac3a606c8a0659d455e08996b91b05c7201a65b08b34447b6fdc24f"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-metal4k.aarch64.raw.gz",
-                "sha256": "22d6d51432f33cbe878dbec20b49cc8f4bdf7e8eb1608996b4ed1c193a4c50b0",
-                "uncompressed-sha256": "01b1b57bab62531b179e439a44314f7ff45e3ccf40993f6f4372df20ad9cc0e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-metal4k.aarch64.raw.gz",
+                "sha256": "6ea1eb3ef2ea5e04cd7489746948e8367a5d7a7f270a98854ef7cd878ecb0823",
+                "uncompressed-sha256": "887633158acb4fbc717d9d30849cc0b0f0c99a2d2a86b33d744b2a4e33fa357c"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-live.aarch64.iso",
-                "sha256": "eea339dfc755aa065d23ca7e9767c30c9158bc7427a1437c9ac023fb314db632"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live.aarch64.iso",
+                "sha256": "4d86ac5ca61fe5341a1a5454e0bfa94358082b7b2d8d988986e8f094a0c6b7c3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-live-kernel-aarch64",
-                "sha256": "260e935d26d1240d158de4235be761d24d179a20c859eac3dfdd176420728a9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-kernel-aarch64",
+                "sha256": "9e44cafd61f5ce4c9c8af8c912c200ff59210b2d239798b21e6ef89a20b8f2dc"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-live-initramfs.aarch64.img",
-                "sha256": "1a6e8e91f948daba237eab025e319fc8e8252d52e75ca7fa3116952fbe405dc9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-initramfs.aarch64.img",
+                "sha256": "5730613c9881086facf63867b23165e918a32b0d37ceb19ef4cf9fe18530169e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-live-rootfs.aarch64.img",
-                "sha256": "a2cb7cd4c019bd0bf7f5cf8efbc62f730fec380035839ed4f02a52b9a2cd96d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-rootfs.aarch64.img",
+                "sha256": "9ace6fd8b1877b44e45bbdc08ad51423adf32e1e9b58022b6c60b243944b0fef"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-metal.aarch64.raw.gz",
-                "sha256": "d85f090fbd70834aa00cf353cf97b5aa986d5d699f288db559ba21eecbd15248",
-                "uncompressed-sha256": "68fa1bf27a091737365d75f40f98404d1f76a00b05e87cc5d553dfcdeb53a2cc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-metal.aarch64.raw.gz",
+                "sha256": "23fcd593bcf73e365620141042f7d0da2056bdbe7c33193c13fa367bc02b7a36",
+                "uncompressed-sha256": "3a61a12ecca36ca99da1f41b6aa1acaf388696ca67dedad5eed1a5032ea63ec5"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-openstack.aarch64.qcow2.gz",
-                "sha256": "eaf358753f8a17901b3936787b520f36d27cdabb5a1a4f3099079842d9c0ab20",
-                "uncompressed-sha256": "c7d3b6f1ab05c03525987a516c7988d47408cc3990e157963a4872c2d4edd3fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-openstack.aarch64.qcow2.gz",
+                "sha256": "a15a3e9186c747d20b3525b666fed7d3ae581e67c840be2fb9e2fbc54f76d72b",
+                "uncompressed-sha256": "5d06aa287c300edc30131764dd08f0d16b113c1e543c7da702b90df444e9c231"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/aarch64/rhcos-414.92.202303281555-0-qemu.aarch64.qcow2.gz",
-                "sha256": "d8a6f0bf9f7f21b3c74a97839f52b607f087b97f9cf0b534236b45f3df701708",
-                "uncompressed-sha256": "c3516d97d1f39e3be2542a8332618facc81034387e568c2d96a59ca4930467b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-qemu.aarch64.qcow2.gz",
+                "sha256": "8b264763c4011de95381ed7c58643f7b04ef849bf90f53d9ee80a172831dafff",
+                "uncompressed-sha256": "ad252bd51ceec94c94bbf8fe4b8afbcaa73cb42da4aaf3848cf93169f9348fa7"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0f4c89f77b2c26275"
+              "release": "414.92.202304131328-0",
+              "image": "ami-01d648d1df618855a"
             },
             "ap-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0d9c9d36a228cc30f"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0d432ebfaf3471ed5"
             },
             "ap-northeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-09635b8674dcda13a"
+              "release": "414.92.202304131328-0",
+              "image": "ami-076751b0faa6423b8"
             },
             "ap-northeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0fb8c538d13661755"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0a9d1d6d11b677ed3"
             },
             "ap-northeast-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0941ae2511ec4e57c"
+              "release": "414.92.202304131328-0",
+              "image": "ami-012bf004ac5fdb45b"
             },
             "ap-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0ae8a57a77ecfc41e"
+              "release": "414.92.202304131328-0",
+              "image": "ami-03b540b64d5e9bde5"
             },
             "ap-south-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0a14fa7435ee0fbc2"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0250c53ab4f9c267e"
             },
             "ap-southeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-013d0c50e7e560514"
+              "release": "414.92.202304131328-0",
+              "image": "ami-087d38fef725043eb"
             },
             "ap-southeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-03521167c85eab7e0"
+              "release": "414.92.202304131328-0",
+              "image": "ami-02ef54c9ae2405066"
             },
             "ap-southeast-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-08b27b1ae54565d4e"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0285bfcdea9484f47"
             },
             "ap-southeast-4": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0ba8b0d0bf61387ab"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0879a1f03dce76f42"
             },
             "ca-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-08777ec4308540c49"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0214af10665b1300c"
             },
             "eu-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0cfc6416fcff5d930"
+              "release": "414.92.202304131328-0",
+              "image": "ami-09d78579cda0ab2d1"
             },
             "eu-central-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0fb8c9d849590008d"
+              "release": "414.92.202304131328-0",
+              "image": "ami-050e6d452f8046e2a"
             },
             "eu-north-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-02cdfacfd1affe130"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0c85b23d9eebfd3e6"
             },
             "eu-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0e4402ebe488911af"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0869b9fdb4eb07fca"
             },
             "eu-south-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-084f68e412fb59564"
+              "release": "414.92.202304131328-0",
+              "image": "ami-024b18791794b0d12"
             },
             "eu-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0e343eda0cf2d1052"
+              "release": "414.92.202304131328-0",
+              "image": "ami-01fed8f3b183e6937"
             },
             "eu-west-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-06c1b5660d602897c"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0357583747a155549"
             },
             "eu-west-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-06aa102d50e4f0e64"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0f286594067680f59"
             },
             "me-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0051717628908bdb2"
+              "release": "414.92.202304131328-0",
+              "image": "ami-044d45db9f6e8d535"
             },
             "me-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0f55541c268b52ac7"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0c3964af800042630"
             },
             "sa-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0608c090238af35b2"
+              "release": "414.92.202304131328-0",
+              "image": "ami-017d3c2a38f5323e6"
             },
             "us-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0b8b3f05313ce6944"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0212e17b88655a79c"
             },
             "us-east-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0c76ab963b80bc2e6"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0a140167d2145a750"
             },
             "us-gov-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0da8a88c2d54da866"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0ffdaea585a65e49f"
             },
             "us-gov-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-05bdb455cfeb09bf6"
+              "release": "414.92.202304131328-0",
+              "image": "ami-00d122b82bff13a57"
             },
             "us-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-048eaa96d6bc8186f"
+              "release": "414.92.202304131328-0",
+              "image": "ami-00f9ba27a30faec9b"
             },
             "us-west-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-03eec4e824eb4dbe9"
+              "release": "414.92.202304131328-0",
+              "image": "ami-07d7881c3f504bccf"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202303281555-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202303281555-0-azure.aarch64.vhd"
+          "release": "414.92.202304131328-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304131328-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-metal4k.ppc64le.raw.gz",
-                "sha256": "a442994d241750aa27bf318dd1746467b6d3d859222d84439a7d343580a38da5",
-                "uncompressed-sha256": "4f9d44b328909d7f7714862a8373c50b2dd8cf5d0cf18170e199ab0e8b6e92fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-metal4k.ppc64le.raw.gz",
+                "sha256": "31c3f2873f844414ce3d9666f514212a52649a3803b5e41a05f99c580b973d2a",
+                "uncompressed-sha256": "8947f61398d39c8a928ee28aa7234cfe64a223a397a6bc8d95a88f680ed8035e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-live.ppc64le.iso",
-                "sha256": "dd63552f2b416f59420e796bd923a9755a352369ef0048cd78aab0bee0128385"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live.ppc64le.iso",
+                "sha256": "861f1c8f1cc4e24296e80faf6d89a3b839d410808b8b179fb02a38f4c8c5c8d6"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-live-kernel-ppc64le",
-                "sha256": "a27a96e0044074a8be57548349fa72b9df62c11746c497b49a944926776b2a67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-kernel-ppc64le",
+                "sha256": "8b77fb7e10f6d1cbedc0dfb397495cd4d5a3060053116b4761984137cb328962"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-live-initramfs.ppc64le.img",
-                "sha256": "89b0069aad44d79ebd8c25e3505050f51840e76b0db9971000996b2151372458"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-initramfs.ppc64le.img",
+                "sha256": "5e437f400db0f9ccf518273d0940a467a301f50622a6bbcdf795e1f8612f5714"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-live-rootfs.ppc64le.img",
-                "sha256": "e0161cbfc10914adf95bd040b925624d14cdad7dd29927439f493bd8c0436831"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-rootfs.ppc64le.img",
+                "sha256": "2ea81b132c60d73e66cfc8f50c95fe6def818175480a61830930e3acaac7a7a2"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-metal.ppc64le.raw.gz",
-                "sha256": "82e4ef37f7a4d6804e8d599d470c7611805a9b14368b47e6d4ebc9d4ef65a4a5",
-                "uncompressed-sha256": "1d1df03675bc205ac475b61150f0039e21dd6497eb6c3fd6113eba661ca240fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-metal.ppc64le.raw.gz",
+                "sha256": "2753d70fa5010210c657e49aab7f8ac38c200eb7fe244c688aa6cc8fc0b9f800",
+                "uncompressed-sha256": "c7fb8ba3b931f0c5d1111c16056eb9d0c756880c46504e5d015dc1af2907743d"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "234b9f9fd3e3588875118f6f744f451d52546d847611bca7348fa80759ef414f",
-                "uncompressed-sha256": "e0f253f3e271654575ce0700a1068ccd89644a470811562acce8face0a90c462"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "b41fdfb03954f82a48f24e2ae1fc1d4380956e200d55d3e824ba3002d3b5aed6",
+                "uncompressed-sha256": "6f34c1927254290c29099c614d7fd6a04e45243db12e1f51796fea644dade3e8"
               }
             }
           }
         },
         "powervs": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-powervs.ppc64le.ova.gz",
-                "sha256": "499d8c614a93d2a2a7b2ed8940f2c89679ce968b09d2a18ff31e30a387ca77b4",
-                "uncompressed-sha256": "a562f7bfdfe7e24140021e13aba52bcd86b13d48893d807e2252bbd3aeee276f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-powervs.ppc64le.ova.gz",
+                "sha256": "0e75efbd643eea1c8746c8fead82f73d186c3f5ec32a9f26bb8558b39e92f1f8",
+                "uncompressed-sha256": "1b5e4593702c9215dd15f3500d2965109eed7521a1868eb08f4ee2c1e9e675df"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/ppc64le/rhcos-414.92.202303281555-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "0deb7b2eee744380aa3f24e89948b432719793456d17a6fe2a46561614c980df",
-                "uncompressed-sha256": "a7508da94fab3b0b135f740467c7aa99c5f9917504a7ede9d9876016ee8047d4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "1f56de8e1dda5fe150437dd3f99eeceb37dfc8d250c07f5b0fdb8d89d720914b",
+                "uncompressed-sha256": "6557a8c9ea0e797ca53194aacae83ce9dbdabf3a49cfb2c72cbc20e6223266ac"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "414.92.202303281555-0",
-              "object": "rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304131328-0",
+              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202303281555-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "2839883c27c7d4e3a16cd12a6a437647b3753b13e7b35cf88695abd004a48b28",
-                "uncompressed-sha256": "84c3c069a45162a303b0c8938e0babecbe71532afaf5d1101bd86a5fd7ca73ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "28f30e1f52a36d6b5d6f33ea9709fc003dcf01ee78e2dbc870f606b089975445",
+                "uncompressed-sha256": "35f4e3f92466521ac1143da184f282de400eb71385d6f83d22527b082cfb3401"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-metal4k.s390x.raw.gz",
-                "sha256": "93c747fef3e818ab7a8f3d34cc048ac7b5303747b5152c366f3a001e458db206",
-                "uncompressed-sha256": "96a77d03cfbfc0649d742bda743d137cb3a4ac419fc3d012744aef4e8c6fa577"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-metal4k.s390x.raw.gz",
+                "sha256": "c756f6aca1c4baafb73da74ff93a3d49ebced31d87099ff9c9f0110714947cf7",
+                "uncompressed-sha256": "63aeaf207a8d144a77dd195508b85e0c15e9b115d96f9d6f7324fa646141ea12"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-live.s390x.iso",
-                "sha256": "29bcfcbdb7cb5199ed35bbb389f26b2fa43aa23d042f999279e5d3e06699c60e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live.s390x.iso",
+                "sha256": "b10a333cea7b3d501a81d047e0bc5bf68fb72c73b5c90b689dda0883441e6891"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-live-kernel-s390x",
-                "sha256": "a5670c42ecbd84e30f0af7653ef0ed6f209d969151060177e526b672aabf2352"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-kernel-s390x",
+                "sha256": "b126f4a81df5d7be59a9a7a6249e0498611774c3458cc62f863b3b36a61bf1f8"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-live-initramfs.s390x.img",
-                "sha256": "80c050c58aac27a4fdb3ccab8547a9aa14f829b571f244e9f49a2c5ad373cccf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-initramfs.s390x.img",
+                "sha256": "a5f6ed8b2b6d3f31718ca87889ec3066ed54e8e109bf3376b256d34ad56a09fe"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-live-rootfs.s390x.img",
-                "sha256": "95d33cb6307b820707ee65015c931ff259baa270ad0c1b3b0a387e10129e43fa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-rootfs.s390x.img",
+                "sha256": "d14530c0a51d79fabac40b3d0be8ecd2d743caff06297789412e5433af063ac2"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-metal.s390x.raw.gz",
-                "sha256": "583b291675daed28d5e3125bf15729463c1333f14eefc7dd7088b179fc2afaa7",
-                "uncompressed-sha256": "960791bf3106fe390718fe22661e78bcf535db08d3ccba7d39f64422f15a1f5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-metal.s390x.raw.gz",
+                "sha256": "921fac304befb6c79712cb20953eaebfe4092cdc9d425a802407a40355d44941",
+                "uncompressed-sha256": "b6cf2e7f2820bb10b2e4da23c316564f46dc9f188324a656375bcfc4fb8bc698"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-openstack.s390x.qcow2.gz",
-                "sha256": "31adf5dabcd80141cd22778eee777e3753c666fc42162ab1587a0f02715118ea",
-                "uncompressed-sha256": "ed05cbb54a6ba4f74e1ba3500475a08be3b450da3b5ca39c2387270ce4f053b4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-openstack.s390x.qcow2.gz",
+                "sha256": "694655a45086936e039b498066838fa61675dbd48f95299f4066556d5019641d",
+                "uncompressed-sha256": "e082ac6fbe39876e545e7e10a8e278718421eb25ab3783128578f0a40b4af54e"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-qemu.s390x.qcow2.gz",
-                "sha256": "1e340fca921ea3bd203d9c0e207890aa576e7082b036ea0895effb4a4390e203",
-                "uncompressed-sha256": "b042441c2c69b61fdb1d3ce46f88f3f7ae07965bb81614c3c9771a9601b98125"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-qemu.s390x.qcow2.gz",
+                "sha256": "a63976c49df0014bfbc02455c743ab7e74b6e9f852e6bd5f0ec1dd016ea93470",
+                "uncompressed-sha256": "baa11074eba6306356bfd4af43a1eff95b60b53e9cbdf039bb72e53296669788"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/s390x/rhcos-414.92.202303281555-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "983f33813de5dc43f8c3c932ceb7b44080991ab8f9ab148841c60a616fb0766a",
-                "uncompressed-sha256": "5b2679a900acdf520d979b00bea95a0078b972568702940e57bcbd80969c0f26"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "21b2162500297831d50e3916ee6dd2d818cd7dd49ebc6d81b716c903b45ac3bb",
+                "uncompressed-sha256": "cf68b855d0c881dba37cae5f8f03267d977290c4adb82718af255fdcd3a9f569"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "258413d2bdedcdcbbfd455201842174097c814f6a649ae5c5e08b8da8ca99da3",
-                "uncompressed-sha256": "73c2ead1f6f0113188b41aa3017e012ec700b72c86e3b914ac8eb55894fb3205"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "b2880964dd21489b32ed8a81eefbf36ba4ed47d2df4a4e591849916e0b326923",
+                "uncompressed-sha256": "d388faeefce1f1a49c6b827c96344f660a330a6edd6c8e49e00eaee7cf81176d"
               }
             }
           }
         },
         "aws": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-aws.x86_64.vmdk.gz",
-                "sha256": "75ed60db665caafe13d9cbd4a62661de914d218c7a865b64cf1198649e11b48f",
-                "uncompressed-sha256": "939b8003a7cb3121ac502b9d3ee9054166ad22c3236bd15dd9db08e2efbc5d06"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-aws.x86_64.vmdk.gz",
+                "sha256": "8bcaafba38a9c21cf614d58514dee038e45448beda30dbd35567201fb17d68e4",
+                "uncompressed-sha256": "14e15be9ba16818e88de588ab3415366a62a67380b3e779992aae7e086e4774b"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-azure.x86_64.vhd.gz",
-                "sha256": "173469d1eb3a8200ed2b7905472f9c5983bddd65f7a1383078a22adea27834d6",
-                "uncompressed-sha256": "0dd9264fc15151ef0a9a34e34ddd99c42f487b3a75a564aa66094efa0a488a2a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-azure.x86_64.vhd.gz",
+                "sha256": "cbc24fe92860d2c4c39a2bd6a1faa5b510c72e15d84eea895b9a2dc2df2467fd",
+                "uncompressed-sha256": "74f127d1df9e06f5a986c30d81305281395ead278cee9c404c811f176a20e47c"
               }
             }
           }
         },
         "azurestack": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-azurestack.x86_64.vhd.gz",
-                "sha256": "6ad09c0fd3cca0cdfe76098ca1d572632ca527d74c60f9f7845ebfadf021aa1a",
-                "uncompressed-sha256": "84489f4e8c9a5822d2bd2f2c733f69519b1984ce4fda5873b73f919ce82e383e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-azurestack.x86_64.vhd.gz",
+                "sha256": "0002495b0ac66114f0b0f9187e6415faa2cd4dcfa0ca543b870c0956571e2a7f",
+                "uncompressed-sha256": "784d47970afc6da7900c36f341f6e2ec361246e95d67ec67df79748f6e1d5b08"
               }
             }
           }
         },
         "gcp": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-gcp.x86_64.tar.gz",
-                "sha256": "1d4f5144ca7d273bed52954ac53f067c323476e782bd85147842ac26e218fcb6",
-                "uncompressed-sha256": "a3a11a1740c65a2ff29ef8b6e2da2e6422ad35757cf5af7b06d7fa4ef59d341f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-gcp.x86_64.tar.gz",
+                "sha256": "0dc470e41031ba3d313e50021191005798d4250ecea65ed40618241bd92ed239",
+                "uncompressed-sha256": "de95a4f2ccd147dac80542b4dfa19184f9a57eb8a0dcefa6d78e905f8512267e"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "bea77dfb43e3da76baa57df0c13844d573473650b6502f71b00b395754b06d3a",
-                "uncompressed-sha256": "c086b13cd504108bd230c977e38314c8e6b6765e8401e912aa1deca6c359e51c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "562de7348053abc829bd171d58628360e1244d4411b3c15ddbe7f6cbb6085f14",
+                "uncompressed-sha256": "6b8f7c52f975ecedc05f72e9c710fd1d1250d96b7664a106f42012197d9706dd"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-metal4k.x86_64.raw.gz",
-                "sha256": "c2640277fa16650c6b07bc047fa2ceadec07891ee893d745d7c08f9b93abe94e",
-                "uncompressed-sha256": "a9b1a4f1d00a2bc7fa1981d0c5a0950674260200ee84f7bdfb37e1699cb370d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-metal4k.x86_64.raw.gz",
+                "sha256": "f711caf3e3ef0dcadd31e97e085cec02304d7427115b567e4922f43267442437",
+                "uncompressed-sha256": "c6e47e5d4d0c417b65f1dbb4b8d35eafcae5bd09867abb45eb1e0605132017ae"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-live.x86_64.iso",
-                "sha256": "980cf3ad2ce40dd247704196f470c242c92468a9a493eb44f5359db7b624ef51"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live.x86_64.iso",
+                "sha256": "ed479a94f7842b8791802919c75a12669b243334c79d763fad04c1efac009a18"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-live-kernel-x86_64",
-                "sha256": "e7003e4ae3e030a1d266fb50917a5a21984c3ea8bd1a89a884e09b81a64bc434"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-kernel-x86_64",
+                "sha256": "833e29fcfde19f8fff62ce3c07ef883042eb476c2468405599eb000da813629d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-live-initramfs.x86_64.img",
-                "sha256": "8429bca7d9ea312cb10ba0fc9980b78b79dcd7a56eeab4145d372e7c0d8a3778"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-initramfs.x86_64.img",
+                "sha256": "ff870016cfed160913345314ff612957e1e4ce825529bba53f1efb74406edefa"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-live-rootfs.x86_64.img",
-                "sha256": "0d266376da0f2b90d597da455851bd5f023a0a5be86ea238a78870aa13ee120b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-rootfs.x86_64.img",
+                "sha256": "b6a133113144d4f44efbca50136deaafc2c9ad09177ad5f90a1a4eef1e36a098"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-metal.x86_64.raw.gz",
-                "sha256": "d9848ac398bbb1a78bd7d43854d4757e0a3dc0e1528e26706b509dfa9ff71d65",
-                "uncompressed-sha256": "473da619ec2769373416b4454841597eb55a01c1567f35d5f3c377a9df8bafcf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-metal.x86_64.raw.gz",
+                "sha256": "1090407f2439706451f0f3b4aff506cbed4836af8e10756dc264aded85b11fe6",
+                "uncompressed-sha256": "be52d0e25b9948430bd35da61b09dd13bebaeb352da8aa2dfc5590ea29f77bb2"
               }
             }
           }
         },
         "nutanix": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-nutanix.x86_64.qcow2",
-                "sha256": "b25a06611dadf533664415efad50eea5ab11740629dbfa0dfa5e0649c0f12d57"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-nutanix.x86_64.qcow2",
+                "sha256": "34bf1db0871fc47208f9973edd2a61965ff42e733641e75ecbdbbf5edd43e26f"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-openstack.x86_64.qcow2.gz",
-                "sha256": "7fdff4c107a284f4f16ae7ff59502f656905cc21835e7bc62d888e79c3e11cf5",
-                "uncompressed-sha256": "b3753708b94f14f5fc672ca6a6bc3181456470fbb4883b43feb67469e26fd2fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-openstack.x86_64.qcow2.gz",
+                "sha256": "f9d920c980a34556f0e63e78132051e328a2f989b6488bd1474aec1e8e35485f",
+                "uncompressed-sha256": "dbcba8d3e7ec473827c44ab6204b6ae36a5d07db20a799abfc9e9cb380a439ef"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-qemu.x86_64.qcow2.gz",
-                "sha256": "079af867bc61d83ffdf1b11ff7425a758f3e9eeae3e76c7489ab1384ce99f040",
-                "uncompressed-sha256": "61ab815710c09a372e15fafd067f5e5bda7f51b4d708b645b05d635a59f85dc8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-qemu.x86_64.qcow2.gz",
+                "sha256": "5cd2458f773987495786fd97f94804b3b48b3bf283920da6ede6b8d5d734b119",
+                "uncompressed-sha256": "9a37af9e8459c900359f4e5a260f0e5a94b0f755b260ffb1f0e6b8cc66c226bd"
               }
             }
           }
         },
         "vmware": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202303281555-0/x86_64/rhcos-414.92.202303281555-0-vmware.x86_64.ova",
-                "sha256": "a0293104489a0ca4827c2290c42fae5f2b711225d1534f9578af68b53fd8aa88"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-vmware.x86_64.ova",
+                "sha256": "229d29ba644ebfb4dc962f40a9b3e410c95fef852582b24805df93768d418130"
               }
             }
           }
@@ -619,249 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-6we8yxj1wfc9s43pdd4y"
+              "release": "414.92.202304131328-0",
+              "image": "m-6we0yfgdovctqblsbk46"
             },
             "ap-northeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "m-mj7845sbs5h7mrfoee07"
+              "release": "414.92.202304131328-0",
+              "image": "m-mj738mxrqnkz8b8orna7"
             },
             "ap-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-a2dea3mpnda68724je0z"
+              "release": "414.92.202304131328-0",
+              "image": "m-a2dgljc02zy39f0pzink"
             },
             "ap-southeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-t4ncma1tozaslarr90j2"
+              "release": "414.92.202304131328-0",
+              "image": "m-t4n34ptmhy3acal8g88g"
             },
             "ap-southeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "m-p0w7g3qd0adqml5zqm9h"
+              "release": "414.92.202304131328-0",
+              "image": "m-p0wfajy4xz2qzph6h581"
             },
             "ap-southeast-3": {
-              "release": "414.92.202303281555-0",
-              "image": "m-8psifw8yec7znw31bqwu"
+              "release": "414.92.202304131328-0",
+              "image": "m-8ps2h7x5kuffyb0zimm0"
             },
             "ap-southeast-5": {
-              "release": "414.92.202303281555-0",
-              "image": "m-k1a7on3fhosh8dk5303p"
+              "release": "414.92.202304131328-0",
+              "image": "m-k1aatqxnd848zece5m36"
             },
             "ap-southeast-6": {
-              "release": "414.92.202303281555-0",
-              "image": "m-5ts9p3uld0zdcu2fitvo"
+              "release": "414.92.202304131328-0",
+              "image": "m-5tsej10uwhwqzswsfqq5"
             },
             "ap-southeast-7": {
-              "release": "414.92.202303281555-0",
-              "image": "m-0jo8figvwh2uvtyhna7e"
+              "release": "414.92.202304131328-0",
+              "image": "m-0jofbllmq2oxmmkhgpne"
             },
             "cn-beijing": {
-              "release": "414.92.202303281555-0",
-              "image": "m-2ze2glm0sheuv9vjemnd"
+              "release": "414.92.202304131328-0",
+              "image": "m-2ze0ebt4f0skgbxht5k5"
             },
             "cn-chengdu": {
-              "release": "414.92.202303281555-0",
-              "image": "m-2vcizr6p5cxqel6p7bpx"
+              "release": "414.92.202304131328-0",
+              "image": "m-2vc35ucempgfu5v53eor"
             },
             "cn-fuzhou": {
-              "release": "414.92.202303281555-0",
-              "image": "m-gw0c0jzg3eiec51m032l"
+              "release": "414.92.202304131328-0",
+              "image": "m-gw0ja648ykhaublhp0eh"
             },
             "cn-guangzhou": {
-              "release": "414.92.202303281555-0",
-              "image": "m-7xv3ad6rrieo3v2cyngk"
+              "release": "414.92.202304131328-0",
+              "image": "m-7xv40n9kjplwtfr836hh"
             },
             "cn-hangzhou": {
-              "release": "414.92.202303281555-0",
-              "image": "m-bp108cp5bfh5hl8bfa9a"
+              "release": "414.92.202304131328-0",
+              "image": "m-bp1cddlj57b65kfyar7m"
             },
             "cn-heyuan": {
-              "release": "414.92.202303281555-0",
-              "image": "m-f8z1ob8ejkbsvldkwrdg"
+              "release": "414.92.202304131328-0",
+              "image": "m-f8zde65mian4qrjkrdf5"
             },
             "cn-hongkong": {
-              "release": "414.92.202303281555-0",
-              "image": "m-j6ccr5l4kqbp0j4kjlev"
+              "release": "414.92.202304131328-0",
+              "image": "m-j6c3t6hsg2i2kwq1rcmf"
             },
             "cn-huhehaote": {
-              "release": "414.92.202303281555-0",
-              "image": "m-hp3azzhp02hrmxnnri33"
+              "release": "414.92.202304131328-0",
+              "image": "m-hp36rojj3xzxfjv7kbbc"
             },
             "cn-nanjing": {
-              "release": "414.92.202303281555-0",
-              "image": "m-gc7hb5yzgtvk9wu3utu3"
+              "release": "414.92.202304131328-0",
+              "image": "m-gc7ivkvqw7u1njg7hawy"
             },
             "cn-qingdao": {
-              "release": "414.92.202303281555-0",
-              "image": "m-m5e2h8olkwo082o08zj8"
+              "release": "414.92.202304131328-0",
+              "image": "m-m5eb72sdbtki78flrq3c"
             },
             "cn-shanghai": {
-              "release": "414.92.202303281555-0",
-              "image": "m-uf65qicvb72j9gju0lei"
+              "release": "414.92.202304131328-0",
+              "image": "m-uf6cjzyzq1e79celyu8o"
             },
             "cn-shenzhen": {
-              "release": "414.92.202303281555-0",
-              "image": "m-wz97lrfnywd969bng6n1"
+              "release": "414.92.202304131328-0",
+              "image": "m-wz94n4lo0cdx622fafq8"
             },
             "cn-wulanchabu": {
-              "release": "414.92.202303281555-0",
-              "image": "m-0jlisxvjwg6548c3ikg7"
+              "release": "414.92.202304131328-0",
+              "image": "m-0jlcqjnf4x7tw2kyloxa"
             },
             "cn-zhangjiakou": {
-              "release": "414.92.202303281555-0",
-              "image": "m-8vb7lxsvsihy5yc35quj"
+              "release": "414.92.202304131328-0",
+              "image": "m-8vb62c3pfwwupkfcmqmh"
             },
             "eu-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-gw83voa4slijr4xepqny"
+              "release": "414.92.202304131328-0",
+              "image": "m-gw81pnvusvzbrf48rzno"
             },
             "eu-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-d7oawrdmsm8dh3jqcwtz"
+              "release": "414.92.202304131328-0",
+              "image": "m-d7o6acw5m5voqhawv4b7"
             },
             "me-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-eb3b9roerl060yj18ugj"
+              "release": "414.92.202304131328-0",
+              "image": "m-eb3152lacdat666p3kkl"
             },
             "us-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-0xi9lpu1faf110pej4d9"
+              "release": "414.92.202304131328-0",
+              "image": "m-0xib22n9huq7k9hueb90"
             },
             "us-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "m-rj9h93xwrhoqonwcchqt"
+              "release": "414.92.202304131328-0",
+              "image": "m-rj990s7tn5umq65d8obu"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-059b1302409415235"
+              "release": "414.92.202304131328-0",
+              "image": "ami-05e65b3787a0cf3d5"
             },
             "ap-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-063851dff7701d379"
+              "release": "414.92.202304131328-0",
+              "image": "ami-043507d172b03a574"
             },
             "ap-northeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-06298b6930e9e1271"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0cf1a642d35dcd037"
             },
             "ap-northeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-088278a67eaeb5b17"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0e8a841a58775d570"
             },
             "ap-northeast-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0ad706081eb829e6a"
+              "release": "414.92.202304131328-0",
+              "image": "ami-08b75516c4fa37092"
             },
             "ap-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0e6c3a201f7b192ec"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0e0b844c8ea8f3074"
             },
             "ap-south-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0ce72127bba4c9601"
+              "release": "414.92.202304131328-0",
+              "image": "ami-06a2f47617a659ca1"
             },
             "ap-southeast-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-05fec7cda14cd66f5"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0df1fabffafa358b2"
             },
             "ap-southeast-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-07e17382b9687ed03"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0c62154a543e78f29"
             },
             "ap-southeast-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0b05dcff07ae83426"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0a64ffeef5dcf1e5c"
             },
             "ap-southeast-4": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0b6cef633e54bc7dc"
+              "release": "414.92.202304131328-0",
+              "image": "ami-00c9b9852cab40743"
             },
             "ca-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0d2410e427aba8d3a"
+              "release": "414.92.202304131328-0",
+              "image": "ami-07ab7080c0380448b"
             },
             "eu-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-043900501635128e0"
+              "release": "414.92.202304131328-0",
+              "image": "ami-02fa13a2ecfa7c84e"
             },
             "eu-central-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-038e73721a6dba7b2"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0691f376dbe11b709"
             },
             "eu-north-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-07ffc37d1327113a8"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0ca77adcff2bd5c9c"
             },
             "eu-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-01102cef7f9fa9055"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0aa804c4e9758ee3d"
             },
             "eu-south-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-00b6d1bf1a06ba17b"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0b2bcb4b17cc24817"
             },
             "eu-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-03b40f8331bff45d9"
+              "release": "414.92.202304131328-0",
+              "image": "ami-06a8110b4d6572713"
             },
             "eu-west-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-068bf5e2355855f78"
+              "release": "414.92.202304131328-0",
+              "image": "ami-05f719f69ac7867a7"
             },
             "eu-west-3": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-02151ccc171b3feb4"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0afbb4b6732b5f97b"
             },
             "me-central-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0589fe51cdb71b810"
+              "release": "414.92.202304131328-0",
+              "image": "ami-08b13b24f8ee8666f"
             },
             "me-south-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0dd523f4bcdf7bfe5"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0e0837ca5ddf8f1fe"
             },
             "sa-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-07574bab2533ad934"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0eae2e91b5aa99269"
             },
             "us-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0ff4fdc5b214f44a9"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0e95030500ad17daa"
             },
             "us-east-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-04ebdc13793bc15b6"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0ec42c0d73fd563c2"
             },
             "us-gov-east-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0c66973876a87e186"
+              "release": "414.92.202304131328-0",
+              "image": "ami-023786863fad955ca"
             },
             "us-gov-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0572064a344f8d17a"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0a940ba338272c5a8"
             },
             "us-west-1": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-08948398edcd81668"
+              "release": "414.92.202304131328-0",
+              "image": "ami-04be355979e907ce6"
             },
             "us-west-2": {
-              "release": "414.92.202303281555-0",
-              "image": "ami-0b7af4e82816f3f17"
+              "release": "414.92.202304131328-0",
+              "image": "ami-0a855644af3f98440"
             }
           }
         },
         "gcp": {
-          "release": "414.92.202303281555-0",
+          "release": "414.92.202304131328-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-414-92-202303281555-0-gcp-x86-64"
+          "name": "rhcos-414-92-202304131328-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202303281555-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202303281555-0-azure.x86_64.vhd"
+          "release": "414.92.202304131328-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304131328-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.14 boot image metadata.

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --name 4.14-9.2 --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=414.92.202304131328-0 aarch64=414.92.202304131328-0 s390x=414.92.202304131328-0 ppc64le=414.92.202304131328-0
```