### PR TITLE
SPLAT-1034: Allow CIDR expansion on single zone deployment in AWS

### DIFF
--- a/data/data/aws/cluster/vpc/vpc.tf
+++ b/data/data/aws/cluster/vpc/vpc.tf
@@ -1,6 +1,18 @@
 locals {
-  new_private_cidr_range = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 1)
-  new_public_cidr_range  = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 0)
+  # The VPC CIDR block is split into two main blocks for private and public subnets.
+  # Both blocks is sliced depending the number of zones to create subnets on it,
+  # using the maximum it can increase bits from the base MachineCIDR (VPC) for each sub-block.
+  # When the IPI deployment is created with a single zone, the allow_expansion_zones will be
+  # triggered to prevent the expansion to consume all the CIDR blocks, allowing the VPC
+  # to be expanded creating new subnets (on regular AZs, Local or other zone types) in Day-2
+  # Operations, then creating manifests to run workloads on it.
+  # For example: On the deployment with single-zone using MachineCIDR 10.0.0.0/16, the terraform creates:
+  # - 2 * subnets /18: 10.0.0.0/18 and 10.0.128.0/18
+  # - keep two block ranges for expansion: 10.0.64.0-10.0.127.255/18 and 10.0.192.0-10.0.255.255/18
+
+  allow_expansion_zones  = length(var.availability_zones) == 1 ? 1 : 0
+  new_private_cidr_range = cidrsubnet(cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 0), local.allow_expansion_zones, 0)
+  new_public_cidr_range  = cidrsubnet(cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 1), local.allow_expansion_zones, 0)
 }
 
 resource "aws_vpc" "new_vpc" {


### PR DESCRIPTION
The goal of this change is to provide flexibility for subnet expansion when deploying a cluster in AWS with default IPI in single-zone on AWS.

Currently the installer tries a best-effort to fill all the CIDR blocks from VPC spliting into two blocks: public and private. The problem when creating in single-zone, it could prevent VPC expansion as it will create two subnets /17, when using MachineCIDR (VPC) with /16.

This change checks the length of zones, and when the user-provided only one Availability Zone on install-config.yaml, it will increase one bit on the available blocks for public and private, leaving free at least 50% of the VPC for future expansions, like creating manually subnets into different locations (Local Zones) when the user need it. It also allows the user to create a cluster cheaper then expand it without needing to create a new cluster with new configuration.

Examples:

- Using MachineCIDR /16, two subnets /18 is created, with empty block /17.
- Using MachineCIDR /20, two subnets /22 created, with empty block /21.

Use case:

- As a User, I would like to evaluate OCP minimally in AWS, single zone, then be able to increase to more availability zones
- As a User extending nodes in Local Zones, I would like to create new subnets on recently announced AWS Local Zones locations, and MachineSet manifests, so I can extend my nodes, and workloads, to the metropolitan regions in Local Zones. (supported on 4.12+)

References:

- [1] https://issues.redhat.com/browse/SPLAT-1034
- [2] https://issues.redhat.com/browse/SPLAT-657
- [3] Open Questions section on [Local Zones EP #1232](https://github.com/openshift/enhancements/pull/1232/files#diff-f2590494c9138551ab5b3d5632d11170fe8742a128256f9e1d8ebc63baa19f41R832-R850)
- [4] Document with tested scenarios covering Local Zones implementation is available here:
 https://docs.google.com/document/d/1ePnQCeTsX0UUhkL8aMWeQPsRw_W84xwz-nW20yNzEko/edit#
- [5] Node limits on cluster https://docs.openshift.com/container-platform/4.12/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits 

## Examples
1) Install-config with single-zone and default MachineCIDR mask `/20`:

```yaml
apiVersion: v1
publish: External
baseDomain: devcluster.openshift.com
metadata:
  name: "lz-p2-69"

platform:
  aws:
    region: us-east-1

controlPlane:   
  hyperthreading: Enabled 
  name: master
  platform:
    aws:
      zones:
      - us-east-1a

compute:
- name: worker
  platform:
    aws:
      zones:
      - us-east-1a
```

Results:

![Screenshot from 2023-04-20 15-04-17](https://user-images.githubusercontent.com/3216894/233450662-17d66613-56bb-4448-bf0b-f81c9a8b1aa0.png)



2) Install-config with single-zone with custom MachineCIDR mask `/20`:

```yaml
apiVersion: v1
publish: External
baseDomain: devcluster.openshift.com
metadata:
  name: "lz-p2-68"

platform:
  aws:
    region: us-east-1

networking:
  machineNetwork:
  - cidr: 10.0.0.0/20

controlPlane:   
  hyperthreading: Enabled 
  name: master
  platform:
    aws:
      zones:
      - us-east-1a

compute:
- name: worker
  platform:
    aws:
      zones:
      - us-east-1a

```

Results:

![Screenshot from 2023-04-20 14-20-46](https://user-images.githubusercontent.com/3216894/233441289-a0b9e482-d77f-48fb-ad55-39b03e4fb7a5.png)

