### PR TITLE
OCPBUGS-11999: fix: remove feature flag for cpu partitioning no longer needed

### DIFF
--- a/pkg/asset/manifests/topologies.go
+++ b/pkg/asset/manifests/topologies.go
@@ -33,9 +33,6 @@ func determineTopologies(installConfig *types.InstallConfig) (controlPlaneTopolo
 }
 
 func determineCPUPartitioning(installConfig *types.InstallConfig) configv1.CPUPartitioningMode {
-	if installConfig.FeatureSet != configv1.TechPreviewNoUpgrade {
-		return configv1.CPUPartitioningNone
-	}
 	switch installConfig.CPUPartitioning {
 	case types.CPUPartitioningAllNodes:
 		return configv1.CPUPartitioningAllNodes


### PR DESCRIPTION
Removing the feature check for tech preview when applying the cpu partitioning flag. This is no longer needed on the installer side. 