### PR TITLE
OCPBUGS-11792: update RHCOS 4.14 bootimage metadata to 414.92.202304252144-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.14",
   "metadata": {
-    "last-modified": "2023-04-13T19:23:23Z",
-    "generator": "plume cosa2stream 7a1f61e"
+    "last-modified": "2023-04-26T19:51:12Z",
+    "generator": "plume cosa2stream 7fa68d0"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-aws.aarch64.vmdk.gz",
-                "sha256": "28bc7034643882a23746e6201c585ba25ab1567d6fc264fabd11feede8c64250",
-                "uncompressed-sha256": "5b6cbea1319b86eda3dd336e7fc824a163e233a183404836e500dee3e375133c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-aws.aarch64.vmdk.gz",
+                "sha256": "a7b1bf762e72ac72313d24a5fc1bba03f4ff7fc7b453cfbacfad74d8c1dea19d",
+                "uncompressed-sha256": "777856b9e7ad7cb71c08c88c993905908ca37b613a4509bc107f0d4cfd186171"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-azure.aarch64.vhd.gz",
-                "sha256": "93418246d661c8be75a2de893140de666ec932e3ff30eb06272d487a877804d0",
-                "uncompressed-sha256": "95f0b7c4bac3a606c8a0659d455e08996b91b05c7201a65b08b34447b6fdc24f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-azure.aarch64.vhd.gz",
+                "sha256": "ea5604ae3d50db52dac4b4e0bac9270d4cd7b4a161b582cb41c5f535e2f379b5",
+                "uncompressed-sha256": "3724abed88c7567e0ad7d95cdc9d24ec8a6ca2c005d0c82499ea446d541956c9"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-metal4k.aarch64.raw.gz",
-                "sha256": "6ea1eb3ef2ea5e04cd7489746948e8367a5d7a7f270a98854ef7cd878ecb0823",
-                "uncompressed-sha256": "887633158acb4fbc717d9d30849cc0b0f0c99a2d2a86b33d744b2a4e33fa357c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-metal4k.aarch64.raw.gz",
+                "sha256": "1c76a5a236594fceefb91fcafb440169c6d0775a425c21493e32e3c40402a241",
+                "uncompressed-sha256": "1906341c853c850c9137b137924b12a8c4c421246439c6d1e7f0b29b4f354488"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live.aarch64.iso",
-                "sha256": "4d86ac5ca61fe5341a1a5454e0bfa94358082b7b2d8d988986e8f094a0c6b7c3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-live.aarch64.iso",
+                "sha256": "4c2ed99f27c9e283e70b21d0714e89dd8f665a22b3a28b92e3df34024c86dc92"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-kernel-aarch64",
-                "sha256": "9e44cafd61f5ce4c9c8af8c912c200ff59210b2d239798b21e6ef89a20b8f2dc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-live-kernel-aarch64",
+                "sha256": "77ef3496cdd9b5beb1795a9957ff36581714594199e3e67f33e746e87021b577"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-initramfs.aarch64.img",
-                "sha256": "5730613c9881086facf63867b23165e918a32b0d37ceb19ef4cf9fe18530169e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-live-initramfs.aarch64.img",
+                "sha256": "1e4d14538d27077ea4403d3fe93645e01da512edac14af7ed7673b13978956e5"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-live-rootfs.aarch64.img",
-                "sha256": "9ace6fd8b1877b44e45bbdc08ad51423adf32e1e9b58022b6c60b243944b0fef"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-live-rootfs.aarch64.img",
+                "sha256": "22e3e02d3a32094417587e32227b724abeae1f12b4318ed612843470303ba4d0"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-metal.aarch64.raw.gz",
-                "sha256": "23fcd593bcf73e365620141042f7d0da2056bdbe7c33193c13fa367bc02b7a36",
-                "uncompressed-sha256": "3a61a12ecca36ca99da1f41b6aa1acaf388696ca67dedad5eed1a5032ea63ec5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-metal.aarch64.raw.gz",
+                "sha256": "daa5299880323d9c8c7279c8c1fe99dcb519d9718e1347c976a6e5f3accbe71f",
+                "uncompressed-sha256": "23cb9fe0faa01118661e4b21079647660b033a4951e617a5ae1b9fc899ecc60f"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-openstack.aarch64.qcow2.gz",
-                "sha256": "a15a3e9186c747d20b3525b666fed7d3ae581e67c840be2fb9e2fbc54f76d72b",
-                "uncompressed-sha256": "5d06aa287c300edc30131764dd08f0d16b113c1e543c7da702b90df444e9c231"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-openstack.aarch64.qcow2.gz",
+                "sha256": "39d3fdc5d2fc18ab01450077053aa3abfdd48546575b6e24cb8ebf2fc9c02c08",
+                "uncompressed-sha256": "cee4bc64ee3e1af95ee5690d04fb82638f42076b7693154e543a27743a05856e"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/aarch64/rhcos-414.92.202304131328-0-qemu.aarch64.qcow2.gz",
-                "sha256": "8b264763c4011de95381ed7c58643f7b04ef849bf90f53d9ee80a172831dafff",
-                "uncompressed-sha256": "ad252bd51ceec94c94bbf8fe4b8afbcaa73cb42da4aaf3848cf93169f9348fa7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/aarch64/rhcos-414.92.202304252144-0-qemu.aarch64.qcow2.gz",
+                "sha256": "213837287b2755e73d9001cd9563934e217be547721247306d8dea6c62b948ea",
+                "uncompressed-sha256": "763e2e559af1381caa7cf54895489a3ddd95eb288f1985862a20ff508a4cfbd7"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-01d648d1df618855a"
+              "release": "414.92.202304252144-0",
+              "image": "ami-012099e0fc2f2755f"
             },
             "ap-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0d432ebfaf3471ed5"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0840d75cb69fb43d0"
             },
             "ap-northeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-076751b0faa6423b8"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0274e0671197364cb"
             },
             "ap-northeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0a9d1d6d11b677ed3"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0e6385bfca369ce92"
             },
             "ap-northeast-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-012bf004ac5fdb45b"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0d4d9989fa977a746"
             },
             "ap-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-03b540b64d5e9bde5"
+              "release": "414.92.202304252144-0",
+              "image": "ami-08f949c9aef41451a"
             },
             "ap-south-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0250c53ab4f9c267e"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0d4813067d72a706b"
             },
             "ap-southeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-087d38fef725043eb"
+              "release": "414.92.202304252144-0",
+              "image": "ami-00e5017d323856c6f"
             },
             "ap-southeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-02ef54c9ae2405066"
+              "release": "414.92.202304252144-0",
+              "image": "ami-07b83024303aa5fed"
             },
             "ap-southeast-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0285bfcdea9484f47"
+              "release": "414.92.202304252144-0",
+              "image": "ami-05c522d9f4dcd7f81"
             },
             "ap-southeast-4": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0879a1f03dce76f42"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0bcb04be533bc937a"
             },
             "ca-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0214af10665b1300c"
+              "release": "414.92.202304252144-0",
+              "image": "ami-065aced1ceb09ccc7"
             },
             "eu-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-09d78579cda0ab2d1"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0558d46358459493d"
             },
             "eu-central-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-050e6d452f8046e2a"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0b4c3201416605ab8"
             },
             "eu-north-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0c85b23d9eebfd3e6"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0a76bc0259a9e229c"
             },
             "eu-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0869b9fdb4eb07fca"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0ec7ffed9b72a95c6"
             },
             "eu-south-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-024b18791794b0d12"
+              "release": "414.92.202304252144-0",
+              "image": "ami-04d66f7f34d6598c7"
             },
             "eu-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-01fed8f3b183e6937"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0af66ac59271d9347"
             },
             "eu-west-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0357583747a155549"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0098361ab91e399d8"
             },
             "eu-west-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0f286594067680f59"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0bc65195339972dc1"
             },
             "me-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-044d45db9f6e8d535"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0d7c4b62bf1fc7d1a"
             },
             "me-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0c3964af800042630"
+              "release": "414.92.202304252144-0",
+              "image": "ami-014297a680b6e3379"
             },
             "sa-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-017d3c2a38f5323e6"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0536d32abe33bb1ab"
             },
             "us-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0212e17b88655a79c"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0242f2d1d29b80e9e"
             },
             "us-east-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0a140167d2145a750"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0cb3e5da28a2a2f80"
             },
             "us-gov-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0ffdaea585a65e49f"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0de1527995d772e75"
             },
             "us-gov-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-00d122b82bff13a57"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0c581c260139dfc10"
             },
             "us-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-00f9ba27a30faec9b"
+              "release": "414.92.202304252144-0",
+              "image": "ami-09b39a9a13157026c"
             },
             "us-west-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-07d7881c3f504bccf"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0daf499cd59825cb5"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202304131328-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304131328-0-azure.aarch64.vhd"
+          "release": "414.92.202304252144-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304252144-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-metal4k.ppc64le.raw.gz",
-                "sha256": "31c3f2873f844414ce3d9666f514212a52649a3803b5e41a05f99c580b973d2a",
-                "uncompressed-sha256": "8947f61398d39c8a928ee28aa7234cfe64a223a397a6bc8d95a88f680ed8035e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-metal4k.ppc64le.raw.gz",
+                "sha256": "9e924fdd82856d7c1ae8796b6ecb98c8cf61f3a28b0cb56a8868d136af620002",
+                "uncompressed-sha256": "e4e303a0e9fdf854006c0ba2620bb2120245297c08d399e4ebb76f2762ee40e6"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live.ppc64le.iso",
-                "sha256": "861f1c8f1cc4e24296e80faf6d89a3b839d410808b8b179fb02a38f4c8c5c8d6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-live.ppc64le.iso",
+                "sha256": "66d7112b0675c40fc38261ae75b4518f2e89916876ae041130091af20992aeed"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-kernel-ppc64le",
-                "sha256": "8b77fb7e10f6d1cbedc0dfb397495cd4d5a3060053116b4761984137cb328962"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-live-kernel-ppc64le",
+                "sha256": "1b33f1fba88386659083bf42b66e4f11bed851ba0597dfcb8ea11a77c5083996"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-initramfs.ppc64le.img",
-                "sha256": "5e437f400db0f9ccf518273d0940a467a301f50622a6bbcdf795e1f8612f5714"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-live-initramfs.ppc64le.img",
+                "sha256": "fafac40da4d7c5e18bd028e86943f6397092396309f3406c13d97cae5494a500"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-live-rootfs.ppc64le.img",
-                "sha256": "2ea81b132c60d73e66cfc8f50c95fe6def818175480a61830930e3acaac7a7a2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-live-rootfs.ppc64le.img",
+                "sha256": "0d4f7993c7410961203986fc5b1a53961853ac08d71ba2f6a5473156dac668d1"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-metal.ppc64le.raw.gz",
-                "sha256": "2753d70fa5010210c657e49aab7f8ac38c200eb7fe244c688aa6cc8fc0b9f800",
-                "uncompressed-sha256": "c7fb8ba3b931f0c5d1111c16056eb9d0c756880c46504e5d015dc1af2907743d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-metal.ppc64le.raw.gz",
+                "sha256": "4aa5779a899f8eb4c4bcd711c3e4b00d7a55abaf82f33b8b5f1c47a95c913dbd",
+                "uncompressed-sha256": "080ac15e2e214e4b76040fb6de1290cbeb1b5014fae9626365d27d0c0a7799e5"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "b41fdfb03954f82a48f24e2ae1fc1d4380956e200d55d3e824ba3002d3b5aed6",
-                "uncompressed-sha256": "6f34c1927254290c29099c614d7fd6a04e45243db12e1f51796fea644dade3e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "667f47569fa2b0535e4d3095a5e19991b72fe7a94caa63f45e9832c0f9b3d64a",
+                "uncompressed-sha256": "cfc9c4c9932d6b69a1e129855e429654e39044a0071e8acbc70a38d734ee8330"
               }
             }
           }
         },
         "powervs": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-powervs.ppc64le.ova.gz",
-                "sha256": "0e75efbd643eea1c8746c8fead82f73d186c3f5ec32a9f26bb8558b39e92f1f8",
-                "uncompressed-sha256": "1b5e4593702c9215dd15f3500d2965109eed7521a1868eb08f4ee2c1e9e675df"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-powervs.ppc64le.ova.gz",
+                "sha256": "4aca393feced34d508b32014a4df3fadd310129bab4fbb8beb995c81ee1f6aa6",
+                "uncompressed-sha256": "ea084af8f5629074006382238a8978f69be75061d8db43ee41af7da750672a12"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/ppc64le/rhcos-414.92.202304131328-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "1f56de8e1dda5fe150437dd3f99eeceb37dfc8d250c07f5b0fdb8d89d720914b",
-                "uncompressed-sha256": "6557a8c9ea0e797ca53194aacae83ce9dbdabf3a49cfb2c72cbc20e6223266ac"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/ppc64le/rhcos-414.92.202304252144-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "b4402ff0ff597d083011401437ed5cdb2f9d56703b337b269a02d71e5ba68ea5",
+                "uncompressed-sha256": "76ee8609e5b250c5816fcc0900ee90944f7e6fdd79fafbf5ffa9dd43add2c771"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "414.92.202304131328-0",
-              "object": "rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202304252144-0",
+              "object": "rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202304252144-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "28f30e1f52a36d6b5d6f33ea9709fc003dcf01ee78e2dbc870f606b089975445",
-                "uncompressed-sha256": "35f4e3f92466521ac1143da184f282de400eb71385d6f83d22527b082cfb3401"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "779742b6e07a64a42c363eaa046733fd62a07a07792002a5a6aff9d513eaff2e",
+                "uncompressed-sha256": "eeb087703f977a93c87ce48c563f199164eb020f3f1da847e6a9cb5d00b2a7dd"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-metal4k.s390x.raw.gz",
-                "sha256": "c756f6aca1c4baafb73da74ff93a3d49ebced31d87099ff9c9f0110714947cf7",
-                "uncompressed-sha256": "63aeaf207a8d144a77dd195508b85e0c15e9b115d96f9d6f7324fa646141ea12"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-metal4k.s390x.raw.gz",
+                "sha256": "e01019e500e817baabe556675921c254545a4030755d99668cef3ba6d1516dca",
+                "uncompressed-sha256": "2096e1e9a3820a83e56952cbc2be9ed706df9f39c92cdb2ecb7d722945ed3c95"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live.s390x.iso",
-                "sha256": "b10a333cea7b3d501a81d047e0bc5bf68fb72c73b5c90b689dda0883441e6891"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-live.s390x.iso",
+                "sha256": "658fb768621e337a0ef7b2d4b2e084ba79aa2bdcb68bf9fba387b0116f588ae2"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-kernel-s390x",
-                "sha256": "b126f4a81df5d7be59a9a7a6249e0498611774c3458cc62f863b3b36a61bf1f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-live-kernel-s390x",
+                "sha256": "a1825253e21599aa9b83c9f4fcfb650a4a536564d0f99328690bdff22c007cea"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-initramfs.s390x.img",
-                "sha256": "a5f6ed8b2b6d3f31718ca87889ec3066ed54e8e109bf3376b256d34ad56a09fe"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-live-initramfs.s390x.img",
+                "sha256": "ac2f81109adc11d7cb430e0ece7e97c38ab209782f4a26b69d479f27ae5a5542"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-live-rootfs.s390x.img",
-                "sha256": "d14530c0a51d79fabac40b3d0be8ecd2d743caff06297789412e5433af063ac2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-live-rootfs.s390x.img",
+                "sha256": "b55249d6f9ee5a5fe329b5d3158685cecab26a59fe043800ecf22a2b9f00c0be"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-metal.s390x.raw.gz",
-                "sha256": "921fac304befb6c79712cb20953eaebfe4092cdc9d425a802407a40355d44941",
-                "uncompressed-sha256": "b6cf2e7f2820bb10b2e4da23c316564f46dc9f188324a656375bcfc4fb8bc698"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-metal.s390x.raw.gz",
+                "sha256": "ee47af897729c94e2df4c7c51f951b53ee62f78b925bd96cbad0f79072f0d6c0",
+                "uncompressed-sha256": "2761c16f43286719ee96541ece65f384288f2b5b50d88e0ab3600a14e44c267a"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-openstack.s390x.qcow2.gz",
-                "sha256": "694655a45086936e039b498066838fa61675dbd48f95299f4066556d5019641d",
-                "uncompressed-sha256": "e082ac6fbe39876e545e7e10a8e278718421eb25ab3783128578f0a40b4af54e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-openstack.s390x.qcow2.gz",
+                "sha256": "dc32a77db389ee7076d6b649caa5f2fe704f5a66abbbc15bf6484d27cad49721",
+                "uncompressed-sha256": "159e8b90e362e441920df32962ab8a20010d3f41f58928223af969c09a72b186"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-qemu.s390x.qcow2.gz",
-                "sha256": "a63976c49df0014bfbc02455c743ab7e74b6e9f852e6bd5f0ec1dd016ea93470",
-                "uncompressed-sha256": "baa11074eba6306356bfd4af43a1eff95b60b53e9cbdf039bb72e53296669788"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-qemu.s390x.qcow2.gz",
+                "sha256": "2e5a70c5de693f1726346c37c3c83b79e47473689f9d6e32fa282ae8f1c456ac",
+                "uncompressed-sha256": "58bdaf28eea2ccb6950bcf0bf3e1bf057d525b2003361ef17c3ff62d13b935d0"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/s390x/rhcos-414.92.202304131328-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "21b2162500297831d50e3916ee6dd2d818cd7dd49ebc6d81b716c903b45ac3bb",
-                "uncompressed-sha256": "cf68b855d0c881dba37cae5f8f03267d977290c4adb82718af255fdcd3a9f569"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/s390x/rhcos-414.92.202304252144-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "3fe67ca4954f6d9a39421d3146b319d5157bb6d0f20d40e0b021813e5d4961de",
+                "uncompressed-sha256": "fdcc077c10ea663002636483ee1c2dfb5ae40fc7285bb193ca1424f9a167177a"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "b2880964dd21489b32ed8a81eefbf36ba4ed47d2df4a4e591849916e0b326923",
-                "uncompressed-sha256": "d388faeefce1f1a49c6b827c96344f660a330a6edd6c8e49e00eaee7cf81176d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "a03488cd499be70725e4cd0af26b8595159147254ad6f17d7c5f105fbd02e3a3",
+                "uncompressed-sha256": "ef2aa7f880366d9b406f9c4d73f00c35efb541f97fb4f58fd81f1d7b736517af"
               }
             }
           }
         },
         "aws": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-aws.x86_64.vmdk.gz",
-                "sha256": "8bcaafba38a9c21cf614d58514dee038e45448beda30dbd35567201fb17d68e4",
-                "uncompressed-sha256": "14e15be9ba16818e88de588ab3415366a62a67380b3e779992aae7e086e4774b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-aws.x86_64.vmdk.gz",
+                "sha256": "7b0112c3cfd32221b67061756816d75852efd7c3b1f1be4050b707124cd7a5fc",
+                "uncompressed-sha256": "bdf30dd60cbae719562f58b5a330e8f706d694c2b8f32a2c21c79bd3c836ecd2"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-azure.x86_64.vhd.gz",
-                "sha256": "cbc24fe92860d2c4c39a2bd6a1faa5b510c72e15d84eea895b9a2dc2df2467fd",
-                "uncompressed-sha256": "74f127d1df9e06f5a986c30d81305281395ead278cee9c404c811f176a20e47c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-azure.x86_64.vhd.gz",
+                "sha256": "35eb9e68dd145e132cdb2d573e12880860f74edaf0951f7ad3145e06a23b53cf",
+                "uncompressed-sha256": "1b423a95fc2b51627cdd5c219e057704024030d62203cafec1b456199a3db690"
               }
             }
           }
         },
         "azurestack": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-azurestack.x86_64.vhd.gz",
-                "sha256": "0002495b0ac66114f0b0f9187e6415faa2cd4dcfa0ca543b870c0956571e2a7f",
-                "uncompressed-sha256": "784d47970afc6da7900c36f341f6e2ec361246e95d67ec67df79748f6e1d5b08"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-azurestack.x86_64.vhd.gz",
+                "sha256": "52ef2e486c34bf5865f1837d33d6e499d0d4e18388a9c2f8ff0875438e4d82f8",
+                "uncompressed-sha256": "874dc15cc356dbe12c44053cd0ba33154318881d296fa33a1ca948cf466e1a0c"
               }
             }
           }
         },
         "gcp": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-gcp.x86_64.tar.gz",
-                "sha256": "0dc470e41031ba3d313e50021191005798d4250ecea65ed40618241bd92ed239",
-                "uncompressed-sha256": "de95a4f2ccd147dac80542b4dfa19184f9a57eb8a0dcefa6d78e905f8512267e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-gcp.x86_64.tar.gz",
+                "sha256": "59ae0accf6adef8e1044d0449ea4125fd9efb4a1cbae9b7537d7f1e869019991",
+                "uncompressed-sha256": "05a8716c564c23b3e44dfb691695e6f20b9b5523fbe99f4ecf80cf227b513b5b"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "562de7348053abc829bd171d58628360e1244d4411b3c15ddbe7f6cbb6085f14",
-                "uncompressed-sha256": "6b8f7c52f975ecedc05f72e9c710fd1d1250d96b7664a106f42012197d9706dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "3b13fa7901601a540181c5fcbb9f0ed5785aea842677b8656fce4aa130ac7cb5",
+                "uncompressed-sha256": "6ab650d1a61e1b6a509c61f0662d7666a38b7c76ab7877fd4105a9723c34ef36"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-metal4k.x86_64.raw.gz",
-                "sha256": "f711caf3e3ef0dcadd31e97e085cec02304d7427115b567e4922f43267442437",
-                "uncompressed-sha256": "c6e47e5d4d0c417b65f1dbb4b8d35eafcae5bd09867abb45eb1e0605132017ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-metal4k.x86_64.raw.gz",
+                "sha256": "9c369d506858cea4f84bca596dabdf039c76166d926cadf32b12d4f3315428d3",
+                "uncompressed-sha256": "0f2b534fbff66e13f624b4dd767f2f0929d72303acf7224f1e04462d92756264"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live.x86_64.iso",
-                "sha256": "ed479a94f7842b8791802919c75a12669b243334c79d763fad04c1efac009a18"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-live.x86_64.iso",
+                "sha256": "985a10fb027295975cac2e5dace95a0f47a6311b04fab3256284234131903ee6"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-kernel-x86_64",
-                "sha256": "833e29fcfde19f8fff62ce3c07ef883042eb476c2468405599eb000da813629d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-live-kernel-x86_64",
+                "sha256": "604de992bfeb9fc6491ee57f209fcecedaafe85e29b75c45b08da963c6599e5b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-initramfs.x86_64.img",
-                "sha256": "ff870016cfed160913345314ff612957e1e4ce825529bba53f1efb74406edefa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-live-initramfs.x86_64.img",
+                "sha256": "7827c282fe2c926a83fcebbf45c9d7963c03e6d9dcb0f152ad57ec302c78c2a0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-live-rootfs.x86_64.img",
-                "sha256": "b6a133113144d4f44efbca50136deaafc2c9ad09177ad5f90a1a4eef1e36a098"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-live-rootfs.x86_64.img",
+                "sha256": "e83558766c4e482f6c4725acf11432a03f160f8d528ed7bb954cbbcca8f22ff8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-metal.x86_64.raw.gz",
-                "sha256": "1090407f2439706451f0f3b4aff506cbed4836af8e10756dc264aded85b11fe6",
-                "uncompressed-sha256": "be52d0e25b9948430bd35da61b09dd13bebaeb352da8aa2dfc5590ea29f77bb2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-metal.x86_64.raw.gz",
+                "sha256": "744416aa580494cb5cc63af18c9b587d0f14fe9b2db7a2006cf2053ee205a329",
+                "uncompressed-sha256": "a7d5fc333007e315e9a6eaf21dca58ce07f9e831cbbbd145ff7961bb7647f520"
               }
             }
           }
         },
         "nutanix": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-nutanix.x86_64.qcow2",
-                "sha256": "34bf1db0871fc47208f9973edd2a61965ff42e733641e75ecbdbbf5edd43e26f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-nutanix.x86_64.qcow2",
+                "sha256": "2ab4be3dad4686435834c7828ab52ba50faaacc691540321e0c2055ee73b1542"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-openstack.x86_64.qcow2.gz",
-                "sha256": "f9d920c980a34556f0e63e78132051e328a2f989b6488bd1474aec1e8e35485f",
-                "uncompressed-sha256": "dbcba8d3e7ec473827c44ab6204b6ae36a5d07db20a799abfc9e9cb380a439ef"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-openstack.x86_64.qcow2.gz",
+                "sha256": "b7225fce14029f620d4e084db59e44a601f7c8eb87b90c9b0c374512dcd43907",
+                "uncompressed-sha256": "f11e758c1d6cbf16dec5123fb683a343754634e159a3b127e0b0865107844ffd"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-qemu.x86_64.qcow2.gz",
-                "sha256": "5cd2458f773987495786fd97f94804b3b48b3bf283920da6ede6b8d5d734b119",
-                "uncompressed-sha256": "9a37af9e8459c900359f4e5a260f0e5a94b0f755b260ffb1f0e6b8cc66c226bd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-qemu.x86_64.qcow2.gz",
+                "sha256": "998f9200bcf3e5a2b3c20bf3d6a59946dc69cf624103b8a28aebe983810dc9cf",
+                "uncompressed-sha256": "866d7056f95800f429f0d6aa7f250b7df0611ce68ca453fc43d4116425fba47d"
               }
             }
           }
         },
         "vmware": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304131328-0/x86_64/rhcos-414.92.202304131328-0-vmware.x86_64.ova",
-                "sha256": "229d29ba644ebfb4dc962f40a9b3e410c95fef852582b24805df93768d418130"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202304252144-0/x86_64/rhcos-414.92.202304252144-0-vmware.x86_64.ova",
+                "sha256": "3caccf55b7d782c956b11adf798fb145bfa467cc52051b189873fa980c91bb66"
               }
             }
           }
@@ -619,249 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-6we0yfgdovctqblsbk46"
+              "release": "414.92.202304252144-0",
+              "image": "m-6we3wz6ub2plefv46cnn"
             },
             "ap-northeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "m-mj738mxrqnkz8b8orna7"
+              "release": "414.92.202304252144-0",
+              "image": "m-mj786zalnqofxvcyq3gk"
             },
             "ap-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-a2dgljc02zy39f0pzink"
+              "release": "414.92.202304252144-0",
+              "image": "m-a2del757c6d79r2k643g"
             },
             "ap-southeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-t4n34ptmhy3acal8g88g"
+              "release": "414.92.202304252144-0",
+              "image": "m-t4najbn1ggds38amc7uc"
             },
             "ap-southeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "m-p0wfajy4xz2qzph6h581"
+              "release": "414.92.202304252144-0",
+              "image": "m-p0wejw8mybw48jt48v13"
             },
             "ap-southeast-3": {
-              "release": "414.92.202304131328-0",
-              "image": "m-8ps2h7x5kuffyb0zimm0"
+              "release": "414.92.202304252144-0",
+              "image": "m-8pshyttivcva7ub0pjc5"
             },
             "ap-southeast-5": {
-              "release": "414.92.202304131328-0",
-              "image": "m-k1aatqxnd848zece5m36"
+              "release": "414.92.202304252144-0",
+              "image": "m-k1a0kha68o0uivpih43u"
             },
             "ap-southeast-6": {
-              "release": "414.92.202304131328-0",
-              "image": "m-5tsej10uwhwqzswsfqq5"
+              "release": "414.92.202304252144-0",
+              "image": "m-5ts7npkqepbll3lm5bm5"
             },
             "ap-southeast-7": {
-              "release": "414.92.202304131328-0",
-              "image": "m-0jofbllmq2oxmmkhgpne"
+              "release": "414.92.202304252144-0",
+              "image": "m-0jo3egg77wma7batcgqo"
             },
             "cn-beijing": {
-              "release": "414.92.202304131328-0",
-              "image": "m-2ze0ebt4f0skgbxht5k5"
+              "release": "414.92.202304252144-0",
+              "image": "m-2zebcbq4eh7v7v8wsyq1"
             },
             "cn-chengdu": {
-              "release": "414.92.202304131328-0",
-              "image": "m-2vc35ucempgfu5v53eor"
+              "release": "414.92.202304252144-0",
+              "image": "m-2vcaifwsuex5qpue0ayy"
             },
             "cn-fuzhou": {
-              "release": "414.92.202304131328-0",
-              "image": "m-gw0ja648ykhaublhp0eh"
+              "release": "414.92.202304252144-0",
+              "image": "m-gw049d6ya9ho4d8gkfaa"
             },
             "cn-guangzhou": {
-              "release": "414.92.202304131328-0",
-              "image": "m-7xv40n9kjplwtfr836hh"
+              "release": "414.92.202304252144-0",
+              "image": "m-7xv25hbsq8vgj46ouprg"
             },
             "cn-hangzhou": {
-              "release": "414.92.202304131328-0",
-              "image": "m-bp1cddlj57b65kfyar7m"
+              "release": "414.92.202304252144-0",
+              "image": "m-bp13yh95aqdhmbwawopa"
             },
             "cn-heyuan": {
-              "release": "414.92.202304131328-0",
-              "image": "m-f8zde65mian4qrjkrdf5"
+              "release": "414.92.202304252144-0",
+              "image": "m-f8z9lwq2cotu878t2ac6"
             },
             "cn-hongkong": {
-              "release": "414.92.202304131328-0",
-              "image": "m-j6c3t6hsg2i2kwq1rcmf"
+              "release": "414.92.202304252144-0",
+              "image": "m-j6c0smg8nmiedzmk1cj4"
             },
             "cn-huhehaote": {
-              "release": "414.92.202304131328-0",
-              "image": "m-hp36rojj3xzxfjv7kbbc"
+              "release": "414.92.202304252144-0",
+              "image": "m-hp38vcbvsw1i7cd8qs59"
             },
             "cn-nanjing": {
-              "release": "414.92.202304131328-0",
-              "image": "m-gc7ivkvqw7u1njg7hawy"
+              "release": "414.92.202304252144-0",
+              "image": "m-gc75zbb4s7ueoqm9x783"
             },
             "cn-qingdao": {
-              "release": "414.92.202304131328-0",
-              "image": "m-m5eb72sdbtki78flrq3c"
+              "release": "414.92.202304252144-0",
+              "image": "m-m5e51sqtwsyimc2chr5z"
             },
             "cn-shanghai": {
-              "release": "414.92.202304131328-0",
-              "image": "m-uf6cjzyzq1e79celyu8o"
+              "release": "414.92.202304252144-0",
+              "image": "m-uf69mak34257st55z901"
             },
             "cn-shenzhen": {
-              "release": "414.92.202304131328-0",
-              "image": "m-wz94n4lo0cdx622fafq8"
+              "release": "414.92.202304252144-0",
+              "image": "m-wz908vvdolkzbwihw750"
             },
             "cn-wulanchabu": {
-              "release": "414.92.202304131328-0",
-              "image": "m-0jlcqjnf4x7tw2kyloxa"
+              "release": "414.92.202304252144-0",
+              "image": "m-0jli9vxiql4omejx3pcg"
             },
             "cn-zhangjiakou": {
-              "release": "414.92.202304131328-0",
-              "image": "m-8vb62c3pfwwupkfcmqmh"
+              "release": "414.92.202304252144-0",
+              "image": "m-8vb8eunfit3989sfn6bj"
             },
             "eu-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-gw81pnvusvzbrf48rzno"
+              "release": "414.92.202304252144-0",
+              "image": "m-gw82ii1z9ns1qajcbrj9"
             },
             "eu-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-d7o6acw5m5voqhawv4b7"
+              "release": "414.92.202304252144-0",
+              "image": "m-d7o9e1z8k549e9grktv5"
             },
             "me-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-eb3152lacdat666p3kkl"
+              "release": "414.92.202304252144-0",
+              "image": "m-eb3icqfdaqm7efurt4hq"
             },
             "us-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-0xib22n9huq7k9hueb90"
+              "release": "414.92.202304252144-0",
+              "image": "m-0xi7a5pr6ugm4bggajza"
             },
             "us-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "m-rj990s7tn5umq65d8obu"
+              "release": "414.92.202304252144-0",
+              "image": "m-rj9itiv2o51hzj1jlid5"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-05e65b3787a0cf3d5"
+              "release": "414.92.202304252144-0",
+              "image": "ami-07749c4c93237b2f7"
             },
             "ap-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-043507d172b03a574"
+              "release": "414.92.202304252144-0",
+              "image": "ami-01c6f1a27979a62bd"
             },
             "ap-northeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0cf1a642d35dcd037"
+              "release": "414.92.202304252144-0",
+              "image": "ami-043e52422a9e99673"
             },
             "ap-northeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0e8a841a58775d570"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0187b2e7f6fba35d8"
             },
             "ap-northeast-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-08b75516c4fa37092"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0ebd17ca9b433d1d8"
             },
             "ap-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0e0b844c8ea8f3074"
+              "release": "414.92.202304252144-0",
+              "image": "ami-003b44dd3eec95f03"
             },
             "ap-south-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-06a2f47617a659ca1"
+              "release": "414.92.202304252144-0",
+              "image": "ami-070b9a162cf193b90"
             },
             "ap-southeast-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0df1fabffafa358b2"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0ba3574ad909c9a1a"
             },
             "ap-southeast-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0c62154a543e78f29"
+              "release": "414.92.202304252144-0",
+              "image": "ami-04a6c198d96f0be16"
             },
             "ap-southeast-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0a64ffeef5dcf1e5c"
+              "release": "414.92.202304252144-0",
+              "image": "ami-07afda53e68b01172"
             },
             "ap-southeast-4": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-00c9b9852cab40743"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0bf93246d77e4de18"
             },
             "ca-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-07ab7080c0380448b"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0b4f8568958854033"
             },
             "eu-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-02fa13a2ecfa7c84e"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0b493b6cff4890adf"
             },
             "eu-central-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0691f376dbe11b709"
+              "release": "414.92.202304252144-0",
+              "image": "ami-071defc2947991d10"
             },
             "eu-north-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0ca77adcff2bd5c9c"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0f4e04b33281b9bf8"
             },
             "eu-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0aa804c4e9758ee3d"
+              "release": "414.92.202304252144-0",
+              "image": "ami-02388aa27f064d3af"
             },
             "eu-south-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0b2bcb4b17cc24817"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0050655c8836a1b88"
             },
             "eu-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-06a8110b4d6572713"
+              "release": "414.92.202304252144-0",
+              "image": "ami-05ec0c3bca787445f"
             },
             "eu-west-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-05f719f69ac7867a7"
+              "release": "414.92.202304252144-0",
+              "image": "ami-023bfe62291a99b37"
             },
             "eu-west-3": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0afbb4b6732b5f97b"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0f4a70a4fa305b215"
             },
             "me-central-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-08b13b24f8ee8666f"
+              "release": "414.92.202304252144-0",
+              "image": "ami-073342932a6febb5a"
             },
             "me-south-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0e0837ca5ddf8f1fe"
+              "release": "414.92.202304252144-0",
+              "image": "ami-00bc0fb2b1f45cef5"
             },
             "sa-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0eae2e91b5aa99269"
+              "release": "414.92.202304252144-0",
+              "image": "ami-083b2aa47d9cfa0c5"
             },
             "us-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0e95030500ad17daa"
+              "release": "414.92.202304252144-0",
+              "image": "ami-07e53e5920d7285fc"
             },
             "us-east-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0ec42c0d73fd563c2"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0b86aab2285956be5"
             },
             "us-gov-east-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-023786863fad955ca"
+              "release": "414.92.202304252144-0",
+              "image": "ami-058ae4da77d039320"
             },
             "us-gov-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0a940ba338272c5a8"
+              "release": "414.92.202304252144-0",
+              "image": "ami-08d79a63e9120be94"
             },
             "us-west-1": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-04be355979e907ce6"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0d2908404b75fc41b"
             },
             "us-west-2": {
-              "release": "414.92.202304131328-0",
-              "image": "ami-0a855644af3f98440"
+              "release": "414.92.202304252144-0",
+              "image": "ami-0bf55e592d1a53710"
             }
           }
         },
         "gcp": {
-          "release": "414.92.202304131328-0",
+          "release": "414.92.202304252144-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-414-92-202304131328-0-gcp-x86-64"
+          "name": "rhcos-414-92-202304252144-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202304131328-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304131328-0-azure.x86_64.vhd"
+          "release": "414.92.202304252144-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202304252144-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

These changes will update the RHCOS 4.14 boot image metadata.

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --name 4.14-9.2 --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=414.92.202304252144-0 aarch64=414.92.202304252144-0 s390x=414.92.202304252144-0 ppc64le=414.92.202304252144-0
```