### PR TITLE
WIP: AGENT-601: support for okd-scos

### DIFF
--- a/data/data/coreos/scos.json
+++ b/data/data/coreos/scos.json
@@ -1,0 +1,629 @@
+{
+    "stream": "stable",
+    "metadata": {
+        "last-modified": "2022-12-14T14:40:02Z",
+        "generator": "fedora-coreos-stream-generator v0.2.8"
+    },
+    "architectures": {
+        "aarch64": {
+            "artifacts": {
+                "aws": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0db088733cac56ebf05e831521f1cca85fcedca4ec0ceab0ea2e82c21df4094d",
+                                "uncompressed-sha256": "0f9f232990fcaa753369ee01f1c7b89a1128e848ecbe3d9d8cafe3220ebc136c"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b2be538986f711985dabeb618dcf9476745cc86df5e8841c1164365268a08978",
+                                "uncompressed-sha256": "c99bec6a134fdf3610da92b2ec265a33318508cf8a2ef8bafad181215ad39a0c"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "349506644f69a3474027a7276a9c73c1cbfc859249709b79a6104dc7fc49edd5",
+                                "uncompressed-sha256": "5cbe91cc77f1121150f35fd0fe9f03978a54f2774082b210bd554bc1b2310ab1"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso.sig",
+                                "sha256": "6e0a3bace39d4cc3f6d3e662c71465ccc7ddd9a4e0e232694562216e1c164dd8"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64.sig",
+                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8722b6d92c9d8a2a3acdbcc109a066e6021a9b6c3a0b1cce2dd20877d009fca9"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5c9c3381369ca6ad6656bc8608240c7d8c5c155412e823b769efddd522ca6aae"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cad5adf20101d03813a944bf89a23db380598608f7317e61b1c884c5ac02a0af",
+                                "uncompressed-sha256": "1b94ce12bf7628d65e7d5a47bc762de359f55f4fd38a0d2ad6e8e0aef5c3d50e"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "77e7329d7eda5a82e1c9c0e7eaba9abd0c3ac45458fef750103e4bf867959e78",
+                                "uncompressed-sha256": "8e61bf86b3a49c222006fc7aeb6d5836e8a56c9a44afa29fd5b4651d5eb284fe"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "566819b697250ab60db0d32ee9e1ab6949e01ea1e99339e6ef236b06eb6ad531",
+                                "uncompressed-sha256": "ae6bc140166de8046e8f6213f781074c39dd127a384b1301dabf025199ef6c68"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "af-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0cf70bcd15eb97f9f"
+                        },
+                        "ap-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0eedbb9b46cb012c8"
+                        },
+                        "ap-northeast-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c665c7562f2c62fa"
+                        },
+                        "ap-northeast-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c4268493fe404f07"
+                        },
+                        "ap-northeast-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0fdaa1084fa96fcf1"
+                        },
+                        "ap-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07f22503fd2de4b09"
+                        },
+                        "ap-southeast-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0eb59fedf8032d46b"
+                        },
+                        "ap-southeast-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ad1c05af2d57479f"
+                        },
+                        "ap-southeast-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08587b5a8c34f081e"
+                        },
+                        "ca-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07faeb56deea10fed"
+                        },
+                        "eu-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0e02c0d2f176711ec"
+                        },
+                        "eu-north-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07478e30242b2d845"
+                        },
+                        "eu-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-06c1f9cb92c099cc8"
+                        },
+                        "eu-west-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0727d1ac18ed8876b"
+                        },
+                        "eu-west-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-097349b7c6c4ccc4d"
+                        },
+                        "eu-west-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c4e2a15183f0e53a"
+                        },
+                        "me-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-05d786ea872565d71"
+                        },
+                        "me-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0a6cfa1e63fcab55e"
+                        },
+                        "sa-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0dca77a4dc4fc8357"
+                        },
+                        "us-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ccee6825d912eac6"
+                        },
+                        "us-east-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0bda223034d8e6700"
+                        },
+                        "us-west-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0de120e10478a5964"
+                        },
+                        "us-west-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c7dc08a47cda7250"
+                        }
+                    }
+                }
+            }
+        },
+        "s390x": {
+            "artifacts": {
+                "ibmcloud": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "377b69e89025c0da16066596cd0a596cfbfe917fb43881f3017b0d2314b227d8",
+                                "uncompressed-sha256": "046c45e681d3d062c2d121a50e163e66af7c8a06882976cb64d1f3d3c6f63ba4"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "035691f8bf819eea01a42da8361321e192da837155de63893260b964cc314492",
+                                "uncompressed-sha256": "29c86a31dddf52b97e1739745f777c4ec32e4c884c8b57c57b125e85f8e9e3a7"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso.sig",
+                                "sha256": "d98f55301b01fa630abc3aaefbd8ec757682ebcd18d50d4e3eb7f3950f944d0e"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x.sig",
+                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "762402f4a08598f6adbca5484dfbbaed923d8582c257897f8a0e432a601f73d5"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3e41e1f48389f7e7567012c4abc3b6fc32f1442bd32d6b58d170b7c5dac6b511"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "3cae2d0b5e143a5761282fd3481eb8339a9bca1bb6e9aaf8b97aea277dc7cca7",
+                                "uncompressed-sha256": "dc0159e3d30fd53cb579b96bca9948e35cd870065a261f0fe21415c1fe983313"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c1a12e21bbdb14d3f024479ff618e33cc6cb6b06ef95904811d42939b013872b",
+                                "uncompressed-sha256": "fcd1044b60940a7205176cc6d023b6d80fda05484ee2c45717a4364d67d6a743"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "35a435c978faea0640f840490a38536e713c75bdd78db95d52371577cc52d3cf",
+                                "uncompressed-sha256": "35bb5793af2abe06b48a2cf831fa07a352229d7806401fb75080fcbb6aee84c7"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "299a63c19cf3e9958c4338dcb566c5e60aa040d57f28cafd72518e618999663c",
+                                "uncompressed-sha256": "33a0718312875a8b4a1f835dcbc8d7287dba328cf01dc5175f9349476aefc377"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "50a6421ed0d9a6f9fcb81b07591628c9eba27b941c02e70d05b3c2f20438d745",
+                                "uncompressed-sha256": "ce2a80ae7ab6d935a4cb329df522429e04922119fb47f7c2edbcb2b2f6634711"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "678ecf7591f03b8738b4f2df4d0ee5892c69c1bcfe52503cd80c6fce69ae1970",
+                                "uncompressed-sha256": "6c0ceac7007c830def84e8f95de331275e2cd3a80b8c90adf8d3f16eefe76f84"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f6fcc890a25d1161db9bef32b2f0b7e0b6c44de2c963144237e16fcad8c41698",
+                                "uncompressed-sha256": "1537468c7225b19f8660f1fa94253c9cd55083914e4db2c86f28d714e1f5e761"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c82b57c6a97fa6eaaaca3f875ca838de8e0f79448b4aa0598ed8c944a9af3771",
+                                "uncompressed-sha256": "8ccefefa1c177a23d20302bb4e20d12db0536ce3f4192b53eb2cd56df3f46559"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e20c1463de7bd1105f1552076fd7d32ec04e7e8e163f7f24204b270566d80008",
+                                "uncompressed-sha256": "655526ddc02ff9661e047b7e51000ed43429dab5bb624cd9a137c8c31188fb22"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9dfb540736b5d68580e143e14eecdabff39c57b693cdb521baf9d97997dd0333",
+                                "uncompressed-sha256": "3998a22a7e17dd14252384d4f0d0f854993893189ab3ba97142f7a9b4d7c4735"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "68bdcbd670456a171e1cad32a9011626dd38b3f4126479c588fb30b6c7177d74",
+                                "uncompressed-sha256": "c9fe59158c024ba294b1f787d3e7b6a034474ef216d5ee79343d2214a0065f49"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "414.9.202304170609-0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4df1725fbc0d6ba108a35184149eef7bbd530b9a0642508c58ebe99035499fe0",
+                                "uncompressed-sha256": "5e60edb7ec4a943fbf4b99f0266e7b5dcaffefd2cb672a04e7c612433317a8a8"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://okd-scos.s3.amazonaws.com/okd-scos/builds/414.9.202304170609-0/x86_64/scos-414.9.202304170609-0-live.x86_64.iso",
+                                "signature": "https://okd-scos.s3.amazonaws.com/okd-scos/builds/414.9.202304170609-0/x86_64/scos-414.9.202304170609-0-live.x86_64.iso.sig",
+                                "sha256": "980cf3ad2ce40dd247704196f470c242c92468a9a493eb44f5359db7b624ef51"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64.sig",
+                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1717235ca2799b6ab7fbbd86eee3b5325010b59dd7b92e089ae8a7ae6e3a0736"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "00e98f13f5c9d781e93d9dda37b85be64dcc030fed75b1ae777f7fa695979c01"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f08644d5a6124f2953dc1f8bb4262be8ae8770861edf3edf1d686cdda56d6ef9",
+                                "uncompressed-sha256": "39516813e72e91158af4192b976deed00fe36af1922dc5fff57056cab78a97d8"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "75b2a23d8946ce3c1158e22ee56074091b49dfd5502d66daa12dff3e128678b3"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "505df7e9116955f6bca9c8281e4094806d345fbf0c561223d749408051eb26d7",
+                                "uncompressed-sha256": "30ebcbda79fa61515852e396adc1bbc0e4d32f91ee5f319e2e0103afc031a201"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4368f11d4fb7ccd12ce59f3acf56e88e84e1fa9c71e8958bb6c82708c43568fc",
+                                "uncompressed-sha256": "d022a66f7a5e331c77bba7167d495e1992fb0731c24689330c40f43de100b4f8"
+                            }
+                        }
+                    }
+                },
+                "virtualbox": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2183f5e0d56b186888627499f5c9db8f53795bb726b81bbdd78c59630bcb40ec"
+                            }
+                        }
+                    }
+                },
+                "vmware": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "90d5909a53ac0549fa8daf7dd6cade89910f4e6cc266be61f8ce0a0ad1b4f73e"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "37.20221127.3.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "772228b152b422314fdd0ec381e28f0aacaa0d4873c00c370d059f8701493bab",
+                                "uncompressed-sha256": "eceecb2315eba83d345f5f85fe77a0565a03b5a1742c701bacc55787c9a5cb3a"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "af-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08be015d5bb663054"
+                        },
+                        "ap-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-06202a1413694ae57"
+                        },
+                        "ap-northeast-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-031ab495179c8c4b2"
+                        },
+                        "ap-northeast-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-033b28ce4c883b454"
+                        },
+                        "ap-northeast-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-05df54cacf5c0f449"
+                        },
+                        "ap-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-015c7f5a6509ddb03"
+                        },
+                        "ap-southeast-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08adf686546982642"
+                        },
+                        "ap-southeast-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0699a95f69bb040b5"
+                        },
+                        "ap-southeast-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-01075e94bdecac8e2"
+                        },
+                        "ca-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-067a4936d2519b72b"
+                        },
+                        "eu-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-094fe1584439e91dd"
+                        },
+                        "eu-north-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-072747595f0c8e23d"
+                        },
+                        "eu-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-072e4b3a048ad8d43"
+                        },
+                        "eu-west-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0907c7277f49cef80"
+                        },
+                        "eu-west-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-088cd193293ffa46d"
+                        },
+                        "eu-west-3": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0d987d085ef4e5397"
+                        },
+                        "me-central-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ef9b1d7d483308f4"
+                        },
+                        "me-south-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0dde7ea2ef172feb3"
+                        },
+                        "sa-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0bdb0448216a5fd04"
+                        },
+                        "us-east-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0e15bde3da645fa47"
+                        },
+                        "us-east-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-042e292bcd953e03a"
+                        },
+                        "us-west-1": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0029dbfa5dfecb227"
+                        },
+                        "us-west-2": {
+                            "release": "37.20221127.3.0",
+                            "image": "ami-070ac896f6520472e"
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "37.20221127.3.0",
+                    "project": "fedora-coreos-cloud",
+                    "family": "fedora-coreos-stable",
+                    "name": "fedora-coreos-37-20221127-3-0-gcp-x86-64"
+                }
+            }
+        }
+    }
+}

--- a/hack/build-coreos-manifest.go
+++ b/hack/build-coreos-manifest.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,15 +19,23 @@ import (
 const (
 	streamRHCOSJSON = "data/data/coreos/rhcos.json"
 	streamFCOSJSON  = "data/data/coreos/fcos.json"
+	streamSCOSJSON  = "data/data/coreos/scos.json"
 	fcosTAG         = "okd"
+	scosTAG         = "scos"
 	dest            = "bin/manifests/coreos-bootimages.yaml"
 )
 
 func run() error {
 	streamJSON := streamRHCOSJSON
-	if tags, _ := os.LookupEnv("TAGS"); strings.Contains(tags, fcosTAG) {
+
+	tags, _ := os.LookupEnv("TAGS")
+	switch tags {
+	case fcosTAG:
 		streamJSON = streamFCOSJSON
+	case scosTAG:
+		streamJSON = streamSCOSJSON
 	}
+
 	bootimages, err := os.ReadFile(streamJSON)
 	if err != nil {
 		return err

--- a/pkg/rhcos/stream_scos.go
+++ b/pkg/rhcos/stream_scos.go
@@ -1,7 +1,7 @@
-//go:build okd || fcos
+//go:build scos
 
 package rhcos
 
 func getStreamFileName() string {
-	return "coreos/fcos.json"
+	return "coreos/scos.json"
 }


### PR DESCRIPTION
This is PoC to explore the required changes to support okd-scos for agent-based installer.

Notes:
* The `scos.json` is identical to the previous `fcos.json` except for x86_64 metal iso
* The extraction of the base ISO from `machine-os-images` has been excluded because not yet available for scos, so using a direct download (that would be required for disconnected installs)