### PR TITLE
OCPBUGS-9081: openstack: Bump Gophercloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,8 +41,8 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/gophercloud/gophercloud v1.1.1
-	github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca
+	github.com/gophercloud/gophercloud v1.3.0
+	github.com/gophercloud/utils v0.0.0-20230330070308-5bd5e1d608f8
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-exec v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -747,10 +747,10 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
-github.com/gophercloud/gophercloud v1.1.1 h1:MuGyqbSxiuVBqkPZ3+Nhbytk1xZxhmfCB2Rg1cJWFWM=
-github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
-github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca h1:HZWyhvVXgS2rx5StixMKhrTjpfUg5vLSNhF/xHkcRNg=
-github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
+github.com/gophercloud/gophercloud v1.3.0 h1:RUKyCMiZoQR3VlVR5E3K7PK1AC3/qppsWYo6dtBiqs8=
+github.com/gophercloud/gophercloud v1.3.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/gophercloud/utils v0.0.0-20230330070308-5bd5e1d608f8 h1:K9r5WEeAiaEgFZsuOP0OYjE4TtyFcCLG1nI08t9AP6A=
+github.com/gophercloud/utils v0.0.0-20230330070308-5bd5e1d608f8/go.mod h1:VSalo4adEk+3sNkmVJLnhHoOyOYYS8sTWLG4mv5BKto=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v0.0.0-20191024121256-f395758b854c/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,3 +1,45 @@
+## v1.3.0 (2023-03-28)
+
+* [GH-2464](https://github.com/gophercloud/gophercloud/pull/2464) keystone: add v3 limits create operation
+* [GH-2512](https://github.com/gophercloud/gophercloud/pull/2512) Manila: add List for share-access-rules API
+* [GH-2529](https://github.com/gophercloud/gophercloud/pull/2529) Added target state "rebuild" for Ironic nodes
+* [GH-2539](https://github.com/gophercloud/gophercloud/pull/2539) Add release instructions
+* [GH-2540](https://github.com/gophercloud/gophercloud/pull/2540) [all] IsEmpty to check for HTTP status 204
+* [GH-2543](https://github.com/gophercloud/gophercloud/pull/2543) keystone: add v3 OS-FEDERATION mappings get operation
+* [GH-2545](https://github.com/gophercloud/gophercloud/pull/2545) baremetal: add inspection_{started,finished}_at to Node
+* [GH-2546](https://github.com/gophercloud/gophercloud/pull/2546) Drop train job for baremetal
+* [GH-2549](https://github.com/gophercloud/gophercloud/pull/2549) objects: Clarify ExtractContent usage
+* [GH-2550](https://github.com/gophercloud/gophercloud/pull/2550) keystone: add v3 OS-FEDERATION mappings update operation
+* [GH-2552](https://github.com/gophercloud/gophercloud/pull/2552) objectstorage: Reject container names with a slash
+* [GH-2555](https://github.com/gophercloud/gophercloud/pull/2555) nova: introduce servers.ListSimple along with the more detailed servers.List
+* [GH-2558](https://github.com/gophercloud/gophercloud/pull/2558) Expand docs on 'clientconfig' usage
+* [GH-2563](https://github.com/gophercloud/gophercloud/pull/2563) Support propagate_uplink_status for Ports
+* [GH-2567](https://github.com/gophercloud/gophercloud/pull/2567) Fix invalid baremetal-introspection service type
+* [GH-2568](https://github.com/gophercloud/gophercloud/pull/2568) Prefer github mirrors over opendev repos
+* [GH-2571](https://github.com/gophercloud/gophercloud/pull/2571) Swift V1: support object versioning
+* [GH-2572](https://github.com/gophercloud/gophercloud/pull/2572) networking v2: add extraroutes Add and Remove methods
+* [GH-2573](https://github.com/gophercloud/gophercloud/pull/2573) Enable tests for object versioning
+* [GH-2576](https://github.com/gophercloud/gophercloud/pull/2576) keystone: add v3 OS-FEDERATION mappings delete operation
+* [GH-2578](https://github.com/gophercloud/gophercloud/pull/2578) Add periodic jobs for OpenStack zed release and reduce periodic jobs frequency
+* [GH-2580](https://github.com/gophercloud/gophercloud/pull/2580) [neutron v2]: Add support for network segments update
+* [GH-2583](https://github.com/gophercloud/gophercloud/pull/2583) Add missing rule protocol constants for IPIP
+* [GH-2584](https://github.com/gophercloud/gophercloud/pull/2584) CI: workaround mongodb dependency for messaging and clustering master jobs
+* [GH-2587](https://github.com/gophercloud/gophercloud/pull/2587) fix: Incorrect Documentation
+* [GH-2593](https://github.com/gophercloud/gophercloud/pull/2593) Make TestMTUNetworkCRUDL deterministic
+* [GH-2594](https://github.com/gophercloud/gophercloud/pull/2594) Bump actions/setup-go from 3 to 4
+
+
+## v1.2.0 (2023-01-27)
+
+Starting with this version, Gophercloud sends its actual version in the
+user-agent string in the format `gophercloud/v1.2.0`. It no longer sends the
+hardcoded string `gophercloud/2.0.0`.
+
+* [GH-2542](https://github.com/gophercloud/gophercloud/pull/2542) Add field hidden in containerinfra/v1/clustertemplates
+* [GH-2537](https://github.com/gophercloud/gophercloud/pull/2537) Support value_specs for Ports
+* [GH-2530](https://github.com/gophercloud/gophercloud/pull/2530) keystone: add v3 OS-FEDERATION mappings create operation
+* [GH-2519](https://github.com/gophercloud/gophercloud/pull/2519) Modify user-agent header to ensure current gophercloud version is provided
+
 ## v1.1.1 (2022-12-07)
 
 The GOPROXY cache for v1.1.0 was corrupted with a tag pointing to the wrong commit. This release fixes the problem by exposing a new release with the same content.
@@ -174,7 +216,7 @@ IMPROVEMENTS
 NOTES / BREAKING CHANGES
 
 * `compute/v2/extensions/keypairs.List` now takes a `ListOptsBuilder` argument [GH-2186](https://github.com/gophercloud/gophercloud/pull/2186)
-* `compute/v2/extensions/keypairs.Get` now takes a `GetOptsBuilder` argument [GH-2186](https://github.com/gophercloud/gophercloud/pull/2186) 
+* `compute/v2/extensions/keypairs.Get` now takes a `GetOptsBuilder` argument [GH-2186](https://github.com/gophercloud/gophercloud/pull/2186)
 * `compute/v2/extensions/keypairs.Delete` now takes a `DeleteOptsBuilder` argument [GH-2186](https://github.com/gophercloud/gophercloud/pull/2186)
 * `compute/v2/extensions/hypervisors.List` now takes a `ListOptsBuilder` argument [GH-2187](https://github.com/gophercloud/gophercloud/pull/2187)
 
@@ -469,7 +511,7 @@ UPGRADE NOTES
 * The various `IDFromName` convenience functions have been moved to https://github.com/gophercloud/utils [GH-1897](https://github.com/gophercloud/gophercloud/pull/1897)
 * `sharedfilesystems/v2/shares.GetExportLocations` was renamed to `sharedfilesystems/v2/shares.ListExportLocations` [GH-1932](https://github.com/gophercloud/gophercloud/pull/1932)
 
-IMPROVEMENTS 
+IMPROVEMENTS
 
 * Added `blockstorage/extensions/volumeactions.SetBootable` [GH-1891](https://github.com/gophercloud/gophercloud/pull/1891)
 * Added `blockstorage/extensions/backups.Export` [GH-1894](https://github.com/gophercloud/gophercloud/pull/1894)
@@ -765,4 +807,4 @@ BUG FIXES
 
 ## 0.1.0 (May 27, 2019)
 
-Initial tagged release. 
+Initial tagged release.

--- a/vendor/github.com/gophercloud/gophercloud/README.md
+++ b/vendor/github.com/gophercloud/gophercloud/README.md
@@ -13,7 +13,7 @@ Gophercloud is an OpenStack Go SDK.
 
 Reference a Gophercloud package in your code:
 
-```Go
+```go
 import "github.com/gophercloud/gophercloud"
 ```
 
@@ -28,43 +28,79 @@ go mod tidy
 ### Credentials
 
 Because you'll be hitting an API, you will need to retrieve your OpenStack
-credentials and either store them as environment variables or in your local Go
-files. The first method is recommended because it decouples credential
-information from source code, allowing you to push the latter to your version
-control system without any security risk.
+credentials and either store them in a `clouds.yaml` file, as environment
+variables, or in your local Go files. The first method is recommended because
+it decouples credential information from source code, allowing you to push the
+latter to your version control system without any security risk.
 
 You will need to retrieve the following:
 
-* username
-* password
-* a valid Keystone identity URL
+* A valid Keystone identity URL
+* Credentials. These can be a username/password combo, a set of Application
+  Credentials, a pre-generated token, or any other supported authentication
+  mechanism.
 
 For users that have the OpenStack dashboard installed, there's a shortcut. If
-you visit the `project/access_and_security` path in Horizon and click on the
-"Download OpenStack RC File" button at the top right hand corner, you will
-download a bash file that exports all of your access details to environment
-variables. To execute the file, run `source admin-openrc.sh` and you will be
-prompted for your password.
+you visit the `project/api_access` path in Horizon and click on the
+"Download OpenStack RC File" button at the top right hand corner, you can
+download either a `clouds.yaml` file or an `openrc` bash file that exports all
+of your access details to environment variables. To use the `clouds.yaml` file,
+place it at `~/.config/openstack/clouds.yaml`. To use the `openrc` file, run
+`source openrc` and you will be prompted for your password.
 
 ### Authentication
 
-> NOTE: It is now recommended to use the `clientconfig` package found at
-> https://github.com/gophercloud/utils/tree/master/openstack/clientconfig
-> for all authentication purposes.
->
-> The below documentation is still relevant. clientconfig simply implements
-> the below and presents it in an easier and more flexible way.
-
 Once you have access to your credentials, you can begin plugging them into
-Gophercloud. The next step is authentication, and this is handled by a base
-"Provider" struct. To get one, you can either pass in your credentials
-explicitly, or tell Gophercloud to use environment variables:
+Gophercloud. The next step is authentication, which is handled by a base
+"Provider" struct. There are number of ways to construct such a struct.
+
+**With `gophercloud/utils`**
+
+The [github.com/gophercloud/utils](https://github.com/gophercloud/utils)
+library provides the `clientconfig` package to simplify authentication. It
+provides additional functionality, such as the ability to read `clouds.yaml`
+files. To generate a "Provider" struct using the `clientconfig` package:
 
 ```go
 import (
-  "github.com/gophercloud/gophercloud"
-  "github.com/gophercloud/gophercloud/openstack"
-  "github.com/gophercloud/gophercloud/openstack/utils"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+)
+
+// You can also skip configuring this and instead set 'OS_CLOUD' in your
+// environment
+opts := new(clientconfig.ClientOpts)
+opts.Cloud = "devstack-admin"
+
+provider, err := clientconfig.AuthenticatedClient(opts)
+```
+
+A provider client is a top-level client that all of your OpenStack service
+clients derive from. The provider contains all of the authentication details
+that allow your Go code to access the API - such as the base URL and token ID.
+
+Once we have a base Provider, we inject it as a dependency into each OpenStack
+service. For example, in order to work with the Compute API, we need a Compute
+service client. This can be created like so:
+
+```go
+client, err := clientconfig.NewServiceClient("compute", opts)
+```
+
+**Without `gophercloud/utils`**
+
+> *Note*
+> gophercloud doesn't provide support for `clouds.yaml` file so you need to
+> implement this functionality yourself if you don't wish to use
+> `gophercloud/utils`.
+
+You can also generate a "Provider" struct without using the `clientconfig`
+package from `gophercloud/utils`. To do this, you can either pass in your
+credentials explicitly or tell Gophercloud to use environment variables:
+
+```go
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 )
 
 // Option 1: Pass in the values yourself
@@ -85,34 +121,29 @@ Once you have the `opts` variable, you can pass it in and get back a
 provider, err := openstack.AuthenticatedClient(opts)
 ```
 
-The `ProviderClient` is the top-level client that all of your OpenStack services
-derive from. The provider contains all of the authentication details that allow
-your Go code to access the API - such as the base URL and token ID.
-
-### Provision a server
-
-Once we have a base Provider, we inject it as a dependency into each OpenStack
-service. In order to work with the Compute API, we need a Compute service
-client; which can be created like so:
+As above, you can then use this provider client to generate a service client
+for a particular OpenStack service:
 
 ```go
 client, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
-  Region: os.Getenv("OS_REGION_NAME"),
+	Region: os.Getenv("OS_REGION_NAME"),
 })
 ```
 
-We then use this `client` for any Compute API operation we want. In our case,
-we want to provision a new server - so we invoke the `Create` method and pass
-in the flavor ID (hardware specification) and image ID (operating system) we're
-interested in:
+### Provision a server
+
+We can use the Compute service client generated above for any Compute API
+operation we want. In our case, we want to provision a new server. To do this,
+we invoke the `Create` method and pass in the flavor ID (hardware
+specification) and image ID (operating system) we're interested in:
 
 ```go
 import "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 
 server, err := servers.Create(client, servers.CreateOpts{
-  Name:      "My new server!",
-  FlavorRef: "flavor_id",
-  ImageRef:  "image_id",
+	Name:      "My new server!",
+	FlavorRef: "flavor_id",
+	ImageRef:  "image_id",
 }).Extract()
 ```
 
@@ -130,6 +161,8 @@ Gophercloud versioning follows [semver](https://semver.org/spec/v2.0.0.html).
 
 Before `v1.0.0`, there were no guarantees. Starting with v1, there will be no breaking changes within a major release.
 
+See the [Release instructions](./RELEASE.md).
+
 ## Contributing
 
 See the [contributing guide](./.github/CONTRIBUTING.md).
@@ -138,19 +171,3 @@ See the [contributing guide](./.github/CONTRIBUTING.md).
 
 If you're struggling with something or have spotted a potential bug, feel free
 to submit an issue to our [bug tracker](https://github.com/gophercloud/gophercloud/issues).
-
-## Thank You
-
-We'd like to extend special thanks and appreciation to the following:
-
-### OpenLab
-
-<a href="http://openlabtesting.org/"><img src="./docs/assets/openlab.png" width="600px"></a>
-
-OpenLab is providing a full CI environment to test each PR and merge for a variety of OpenStack releases.
-
-### VEXXHOST
-
-<a href="https://vexxhost.com/"><img src="./docs/assets/vexxhost.png" width="600px"></a>
-
-VEXXHOST is providing their services to assist with the development and testing of Gophercloud.

--- a/vendor/github.com/gophercloud/gophercloud/RELEASE.md
+++ b/vendor/github.com/gophercloud/gophercloud/RELEASE.md
@@ -1,0 +1,79 @@
+# Gophercloud release
+
+## Contributions
+
+### The semver label
+
+Gophercloud follows [semver](https://semver.org/).
+
+Each Pull request must have a label indicating its impact on the API:
+* `semver:patch` for changes that don't impact the API
+* `semver:minor` for changes that impact the API in a backwards-compatible fashion
+* `semver:major` for changes that introduce a breaking change in the API
+
+Automation prevents merges if the label is not present.
+
+### Metadata
+
+The release notes for a given release are generated based on the PR title: make
+sure that the PR title is descriptive.
+
+## Release of a new version
+
+Requirements:
+* [`gh`](https://github.com/cli/cli)
+* [`jq`](https://stedolan.github.io/jq/)
+
+### Step 1: Collect all PRs since the last release
+
+Supposing that the base release is `v1.2.0`:
+
+```
+for commit_sha in $(git log --pretty=format:"%h" v1.2.0..HEAD); do
+        gh pr list --search "$commit_sha" --state merged --json number,title,labels,url
+done | jq '.[]' | jq --slurp 'unique_by(.number)' > prs.json
+```
+
+This JSON file will be useful later.
+
+### Step 2: Determine the version
+
+In order to determine the version of the next release, we first check that no incompatible change is detected in the code that has been merged since the last release. This step can be automated with the `gorelease` tool:
+
+```shell
+gorelease | grep -B2 -A0 '^## incompatible changes'
+```
+
+If the tool detects incompatible changes outside a `testing` package, then the bump is major.
+
+Next, we check all PRs merged since the last release using the file `prs.json` that we generated above.
+
+* Find PRs labeled with `semver:major`: `jq 'map(select(contains({labels: [{name: "semver:major"}]}) ))' prs.json`
+* Find PRs labeled with `semver:minor`: `jq 'map(select(contains({labels: [{name: "semver:minor"}]}) ))' prs.json`
+
+The highest semver descriptor determines the release bump.
+
+### Step 3: Release notes and version string
+
+Once all PRs have a sensible title, generate the release notes:
+
+```shell
+jq -r '.[] | "* [GH-\(.number)](\(.url)) \(.title)"' prs.json
+```
+
+Add that to the top of `CHANGELOG.md`. Also add any information that could be useful to consumers willing to upgrade.
+
+**Set the new version string in the `DefaultUserAgent` constant in `provider_client.go`.**
+
+Create a PR with these two changes. The new PR should be labeled with the semver label corresponding to the type of bump.
+
+### Step 3: Git tag and Github release
+
+The Go mod system relies on Git tags. In order to simulate a review mechanism, we rely on Github to create the tag through the Release mechanism.
+
+* [Prepare a new release](https://github.com/gophercloud/gophercloud/releases/new)
+* Let Github generate the  release notes by clicking on Generate release notes
+* Click on **Save draft**
+* Ask another Gophercloud maintainer to review and publish the release
+
+_Note: never change a release or force-push a tag. Tags are almost immediately picked up by the Go proxy and changing the commit it points to will be detected as tampering._

--- a/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
@@ -46,6 +46,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	applicationCredentialID := os.Getenv("OS_APPLICATION_CREDENTIAL_ID")
 	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
 	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
+	systemScope := os.Getenv("OS_SYSTEM_SCOPE")
 
 	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
 	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
@@ -109,6 +110,13 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		}
 	}
 
+	var scope *gophercloud.AuthScope
+	if systemScope == "all" {
+		scope = &gophercloud.AuthScope{
+			System: true,
+		}
+	}
+
 	ao := gophercloud.AuthOptions{
 		IdentityEndpoint:            authURL,
 		UserID:                      userID,
@@ -122,6 +130,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		ApplicationCredentialID:     applicationCredentialID,
 		ApplicationCredentialName:   applicationCredentialName,
 		ApplicationCredentialSecret: applicationCredentialSecret,
+		Scope:                       scope,
 	}
 
 	return ao, nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots/results.go
@@ -85,6 +85,10 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 
 // IsEmpty returns true if a SnapshotPage contains no Snapshots.
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractSnapshots(r)
 	return len(volumes) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/results.go
@@ -111,6 +111,10 @@ type VolumePage struct {
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/results.go
@@ -30,6 +30,10 @@ type VolumeTypePage struct {
 
 // IsEmpty returns true if a ListResult contains no Volume Types.
 func (r VolumeTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumetypes, err := ExtractVolumeTypes(r)
 	return len(volumetypes) == 0, err
 }
@@ -168,6 +172,10 @@ type AccessPage struct {
 
 // IsEmpty indicates whether an AccessPage is empty.
 func (page AccessPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractAccesses(page)
 	return len(v) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -369,7 +369,7 @@ func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 // NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
 // bare metal introspection package.
 func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "baremetal-inspector")
+	return initClientOpts(client, eo, "baremetal-introspection")
 }
 
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1

--- a/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/results.go
@@ -37,6 +37,10 @@ type ExtensionPage struct {
 
 // IsEmpty checks whether an ExtensionPage struct is empty.
 func (r ExtensionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractExtensions(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets/results.go
@@ -128,6 +128,10 @@ type QuotaSetPage struct {
 
 // IsEmpty determines whether or not a QuotaSetsetPage is empty.
 func (page QuotaSetPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	ks, err := ExtractQuotaSets(page)
 	return len(ks) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
@@ -64,6 +64,10 @@ type ServerGroupPage struct {
 
 // IsEmpty determines whether or not a ServerGroupsPage is empty.
 func (page ServerGroupPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractServerGroups(page)
 	return len(va) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
@@ -121,6 +121,10 @@ type FlavorPage struct {
 
 // IsEmpty determines if a FlavorPage contains any results.
 func (page FlavorPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	flavors, err := ExtractFlavors(page)
 	return len(flavors) == 0, err
 }
@@ -155,6 +159,10 @@ type AccessPage struct {
 
 // IsEmpty indicates whether an AccessPage is empty.
 func (page AccessPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractAccesses(page)
 	return len(v) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/doc.go
@@ -11,6 +11,26 @@ Example to List Servers
 		AllTenants: true,
 	}
 
+	allPages, err := servers.ListSimple(computeClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServers, err := servers.ExtractServers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, server := range allServers {
+		fmt.Printf("%+v\n", server)
+	}
+
+Example to List Detail Servers
+
+	listOpts := servers.ListOpts{
+		AllTenants: true,
+	}
+
 	allPages, err := servers.List(computeClient, listOpts).AllPages()
 	if err != nil {
 		panic(err)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -94,7 +94,22 @@ func (opts ListOpts) ToServerListQuery() (string, error) {
 	return q.String(), err
 }
 
-// List makes a request against the API to list servers accessible to you.
+// ListSimple makes a request against the API to list servers accessible to you.
+func ListSimple(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToServerListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// List makes a request against the API to list servers details accessible to you.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
@@ -277,6 +277,10 @@ type ServerPage struct {
 
 // IsEmpty returns true if a page contains no Server results.
 func (r ServerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractServers(r)
 	return len(s) == 0, err
 }
@@ -385,6 +389,10 @@ type AddressPage struct {
 
 // IsEmpty returns true if an AddressPage contains no networks.
 func (r AddressPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	addresses, err := ExtractAddresses(r)
 	return len(addresses) == 0, err
 }
@@ -410,6 +418,10 @@ type NetworkAddressPage struct {
 
 // IsEmpty returns true if a NetworkAddressPage contains no addresses.
 func (r NetworkAddressPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	addresses, err := ExtractNetworkAddresses(r)
 	return len(addresses) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/results.go
@@ -27,6 +27,10 @@ type TenantPage struct {
 
 // IsEmpty determines whether or not a page of Tenants contains any results.
 func (r TenantPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	tenants, err := ExtractTenants(r)
 	return len(tenants) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/oauth1/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/oauth1/results.go
@@ -52,6 +52,10 @@ type GetConsumerResult struct {
 
 // IsEmpty determines whether or not a page of Consumers contains any results.
 func (c ConsumersPage) IsEmpty() (bool, error) {
+	if c.StatusCode == 204 {
+		return true, nil
+	}
+
 	consumers, err := ExtractConsumers(c)
 	return len(consumers) == 0, err
 }
@@ -208,6 +212,10 @@ type AccessTokensPage struct {
 
 // IsEmpty determines whether or not a an AccessTokensPage contains any results.
 func (r AccessTokensPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessTokens, err := ExtractAccessTokens(r)
 	return len(accessTokens) == 0, err
 }
@@ -251,6 +259,10 @@ type AccessTokenRolesPage struct {
 
 // IsEmpty determines whether or not a an AccessTokensPage contains any results.
 func (r AccessTokenRolesPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessTokenRoles, err := ExtractAccessTokenRoles(r)
 	return len(accessTokenRoles) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
@@ -204,6 +204,10 @@ type ImagePage struct {
 
 // IsEmpty returns true if an ImagePage contains no Images results.
 func (r ImagePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	images, err := ExtractImages(r)
 	return len(images) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions/results.go
@@ -17,6 +17,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies/results.go
@@ -137,6 +137,10 @@ func (r L7PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a L7PolicyPage struct is empty.
 func (r L7PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractL7Policies(r)
 	return len(is) == 0, err
 }
@@ -211,6 +215,10 @@ func (r RulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RulePage struct is empty.
 func (r RulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
@@ -157,6 +157,10 @@ func (r ListenerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ListenerPage struct is empty.
 func (r ListenerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractListeners(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -161,6 +161,10 @@ func (r LoadBalancerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a LoadBalancerPage struct is empty.
 func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractLoadBalancers(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
@@ -110,6 +110,10 @@ func (r MonitorPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MonitorPage struct is empty.
 func (r MonitorPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMonitors(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/results.go
@@ -135,6 +135,10 @@ func (r PoolPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PoolPage struct is empty.
 func (r PoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPools(r)
 	return len(is) == 0, err
 }
@@ -265,6 +269,10 @@ func (r MemberPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MemberPage struct is empty.
 func (r MemberPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMembers(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -157,6 +157,10 @@ func (r FloatingIPPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a FloatingIPPage struct is empty.
 func (r FloatingIPPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractFloatingIPs(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -100,6 +100,10 @@ func (r RouterPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RouterPage struct is empty.
 func (r RouterPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRouters(r)
 	return len(is) == 0, err
 }
@@ -263,6 +267,10 @@ type ListL3AgentsPage struct {
 }
 
 func (r ListL3AgentsPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractL3Agents(r)
 	return len(v) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -101,6 +101,10 @@ func (r SecGroupPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SecGroupPage struct is empty.
 func (r SecGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractGroups(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -60,6 +60,7 @@ const (
 	ProtocolGRE       RuleProtocol  = "gre"
 	ProtocolICMP      RuleProtocol  = "icmp"
 	ProtocolIGMP      RuleProtocol  = "igmp"
+	ProtocolIPIP      RuleProtocol  = "ipip"
 	ProtocolIPv6Encap RuleProtocol  = "ipv6-encap"
 	ProtocolIPv6Frag  RuleProtocol  = "ipv6-frag"
 	ProtocolIPv6ICMP  RuleProtocol  = "ipv6-icmp"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -80,6 +80,10 @@ func (r SecGroupRulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SecGroupRulePage struct is empty.
 func (r SecGroupRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/results.go
@@ -251,6 +251,10 @@ func (r SubnetPoolPage) NextPageURL() (string, error) {
 
 // IsEmpty determines whether or not a SubnetPoolPage is empty.
 func (r SubnetPoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	subnetpools, err := ExtractSubnetPools(r)
 	return len(subnetpools) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks/results.go
@@ -111,6 +111,10 @@ type TrunkPage struct {
 }
 
 func (page TrunkPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	trunks, err := ExtractTrunks(page)
 	return len(trunks) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -155,6 +155,10 @@ func (r NetworkPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a NetworkPage struct is empty.
 func (r NetworkPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractNetworks(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -110,18 +110,20 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents the attributes used when creating a new port.
 type CreateOpts struct {
-	NetworkID           string        `json:"network_id" required:"true"`
-	Name                string        `json:"name,omitempty"`
-	Description         string        `json:"description,omitempty"`
-	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
-	MACAddress          string        `json:"mac_address,omitempty"`
-	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
-	DeviceID            string        `json:"device_id,omitempty"`
-	DeviceOwner         string        `json:"device_owner,omitempty"`
-	TenantID            string        `json:"tenant_id,omitempty"`
-	ProjectID           string        `json:"project_id,omitempty"`
-	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	NetworkID             string             `json:"network_id" required:"true"`
+	Name                  string             `json:"name,omitempty"`
+	Description           string             `json:"description,omitempty"`
+	AdminStateUp          *bool              `json:"admin_state_up,omitempty"`
+	MACAddress            string             `json:"mac_address,omitempty"`
+	FixedIPs              interface{}        `json:"fixed_ips,omitempty"`
+	DeviceID              string             `json:"device_id,omitempty"`
+	DeviceOwner           string             `json:"device_owner,omitempty"`
+	TenantID              string             `json:"tenant_id,omitempty"`
+	ProjectID             string             `json:"project_id,omitempty"`
+	SecurityGroups        *[]string          `json:"security_groups,omitempty"`
+	AllowedAddressPairs   []AddressPair      `json:"allowed_address_pairs,omitempty"`
+	PropagateUplinkStatus *bool              `json:"propagate_uplink_status,omitempty"`
+	ValueSpecs            *map[string]string `json:"value_specs,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -150,14 +152,16 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                *string        `json:"name,omitempty"`
-	Description         *string        `json:"description,omitempty"`
-	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
-	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
-	DeviceID            *string        `json:"device_id,omitempty"`
-	DeviceOwner         *string        `json:"device_owner,omitempty"`
-	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
-	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	Name                  *string            `json:"name,omitempty"`
+	Description           *string            `json:"description,omitempty"`
+	AdminStateUp          *bool              `json:"admin_state_up,omitempty"`
+	FixedIPs              interface{}        `json:"fixed_ips,omitempty"`
+	DeviceID              *string            `json:"device_id,omitempty"`
+	DeviceOwner           *string            `json:"device_owner,omitempty"`
+	SecurityGroups        *[]string          `json:"security_groups,omitempty"`
+	AllowedAddressPairs   *[]AddressPair     `json:"allowed_address_pairs,omitempty"`
+	PropagateUplinkStatus *bool              `json:"propagate_uplink_status,omitempty"`
+	ValueSpecs            *map[string]string `json:"value_specs,omitempty"`
 
 	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
 	// will set revision_number=%s. If the revision number does not match, the

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -111,6 +111,12 @@ type Port struct {
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
 
+	// PropagateUplinkStatus enables/disables propagate uplink status on the port.
+	PropagateUplinkStatus bool `json:"propagate_uplink_status"`
+
+	// Extra parameters to include in the request.
+	ValueSpecs map[string]string `json:"value_specs"`
+
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
 
@@ -181,6 +187,10 @@ func (r PortPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PortPage struct is empty.
 func (r PortPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPorts(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
@@ -142,6 +142,10 @@ func (r SubnetPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SubnetPage struct is empty.
 func (r SubnetPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractSubnets(r)
 	return len(is) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/errors.go
@@ -1,0 +1,13 @@
+package containers
+
+import "github.com/gophercloud/gophercloud"
+
+// ErrInvalidContainerName signals a container name containing an illegal
+// character.
+type ErrInvalidContainerName struct {
+	gophercloud.BaseError
+}
+
+func (e ErrInvalidContainerName) Error() string {
+	return "A container name must not contain: " + forbiddenContainerRunes
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
@@ -80,6 +80,7 @@ type CreateOpts struct {
 	TempURLKey        string `h:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2       string `h:"X-Container-Meta-Temp-URL-Key-2"`
 	StoragePolicy     string `h:"X-Storage-Policy"`
+	VersionsEnabled   bool   `h:"X-Versions-Enabled"`
 }
 
 // ToContainerCreateMap formats a CreateOpts into a map of headers.
@@ -96,6 +97,11 @@ func (opts CreateOpts) ToContainerCreateMap() (map[string]string, error) {
 
 // Create is a function that creates a new container.
 func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsBuilder) (r CreateResult) {
+	url, err := createURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerCreateMap()
@@ -107,7 +113,7 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("PUT", createURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Request("PUT", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -138,7 +144,12 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 
 // Delete is a function that deletes a container.
 func Delete(c *gophercloud.ServiceClient, containerName string) (r DeleteResult) {
-	resp, err := c.Delete(deleteURL(c, containerName), nil)
+	url, err := deleteURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Delete(url, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -166,6 +177,7 @@ type UpdateOpts struct {
 	HistoryLocation        string  `h:"X-History-Location"`
 	TempURLKey             string  `h:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2            string  `h:"X-Container-Meta-Temp-URL-Key-2"`
+	VersionsEnabled        *bool   `h:"X-Versions-Enabled"`
 }
 
 // ToContainerUpdateMap formats a UpdateOpts into a map of headers.
@@ -189,6 +201,11 @@ func (opts UpdateOpts) ToContainerUpdateMap() (map[string]string, error) {
 // Update is a function that creates, updates, or deletes a container's
 // metadata.
 func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	url, err := updateURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerUpdateMap()
@@ -201,7 +218,7 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("POST", updateURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Request("POST", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -229,6 +246,11 @@ func (opts GetOpts) ToContainerGetMap() (map[string]string, error) {
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
 func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder) (r GetResult) {
+	url, err := getURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerGetMap()
@@ -241,7 +263,7 @@ func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder
 			h[k] = v
 		}
 	}
-	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Head(url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200, 204},
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,15 +110,17 @@ type GetHeader struct {
 	TempURLKey       string    `json:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2      string    `json:"X-Container-Meta-Temp-URL-Key-2"`
 	Timestamp        float64   `json:"X-Timestamp,string"`
+	VersionsEnabled  bool      `json:"-"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	type tmp GetHeader
 	var s struct {
 		tmp
-		Write string                  `json:"X-Container-Write"`
-		Read  string                  `json:"X-Container-Read"`
-		Date  gophercloud.JSONRFC1123 `json:"Date"`
+		Write           string                  `json:"X-Container-Write"`
+		Read            string                  `json:"X-Container-Read"`
+		Date            gophercloud.JSONRFC1123 `json:"Date"`
+		VersionsEnabled string                  `json:"X-Versions-Enabled"`
 	}
 
 	err := json.Unmarshal(b, &s)
@@ -131,6 +134,12 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	r.Write = strings.Split(s.Write, ",")
 
 	r.Date = time.Time(s.Date)
+
+	if s.VersionsEnabled != "" {
+		// custom unmarshaller here is required to handle boolean value
+		// that starts with a capital letter
+		r.VersionsEnabled, err = strconv.ParseBool(s.VersionsEnabled)
+	}
 
 	return err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/urls.go
@@ -1,24 +1,51 @@
 package containers
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+const forbiddenContainerRunes = "/"
+
+func CheckContainerName(s string) error {
+	if strings.ContainsAny(s, forbiddenContainerRunes) {
+		return ErrInvalidContainerName{}
+	}
+
+	// The input could (and should) already have been escaped. This cycle
+	// checks for the escaped versions of the forbidden characters. Note
+	// that a simple "contains" is sufficient, because Go's http library
+	// won't accept invalid escape sequences (e.g. "%%2F").
+	for _, r := range forbiddenContainerRunes {
+		if strings.Contains(strings.ToLower(s), fmt.Sprintf("%%%x", r)) {
+			return ErrInvalidContainerName{}
+		}
+	}
+	return nil
+}
 
 func listURL(c *gophercloud.ServiceClient) string {
 	return c.Endpoint
 }
 
-func createURL(c *gophercloud.ServiceClient, container string) string {
-	return c.ServiceURL(container)
+func createURL(c *gophercloud.ServiceClient, container string) (string, error) {
+	if err := CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container), nil
 }
 
-func getURL(c *gophercloud.ServiceClient, container string) string {
+func getURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container string) string {
+func deleteURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container string) string {
+func updateURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
@@ -32,6 +32,13 @@ type Object struct {
 
 	// Subdir denotes if the result contains a subdir.
 	Subdir string `json:"subdir"`
+
+	// IsLatest indicates whether the object version is the latest one.
+	IsLatest bool `json:"is_latest"`
+
+	// VersionID contains a version ID of the object, when container
+	// versioning is enabled.
+	VersionID string `json:"version_id"`
 }
 
 func (r *Object) UnmarshalJSON(b []byte) error {
@@ -146,6 +153,7 @@ type DownloadHeader struct {
 	ObjectManifest     string    `json:"X-Object-Manifest"`
 	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
 }
 
 func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
@@ -224,6 +232,7 @@ type GetHeader struct {
 	ObjectManifest     string    `json:"X-Object-Manifest"`
 	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {
@@ -290,12 +299,13 @@ func (r GetResult) ExtractMetadata() (map[string]string, error) {
 // CreateHeader represents the headers returned in the response from a
 // Create request.
 type CreateHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	ETag          string    `json:"Etag"`
-	LastModified  time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	ETag            string    `json:"Etag"`
+	LastModified    time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
 }
 
 func (r *CreateHeader) UnmarshalJSON(b []byte) error {
@@ -337,10 +347,11 @@ func (r CreateResult) Extract() (*CreateHeader, error) {
 // UpdateHeader represents the headers returned in the response from a
 // Update request.
 type UpdateHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
 }
 
 func (r *UpdateHeader) UnmarshalJSON(b []byte) error {
@@ -376,10 +387,12 @@ func (r UpdateResult) Extract() (*UpdateHeader, error) {
 // DeleteHeader represents the headers returned in the response from a
 // Delete request.
 type DeleteHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength          int64     `json:"Content-Length,string"`
+	ContentType            string    `json:"Content-Type"`
+	Date                   time.Time `json:"-"`
+	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
+	ObjectCurrentVersionID string    `json:"X-Object-Current-Version-Id"`
 }
 
 func (r *DeleteHeader) UnmarshalJSON(b []byte) error {
@@ -423,6 +436,7 @@ type CopyHeader struct {
 	ETag                   string    `json:"Etag"`
 	LastModified           time.Time `json:"-"`
 	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
 }
 
 func (r *CopyHeader) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/urls.go
@@ -2,33 +2,40 @@ package objects
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
 )
 
-func listURL(c *gophercloud.ServiceClient, container string) string {
-	return c.ServiceURL(container)
+func listURL(c *gophercloud.ServiceClient, container string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container), nil
 }
 
-func copyURL(c *gophercloud.ServiceClient, container, object string) string {
-	return c.ServiceURL(container, object)
+func copyURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container, object), nil
 }
 
-func createURL(c *gophercloud.ServiceClient, container, object string) string {
+func createURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func getURL(c *gophercloud.ServiceClient, container, object string) string {
+func getURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container, object string) string {
+func deleteURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func downloadURL(c *gophercloud.ServiceClient, container, object string) string {
+func downloadURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container, object string) string {
+func updateURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares/results.go
@@ -178,6 +178,10 @@ func (r SharePage) LastMarker() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (r SharePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	shares, err := ExtractShares(r)
 	return len(shares) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots/results.go
@@ -139,6 +139,10 @@ func (r SnapshotPage) LastMarker() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	snapshots, err := ExtractSnapshots(r)
 	return len(snapshots) == 0, err
 }

--- a/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
+++ b/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
@@ -134,6 +134,9 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 // AllPages returns all the pages from a `List` operation in a single page,
 // allowing the user to retrieve all the pages at once.
 func (p Pager) AllPages() (Page, error) {
+	if p.Err != nil {
+		return nil, p.Err
+	}
 	// pagesSlice holds all the pages until they get converted into as Page Body.
 	var pagesSlice []interface{}
 	// body will contain the final concatenated Page body.

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -14,7 +14,7 @@ import (
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
-	DefaultUserAgent         = "gophercloud/2.0.0"
+	DefaultUserAgent         = "gophercloud/v1.3.0"
 	DefaultMaxBackoffRetries = 60
 )
 

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/requests.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/requests.go
@@ -644,6 +644,12 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
+	if cloud.AuthInfo.SystemScope == "" {
+		if v := env.Getenv(envPrefix + "SYSTEM_SCOPE"); v != "" {
+			cloud.AuthInfo.SystemScope = v
+		}
+	}
+
 	// Build a scope and try to do it correctly.
 	// https://github.com/openstack/os-client-config/blob/master/os_client_config/config.py#L595
 	scope := new(gophercloud.AuthScope)
@@ -659,6 +665,9 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 				scope.DomainID = cloud.AuthInfo.DomainID
 			} else if cloud.AuthInfo.DomainName != "" {
 				scope.DomainName = cloud.AuthInfo.DomainName
+			}
+			if cloud.AuthInfo.SystemScope != "" {
+				scope.System = true
 			}
 		} else {
 			// If Domain* is set, but UserDomain* or ProjectDomain* aren't,
@@ -905,6 +914,8 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		}
 	case "image":
 		return openstack.NewImageServiceV2(pClient, eo)
+	case "key-manager":
+		return openstack.NewKeyManagerV1(pClient, eo)
 	case "load-balancer":
 		return openstack.NewLoadBalancerV2(pClient, eo)
 	case "network":
@@ -913,6 +924,8 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		return openstack.NewObjectStorageV1(pClient, eo)
 	case "orchestration":
 		return openstack.NewOrchestrationV1(pClient, eo)
+	case "placement":
+		return openstack.NewPlacementV1(pClient, eo)
 	case "sharev2":
 		return openstack.NewSharedFileSystemV2(pClient, eo)
 	case "volume":

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/results.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/results.go
@@ -78,6 +78,9 @@ type AuthInfo struct {
 	// Application Credential secret to login with.
 	ApplicationCredentialSecret string `yaml:"application_credential_secret,omitempty" json:"application_credential_secret,omitempty"`
 
+	// SystemScope is a system information to scope to.
+	SystemScope string `yaml:"system_scope,omitempty" json:"system_scope,omitempty"`
+
 	// ProjectName is the common/human-readable name of a project.
 	// Users can be scoped to a project.
 	// ProjectName on its own is not enough to ensure a unique scope. It must

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -544,7 +544,7 @@ github.com/googleapis/gax-go/v2
 github.com/googleapis/gax-go/v2/apierror
 github.com/googleapis/gax-go/v2/apierror/internal/proto
 github.com/googleapis/gax-go/v2/internal
-# github.com/gophercloud/gophercloud v1.1.1
+# github.com/gophercloud/gophercloud v1.3.0
 ## explicit; go 1.14
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
@@ -592,7 +592,7 @@ github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
-# github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca
+# github.com/gophercloud/utils v0.0.0-20230330070308-5bd5e1d608f8
 ## explicit; go 1.15
 github.com/gophercloud/utils/env
 github.com/gophercloud/utils/gnocchi


### PR DESCRIPTION
Version v1.3.0 contains an improved handling of the bulk deletion of Swift objects, leading to a faster deprovisioning of clusters.