### PR TITLE
[CORS-2666] Add ControlPlaneMachineSet for Nutanix

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -487,7 +487,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		pool.Platform.Nutanix = &mpool
 		templateName := nutanixtypes.RHCOSImageName(clusterID.InfraID)
 
-		machines, err = nutanix.Machines(clusterID.InfraID, ic, &pool, templateName, "master", masterUserDataSecretName)
+		machines, controlPlaneMachineSet, err = nutanix.Machines(clusterID.InfraID, ic, &pool, templateName, "master", masterUserDataSecretName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}


### PR DESCRIPTION
Set ControlPlaneMachineSet to Active. This generates a `ControlPlaneMachineSet` manifest in the openshift directory when running `create manifests` command.

**How was this tested?**
1. Create a CPMSO image with the changes in [cluster-control-plane-machine-set-operator#200](https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/200)
2. Create a new release image based on a [recent 4.14 release image](registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-04-19-125337) using `oc adm release new --from-release registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-04-19-125337 cluster-control-plane-machine-set-operator=image-registry:cluster-control-plane-machine-set-operator --to-image image-registry:release` and set the release image override environment variable to the newly created release image using `export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=image-registry:release`
3. Create a install-config using `openshift-installer create install-config`
4. Run `openshift-installer create manifests` and verify ControlPlaneMachineSet manifest generated is as expected
```
apiVersion: machine.openshift.io/v1
kind: ControlPlaneMachineSet
metadata:
  creationTimestamp: null
  labels:
    machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
  name: cluster
  namespace: openshift-machine-api
spec:
  replicas: 3
  selector:
    matchLabels:
      machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
      machine.openshift.io/cluster-api-machine-role: master
      machine.openshift.io/cluster-api-machine-type: master
  strategy: {}
  template:
    machineType: machines_v1beta1_machine_openshift_io
    machines_v1beta1_machine_openshift_io:
      failureDomains:
        platform: ""
      metadata:
        labels:
          machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
          machine.openshift.io/cluster-api-machine-role: master
          machine.openshift.io/cluster-api-machine-type: master
      spec:
        lifecycleHooks: {}
        metadata: {}
        providerSpec:
          value:
            apiVersion: machine.openshift.io/v1
            bootType: ""
            categories: null
            cluster:
              type: uuid
              uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
            credentialsSecret:
              name: nutanix-credentials
            image:
              name: openshiftsid-wvs7z-rhcos
              type: name
            kind: NutanixMachineProviderConfig
            memorySize: 16Gi
            metadata:
              creationTimestamp: null
            project:
              type: ""
            subnets:
            - type: uuid
              uuid: c7938dc6-7659-453e-a688-e26020c68e43
            systemDiskSize: 120Gi
            userDataSecret:
              name: master-user-data
            vcpuSockets: 8
            vcpusPerSocket: 1
status: {}
```
5. Create a cluster successfully using `openshift-install create cluster`
```
$ oc get machines -A
NAMESPACE               NAME                              PHASE         TYPE   REGION    ZONE    AGE
openshift-machine-api   openshiftsid-v2tv8-master-0       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-master-1       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-master-2       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-worker-6xc8s   Running       AHV    Unnamed   ganon   12m
openshift-machine-api   openshiftsid-v2tv8-worker-c57mc   Running       AHV    Unnamed   ganon   12m
openshift-machine-api   openshiftsid-v2tv8-worker-pnc5c   Running       AHV    Unnamed   ganon   12m
```
6. Verify that the `ControlPlaneMachineSet` is `Active` and deleting ControlPlane and Worker machines leads to creation of new ones
```
$ oc -n openshift-machine-api get controlplanemachineset
NAME      DESIRED   CURRENT   READY   UPDATED   UNAVAILABLE   STATE    AGE
cluster   3         3         3       3                       Active   75m

$ oc -n openshift-machine-api delete machine openshiftsid-v2tv8-master-0
machine.machine.openshift.io "openshiftsid-v2tv8-master-0" deleted

$ oc -n openshift-machine-api delete machine openshiftsid-v2tv8-worker-pnc5c
machine.machine.openshift.io "openshiftsid-v2tv8-worker-pnc5c" deleted

$ oc -n openshift-machine-api get machines
NAME                                PHASE     TYPE   REGION    ZONE    AGE
openshiftsid-v2tv8-master-1         Running   AHV    Unnamed   ganon   75m
openshiftsid-v2tv8-master-2         Running   AHV    Unnamed   ganon   75m
openshiftsid-v2tv8-master-4rpfd-0   Running   AHV    Unnamed   ganon   24m
openshiftsid-v2tv8-worker-6xc8s     Running   AHV    Unnamed   ganon   65m
openshiftsid-v2tv8-worker-c57mc     Running   AHV    Unnamed   ganon   65m
openshiftsid-v2tv8-worker-ps5tn     Running   AHV    Unnamed   ganon   21m
```