### PR TITLE
SPLAT-657: AWS Local Zones subnets automation for edge compute pool

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -18,6 +18,14 @@ variable "private_subnet_ids" {
   type = list(string)
 }
 
+variable "edge_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "edge_private_subnet_ids" {
+  type = list(string)
+}
+
 variable "master_sg_id" {
   type = string
 }

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -88,12 +88,17 @@ module "vpc" {
   private_subnets  = var.aws_private_subnets
   publish_strategy = var.aws_publish_strategy
 
-  availability_zones = distinct(
-    concat(
-      var.aws_master_availability_zones,
-      var.aws_worker_availability_zones,
-    ),
+  availability_zones = sort(
+    distinct(
+      concat(
+        var.aws_master_availability_zones,
+        var.aws_worker_availability_zones,
+      ),
+    )
   )
+
+  edge_zones         = distinct(var.aws_edge_local_zones)
+  edge_parent_gw_map = var.aws_edge_parent_zones_index
 
   tags = local.tags
 }

--- a/data/data/aws/cluster/outputs.tf
+++ b/data/data/aws/cluster/outputs.tf
@@ -22,6 +22,14 @@ output "private_subnet_ids" {
   value = values(module.vpc.az_to_private_subnet_id)
 }
 
+output "edge_public_subnet_ids" {
+  value = values(module.vpc.az_to_edge_public_subnet_id)
+}
+
+output "edge_private_subnet_ids" {
+  value = values(module.vpc.az_to_edge_private_subnet_id)
+}
+
 output "master_sg_id" {
   value = module.vpc.master_sg_id
 }

--- a/data/data/aws/cluster/vpc/common.tf
+++ b/data/data/aws/cluster/vpc/common.tf
@@ -4,6 +4,34 @@
 locals {
   public_endpoints = var.publish_strategy == "External" ? true : false
   description      = "Created By OpenShift Installer"
+
+  # CIDR block distribution:
+  # allow_expansion_* flags checks if is a single-zone deployment, if true (1) the
+  # available CIDR block will be split into two to allow user expansion.
+  allow_expansion_zones = length(var.availability_zones) == 1 ? 1 : 0
+  allow_expansion_edge  = length(var.edge_zones) == 1 ? 1 : 0
+
+  # edge_enabled flag is enabled when edge zones (Local Zone) are provided.
+  edge_enabled = length(var.edge_zones) > 0 ? 1 : 0
+
+  # CIDR blocks for default IPI installation
+  cidr_dedicated_private = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 0)
+  cidr_dedicated_public  = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 1)
+
+  # CIDR blocks used when creating subnets into edge zones.
+  # The Public CIDR is used to create the CIDR blocks for edge subnets.
+  cidr_shared_public = cidrsubnet(local.cidr_dedicated_public, 1, 0)
+  cidr_shared_edge   = cidrsubnet(local.cidr_dedicated_public, 1, 1)
+
+  # CIDR blocks for edge subnets
+  cidr_edge_private = cidrsubnet(local.cidr_shared_edge, 1, 0)
+  cidr_edge_public  = cidrsubnet(local.cidr_shared_edge, 1, 1)
+
+  # CIDR blocks pool used to create subnets for each zone
+  new_private_cidr_range      = cidrsubnet(local.cidr_dedicated_private, local.allow_expansion_zones, 0)
+  new_public_cidr_range       = local.edge_enabled == 0 ? cidrsubnet(local.cidr_dedicated_public, local.allow_expansion_zones, 0) : cidrsubnet(local.cidr_shared_public, local.allow_expansion_zones, 0)
+  new_edge_private_cidr_range = local.allow_expansion_edge == 0 ? local.cidr_edge_private : cidrsubnet(local.cidr_edge_private, local.allow_expansion_edge, 0)
+  new_edge_public_cidr_range  = local.allow_expansion_edge == 0 ? local.cidr_edge_public : cidrsubnet(local.cidr_edge_public, local.allow_expansion_edge, 0)
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs
@@ -23,4 +51,16 @@ data "aws_subnet" "private" {
   count = var.private_subnets == null ? length(var.availability_zones) : length(var.private_subnets)
 
   id = var.private_subnets == null ? aws_subnet.private_subnet[count.index].id : var.private_subnets[count.index]
+}
+
+data "aws_subnet" "edge_private" {
+  count = var.edge_zones == null ? 0 : length(var.edge_zones)
+
+  id = var.edge_zones == null ? null : aws_subnet.edge_private_subnet[count.index].id
+}
+
+data "aws_subnet" "edge_public" {
+  count = var.edge_zones == null ? 0 : length(var.edge_zones)
+
+  id = var.edge_zones == null ? null : aws_subnet.edge_public_subnet[count.index].id
 }

--- a/data/data/aws/cluster/vpc/outputs.tf
+++ b/data/data/aws/cluster/vpc/outputs.tf
@@ -10,12 +10,28 @@ output "az_to_public_subnet_id" {
   value = zipmap(data.aws_subnet.public.*.availability_zone, data.aws_subnet.public.*.id)
 }
 
+output "az_to_edge_private_subnet_id" {
+  value = zipmap(data.aws_subnet.edge_private.*.availability_zone, data.aws_subnet.edge_private.*.id)
+}
+
+output "az_to_edge_public_subnet_id" {
+  value = zipmap(data.aws_subnet.edge_public.*.availability_zone, data.aws_subnet.edge_public.*.id)
+}
+
 output "public_subnet_ids" {
   value = data.aws_subnet.public.*.id
 }
 
 output "private_subnet_ids" {
   value = data.aws_subnet.private.*.id
+}
+
+output "edge_public_subnet_ids" {
+  value = data.aws_subnet.edge_public.*.id
+}
+
+output "edge_private_subnet_ids" {
+  value = data.aws_subnet.edge_private.*.id
 }
 
 output "master_sg_id" {

--- a/data/data/aws/cluster/vpc/variables.tf
+++ b/data/data/aws/cluster/vpc/variables.tf
@@ -3,6 +3,18 @@ variable "availability_zones" {
   description = "The availability zones in which to provision subnets."
 }
 
+variable "edge_zones" {
+  type        = list(string)
+  default     = []
+  description = "The local zones to provision subnets."
+}
+
+variable "edge_parent_gw_map" {
+  type        = map(string)
+  default     = {}
+  description = "The parent zone index used to lookup the NAT gateway for private subnets in Local Zone."
+}
+
 variable "cidr_blocks" {
   type        = list(string)
   description = "A list of IPv4 CIDRs with 0 index being the main CIDR."

--- a/data/data/aws/cluster/vpc/vpc-private.tf
+++ b/data/data/aws/cluster/vpc/vpc-private.tf
@@ -42,9 +42,37 @@ resource "aws_subnet" "private_subnet" {
   )
 }
 
+resource "aws_subnet" "edge_private_subnet" {
+  count = var.edge_zones == null ? 0 : length(var.edge_zones)
+
+  vpc_id            = data.aws_vpc.cluster_vpc.id
+  cidr_block        = cidrsubnet(local.new_edge_private_cidr_range, ceil(log(length(var.edge_zones), 2)), count.index)
+  availability_zone = var.edge_zones[count.index]
+
+  tags = merge(
+    {
+      "Name" = "${var.cluster_id}-private-${var.edge_zones[count.index]}"
+    },
+    var.tags,
+  )
+
+}
+
 resource "aws_route_table_association" "private_routing" {
   count = var.private_subnets == null ? length(var.availability_zones) : 0
 
   route_table_id = aws_route_table.private_routes[count.index].id
   subnet_id      = aws_subnet.private_subnet[count.index].id
+}
+
+resource "aws_route_table_association" "edge_private_routing" {
+  count = var.edge_zones == null ? 0 : length(var.edge_zones)
+
+  # Lookup the index of the parent zone from a given Local Zone name,
+  # getting the index for the route table id for that zone (parent),
+  # when not found (parent zone's gateway does not exists), the first
+  # route table will be used.
+  # Example edge_parent_gw_map = {us-east-1-nyc-1a=0}
+  route_table_id = aws_route_table.private_routes[lookup(var.edge_parent_gw_map, aws_subnet.edge_private_subnet[count.index].availability_zone, 0)].id
+  subnet_id      = aws_subnet.edge_private_subnet[count.index].id
 }

--- a/data/data/aws/cluster/vpc/vpc.tf
+++ b/data/data/aws/cluster/vpc/vpc.tf
@@ -1,8 +1,3 @@
-locals {
-  new_private_cidr_range = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 1)
-  new_public_cidr_range  = cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block, 1, 0)
-}
-
 resource "aws_vpc" "new_vpc" {
   count = var.vpc == null ? 1 : 0
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -120,49 +120,69 @@ variable "aws_worker_availability_zones" {
   description = "The availability zones to provision for workers.  Worker instances are created by the machine-API operator, but this variable controls their supporting infrastructure (subnets, routing, etc.)."
 }
 
+variable "aws_edge_local_zones" {
+  type    = list(string)
+  default = []
+
+  description = "The zones to provision subnets for the edge pool. Edge instances are created by the machine-API operator, but this variable controls their supporting infrastructure (subnets, routing, etc.)."
+}
+
+variable "aws_edge_parent_zones_index" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOF
+(optional) A map of the Edge's Parent Zone indexes to discover the private's route table ID used by the private subnet from the parent's Zone in the Region.
+Each Local or Wavelength Zone is connected to a parent zone in the Region. If the parent zone has private Route tables, the installer
+uses the index to associate with the private edge subnets.
+
+Example: `{ "us-east-1-nyc-1a"=5, "us-east-1-wl1-nyc-wlz-1"=2 }`
+EOF
+}
+
 variable "aws_vpc" {
-  type        = string
-  default     = null
+  type = string
+  default = null
   description = "(optional) An existing network (VPC ID) into which the cluster should be installed."
 }
 
 variable "aws_public_subnets" {
-  type        = list(string)
-  default     = null
+  type = list(string)
+  default = null
   description = "(optional) Existing public subnets into which the cluster should be installed."
 }
 
 variable "aws_private_subnets" {
-  type        = list(string)
-  default     = null
+  type = list(string)
+  default = null
   description = "(optional) Existing private subnets into which the cluster should be installed."
 }
 
 variable "aws_internal_zone" {
-  type        = string
-  default     = null
+  type = string
+  default = null
   description = "(optional) An existing hosted zone (zone ID) to use for the internal API."
 }
 
 variable "aws_internal_zone_role" {
-  type        = string
-  default     = null
+  type = string
+  default = null
   description = "(optional) A role to assume when using an existing hosted zone from another account."
 }
 
 
 variable "aws_publish_strategy" {
-  type        = string
+  type = string
   description = "The cluster publishing strategy, either Internal or External"
 }
 
 variable "aws_ignition_bucket" {
-  type        = string
+  type = string
   description = "The S3 bucket where the ignition configuration is stored"
 }
 
 variable "aws_bootstrap_stub_ignition" {
-  type        = string
+  type = string
   description = <<EOF
 The stub Ignition config that should be used to boot the bootstrap instance. This already points to the presigned URL for the s3 bucket
 specified in aws_ignition_bucket.
@@ -170,13 +190,13 @@ EOF
 }
 
 variable "aws_master_iam_role_name" {
-  type = string
+  type        = string
   description = "The name of the IAM role that will be attached to master instances."
-  default = ""
+  default     = ""
 }
 
 variable "aws_worker_iam_role_name" {
-  type = string
+  type        = string
   description = "The name of the IAM role that will be attached to worker instances."
-  default = ""
+  default     = ""
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -287,10 +287,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			masterIAMRoleName = awsMP.IAMRole
 		}
 
+		// AWS Zones is used to determine which route table the edge zone will be associated.
+		allZones, err := installConfig.AWS.AllZones(ctx)
+		if err != nil {
+			return err
+		}
+
 		data, err := awstfvars.TFVars(awstfvars.TFVarsSources{
 			VPC:                   vpc,
 			PrivateSubnets:        privateSubnets,
 			PublicSubnets:         publicSubnets,
+			AvailabilityZones:     allZones,
 			InternalZone:          installConfig.Config.AWS.HostedZone,
 			InternalZoneRole:      installConfig.Config.AWS.HostedZoneRole,
 			Services:              installConfig.Config.AWS.ServiceEndpoints,
@@ -1015,7 +1022,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 		natGatewayZones, err := client.ListEnhanhcedNatGatewayAvailableZones()
 		if err != nil {
-			return errors.Wrapf(err, "failed to list avaliable zones for NAT gateway")
+			return errors.Wrapf(err, "failed to list available zones for NAT gateway")
 		}
 		natGatewayZoneID := natGatewayZones.Zones[0].ZoneId
 

--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -11,10 +11,40 @@ import (
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 )
 
+// Zones stores the map of Zone attributes indexed by Zone Name.
+type Zones map[string]*Zone
+
+// Zone stores the Availability or Local Zone attributes used to set machine attributes, and to
+// feed VPC resources as a source for for terraform variables.
+type Zone struct {
+
+	// Name is the availability, local or wavelength zone name.
+	Name string
+
+	// ZoneType is the type of subnet's availability zone.
+	// The valid values are availability-zone and local-zone.
+	Type string
+
+	// ZoneGroupName is the AWS zone group name.
+	// For Availability Zones, this parameter has the same value as the Region name.
+	//
+	// For Local Zones, the name of the associated group, for example us-west-2-lax-1.
+	GroupName string
+
+	// ParentZoneName is the name of the zone that handles some of the Local Zone
+	// control plane operations, such as API calls.
+	ParentZoneName string
+
+	// PreferredInstanceType is the offered instance type on the subnet's zone.
+	// It's used for the edge pools which does not offer the same type across different zone groups.
+	PreferredInstanceType string
+}
+
 // describeAvailabilityZones retrieves a list of all zones for the given region.
-func describeAvailabilityZones(ctx context.Context, session *session.Session, region string) ([]*ec2.AvailabilityZone, error) {
+func describeAvailabilityZones(ctx context.Context, session *session.Session, region string, zones []string) ([]*ec2.AvailabilityZone, error) {
 	client := ec2.New(session, aws.NewConfig().WithRegion(region))
-	resp, err := client.DescribeAvailabilityZonesWithContext(ctx, &ec2.DescribeAvailabilityZonesInput{
+	input := &ec2.DescribeAvailabilityZonesInput{
+		AllAvailabilityZones: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("region-name"),
@@ -25,7 +55,13 @@ func describeAvailabilityZones(ctx context.Context, session *session.Session, re
 				Values: []*string{aws.String("available")},
 			},
 		},
-	})
+	}
+	if len(zones) > 0 {
+		for _, zone := range zones {
+			input.ZoneNames = append(input.ZoneNames, aws.String(zone))
+		}
+	}
+	resp, err := client.DescribeAvailabilityZonesWithContext(ctx, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching zones")
 	}
@@ -33,22 +69,43 @@ func describeAvailabilityZones(ctx context.Context, session *session.Session, re
 	return resp.AvailabilityZones, nil
 }
 
-// availabilityZones retrieves a list of zones type 'availability-zone' for the region.
-func availabilityZones(ctx context.Context, session *session.Session, region string) ([]string, error) {
-	azs, err := describeAvailabilityZones(ctx, session, region)
+// zonesByType retrieves a list of zones by a given ZoneType attribute within the region.
+// ZoneType can be availability-zone, local-zone or wavelength-zone.
+func zonesByType(ctx context.Context, session *session.Session, region string, zoneType string) ([]string, error) {
+	azs, err := describeAvailabilityZones(ctx, session, region, []string{})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching availability zones")
+		return nil, errors.Wrapf(err, "fetching %s", zoneType)
 	}
 	zones := []string{}
 	for _, zone := range azs {
-		if *zone.ZoneType == typesaws.AvailabilityZoneType {
-			zones = append(zones, *zone.ZoneName)
+		if aws.StringValue(zone.ZoneType) == zoneType {
+			zones = append(zones, aws.StringValue(zone.ZoneName))
 		}
 	}
 
 	if len(zones) == 0 {
-		return nil, errors.Errorf("no available zones in %s", region)
+		return nil, errors.Errorf("no zones with type %s in %s", zoneType, region)
 	}
 
 	return zones, nil
+}
+
+// availabilityZones retrieves a list of zones type 'availability-zone' for the region.
+func availabilityZones(ctx context.Context, session *session.Session, region string) ([]string, error) {
+	return zonesByType(ctx, session, region, typesaws.AvailabilityZoneType)
+}
+
+// localZones retrieves a list of zones type 'local-zone' for the region.
+func localZones(ctx context.Context, session *session.Session, region string) ([]string, error) {
+	return zonesByType(ctx, session, region, typesaws.LocalZoneType)
+}
+
+// describeFilteredZones retrieves a list of all zones for the given region.
+func describeFilteredZones(ctx context.Context, session *session.Session, region string, zones []string) ([]*ec2.AvailabilityZone, error) {
+	azs, err := describeAvailabilityZones(ctx, session, region, zones)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching %s", zones)
+	}
+
+	return azs, nil
 }

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -127,8 +127,8 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 
 // finishAWS set defaults for AWS Platform before the config validation.
 func (a *InstallConfig) finishAWS() error {
-	// Set the Default Edge Compute pool when the subnets are defined.
-	// Edge Compute Pool/AWS Local Zones is supported only when installing in existing VPC.
+	// Set the Default Edge Compute pool when the subnets in AWS Local Zones are defined,
+	// when installing a cluster in existing VPC.
 	if len(a.Config.Platform.AWS.Subnets) > 0 {
 		edgeSubnets, err := a.AWS.EdgeSubnets(context.TODO())
 		if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -201,7 +201,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 				return err
 			}
 			for id, subnet := range subnetMeta {
-				subnets[subnet.Zone] = id
+				subnets[subnet.Zone.Name] = id
 			}
 		}
 

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -197,23 +197,21 @@ func defaultNutanixMachinePoolPlatform() nutanixtypes.MachinePool {
 	}
 }
 
-// awsDiscoveryPreferredEdgeInstanceByZone discover supported instanceType for each subnet's
-// zone using the preferred list of instances allowed for OCP.
-func awsDiscoveryPreferredEdgeInstanceByZone(ctx context.Context, defaultTypes []string, meta *icaws.Metadata, subnets icaws.Subnets) (ok bool, err error) {
-	for zone := range subnets {
-		subnet, ok := subnets[zone]
-		if !ok {
-			return ok, errors.Wrap(err, fmt.Sprintf("failed to get subnet's zone[%v] to lookup preferred instance type.", zone))
-		}
-
+// awsSetPreferredInstanceByEdgeZone discovers supported instanceType for each edge pool
+// using the existing preferred instance list used by worker compute pool.
+// Each machine set in the edge pool, created for each zone, can use different instance
+// types depending on the instance offerings in the location (Local Zones).
+func awsSetPreferredInstanceByEdgeZone(ctx context.Context, defaultTypes []string, meta *icaws.Metadata, zones icaws.Zones) (ok bool, err error) {
+	for zone := range zones {
 		preferredType, err := aws.PreferredInstanceType(ctx, meta, defaultTypes, []string{zone})
 		if err != nil {
 			logrus.Warn(errors.Wrap(err, fmt.Sprintf("unable to select instanceType on the zone[%v] from the preferred list: %v. You must update the MachineSet manifest", zone, defaultTypes)))
 			continue
 		}
-
-		subnet.PreferredEdgeInstanceType = preferredType
-		subnets[zone] = subnet
+		if _, ok := zones[zone]; !ok {
+			zones[zone] = &icaws.Zone{Name: zone}
+		}
+		zones[zone].PreferredInstanceType = preferredType
 	}
 	return true, nil
 }
@@ -343,6 +341,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 		case awstypes.Name:
 			subnets := icaws.Subnets{}
+			zones := icaws.Zones{}
 			if len(ic.Platform.AWS.Subnets) > 0 {
 				var subnetsMeta icaws.Subnets
 				switch pool.Name {
@@ -351,10 +350,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 					if err != nil {
 						return err
 					}
-					if *pool.Replicas == 0 {
-						sbCount := int64(len(subnetsMeta))
-						pool.Replicas = &sbCount
-					}
 				default:
 					subnetsMeta, err = installConfig.AWS.PrivateSubnets(ctx)
 					if err != nil {
@@ -362,10 +357,9 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 					}
 				}
 				for _, subnet := range subnetsMeta {
-					subnets[subnet.Zone] = subnet
+					subnets[subnet.Zone.Name] = subnet
 				}
 			}
-
 			mpool := defaultAWSMachinePoolPlatform(pool.Name)
 
 			osImage := strings.SplitN(string(*rhcosImage), ",", 2)
@@ -380,8 +374,12 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			zoneDefaults := false
 			if len(mpool.Zones) == 0 {
 				if len(subnets) > 0 {
-					for zone := range subnets {
-						mpool.Zones = append(mpool.Zones, zone)
+					for _, subnet := range subnets {
+						if subnet.Zone == nil {
+							return errors.Wrapf(err, "failed to find zone attributes for subnet %s", subnet.ID)
+						}
+						mpool.Zones = append(mpool.Zones, subnet.Zone.Name)
+						zones[subnet.Zone.Name] = subnets[subnet.Zone.Name].Zone
 					}
 				} else {
 					mpool.Zones, err = installConfig.AWS.AvailabilityZones(ctx)
@@ -392,12 +390,23 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				}
 			}
 
+			// Requirements when using edge compute pools to populate machine sets.
+			if pool.Name == types.MachinePoolEdgeRoleName {
+				err = installConfig.AWS.SetZoneAttributes(ctx, mpool.Zones, zones)
+				if err != nil {
+					return errors.Wrap(err, "failed to retrieve zone attributes for edge compute pool")
+				}
+
+				if pool.Replicas == nil || *pool.Replicas == 0 {
+					pool.Replicas = pointer.Int64(int64(len(mpool.Zones)))
+				}
+			}
+
 			if mpool.InstanceType == "" {
 				instanceTypes := awsdefaults.InstanceTypes(installConfig.Config.Platform.AWS.Region, installConfig.Config.ControlPlane.Architecture, configv1.HighlyAvailableTopologyMode)
-
 				switch pool.Name {
 				case types.MachinePoolEdgeRoleName:
-					ok, err := awsDiscoveryPreferredEdgeInstanceByZone(ctx, instanceTypes, installConfig.AWS, subnets)
+					ok, err := awsSetPreferredInstanceByEdgeZone(ctx, instanceTypes, installConfig.AWS, zones)
 					if err != nil {
 						return errors.Wrap(err, "failed to find default instance type for edge pool, you must define on the compute pool")
 					}
@@ -408,7 +417,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				default:
 					mpool.InstanceType, err = aws.PreferredInstanceType(ctx, installConfig.AWS, instanceTypes, mpool.Zones)
 					if err != nil {
-						logrus.Warn(errors.Wrap(err, "failed to find default instance type"))
+						logrus.Warn(errors.Wrapf(err, "failed to find default instance type for %s pool", pool.Name))
 						mpool.InstanceType = instanceTypes[0]
 					}
 				}
@@ -422,15 +431,15 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 
 			pool.Platform.AWS = &mpool
-			sets, err := aws.MachineSets(
-				clusterID.InfraID,
-				installConfig.Config.Platform.AWS.Region,
-				subnets,
-				&pool,
-				pool.Name,
-				workerUserDataSecretName,
-				installConfig.Config.Platform.AWS.UserTags,
-			)
+			sets, err := aws.MachineSets(&aws.MachineSetInput{
+				ClusterID:                clusterID.InfraID,
+				InstallConfigPlatformAWS: installConfig.Config.Platform.AWS,
+				Subnets:                  subnets,
+				Zones:                    zones,
+				Pool:                     &pool,
+				Role:                     pool.Name,
+				UserDataSecret:           workerUserDataSecretName,
+			})
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}

--- a/pkg/types/aws/availabilityzones.go
+++ b/pkg/types/aws/availabilityzones.go
@@ -5,4 +5,8 @@ const (
 	AvailabilityZoneType = "availability-zone"
 	// LocalZoneType is the type of Local zone placed on the metropolitan areas.
 	LocalZoneType = "local-zone"
+	// ZoneOptInStatusOptedIn is the opt-in status of the zone.
+	// For Availability Zones, this parameter always has the value of opt-in-not-required.
+	// For Local Zones and Wavelength Zones, this parameter is the opt-in status.
+	ZoneOptInStatusOptedIn = "opted-in"
 )

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -26,15 +26,20 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	}
 }
 
-// CreateEdgeMachinePoolDefaults create the edge compute pool when it is not already defined.
-func CreateEdgeMachinePoolDefaults(pools []types.MachinePool, platform string, replicas int64) *types.MachinePool {
+// hasEdgePoolConfig checks if the Edge compute pool has been defined on install-config.
+func hasEdgePoolConfig(pools []types.MachinePool) bool {
 	edgePoolDefined := false
 	for _, compute := range pools {
 		if compute.Name == types.MachinePoolEdgeRoleName {
 			edgePoolDefined = true
 		}
 	}
-	if edgePoolDefined {
+	return edgePoolDefined
+}
+
+// CreateEdgeMachinePoolDefaults create the edge compute pool when it is not already defined.
+func CreateEdgeMachinePoolDefaults(pools []types.MachinePool, platform string, replicas int64) *types.MachinePool {
+	if hasEdgePoolConfig(pools) {
 		return nil
 	}
 	pool := &types.MachinePool{

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -128,3 +128,40 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestHasEdgePoolConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		pool     []types.MachinePool
+		expected bool
+	}{
+		{
+			name:     "empty",
+			pool:     []types.MachinePool{*defaultMachinePool("non-edge")},
+			expected: false,
+		}, {
+			name:     "worker",
+			pool:     []types.MachinePool{*defaultMachinePool("worker")},
+			expected: false,
+		}, {
+			name:     "edge",
+			pool:     []types.MachinePool{*defaultEdgeMachinePool("edge")},
+			expected: true,
+		}, {
+			name:     "edge",
+			pool:     []types.MachinePool{*defaultEdgeMachinePool("edge"), *defaultMachinePool("non-edge")},
+			expected: true,
+		}, {
+			name:     "edge",
+			pool:     []types.MachinePool{*defaultEdgeMachinePool("edge"), *defaultMachinePool("worker")},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := hasEdgePoolConfig(tc.pool)
+			assert.Equal(t, tc.expected, res, "unexpected machine pool")
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces the automation required to installer create subnets on AWS Local Zones when that zone names are set in the instal-config.yaml, Phase 2 of AWS Local Zones described on [EP 1232](https://github.com/openshift/enhancements/pull/1232)

Feature: [RFE-2782](https://issues.redhat.com/browse/RFE-2782) / [SPLAT-657](https://issues.redhat.com/browse/SPLAT-657)
Enhancement: https://github.com/openshift/enhancements/pull/1232

Workflow example:

- Create Install-config with support of Local Zones (Example region `us-east-1`)

```yaml
apiVersion: v1
publish: External
baseDomain: devcluster.openshift.com
metadata:
  name: "cluster-name"
pullSecret: ...
sshKey: ...
platform:
  aws:
    region: us-east-1
compute:
- name: edge
  platform:
    aws:
      zones:
      - us-east-1-atl-1a
      - us-east-1-bos-1a
      - us-east-1-bue-1a
      - us-east-1-chi-1a
      - us-east-1-dfw-1a
      - us-east-1-iah-1a
      - us-east-1-lim-1a
      - us-east-1-mci-1a
      - us-east-1-mia-1a
      - us-east-1-msp-1a
      - us-east-1-nyc-1a
      - us-east-1-phl-1a
      - us-east-1-qro-1a
      - us-east-1-scl-1a
```

- Create the cluster



/hold

- [x] Installer checks if the zone group has been enabled
- [x] Installer automation to detect Local Zones from install-config.yaml on the edge compute pool
- [x] Installer automation to create subnets on Local Zones locations
- [x] Documentation of Local Zones Phase II development
- [x] Review tests coverage
- [x] Review/isolate changes: CIDR blocks 'expansion' when deploying in single-zone: https://github.com/openshift/installer/pull/7115
- [x] Split commit change set

e2e tests:
- https://github.com/openshift/release/pull/39902
- https://github.com/openshift/release/pull/40031