### PR TITLE
CORS-2525: Azure: remove storage account with bootstrap destroy

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -16,7 +16,7 @@ provider "azurerm" {
 }
 
 data "azurerm_storage_account" "storage_account" {
-  name                = var.storage_account_name
+  name                = azurerm_storage_account.cluster.name
   resource_group_name = var.resource_group_name
 }
 
@@ -56,14 +56,14 @@ data "azurerm_storage_account_sas" "ignition" {
 
 resource "azurerm_storage_container" "ignition" {
   name                  = "ignition"
-  storage_account_name  = var.storage_account_name
+  storage_account_name  = azurerm_storage_account.cluster.name
   container_access_type = "private"
 }
 
 resource "azurerm_storage_blob" "ignition" {
   name                   = "bootstrap.ign"
   source                 = var.ignition_bootstrap_file
-  storage_account_name   = var.storage_account_name
+  storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.ignition.name
   type                   = "Block"
 }
@@ -217,7 +217,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
     disk_encryption_set_id = var.azure_master_disk_encryption_set_id
   }
 
-  source_image_id = var.vm_image
+  source_image_id = azurerm_shared_image_version.bootstrap_image_version.id
 
   computer_name = "${var.cluster_id}-bootstrap-vm"
   custom_data   = base64encode(data.ignition_config.redirect.rendered)

--- a/data/data/azure/bootstrap/outputs.tf
+++ b/data/data/azure/bootstrap/outputs.tf
@@ -1,3 +1,11 @@
 output "bootstrap_ip" {
   value = var.azure_private ? azurerm_network_interface.bootstrap.private_ip_address : azurerm_public_ip.bootstrap_public_ip_v4[0].ip_address
 }
+
+output "storage_account_id" {
+  value = azurerm_storage_account.cluster.id
+}
+
+output "storage_rhcos_image_url" {
+  value = azurerm_storage_blob.rhcos_image.url
+}

--- a/data/data/azure/bootstrap/storage.tf
+++ b/data/data/azure/bootstrap/storage.tf
@@ -1,0 +1,73 @@
+locals {
+  tags = merge(
+    {
+      "kubernetes.io_cluster.${var.cluster_id}" = "owned"
+    },
+    var.azure_extra_tags,
+  )
+
+  # At this time min_tls_version is only supported in the Public Cloud and US Government Cloud.
+  environments_with_min_tls_version = ["public", "usgovernment"]
+}
+
+resource "azurerm_storage_account" "cluster" {
+  name                            = "cluster${var.random_storage_account_suffix}"
+  resource_group_name             = var.resource_group_name
+  location                        = var.azure_region
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
+  allow_nested_items_to_be_public = false
+  tags                            = var.azure_extra_tags
+}
+
+# copy over the vhd to cluster resource group and create an image using that
+resource "azurerm_storage_container" "vhd" {
+  name                 = "vhd"
+  storage_account_name = azurerm_storage_account.cluster.name
+}
+
+resource "azurerm_storage_blob" "rhcos_image" {
+  name                   = "rhcos${var.random_storage_account_suffix}.vhd"
+  storage_account_name   = azurerm_storage_account.cluster.name
+  storage_container_name = azurerm_storage_container.vhd.name
+  type                   = "Page"
+  source_uri             = var.azure_image_url
+  metadata               = tomap({ source_uri = var.azure_image_url })
+}
+
+resource "azurerm_shared_image" "bootstrap_gen2" {
+  name                = "${var.cluster_id}-bootstrap-gen2"
+  gallery_name        = var.image_version_gallery_name
+  resource_group_name = var.resource_group_name
+  location            = var.azure_region
+  os_type             = "Linux"
+  hyper_v_generation  = "V2"
+  architecture        = var.azure_vm_architecture
+
+  identifier {
+    publisher = "RedHat-gen2"
+    offer     = "rhcos-gen2"
+    sku       = "bootstrap"
+  }
+
+  tags = var.azure_extra_tags
+}
+
+resource "azurerm_shared_image_version" "bootstrap_image_version" {
+  name                = var.azure_image_release
+  gallery_name        = azurerm_shared_image.bootstrap_gen2.gallery_name
+  image_name          = azurerm_shared_image.bootstrap_gen2.name
+  resource_group_name = var.resource_group_name
+  location            = var.azure_region
+
+  blob_uri           = azurerm_storage_blob.rhcos_image.url
+  storage_account_id = azurerm_storage_account.cluster.id
+
+  target_region {
+    name                   = var.azure_region
+    regional_replica_count = 1
+  }
+
+  tags = var.azure_extra_tags
+}

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -37,14 +37,24 @@ variable "resource_group_name" {
   description = "The resource group name for the deployment."
 }
 
-variable "storage_account_name" {
+variable "image_version_gallery_name" {
   type        = string
-  description = "the name of the storage account for the cluster. It can be used for boot diagnostics."
+  description = "The name of the image gallery used to set up shared images."
 }
 
-variable "vm_image" {
+variable "image_version_gen2_gallery_name" {
   type        = string
-  description = "The resource id of the vm image used for bootstrap."
+  description = "The name of the gen2 image gallery used to set up shared images."
+}
+
+variable "image_version_name" {
+  type        = string
+  description = "The name of shared image used to set up shared images."
+}
+
+variable "image_version_gen2_name" {
+  type        = string
+  description = "The name of the gen2 shared image used to set up shared images."
 }
 
 variable "identity" {

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -24,7 +24,6 @@ module "master" {
   vm_size                    = var.azure_master_vm_type
   disk_encryption_set_id     = var.azure_master_disk_encryption_set_id
   encryption_at_host_enabled = var.azure_master_encryption_at_host_enabled
-  vm_image                   = var.vm_image
   identity                   = var.identity
   ignition                   = var.ignition_master
   elb_backend_pool_v4_id     = var.elb_backend_pool_v4_id
@@ -40,6 +39,16 @@ module "master" {
   ultra_ssd_enabled          = var.azure_control_plane_ultra_ssd_enabled
   vm_networking_type         = var.azure_control_plane_vm_networking_type
   azure_extra_tags           = var.azure_extra_tags
+
+  storage_account_id              = var.storage_account_id
+  storage_rhcos_image_url         = var.storage_rhcos_image_url
+  image_version_gallery_name      = var.image_version_gallery_name
+  image_version_gen2_gallery_name = var.image_version_gen2_gallery_name
+  image_version_name              = var.image_version_name
+  image_version_gen2_name         = var.image_version_gen2_name
+  azure_image_release             = var.azure_image_release
+  azure_region                    = var.azure_region
+  azure_hypervgeneration_version  = var.azure_hypervgeneration_version
 
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -27,9 +27,46 @@ variable "encryption_at_host_enabled" {
   description = "Enables encryption at the VM host."
 }
 
-variable "vm_image" {
+variable "storage_account_id" {
   type        = string
-  description = "The resource id of the vm image used for masters."
+  description = "The storage account ID for the cluster. It can be used for boot diagnostics"
+}
+
+variable "storage_rhcos_image_url" {
+  type        = string
+  description = "The rhcos image url used to identify the vm image for bootstrap and cluster."
+}
+
+variable "image_version_gallery_name" {
+  type        = string
+  description = "The name of the image gallery used to set up shared images."
+}
+
+variable "image_version_gen2_gallery_name" {
+  type        = string
+  description = "The name of the gen2 image gallery used to set up shared images."
+}
+
+variable "image_version_name" {
+  type        = string
+  description = "The name of shared image used to set up shared images."
+}
+
+variable "image_version_gen2_name" {
+  type        = string
+  description = "The name of the gen2 shared image used to set up shared images."
+}
+
+variable "azure_region" {
+  type = string
+}
+
+variable "azure_image_release" {
+  type = string
+}
+
+variable "azure_hypervgeneration_version" {
+  type = string
 }
 
 variable "identity" {

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -62,9 +62,34 @@ variable "resource_group_name" {
   description = "The resource group name for the deployment."
 }
 
-variable "vm_image" {
+variable "storage_account_id" {
   type        = string
-  description = "The resource id of the vm image used for bootstrap."
+  description = "The storage account ID for the cluster. It can be used for boot diagnostics"
+}
+
+variable "storage_rhcos_image_url" {
+  type        = string
+  description = "The rhcos image url used to identify the vm image for bootstrap and cluster."
+}
+
+variable "image_version_gallery_name" {
+  type        = string
+  description = "The name of the image gallery used to set up shared images."
+}
+
+variable "image_version_gen2_gallery_name" {
+  type        = string
+  description = "The name of the gen2 image gallery used to set up shared images."
+}
+
+variable "image_version_name" {
+  type        = string
+  description = "The name of shared image used to set up shared images."
+}
+
+variable "image_version_gen2_name" {
+  type        = string
+  description = "The name of the gen2 shared image used to set up shared images."
 }
 
 variable "identity" {

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -6,8 +6,6 @@ locals {
     var.azure_extra_tags,
   )
   description = "Created By OpenShift Installer"
-  # At this time min_tls_version is only supported in the Public Cloud and US Government Cloud.
-  environments_with_min_tls_version = ["public", "usgovernment"]
 
 }
 
@@ -42,17 +40,6 @@ data "azurerm_resource_group" "network" {
   name = var.azure_network_resource_group_name
 }
 
-resource "azurerm_storage_account" "cluster" {
-  name                            = "cluster${var.random_storage_account_suffix}"
-  resource_group_name             = data.azurerm_resource_group.main.name
-  location                        = var.azure_region
-  account_tier                    = "Standard"
-  account_replication_type        = "LRS"
-  min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
-  allow_nested_items_to_be_public = false
-  tags                            = var.azure_extra_tags
-}
-
 resource "azurerm_user_assigned_identity" "main" {
   resource_group_name = data.azurerm_resource_group.main.name
   location            = data.azurerm_resource_group.main.location
@@ -74,20 +61,6 @@ resource "azurerm_role_assignment" "network" {
   principal_id         = azurerm_user_assigned_identity.main.principal_id
 }
 
-# copy over the vhd to cluster resource group and create an image using that
-resource "azurerm_storage_container" "vhd" {
-  name                 = "vhd"
-  storage_account_name = azurerm_storage_account.cluster.name
-}
-
-resource "azurerm_storage_blob" "rhcos_image" {
-  name                   = "rhcos${var.random_storage_account_suffix}.vhd"
-  storage_account_name   = azurerm_storage_account.cluster.name
-  storage_container_name = azurerm_storage_container.vhd.name
-  type                   = "Page"
-  source_uri             = var.azure_image_url
-  metadata               = tomap({ source_uri = var.azure_image_url })
-}
 
 # Creates Shared Image Gallery
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/shared_image_gallery
@@ -134,40 +107,3 @@ resource "azurerm_shared_image" "clustergen2" {
 
   tags = var.azure_extra_tags
 }
-
-resource "azurerm_shared_image_version" "cluster_image_version" {
-  name                = var.azure_image_release
-  gallery_name        = azurerm_shared_image.cluster.gallery_name
-  image_name          = azurerm_shared_image.cluster.name
-  resource_group_name = azurerm_shared_image.cluster.resource_group_name
-  location            = azurerm_shared_image.cluster.location
-
-  blob_uri           = azurerm_storage_blob.rhcos_image.url
-  storage_account_id = azurerm_storage_account.cluster.id
-
-  target_region {
-    name                   = azurerm_shared_image.cluster.location
-    regional_replica_count = 1
-  }
-
-  tags = var.azure_extra_tags
-}
-
-resource "azurerm_shared_image_version" "clustergen2_image_version" {
-  name                = var.azure_image_release
-  gallery_name        = azurerm_shared_image.clustergen2.gallery_name
-  image_name          = azurerm_shared_image.clustergen2.name
-  resource_group_name = azurerm_shared_image.clustergen2.resource_group_name
-  location            = azurerm_shared_image.clustergen2.location
-
-  blob_uri           = azurerm_storage_blob.rhcos_image.url
-  storage_account_id = azurerm_storage_account.cluster.id
-
-  target_region {
-    name                   = azurerm_shared_image.clustergen2.location
-    regional_replica_count = 1
-  }
-
-  tags = var.azure_extra_tags
-}
-

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -50,10 +50,6 @@ output "resource_group_name" {
   value = data.azurerm_resource_group.main.name
 }
 
-output "vm_image" {
-  value = var.azure_hypervgeneration_version == "V2" ? azurerm_shared_image_version.clustergen2_image_version.id : azurerm_shared_image_version.cluster_image_version.id
-}
-
 output "identity" {
   value = azurerm_user_assigned_identity.main.id
 }
@@ -62,10 +58,22 @@ output "subnet_id" {
   value = local.master_subnet_id
 }
 
-output "storage_account_name" {
-  value = azurerm_storage_account.cluster.name
-}
-
 output "outbound_udr" {
   value = var.azure_outbound_user_defined_routing
+}
+
+output "image_version_gallery_name" {
+  value = azurerm_shared_image.cluster.gallery_name
+}
+
+output "image_version_gen2_gallery_name" {
+  value = azurerm_shared_image.clustergen2.gallery_name
+}
+
+output "image_version_name" {
+  value = azurerm_shared_image.cluster.name
+}
+
+output "image_version_gen2_name" {
+  value = azurerm_shared_image.clustergen2.name
 }


### PR DESCRIPTION
The work is being done to address the issue of Azure storage accounts being persisted for the life of an OpenShift cluster, which incurs costs and management effort. The goal is to destroy the storage account along with other bootstrap resources during the bootstrap destroy process.