### PR TITLE
CORS-2372: Azure: auth Installer with Managed Identity from VM

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -13,6 +13,7 @@ provider "azurerm" {
   client_certificate_path     = var.azure_certificate_path
   tenant_id                   = var.azure_tenant_id
   environment                 = var.azure_environment
+  use_msi                     = var.azure_use_msi
 }
 
 data "azurerm_storage_account" "storage_account" {

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -12,6 +12,7 @@ provider "azurerm" {
   client_certificate_password = var.azure_certificate_password
   client_certificate_path     = var.azure_certificate_path
   tenant_id                   = var.azure_tenant_id
+  use_msi                     = var.azure_use_msi
   environment                 = var.azure_environment
 }
 

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -99,6 +99,7 @@ variable "azure_subscription_id" {
 variable "azure_client_id" {
   type = string
   description = "The app ID that should be used to interact with Azure API"
+  default = ""
 }
 
 variable "azure_client_secret" {
@@ -122,6 +123,12 @@ variable "azure_certificate_password" {
 variable "azure_tenant_id" {
   type = string
   description = "The tenant ID that should be used to interact with Azure API"
+}
+
+variable "azure_use_msi" {
+  type = bool
+  default = false
+  description = "Specifies if we are to use a managed identity for authentication"
 }
 
 variable "azure_master_availability_zones" {

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -19,6 +19,7 @@ provider "azurerm" {
   client_certificate_password = var.azure_certificate_password
   client_certificate_path     = var.azure_certificate_path
   tenant_id                   = var.azure_tenant_id
+  use_msi                     = var.azure_use_msi
   environment                 = var.azure_environment
 }
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -315,6 +315,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
 		auth := azuretfvars.Auth{
 			SubscriptionID:            session.Credentials.SubscriptionID,
 			ClientID:                  session.Credentials.ClientID,
@@ -322,6 +323,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			TenantID:                  session.Credentials.TenantID,
 			ClientCertificatePath:     session.Credentials.ClientCertificatePath,
 			ClientCertificatePassword: session.Credentials.ClientCertificatePassword,
+			UseMSI:                    session.AuthType == aztypes.ManagedIdentityAuth,
 		}
 		masters, err := mastersAsset.Machines()
 		if err != nil {

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
+	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	ibmcloudconfig "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
@@ -94,8 +95,11 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "creating Azure session")
 		}
-		if azureSession.Credentials.ClientCertificatePath != "" && ic.Config.CredentialsMode != types.ManualCredentialsMode {
-			return fmt.Errorf("authentication with client certificates is only supported in manual credentials mode")
+		switch azureSession.AuthType {
+		case azureconfig.ClientCertificateAuth, azureconfig.ManagedIdentityAuth:
+			if ic.Config.CredentialsMode != types.ManualCredentialsMode {
+				return fmt.Errorf("authentication with client certificates or managed identity is only supported in manual credentials mode")
+			}
 		}
 	case ovirt.Name:
 		con, err := ovirtconfig.NewConnection()

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -22,6 +22,7 @@ type Auth struct {
 	TenantID                  string `json:"azure_tenant_id,omitempty"`
 	ClientCertificatePath     string `json:"azure_certificate_path,omitempty"`
 	ClientCertificatePassword string `json:"azure_certificate_password,omitempty"`
+	UseMSI                    bool   `json:"azure_use_msi,omitempty"`
 }
 
 type config struct {


### PR DESCRIPTION
Use the managed identity from the installer host VM (running in Azure) so that a user can install a cluster without copying credentials to the installer host.