### PR TITLE
[release-4.13] OCPBUGS-12179: agent: copy also symbolic link when storing agent-tui related files into the agent ISO

### DIFF
--- a/cmd/openshift-install/agent_internal_integration_test.go
+++ b/cmd/openshift-install/agent_internal_integration_test.go
@@ -105,6 +105,7 @@ func runIntegrationTest(t *testing.T, testFolder string) {
 		Cmds: map[string]func(*testscript.TestScript, bool, []string){
 			"isocmp":              isoCmp,
 			"ignitionImgContains": ignitionImgContains,
+			"initrdImgContains":   initrdImgContains,
 		},
 	})
 }

--- a/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
@@ -5,6 +5,9 @@ exec openshift-install agent create image --dir $WORK
 exists $WORK/agent.x86_64.iso
 
 ignitionImgContains agent.x86_64.iso config.ign
+initrdImgContains agent.x86_64.iso /agent-files/agent-tui
+initrdImgContains agent.x86_64.iso /agent-files/libnmstate.so.*
+initrdImgContains agent.x86_64.iso /usr/lib/dracut/hooks/pre-pivot/99-agent-copy-files.sh
 
 -- install-config.yaml --
 apiVersion: v1

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -78,16 +78,19 @@ func (a *AgentImage) fetchAgentTuiFiles(releaseImage string, pullSecret string, 
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {
-		f, err := release.ExtractFile("agent-installer-node-agent", srcFile)
+		extracted, err := release.ExtractFile("agent-installer-node-agent", srcFile)
 		if err != nil {
 			return nil, err
 		}
-		// Make sure it could be executed
-		err = os.Chmod(f, 0o555)
-		if err != nil {
-			return nil, err
+
+		for _, f := range extracted {
+			// Make sure it could be executed
+			err = os.Chmod(f, 0o555)
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, f)
 		}
-		files = append(files, f)
 	}
 
 	return files, nil


### PR DESCRIPTION
This is a manual cherry-pick of #7095 