### PR TITLE
AGENT-567: Re-enable 'create pxe-files' command

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -70,7 +70,6 @@ var (
 		},
 	}
 
-	//nolint:varcheck,deadcode
 	agentPXEFilesTarget = target{
 		name: "Agent PXE Files",
 		command: &cobra.Command{
@@ -85,7 +84,7 @@ var (
 		},
 	}
 
-	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget}
+	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget}
 )
 
 func newAgentCreateCmd() *cobra.Command {

--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
@@ -1,7 +1,5 @@
 # Verify a default configuration for the SNO topology
 
-skip 'pxe-files generation is disabled'
-
 exec openshift-install agent create pxe-files --dir $WORK
 
 stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'


### PR DESCRIPTION
This reverts commit 93f78427bb73a7046b7f57dca6c8cf4f837ade4a from PR https://github.com/openshift/installer/pull/6927 and enables the `create pxe-files` command