### PR TITLE
OCPBUGS-11796: azure: skip NSG creation when BYO vnet

### DIFF
--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -20,6 +20,7 @@ resource "azurerm_subnet_network_security_group_association" "worker" {
 }
 
 resource "azurerm_network_security_rule" "apiserver_in" {
+  count                       = var.azure_preexisting_network ? 0 : 1
   name                        = "apiserver_in"
   priority                    = 101
   direction                   = "Inbound"


### PR DESCRIPTION
In an install where users bring their networks they also bring their own NSGs. However, the installer still creates NSG. In Azure environments using the rule [1] below, users are prohibited from installing cluster, as the apiserver_in rule has the rule set as 0.0.0.0. Having a rule in place where the users could define this before install would allow them to set this connectivity without having the inbound access.

[1] - Rule: Network Security Groups shall not allow rule with 0.0.0.0/Any Source/Destination IP Addresses - Custom Deny