### PR TITLE
OCPBUGS-11801: Fix agent-tui libnmstate dependency name

### DIFF
--- a/cmd/openshift-install/agent_internal_integration_test.go
+++ b/cmd/openshift-install/agent_internal_integration_test.go
@@ -322,7 +322,11 @@ func checkFileFromInitrdImg(isoPath string, fileName string) error {
 
 			// check if the current cpio files match the required ones
 			for _, f := range files {
-				if f == fileName {
+				matched, err := filepath.Match(fileName, f)
+				if err != nil {
+					return err
+				}
+				if matched {
 					return nil
 				}
 			}

--- a/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
@@ -6,7 +6,7 @@ exists $WORK/agent.x86_64.iso
 
 ignitionImgContains agent.x86_64.iso config.ign
 initrdImgContains agent.x86_64.iso /agent-files/agent-tui
-initrdImgContains agent.x86_64.iso /agent-files/libnmstate.so.1.3.3
+initrdImgContains agent.x86_64.iso /agent-files/libnmstate.so.*
 initrdImgContains agent.x86_64.iso /usr/lib/dracut/hooks/pre-pivot/99-agent-copy-files.sh
 
 -- install-config.yaml --

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -78,16 +78,19 @@ func (a *AgentImage) fetchAgentTuiFiles(releaseImage string, pullSecret string, 
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {
-		f, err := release.ExtractFile("agent-installer-node-agent", srcFile)
+		extracted, err := release.ExtractFile("agent-installer-node-agent", srcFile)
 		if err != nil {
 			return nil, err
 		}
-		// Make sure it could be executed
-		err = os.Chmod(f, 0o555)
-		if err != nil {
-			return nil, err
+
+		for _, f := range extracted {
+			// Make sure it could be executed
+			err = os.Chmod(f, 0o555)
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, f)
 		}
-		files = append(files, f)
 	}
 
 	return files, nil


### PR DESCRIPTION
This patch fixes the https://issues.redhat.com/browse/OCPBUGS-11801 bug by:
* removing the hard-coded version when extracting libnmstate
*  copying also the symlinks in the agent cpio archive

Due a recent bump in the repos, the agent-tui (currently shipped in the `agent-installer-node-agent` image) is now comprised of the following files:
```
agent-tui
libnmstate.so.2 -> libnmstate.so.2.2.9 (symlink)
libnmstate.so.2.2.9
```
