### PR TITLE
OCPBUGS-12964: Bootstrap on aws should have same metadata service type as on other nodes

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -166,6 +166,11 @@ resource "aws_instance" "bootstrap" {
     local.tags,
   )
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = var.aws_bootstrap_instance_metadata_authentication
+  }
+
   root_block_device {
     volume_type = local.volume_type
     volume_size = local.volume_size

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -25,3 +25,4 @@ variable "master_sg_id" {
 variable "ami_id" {
   type = string
 }
+

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -99,6 +99,12 @@ variable "aws_master_instance_metadata_authentication" {
   description = "The session tokens requirement, also referred to as Instance Metadata Service Version 2 (IMDSv2). Values are optional or required. Defaults to optional."
 }
 
+variable "aws_bootstrap_instance_metadata_authentication" {
+  type        = string
+  default     = "optional"
+  description = "The session tokens requirement, also referred to as Instance Metadata Service Version 2 (IMDSv2). Values are optional or required. Defaults to optional."
+}
+
 variable "aws_region" {
   type        = string
   description = "The target AWS region for the cluster."

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -15,30 +15,31 @@ import (
 )
 
 type config struct {
-	AMI                          string            `json:"aws_ami"`
-	AMIRegion                    string            `json:"aws_ami_region"`
-	CustomEndpoints              map[string]string `json:"custom_endpoints,omitempty"`
-	ExtraTags                    map[string]string `json:"aws_extra_tags,omitempty"`
-	BootstrapInstanceType        string            `json:"aws_bootstrap_instance_type,omitempty"`
-	MasterInstanceType           string            `json:"aws_master_instance_type,omitempty"`
-	MasterAvailabilityZones      []string          `json:"aws_master_availability_zones"`
-	WorkerAvailabilityZones      []string          `json:"aws_worker_availability_zones"`
-	IOPS                         int64             `json:"aws_master_root_volume_iops"`
-	Size                         int64             `json:"aws_master_root_volume_size,omitempty"`
-	Type                         string            `json:"aws_master_root_volume_type,omitempty"`
-	Encrypted                    bool              `json:"aws_master_root_volume_encrypted"`
-	KMSKeyID                     string            `json:"aws_master_root_volume_kms_key_id,omitempty"`
-	Region                       string            `json:"aws_region,omitempty"`
-	VPC                          string            `json:"aws_vpc,omitempty"`
-	PrivateSubnets               []string          `json:"aws_private_subnets,omitempty"`
-	PublicSubnets                *[]string         `json:"aws_public_subnets,omitempty"`
-	InternalZone                 string            `json:"aws_internal_zone,omitempty"`
-	PublishStrategy              string            `json:"aws_publish_strategy,omitempty"`
-	IgnitionBucket               string            `json:"aws_ignition_bucket"`
-	BootstrapIgnitionStub        string            `json:"aws_bootstrap_stub_ignition"`
-	MasterIAMRoleName            string            `json:"aws_master_iam_role_name,omitempty"`
-	WorkerIAMRoleName            string            `json:"aws_worker_iam_role_name,omitempty"`
-	MasterMetadataAuthentication string            `json:"aws_master_instance_metadata_authentication,omitempty"`
+	AMI                             string            `json:"aws_ami"`
+	AMIRegion                       string            `json:"aws_ami_region"`
+	CustomEndpoints                 map[string]string `json:"custom_endpoints,omitempty"`
+	ExtraTags                       map[string]string `json:"aws_extra_tags,omitempty"`
+	BootstrapInstanceType           string            `json:"aws_bootstrap_instance_type,omitempty"`
+	MasterInstanceType              string            `json:"aws_master_instance_type,omitempty"`
+	MasterAvailabilityZones         []string          `json:"aws_master_availability_zones"`
+	WorkerAvailabilityZones         []string          `json:"aws_worker_availability_zones"`
+	IOPS                            int64             `json:"aws_master_root_volume_iops"`
+	Size                            int64             `json:"aws_master_root_volume_size,omitempty"`
+	Type                            string            `json:"aws_master_root_volume_type,omitempty"`
+	Encrypted                       bool              `json:"aws_master_root_volume_encrypted"`
+	KMSKeyID                        string            `json:"aws_master_root_volume_kms_key_id,omitempty"`
+	Region                          string            `json:"aws_region,omitempty"`
+	VPC                             string            `json:"aws_vpc,omitempty"`
+	PrivateSubnets                  []string          `json:"aws_private_subnets,omitempty"`
+	PublicSubnets                   *[]string         `json:"aws_public_subnets,omitempty"`
+	InternalZone                    string            `json:"aws_internal_zone,omitempty"`
+	PublishStrategy                 string            `json:"aws_publish_strategy,omitempty"`
+	IgnitionBucket                  string            `json:"aws_ignition_bucket"`
+	BootstrapIgnitionStub           string            `json:"aws_bootstrap_stub_ignition"`
+	MasterIAMRoleName               string            `json:"aws_master_iam_role_name,omitempty"`
+	WorkerIAMRoleName               string            `json:"aws_worker_iam_role_name,omitempty"`
+	MasterMetadataAuthentication    string            `json:"aws_master_instance_metadata_authentication,omitempty"`
+	BootstrapMetadataAuthentication string            `json:"aws_bootstrap_instance_metadata_authentication,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -181,6 +182,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 
 	if masterConfig.MetadataServiceOptions.Authentication != "" {
 		cfg.MasterMetadataAuthentication = strings.ToLower(string(masterConfig.MetadataServiceOptions.Authentication))
+		cfg.BootstrapMetadataAuthentication = cfg.MasterMetadataAuthentication
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
OCPBUGS-12964: Bootstrap on aws should have same metadata service type as on other nodes