### PR TITLE
OPNET-298: Allow primary-v6 dual-stack on vSphere

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -252,6 +252,8 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 			// We now support ipv6-primary dual stack on baremetal
 			allowV6Primary = true
 		case p.VSphere != nil:
+			// as well as on vSphere
+			allowV6Primary = true
 		case p.OpenStack != nil:
 		case p.Ovirt != nil:
 		case p.Nutanix != nil:
@@ -531,9 +533,6 @@ func validateVIPsForPlatform(network *types.Networking, platform *types.Platform
 
 		allErrs = append(allErrs, validateAPIAndIngressVIPs(virtualIPs, newVIPsFields, true, true, network, fldPath.Child(openstack.Name))...)
 	case platform.VSphere != nil:
-		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.VSphere.APIVIPs, fldPath.Child(vsphere.Name, newVIPsFields.APIVIPs))...)
-		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.VSphere.IngressVIPs, fldPath.Child(vsphere.Name, newVIPsFields.IngressVIPs))...)
-
 		virtualIPs = vips{
 			API:     platform.VSphere.APIVIPs,
 			Ingress: platform.VSphere.IngressVIPs,


### PR DESCRIPTION
Previously we only supported primary-v6 dual-stack installations only on baremetal. As we are now extending full support of dual-stack to vSphere, we no longer need to enforce the order of networks on those clusters.

Closes: [OPNET-298](https://issues.redhat.com//browse/OPNET-298)
Contributes-to: [OPNET-230](https://issues.redhat.com//browse/OPNET-230)