### PR TITLE
OCPBUGS-6759: Fix discrepancy with disk size master

### DIFF
--- a/data/data/azurestack/cluster/master/master.tf
+++ b/data/data/azurestack/cluster/master/master.tf
@@ -54,7 +54,7 @@ resource "azurestack_virtual_machine" "master" {
   storage_os_disk {
     name              = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
     create_option     = "FromImage"
-    disk_size_gb      = min(var.os_volume_size, 1023)
+    disk_size_gb      = var.os_volume_size
     managed_disk_type = var.os_volume_type
   }
 

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -344,6 +344,9 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			installConfig.Config.ControlPlane.Architecture,
 		)
 		mpool.OSDisk.DiskSizeGB = 1024
+		if installConfig.Config.Platform.Azure.CloudName == azuretypes.StackCloud {
+			mpool.OSDisk.DiskSizeGB = azuredefaults.AzurestackMinimumDiskSize
+		}
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 

--- a/pkg/types/azure/defaults/platform.go
+++ b/pkg/types/azure/defaults/platform.go
@@ -7,6 +7,11 @@ import (
 var (
 	// Overrides
 	defaultMachineClass = map[string]string{}
+
+	// AzurestackMinimumDiskSize is the minimum disk size value for azurestack.
+	AzurestackMinimumDiskSize int32 = 128
+	// AzurestackMaximumDiskSize is the maximum disk size value for azurestack.
+	AzurestackMaximumDiskSize int32 = 1023
 )
 
 // SetPlatformDefaults sets the defaults for the platform.

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/azure/defaults"
 )
 
 // ValidateMachinePool checks that the specified machine pool is valid.
@@ -13,6 +14,8 @@ func ValidateMachinePool(p *azure.MachinePool, poolName string, platform *azure.
 
 	if p.OSDisk.DiskSizeGB < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "Storage DiskSizeGB must be positive"))
+	} else if platform.CloudName == azure.StackCloud && p.OSDisk.DiskSizeGB != 0 && (p.OSDisk.DiskSizeGB < defaults.AzurestackMinimumDiskSize || p.OSDisk.DiskSizeGB > defaults.AzurestackMaximumDiskSize) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "Storage DiskSizeGB must be between 128 and 1023 inclusive for Azure Stack"))
 	}
 
 	if p.OSDisk.DiskType != "" {

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -12,12 +12,14 @@ import (
 
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
-		name     string
-		pool     *types.MachinePool
-		expected string
+		name          string
+		azurePlatform azure.CloudEnvironment
+		pool          *types.MachinePool
+		expected      string
 	}{
 		{
-			name: "empty",
+			name:          "empty",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -26,7 +28,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "valid iops",
+			name:          "valid iops",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -39,7 +42,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid iops",
+			name:          "invalid iops",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -53,7 +57,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.diskSizeGB: Invalid value: -120: Storage DiskSizeGB must be positive$`,
 		},
 		{
-			name: "valid disk",
+			name:          "valid disk",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -66,7 +71,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid disk",
+			name:          "invalid disk",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -80,7 +86,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.diskType: Unsupported value: "LRS": supported values: "Premium_LRS", "StandardSSD_LRS", "Standard_LRS"$`,
 		},
 		{
-			name: "unsupported disk master",
+			name:          "unsupported disk master",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "master",
 				Platform: types.MachinePoolPlatform{
@@ -94,7 +101,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.diskType: Unsupported value: "Standard_LRS": supported values: "Premium_LRS", "StandardSSD_LRS"$`,
 		},
 		{
-			name: "unsupported disk default pool",
+			name:          "unsupported disk default pool",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "",
 				Platform: types.MachinePoolPlatform{
@@ -108,7 +116,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.diskType: Unsupported value: "Standard_LRS": supported values: "Premium_LRS", "StandardSSD_LRS"$`,
 		},
 		{
-			name: "supported disk worker",
+			name:          "supported disk worker",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -138,7 +147,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "valid OS image with purchase plan omitted",
+			name:          "valid OS image with purchase plan omitted",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -154,7 +164,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "OS image missing publisher",
+			name:          "OS image missing publisher",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -170,7 +181,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.osImage.publisher: Required value: must specify publisher for the OS image$`,
 		},
 		{
-			name: "OS image missing offer",
+			name:          "OS image missing offer",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -186,7 +198,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.osImage.offer: Required value: must specify offer for the OS image$`,
 		},
 		{
-			name: "OS image missing sku",
+			name:          "OS image missing sku",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -202,7 +215,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.osImage.sku: Required value: must specify SKU for the OS image$`,
 		},
 		{
-			name: "OS image missing version",
+			name:          "OS image missing version",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -218,7 +232,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.osImage.version: Required value: must specify version for the OS image$`,
 		},
 		{
-			name: "OS image with invalid plan",
+			name:          "OS image with invalid plan",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
@@ -236,7 +251,8 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.osImage.plan: Unsupported value: ".*": supported values: "NoPurchasePlan", "WithPurchasePlan"$`,
 		},
 		{
-			name: "OS image for master",
+			name:          "OS image for master",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "master",
 				Platform: types.MachinePoolPlatform{
@@ -252,7 +268,8 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "OS image for default pool",
+			name:          "OS image for default pool",
+			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "",
 				Platform: types.MachinePoolPlatform{
@@ -267,10 +284,50 @@ func TestValidateMachinePool(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "insufficient disk size azurestack",
+			azurePlatform: azure.StackCloud,
+			pool: &types.MachinePool{
+				Name: "",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						OSDisk: azure.OSDisk{
+							DiskSizeGB: 120,
+						},
+					},
+				},
+			},
+			expected: `^test-path.diskSizeGB: Invalid value: 120: Storage DiskSizeGB must be between 128 and 1023 inclusive for Azure Stack$`,
+		},
+		{
+			name:          "excessive disk size azurestack",
+			azurePlatform: azure.StackCloud,
+			pool: &types.MachinePool{
+				Name: "",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						OSDisk: azure.OSDisk{
+							DiskSizeGB: 1200,
+						},
+					},
+				},
+			},
+			expected: `^test-path.diskSizeGB: Invalid value: 1200: Storage DiskSizeGB must be between 128 and 1023 inclusive for Azure Stack$`,
+		},
+		{
+			name:          "empty disk size azurestack",
+			azurePlatform: azure.StackCloud,
+			pool: &types.MachinePool{
+				Name: "",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{},
+				},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			azurePlatform := &azure.Platform{CloudName: azure.PublicCloud}
+			azurePlatform := &azure.Platform{CloudName: tc.azurePlatform}
 			err := ValidateMachinePool(tc.pool.Platform.Azure, tc.pool.Name, azurePlatform, field.NewPath("test-path")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)


### PR DESCRIPTION
The master disk size default is set to 1024 when the max size allowed in azurestack is 1024. Futhermore, the check in the tfvars sets the minimum value for disk size to 1023 which should not be done since the users can configure their own size. Changing these values.