### PR TITLE
OCPBUGS-12196: bump CVO to stable-4.14

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.13
+  channel: stable-4.14
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
After 4.14 branching, bump CVO to the correct version.