### PR TITLE
OCPBUGS-11921: GCP XPN: Pass instance service acct in manual mode

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -155,8 +155,12 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	}
 
 	instanceServiceAccount := fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
-	// Passthrough service accounts are only needed for GCP XPN.
-	if len(platform.NetworkProjectID) > 0 && credentialsMode == types.PassthroughCredentialsMode {
+	// In a vanilla install, the installer will create a service account with the naming convention above.
+	// These service accounts require permissions to check for firewalls. In a GCP XPN install, that permission
+	// would be required in the host project, but the installer is not likely to have permissions to create
+	// service accounts with host project privileges. Instead, we can use the existing service account provided
+	// to the installer.
+	if len(platform.NetworkProjectID) > 0 {
 		sess, err := gcpconfig.GetSession(context.TODO())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The installer service account was being passed through only in pass through mode, which meant manual mode installs would always fail.
