### PR TITLE
OCPBUGS-12904: openstack: Add netcat to the Installer image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -26,7 +26,7 @@ RUN yum install --setopt=tsflags=nodocs -y gettext make git gzip util-linux glib
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq && \
+    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq nmap && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN python -m pip install yq


### PR DESCRIPTION
ncat is needed for setting up load balancer and proxy environments in the CI.