### PR TITLE
OCPBUGS-11789: update RHCOS 4.13 bootimage metadata to 413.92.202304131328-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-03-29T00:13:37Z",
-    "generator": "plume cosa2stream 0.15.0+154-g2c151cf83"
+    "last-modified": "2023-04-13T19:38:53Z",
+    "generator": "plume cosa2stream 7a1f61e"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-aws.aarch64.vmdk.gz",
-                "sha256": "528e8b2876955d91d553607a023e2b600d2dbb100fd1c46cc010374062b9b01c",
-                "uncompressed-sha256": "eb51fd7e566865bfdfc729d36148b31056a1cec2aff0e7799adb875a58b2f56b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-aws.aarch64.vmdk.gz",
+                "sha256": "596fdccc1b226ab18a5e4e705a1a928ff6c17aac3fa74360912142eee9ac74c9",
+                "uncompressed-sha256": "7dfa48ef70b4c96caf1fed8a7c66ea673fbdd73ff22925dfda7f116c03de5fc4"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-azure.aarch64.vhd.gz",
-                "sha256": "74fd3e3ee96685cdf5c4e991f788d31ec7734fb5f96a497e813204fde9aaf488",
-                "uncompressed-sha256": "070b8999d2b982f541cba36ff21bfb07db69f2aa6c1dca03c676b9713b8b15a2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-azure.aarch64.vhd.gz",
+                "sha256": "a7755b005f8c48d95f312a7e966c8e4db07d3ff44520b1af108e38d29b508107",
+                "uncompressed-sha256": "f21a92579d7cdea8509879a691499cd03669c5d928dd79580b5a4fb96864961d"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-metal4k.aarch64.raw.gz",
-                "sha256": "68366a351ccc850c3d98fa2ae932a256986c893f41a6e1b0c9091d545fcc20e1",
-                "uncompressed-sha256": "943b9be6fb7c2eda0a301d365cac9b20ef81e22af0d50971e339b82a1eedbb96"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-metal4k.aarch64.raw.gz",
+                "sha256": "3aeade4dce31025d6a9c897fc9565518d3441ae20d280bda7fa3dc437f4572a4",
+                "uncompressed-sha256": "00c9fbcb246e369ba5c4ebe79146604669f4264c1b2af2357c27ba71ef66efbd"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-live.aarch64.iso",
-                "sha256": "1b5938b35091467f2b719cefd7d1d62598fc64d901758c6ce9ddd2885cbf2358"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live.aarch64.iso",
+                "sha256": "6786dc55f751391e0e8bfce4e739d4163bb83000d40095cc57ab32d9c788bcbc"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-live-kernel-aarch64",
-                "sha256": "260e935d26d1240d158de4235be761d24d179a20c859eac3dfdd176420728a9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-kernel-aarch64",
+                "sha256": "9e44cafd61f5ce4c9c8af8c912c200ff59210b2d239798b21e6ef89a20b8f2dc"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-live-initramfs.aarch64.img",
-                "sha256": "e83f4205b219f9cc2f64d042c8b0c035258d624bc0643d3982d8f3ad45ccc3fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-initramfs.aarch64.img",
+                "sha256": "f6e87e4d82fca59e8807a6c833a950d51129b4d5dac328cc88b6a4061dba9d37"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-live-rootfs.aarch64.img",
-                "sha256": "04c0c865e8a43e18f1fa222ef53eff6c17d09c7a37065ee61712c2daf20a8c8c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-rootfs.aarch64.img",
+                "sha256": "f36d134acfd958e5c69224cfb52f83954f4f0f5b2a2f6516010c94b9c2d1a24a"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-metal.aarch64.raw.gz",
-                "sha256": "cd1b07c767bc202b5d89661b88938b28250e7b44768bea3b8910338609f25c84",
-                "uncompressed-sha256": "b4701b9f41983e1e5b65e5ce5c502f5c390a84961d177defc615234a09ee514e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-metal.aarch64.raw.gz",
+                "sha256": "5a5864addc018c3faf471037dae4aafa1fe67e834494e7b942cb8829f814566b",
+                "uncompressed-sha256": "1ffd5f5112843e0694ca3d3cb00a35805c2e4ce2c18360c8e22f6238fe5d7981"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-openstack.aarch64.qcow2.gz",
-                "sha256": "552a680ad3aa5b86f828ff23606f2efc43d6c34965fe197d6b93ab7d774be5ea",
-                "uncompressed-sha256": "8122ff59aedf523c00bb9ee09d077ebb1f997c937dfecead614c2b6401ce4170"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-openstack.aarch64.qcow2.gz",
+                "sha256": "025cd6bdf94e51fbe40d3e0352c1045aad154fe2e026e6b3b9bfe2001f2bc03f",
+                "uncompressed-sha256": "a1548f02f2c996055efed9118c44257d9e4e6b21b799ba93cd6b5bf1e5b2b057"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/aarch64/rhcos-413.92.202303281804-0-qemu.aarch64.qcow2.gz",
-                "sha256": "070122eeb7042e6cc8285eb3e3a495d466120a57ff45da1164714e1dfd9a922e",
-                "uncompressed-sha256": "3b12fe3dcea6c104ba05721026d657b7051fbc0dd8c1597f6aef1c110d33f895"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-qemu.aarch64.qcow2.gz",
+                "sha256": "ca7d574b2c28d01f415ae69a45ad0cb053a51e2ad7c021fa06de8269499b6539",
+                "uncompressed-sha256": "17981760ec1f0a71a2acc43d374307a72a2614528b160d39745b7463cf09f71a"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0a95ad6034cfd99db"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0bb65810adc5ca543"
             },
             "ap-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0853c1d28287597fd"
+              "release": "413.92.202304131328-0",
+              "image": "ami-012f26a2a97f6c452"
             },
             "ap-northeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0843e19202761054f"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0bd791e17565439ad"
             },
             "ap-northeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0799985dd2d9b0d05"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0dc21a63bb0952a91"
             },
             "ap-northeast-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-039b377bc1d1b9c1f"
+              "release": "413.92.202304131328-0",
+              "image": "ami-013f8a2af201ba65c"
             },
             "ap-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-035588c8999576bf9"
+              "release": "413.92.202304131328-0",
+              "image": "ami-091851be5f00c09d0"
             },
             "ap-south-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-06fce250a3c2b7c9b"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0432a8d5529538f9f"
             },
             "ap-southeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0081e21bb050a3601"
+              "release": "413.92.202304131328-0",
+              "image": "ami-035767797f8b055f2"
             },
             "ap-southeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0537169f7858e22a1"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0b51d82fe56befe0a"
             },
             "ap-southeast-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-05d0f6be43bf81988"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0aa543cf2707622ca"
             },
             "ap-southeast-4": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-077db34a34f1a855e"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0cae5ad273ecc7983"
             },
             "ca-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-01bdbc230e3c88d47"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0c51f1d44900be6e5"
             },
             "eu-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0f4888bf9556d9021"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0f65d93e29628b78a"
             },
             "eu-central-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-04239fec57239cb61"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0df5a72495111fd66"
             },
             "eu-north-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-00a87511d303f0ad2"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0fa9a849f34ad48a9"
             },
             "eu-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-067f9a1b68d5b59b6"
+              "release": "413.92.202304131328-0",
+              "image": "ami-07adde5e5568a745f"
             },
             "eu-south-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-014ff2ea3eee3a1ed"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0859c02ad7be51b79"
             },
             "eu-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0439fd0e3f891cc37"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0dcff52b004380bff"
             },
             "eu-west-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-040efd77f90593ea1"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0506763e6b3ea4a91"
             },
             "eu-west-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0d7960e064909e848"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0f6de799bad717ba9"
             },
             "me-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-009357ff7f36d663e"
+              "release": "413.92.202304131328-0",
+              "image": "ami-00f5b8abb7023fcfa"
             },
             "me-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0999ac00bbe821f53"
+              "release": "413.92.202304131328-0",
+              "image": "ami-030071ed9776932f8"
             },
             "sa-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-03ef8972e22aaad9a"
+              "release": "413.92.202304131328-0",
+              "image": "ami-02ded16bdde6f1e37"
             },
             "us-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0823cadfc441ae9bd"
+              "release": "413.92.202304131328-0",
+              "image": "ami-028daadbb014b7680"
             },
             "us-east-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0420812e1b948e8c8"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0415c3c5a2d24606d"
             },
             "us-gov-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0abe2145916f11194"
+              "release": "413.92.202304131328-0",
+              "image": "ami-07c9c2218eb2af040"
             },
             "us-gov-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0bffb6bcad4770471"
+              "release": "413.92.202304131328-0",
+              "image": "ami-077f449c4d42271a7"
             },
             "us-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-03ad02341b7141d8e"
+              "release": "413.92.202304131328-0",
+              "image": "ami-09d0aa8c2c3785abc"
             },
             "us-west-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0d540d0a01046eacd"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0b43bbeeb2032c8fb"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202303281804-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202303281804-0-azure.aarch64.vhd"
+          "release": "413.92.202304131328-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202304131328-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-metal4k.ppc64le.raw.gz",
-                "sha256": "2f773d856a67bcf12a9dc40b43b8d17ea5359e2c7f16ce9ee2fe949a68d009b7",
-                "uncompressed-sha256": "c89d0583547203a5ca0ef58996ebbdac271e802943839c121a09c81929d5c282"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-metal4k.ppc64le.raw.gz",
+                "sha256": "e4d91f86d37064a6c4be40b6f1c9b3b606a2dfb5818bafc7296a98b389196434",
+                "uncompressed-sha256": "94077e622acbeb01ab34797741a3bdf35e16c10ef772f2b16d5b3f981fab0be6"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-live.ppc64le.iso",
-                "sha256": "98c56072f53a88440420bc5de15cd28d252e7d4ba1f0cb13de06713a75b765b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live.ppc64le.iso",
+                "sha256": "f9682339b0cf1f4b28fd8d64558d50ac849a6c0a3d71a515c9786ca91dd377b9"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-live-kernel-ppc64le",
-                "sha256": "a27a96e0044074a8be57548349fa72b9df62c11746c497b49a944926776b2a67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-kernel-ppc64le",
+                "sha256": "8b77fb7e10f6d1cbedc0dfb397495cd4d5a3060053116b4761984137cb328962"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-live-initramfs.ppc64le.img",
-                "sha256": "a178750e914ec6b8af7a7539ea6698ca97a80ff4e00d860438adabd90ce61d7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-initramfs.ppc64le.img",
+                "sha256": "89ae5202f65a7cda98417f8b8b95dc6f09fb818f68725fc629f9c4bd4186bd22"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-live-rootfs.ppc64le.img",
-                "sha256": "41824716b31d3a8ccdf616bdd3cb18c16350e4e154bb6a3290cce486a9e127ec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-rootfs.ppc64le.img",
+                "sha256": "75797bad27fe509693dabfd616b88a6591e3ff6f5531fc8e33814bb47f5b4ed2"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-metal.ppc64le.raw.gz",
-                "sha256": "e4df513c897b8bb2ba3f8060cf469a41d785309d58a6c9b60ea2a8010d626e56",
-                "uncompressed-sha256": "92267ef4ebb4238336fe62f63fcfe6fd7e4076e75ae007ae365a9cdaa1930425"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-metal.ppc64le.raw.gz",
+                "sha256": "f7413e3ad98af952a3c28598f363d854cb613ac22f7bfc554a2dd66f6718ff2f",
+                "uncompressed-sha256": "a3b2bc2fc9ab524267af1bc04b6938bb2c2313b37bbe7631e4540244390cf764"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "59f8bcc831074708ddf3220ae6620ce743c436a484e849a99896143efaaf716d",
-                "uncompressed-sha256": "338bd673d519ab15db22d3118419d1de0d0200fd0ae20657035c0884b22799f3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "e60bc7f4042bb6d58eb0fa23aab2e77116aab4ff2df22b6991c89e159fe1616a",
+                "uncompressed-sha256": "c68eb03a27efdd0cfafbe37bb8cf0888d4f1da590193bc223d927088c5b466d3"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-powervs.ppc64le.ova.gz",
-                "sha256": "1fc4c590350e107af2f5efca7d023549fa18fee84d09369f5b1fd18c1c35ab7b",
-                "uncompressed-sha256": "9d97b1af5101680ed863e382036d56d15a1d66f653a610c50aa8af1069fac19f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-powervs.ppc64le.ova.gz",
+                "sha256": "eda197f829ac354a8b711964064864ff3e350bcfcf893ea822e254a48e026039",
+                "uncompressed-sha256": "b3d02e8d120958d511a1f17771d91607730e84be259c23161b211d0ad41769dd"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/ppc64le/rhcos-413.92.202303281804-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "18cd24c3cad91f1566b28c755042d93d47ca41fd62403585180006e30c7835c9",
-                "uncompressed-sha256": "9ca673ee5d815ba140650731ae647319a23ca8f5d6bb05c1a0b364470b6d69a0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "32b2acc26af0fbcbf0b72965417ee0de16e92424e135a33ceb341b8a67d4cb46",
+                "uncompressed-sha256": "f29224c9efdf703b79506e0483816a9f7c6abc89084a3871d5eff3a20c5ec08c"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.92.202303281804-0",
-              "object": "rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202304131328-0",
+              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202303281804-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "c9dd32cc4173d9624e7cb802714b03f172a261f7357abad92a44b426ec86d7e7",
-                "uncompressed-sha256": "6e7f0bc909cf3011544f022f723583f4b22ad9c7616073aa1b781d995afebe71"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "4b3799f78eb57448eb165d805c0db3d02024c9d6c906020bdf447be1551f1dfa",
+                "uncompressed-sha256": "c55f416866db7484d211da6dfef026c272d4bd823babd0f3ac6a143e35ecbd56"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-metal4k.s390x.raw.gz",
-                "sha256": "09e2ec74b5399dec18e88b6e64f22f34ad4b85f4686a08aa45655a60f75e6425",
-                "uncompressed-sha256": "9396fd829707b3b23a4145b15788818dcd904a91c3b796adf89361194d86dfdc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-metal4k.s390x.raw.gz",
+                "sha256": "0cdb5172c8e719716869f88e4239e1dce0578d8b17ee977cd380d4ec8b0a055c",
+                "uncompressed-sha256": "baf53441c19672e67870a9addea9a76a499846eebf5af26b47c1d38e14bf3bcf"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-live.s390x.iso",
-                "sha256": "272438f8f36eb2d57712f9d68beeb0b81e055a1c01d4c67f6f234e5d046ea1fe"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live.s390x.iso",
+                "sha256": "52cf4c012c5f69b9575b66c6942a4ec3e1ab822dc7de4c33b158ee5c923079ee"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-live-kernel-s390x",
-                "sha256": "a5670c42ecbd84e30f0af7653ef0ed6f209d969151060177e526b672aabf2352"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-kernel-s390x",
+                "sha256": "b126f4a81df5d7be59a9a7a6249e0498611774c3458cc62f863b3b36a61bf1f8"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-live-initramfs.s390x.img",
-                "sha256": "ef11e7ac1b0e937f1cb63d026e59f4587254f8f6a968450cb0ade9adb51adf4b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-initramfs.s390x.img",
+                "sha256": "fc2702f42ed282874e61bb9f7893a1054b9566f3620a9137d122b939d4932e22"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-live-rootfs.s390x.img",
-                "sha256": "85791b5de327a86091aada175d3563274038a015d1bbf13877bae3f946f0c48c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-rootfs.s390x.img",
+                "sha256": "e3a81a19c02b36a5cfc8126a6bd216655138a7391e201a6f756e03e522e4c9d6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-metal.s390x.raw.gz",
-                "sha256": "5537559a745438e8daaed4bb8ae8ae190aaa40da3d12f680fa190e975ae97a13",
-                "uncompressed-sha256": "2cd691b3d9f448145f5a539345659196ab250fd63df3cc5de015b02fe02e1569"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-metal.s390x.raw.gz",
+                "sha256": "b14d3acceebb5e4e95073f6b71fcc23fcd4b43e161bbd13b110fc326f0589a45",
+                "uncompressed-sha256": "a58d5c8eee0e634711abc262c01a1ad046838e0d4693132cd3af5a05cd48c662"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-openstack.s390x.qcow2.gz",
-                "sha256": "82f2a492f2030cda9fa8695fb133a010dbdf99af3d31657c13ee0deece055046",
-                "uncompressed-sha256": "e0d43266ee1dbffafa89a6b212c5fbed6dafa0f7cadc0326d70a0f7649856e48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-openstack.s390x.qcow2.gz",
+                "sha256": "ac9ce852418217c1d9295d05197b6ded417e3bcaf97ecd2a91589e5b78d02ccb",
+                "uncompressed-sha256": "7fa844069039e96aa00001c1e3ae58bfb1d384e2616ddf6d7d307b75a1ef0ff0"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-qemu.s390x.qcow2.gz",
-                "sha256": "8fdf39fc516d57ae70c2e07e278be05223aab3f735403b0f84bc8f8d2ea6bcf9",
-                "uncompressed-sha256": "ca452e45c51c2e0dacf8c96a1d64a086837f9fa3393bd3f4cd5d02d8fe54e549"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-qemu.s390x.qcow2.gz",
+                "sha256": "8de5edf59adfa5306e1dc6a7b8062851228820456f6927a22bfe4af8a096ad23",
+                "uncompressed-sha256": "d101884e6cb0c0f4ee96a0ff3d9a4ee6d678c18c437354f473437b46eff816f8"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/s390x/rhcos-413.92.202303281804-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "5916fdd201833cf228ba42d1ff6df661992c0b6e48bb950a153c161c37da7496",
-                "uncompressed-sha256": "e604e7e37ac264a18d91e6924bf691fa1d63d98bcca20b497529dbf531245fa2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "f08d26bea3371d05fc1fd29603a08b66b78ac6f748825cba2c86572cbff27ad5",
+                "uncompressed-sha256": "b593e13cc3b8b7fa9ca15302feb77ad79de30f359b9a6980ee2df15f03fdc733"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "c27da0e5be08e2a8e6de8035f76a5c69020ae5c370edc4cebd4a6f22c349de0a",
-                "uncompressed-sha256": "6692bb4beda42cf301c965302b8e95edd9377f6051e194ca9835d5def077cca2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "2e0c7ea191e3bfd1388231b1bcf83fa03638a02a603d7eb84b7ddb83e7dbc448",
+                "uncompressed-sha256": "6416c1db3c3a90d50b63c40d267990903f685a3066468b705c25acb05f444999"
               }
             }
           }
         },
         "aws": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-aws.x86_64.vmdk.gz",
-                "sha256": "5b3810ad0490dddd016b5d0f699415fb28eb641d0bf17bf411cf0fb48c3f04c9",
-                "uncompressed-sha256": "15cbca3014a01210e6a6ae93d35712da5f632b271ccca2311feaccaaaa99e091"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-aws.x86_64.vmdk.gz",
+                "sha256": "92c96bc8f728e59ef0c4c41b9a141efb47b70c149a228d6402468ca44b9d4a26",
+                "uncompressed-sha256": "520473de28e2180c6eab4a48d028ece2a6079d6ae6dd6ac3db7efa96f008f1fd"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-azure.x86_64.vhd.gz",
-                "sha256": "691f5e2eda949e2d99c6e29bbe13818b6f6f8d735bf1393d61ccae605fe1055e",
-                "uncompressed-sha256": "6dab7b496471dc5d82a9b58e44c1fce155fd77e70bd63b56a9cc5b03cb923e35"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-azure.x86_64.vhd.gz",
+                "sha256": "b92ff80fb8ab81252f958992e0e68cbc6b78f1ca6d10ee52e6dea62f123ecbba",
+                "uncompressed-sha256": "f06e265dcdaaa030379540780fa5dc9ca6bcded6a84c0808916766ab426b628f"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-azurestack.x86_64.vhd.gz",
-                "sha256": "47dba7a59ed5538bfdf5da2dd404dcb49d13d6ad05f7083143103c7dd46408d6",
-                "uncompressed-sha256": "b11be7772d03237e81f7ac0b04f7c8bb0cd751376a35179458662aa84725509d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-azurestack.x86_64.vhd.gz",
+                "sha256": "4cbb522d68562bb931b9417b57b19fd848e6a6b04d42b80b70d8424c8a4279e2",
+                "uncompressed-sha256": "4660aacf740307c242f51e3ab27374c01470aeb2990ebb1356a04e472aaf4198"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-gcp.x86_64.tar.gz",
-                "sha256": "aca5c3445b8822c4ce1250ab625081b37f73506d8eececf1aea5c5c6feb2a6a8",
-                "uncompressed-sha256": "a65b8874fc16528031f70d26e06bbc5738497b6688ad32b697932f4d5397776f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-gcp.x86_64.tar.gz",
+                "sha256": "1968dcb443ee88594363043170460fd0871ba12e1fc3782a242bba27a3052a41",
+                "uncompressed-sha256": "a4a7a228fdf85321f02b2c4a4c6f76da38201c4f2c8491fe993ba8a8e46c801d"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "f9cbdb7df576e8181290b3bdfd1a35ce7beda16f36fd9e71d516483845dae5fc",
-                "uncompressed-sha256": "a5c40cd61caa51e58e3aaf4a95e3d0d68c3be729109fbf2daedad15e458be85a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "cc823bb7466a17a61b0a8aaecbeac091014bc8a5bddcfcef50b5107841360ff5",
+                "uncompressed-sha256": "ca3a5ed1bd147581a03652971d86f77eec03e374c20b2c8f71cb63461107d0f1"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-metal4k.x86_64.raw.gz",
-                "sha256": "8e1352b211c98067c90ba6e60cd48e599036b11d942c8cd3c320a202bba205a0",
-                "uncompressed-sha256": "2fd040594cbd0a25e9f9227290d5666160e487cd54c11efa414d980b500862be"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-metal4k.x86_64.raw.gz",
+                "sha256": "a3c2ab728d1b86982f4f844d1faade74b292f26a7fb9f5907e366d8b19d1bb5e",
+                "uncompressed-sha256": "cf6aff927138d881e6b43f648ca929e9d2cbe2bd6274e41524f8fcbcafde700f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-live.x86_64.iso",
-                "sha256": "da46769d567145f51f47e6e0254dd9860b75512eabaad9273b241ca431d47b69"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live.x86_64.iso",
+                "sha256": "c16edd4c7a43401a2203e2d19631795c0598160f9cdd884292e4c7eafd3fc1d5"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-live-kernel-x86_64",
-                "sha256": "e7003e4ae3e030a1d266fb50917a5a21984c3ea8bd1a89a884e09b81a64bc434"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-kernel-x86_64",
+                "sha256": "833e29fcfde19f8fff62ce3c07ef883042eb476c2468405599eb000da813629d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-live-initramfs.x86_64.img",
-                "sha256": "2ff09a519c00e438aaa338d0062269d9099a5fce62a559760f28fba419cb9277"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-initramfs.x86_64.img",
+                "sha256": "4dec2f088edd4e8e7fa637783cb8cacebdddd637699fdb0c05da56edfef71f4d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-live-rootfs.x86_64.img",
-                "sha256": "052c1575a54be5aabbfe9b26304ea9aadc4bd36115e048439f175a43c92d72ba"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-rootfs.x86_64.img",
+                "sha256": "e8d3b0dfda5cc73f88d7a33af8b1c1cfdf8770b782e5d78b3ae0e3a241329d76"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-metal.x86_64.raw.gz",
-                "sha256": "beb0923dd7c9e861d39263914956b584e9337cd66157c23f77934e080ae29915",
-                "uncompressed-sha256": "79c03be19dcee97ba18a214fc7679d7248ef45e652f7fbf0085755b93fdf2970"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-metal.x86_64.raw.gz",
+                "sha256": "a65a33d3601cad1a5dd7ef249e5f10e4dc0d77c79c1169567cb3e0e40d8b7117",
+                "uncompressed-sha256": "8a87af3edc9b0b3abf5bef3164585f394e64e1c9a18118075d0f26290e064a2c"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-nutanix.x86_64.qcow2",
-                "sha256": "9f1a758ebe975722a1f72b60326f3fdb5f51c5e8b70891b85db8e0a5304899c3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-nutanix.x86_64.qcow2",
+                "sha256": "ee827471b3f0f72c840fb05dc068f00b0fdbc042c4adb2ed19d5539ae7d660ef"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-openstack.x86_64.qcow2.gz",
-                "sha256": "524750e52761fe8e53a70ce151cbbd6ce701ef099d0581576529800e9ebc095b",
-                "uncompressed-sha256": "2a788a56a2ef0381c3d3f0dfce74aea9435901071503d6c4c243cf028e21afec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-openstack.x86_64.qcow2.gz",
+                "sha256": "18309a0bf2de258c89e76b82fbf7eafdf76b5ba568ecdea27cdf91da7ee368d3",
+                "uncompressed-sha256": "885e3973a03d60596a869949e9ee1fad4e5ace974508b5f6d76eb216d80c7e5b"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-qemu.x86_64.qcow2.gz",
-                "sha256": "2d947a4f12d8ce2853e6d273a2983825d215fb901f67ef6e42589cc5396f8e06",
-                "uncompressed-sha256": "7680e876bff3228751aa0868da15b472d6ba8e2a4da45beddc85f9af6a40dc29"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-qemu.x86_64.qcow2.gz",
+                "sha256": "f591e821bcc04552020a02c0131020db728570a91a4d10cab86ce7979900c04a",
+                "uncompressed-sha256": "de666ab498df922ba266a1ff230b520987875e4c546353a8cb08c165ccb71ec8"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303281804-0/x86_64/rhcos-413.92.202303281804-0-vmware.x86_64.ova",
-                "sha256": "90d36f48efc63e74337a6c7c120ceca6dc204233109b5a15b35a5f1253e4f6cb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-vmware.x86_64.ova",
+                "sha256": "c3e9e9e863309436855bd4553b1656ed02f14eba68df8d3cb76a05d6e86ff222"
               }
             }
           }
@@ -619,249 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-6we8yxj1wfc9u34tfc93"
+              "release": "413.92.202304131328-0",
+              "image": "m-6we6sft8lefh54fnr1jw"
             },
             "ap-northeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "m-mj71pkgowjqhhrx2lese"
+              "release": "413.92.202304131328-0",
+              "image": "m-mj775wbd0ntw4vfksrsz"
             },
             "ap-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-a2d7ldswsana3f0dey0z"
+              "release": "413.92.202304131328-0",
+              "image": "m-a2d4b7plxce7w0nsmnbk"
             },
             "ap-southeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-t4n5ydg0eiyx40cdvjyo"
+              "release": "413.92.202304131328-0",
+              "image": "m-t4n9zne6aawpiduagrs1"
             },
             "ap-southeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "m-p0w7g3qd0adqos388ta2"
+              "release": "413.92.202304131328-0",
+              "image": "m-p0wcmhrnz37gnbo1z55y"
             },
             "ap-southeast-3": {
-              "release": "413.92.202303281804-0",
-              "image": "m-8psi82se2beg5xvn5lnf"
+              "release": "413.92.202304131328-0",
+              "image": "m-8psi54o0farwi5qstbzk"
             },
             "ap-southeast-5": {
-              "release": "413.92.202303281804-0",
-              "image": "m-k1a2q4y8x9ytdoeliiwc"
+              "release": "413.92.202304131328-0",
+              "image": "m-k1aatqxnd848ziagdq1f"
             },
             "ap-southeast-6": {
-              "release": "413.92.202303281804-0",
-              "image": "m-5ts9p3uld0zde5f685ah"
+              "release": "413.92.202304131328-0",
+              "image": "m-5tsc0is76jl4awdweovm"
             },
             "ap-southeast-7": {
-              "release": "413.92.202303281804-0",
-              "image": "m-0joid3h9sewmfvu6ppsl"
+              "release": "413.92.202304131328-0",
+              "image": "m-0joebex44r15d6sc1vvd"
             },
             "cn-beijing": {
-              "release": "413.92.202303281804-0",
-              "image": "m-2zehrht81kb09venkhcw"
+              "release": "413.92.202304131328-0",
+              "image": "m-2zef091umjxs3nm25z3g"
             },
             "cn-chengdu": {
-              "release": "413.92.202303281804-0",
-              "image": "m-2vcizr6p5cxqhfsb26fs"
+              "release": "413.92.202304131328-0",
+              "image": "m-2vc5dgmgfcqyucz4zhm0"
             },
             "cn-fuzhou": {
-              "release": "413.92.202303281804-0",
-              "image": "m-gw0hb5yzgtvkc1sb8yvg"
+              "release": "413.92.202304131328-0",
+              "image": "m-gw0ivkvqw7u1nz8gdqpv"
             },
             "cn-guangzhou": {
-              "release": "413.92.202303281804-0",
-              "image": "m-7xv371zrkq3iyyfzkgia"
+              "release": "413.92.202304131328-0",
+              "image": "m-7xv3as0di5cerys82fa0"
             },
             "cn-hangzhou": {
-              "release": "413.92.202303281804-0",
-              "image": "m-bp136fjd5kkxc4ipbtc3"
+              "release": "413.92.202304131328-0",
+              "image": "m-bp14yq8pqzx5t73z1twt"
             },
             "cn-heyuan": {
-              "release": "413.92.202303281804-0",
-              "image": "m-f8zb8i2zinhp5do2pfss"
+              "release": "413.92.202304131328-0",
+              "image": "m-f8zce08slb14ct1sbvd2"
             },
             "cn-hongkong": {
-              "release": "413.92.202303281804-0",
-              "image": "m-j6cb2c92wq3uus40hl9c"
+              "release": "413.92.202304131328-0",
+              "image": "m-j6c4482d659aq3kf812x"
             },
             "cn-huhehaote": {
-              "release": "413.92.202303281804-0",
-              "image": "m-hp3fwnus2jb5pj0pagm2"
+              "release": "413.92.202304131328-0",
+              "image": "m-hp3jdu6sts43i0w0mdkd"
             },
             "cn-nanjing": {
-              "release": "413.92.202303281804-0",
-              "image": "m-gc7c0jzg3eiedmbg1kem"
+              "release": "413.92.202304131328-0",
+              "image": "m-gc7165thk05axefqlno3"
             },
             "cn-qingdao": {
-              "release": "413.92.202303281804-0",
-              "image": "m-m5e91sjyknpxrf76pvus"
+              "release": "413.92.202304131328-0",
+              "image": "m-m5eddrru28t2ab1m7rmg"
             },
             "cn-shanghai": {
-              "release": "413.92.202303281804-0",
-              "image": "m-uf63869ojufm2mu52qsq"
+              "release": "413.92.202304131328-0",
+              "image": "m-uf6crk739nql90ad2yw0"
             },
             "cn-shenzhen": {
-              "release": "413.92.202303281804-0",
-              "image": "m-wz90qnj7y10xajpa62ax"
+              "release": "413.92.202304131328-0",
+              "image": "m-wz925oz0glj75vlh4q35"
             },
             "cn-wulanchabu": {
-              "release": "413.92.202303281804-0",
-              "image": "m-0jlhcbu4ffvork3jg4o5"
+              "release": "413.92.202304131328-0",
+              "image": "m-0jlj1bbn1zk31w66t29m"
             },
             "cn-zhangjiakou": {
-              "release": "413.92.202303281804-0",
-              "image": "m-8vbg1ubn57q4hlgeo6t8"
+              "release": "413.92.202304131328-0",
+              "image": "m-8vb3d38l2pqmkapkkntw"
             },
             "eu-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-gw85cowv0kse3xzk54mt"
+              "release": "413.92.202304131328-0",
+              "image": "m-gw822ez51zqq7hizj5b3"
             },
             "eu-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-d7ofzdj8r10zq21w6min"
+              "release": "413.92.202304131328-0",
+              "image": "m-d7obpolokx813qvoxjmp"
             },
             "me-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-eb3it0ehuqv3p4hxspj3"
+              "release": "413.92.202304131328-0",
+              "image": "m-eb37o5ejhjzak25z2kmd"
             },
             "us-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-0xi9lpu1faf12nwbwrmo"
+              "release": "413.92.202304131328-0",
+              "image": "m-0xihajgqbixg5sagyxpr"
             },
             "us-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "m-rj9cgbbs68qubhbkhbyn"
+              "release": "413.92.202304131328-0",
+              "image": "m-rj990s7tn5umpkg102lk"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-02bdfe8b0dbdedea5"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0a27a19561c494289"
             },
             "ap-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0f2afea82d7d277d2"
+              "release": "413.92.202304131328-0",
+              "image": "ami-03039b6b4fd63f5e4"
             },
             "ap-northeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0acd2490bd648ecc8"
+              "release": "413.92.202304131328-0",
+              "image": "ami-08b05213421ac1a62"
             },
             "ap-northeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-01a31d4d82e842401"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0bc30b044ecf6ea73"
             },
             "ap-northeast-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0fb7c9f764fc8fdfc"
+              "release": "413.92.202304131328-0",
+              "image": "ami-06d6a7d0a15f4a889"
             },
             "ap-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0faaf04adf46980ed"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0d4f43f96250ddd54"
             },
             "ap-south-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0fa0125e20e0d636a"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0340cea17be8877d3"
             },
             "ap-southeast-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-01b0eb9472477d284"
+              "release": "413.92.202304131328-0",
+              "image": "ami-031ff0026f2f2c931"
             },
             "ap-southeast-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-00f976ad03443d8dc"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0cdc8fbb99f5c30bc"
             },
             "ap-southeast-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0cf9b71d3fea84018"
+              "release": "413.92.202304131328-0",
+              "image": "ami-07cba44f2cca22e6c"
             },
             "ap-southeast-4": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-01eec27b6a8c1e5b5"
+              "release": "413.92.202304131328-0",
+              "image": "ami-001ab4772243af582"
             },
             "ca-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-02ac6a9a7ceaf2d69"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0524c96b60b5765d6"
             },
             "eu-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-006876ea7aa69bff9"
+              "release": "413.92.202304131328-0",
+              "image": "ami-045ea69599b03cf00"
             },
             "eu-central-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-07b2242ea110b10d4"
+              "release": "413.92.202304131328-0",
+              "image": "ami-092330d200e659be2"
             },
             "eu-north-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-017f05ccbf4a01421"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0220cdf67c21e544b"
             },
             "eu-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-02bd802b27097b3b3"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0619eacd0693f738f"
             },
             "eu-south-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0edd853d147eed084"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0581ea608220a233c"
             },
             "eu-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0aba5331dc032f18f"
+              "release": "413.92.202304131328-0",
+              "image": "ami-03bac910dd6bef9d0"
             },
             "eu-west-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0dfb74215aa974130"
+              "release": "413.92.202304131328-0",
+              "image": "ami-02e0abc0367daa3bc"
             },
             "eu-west-3": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0e8d48abc160d7155"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0426f858e1b17f150"
             },
             "me-central-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0c8eca1d35bbcfc7d"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0bd95efcd6ea97dd6"
             },
             "me-south-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0b2e381be7bb4dc18"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0947f72bf80e4825f"
             },
             "sa-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0287494ebdb83ebf4"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0c87a19515f5c7ca2"
             },
             "us-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-04e87521e45f3f2ec"
+              "release": "413.92.202304131328-0",
+              "image": "ami-0d17184a4270b8a35"
             },
             "us-east-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-09b633f95a81eb8c0"
+              "release": "413.92.202304131328-0",
+              "image": "ami-047898836dfc05f97"
             },
             "us-gov-east-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0f266fadf7863dafb"
+              "release": "413.92.202304131328-0",
+              "image": "ami-009696dcd1c0f050a"
             },
             "us-gov-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-060a371f61051f6ec"
+              "release": "413.92.202304131328-0",
+              "image": "ami-09a1a9bc37fc8c0e8"
             },
             "us-west-1": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-0ff931d09ab1cdccd"
+              "release": "413.92.202304131328-0",
+              "image": "ami-02cd5e46fa8bdc4a7"
             },
             "us-west-2": {
-              "release": "413.92.202303281804-0",
-              "image": "ami-097b637f3b332a72a"
+              "release": "413.92.202304131328-0",
+              "image": "ami-021596e74e41d905a"
             }
           }
         },
         "gcp": {
-          "release": "413.92.202303281804-0",
+          "release": "413.92.202304131328-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-92-202303281804-0-gcp-x86-64"
+          "name": "rhcos-413-92-202304131328-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202303281804-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202303281804-0-azure.x86_64.vhd"
+          "release": "413.92.202304131328-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202304131328-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 bootimage metadata.

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --name 4.13-9.2 --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=413.92.202304131328-0 aarch64=413.92.202304131328-0 s390x=413.92.202304131328-0 ppc64le=413.92.202304131328-0
```