### PR TITLE
OpenStack: configure IPv6 address in the bootstrap node

### DIFF
--- a/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
+++ b/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
@@ -1,0 +1,6 @@
+{{ if .UseDualForNodeIP }}
+[connection]
+type=ethernet
+[ipv6]
+method=auto
+{{end}}


### PR DESCRIPTION
This commit adds a template that configures IPv6 addresses in the ethernet interface of the bootstrap host when creating a dual-stack cluster for any type of IPv6 address stateful/slaac. Without it the bootstrap node wouldn't have the correct IPv6 address configured.

Partially Implements: https://github.com/openshift/enhancements/pull/1365