### PR TITLE
OCPBUGS-14077: MULTIARCH-3492: Avoid conflicting subnets

### DIFF
--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -42,11 +42,6 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 				{CIDR: *libvirtdefaults.DefaultMachineCIDR},
 			}
 		}
-		if c.Platform.PowerVS != nil {
-			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
-				{CIDR: *powervsdefaults.DefaultMachineCIDR},
-			}
-		}
 	}
 	if c.Networking.NetworkType == "" {
 		c.Networking.NetworkType = defaultNetworkType
@@ -122,6 +117,9 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		}
 	case c.Platform.PowerVS != nil:
 		powervsdefaults.SetPlatformDefaults(c.Platform.PowerVS)
+		c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: *powervsdefaults.DefaultMachineCIDR},
+		}
 	case c.Platform.None != nil:
 		nonedefaults.SetPlatformDefaults(c.Platform.None)
 	case c.Platform.Nutanix != nil:

--- a/pkg/types/powervs/defaults/platform.go
+++ b/pkg/types/powervs/defaults/platform.go
@@ -1,6 +1,10 @@
 package defaults
 
 import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/powervs"
 )
@@ -13,4 +17,11 @@ var (
 
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *powervs.Platform) {
+	n, err := rand.Int(rand.Reader, big.NewInt(253))
+	if err != nil {
+		panic(err)
+	}
+	subnet := n.Int64()
+	// MustParseCIDR parses a CIDR from its string representation. If the parse fails, the function will panic.
+	DefaultMachineCIDR = ipnet.MustParseCIDR(fmt.Sprintf("192.168.%d.0/24", subnet))
 }


### PR DESCRIPTION
Use a random number for DefaultMachineCIDR: 192.168.%d.0/24 This should significantly reduce the chances for collisions.