### PR TITLE
OCPBUGS-12748: use python3 for cloud sdk

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -58,8 +58,10 @@ RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz &&
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
-ENV CLOUDSDK_PYTHON=/usr/bin/python
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 
+RUN pip3 install --upgrade pip
+RUN python3 -m pip install pyOpenSSL
 RUN python3 -m pip install yq
 
 ENV TERRAFORM_VERSION=1.0.11


### PR DESCRIPTION
We got "_ERROR: Python 2 is not compatible with the Google Cloud SDK. Please use Python version 3.5 and up_" (see [job](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-gcp-ipi-proxy-private-p1-f4/1649243964022198272)) recently, so set the env `CLOUDSDK_PYTHON` as `/usr/bin/python3`.