### PR TITLE
CORS-2631: Add additional security group ids in AWS

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -159,6 +159,13 @@ spec:
                       description: AWS is the configuration used when installing on
                         AWS.
                       properties:
+                        additionalSecurityGroupIDs:
+                          description: AdditionalSecurityGroupIDs contains IDs of
+                            additional security groups for machines, where each ID
+                            is presented in the format sg-xxxx.
+                          items:
+                            type: string
+                          type: array
                         amiID:
                           description: AMIID is the AMI that should be used to boot
                             the ec2 instance. If set, the AMI should belong to the
@@ -1066,6 +1073,13 @@ spec:
                     description: AWS is the configuration used when installing on
                       AWS.
                     properties:
+                      additionalSecurityGroupIDs:
+                        description: AdditionalSecurityGroupIDs contains IDs of additional
+                          security groups for machines, where each ID is presented
+                          in the format sg-xxxx.
+                        items:
+                          type: string
+                        type: array
                       amiID:
                         description: AMIID is the AMI that should be used to boot
                           the ec2 instance. If set, the AMI should belong to the same
@@ -2182,6 +2196,13 @@ spec:
                       used when installing on AWS for machine pools which do not define
                       their own platform configuration.
                     properties:
+                      additionalSecurityGroupIDs:
+                        description: AdditionalSecurityGroupIDs contains IDs of additional
+                          security groups for machines, where each ID is presented
+                          in the format sg-xxxx.
+                        items:
+                          type: string
+                        type: array
                       amiID:
                         description: AMIID is the AMI that should be used to boot
                           the ec2 instance. If set, the AMI should belong to the same

--- a/pkg/asset/installconfig/aws/ec2.go
+++ b/pkg/asset/installconfig/aws/ec2.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// GetVpcsFromSecurityGroups will get the list of VPCs that are attached to the security groups with the ids provided.
+func GetVpcsFromSecurityGroups(ctx context.Context, session *session.Session, securityGroupIDs []string, region string) ([]string, error) {
+	client := ec2.New(session, aws.NewConfig().WithRegion(region))
+
+	sgIDPtrs := []*string{}
+	for _, sgid := range securityGroupIDs {
+		sgidAlias := sgid
+		sgIDPtrs = append(sgIDPtrs, &sgidAlias)
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	sgOutput, err := client.DescribeSecurityGroupsWithContext(cctx, &ec2.DescribeSecurityGroupsInput{GroupIds: sgIDPtrs})
+	if err != nil {
+		return nil, err
+	}
+
+	vpcIds := sets.New[string]()
+	for _, sg := range sgOutput.SecurityGroups {
+		vpcIds.Insert(*sg.VpcId)
+	}
+	return sets.List(vpcIds), nil
+}

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -63,18 +63,19 @@ func MachineSets(clusterID string, region string, subnets icaws.Subnets, pool *t
 		}
 
 		provider, err := provider(&machineProviderInput{
-			clusterID:      clusterID,
-			region:         region,
-			subnet:         subnet.ID,
-			instanceType:   instanceType,
-			osImage:        mpool.AMIID,
-			zone:           az,
-			role:           "worker",
-			userDataSecret: userDataSecret,
-			root:           &mpool.EC2RootVolume,
-			imds:           mpool.EC2Metadata,
-			userTags:       userTags,
-			publicSubnet:   publicSubnet,
+			clusterID:        clusterID,
+			region:           region,
+			subnet:           subnet.ID,
+			instanceType:     instanceType,
+			osImage:          mpool.AMIID,
+			zone:             az,
+			role:             "worker",
+			userDataSecret:   userDataSecret,
+			root:             &mpool.EC2RootVolume,
+			imds:             mpool.EC2Metadata,
+			userTags:         userTags,
+			publicSubnet:     publicSubnet,
+			securityGroupIDs: pool.Platform.AWS.AdditionalSecurityGroupIDs,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -34,6 +34,12 @@ type MachinePool struct {
 	// Leave unset to have the installer create the IAM Role on your behalf.
 	// +optional
 	IAMRole string `json:"iamRole,omitempty"`
+
+	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines, where each ID
+	// is presented in the format sg-xxxx.
+	//
+	// +optional
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -73,6 +79,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.IAMRole != "" {
 		a.IAMRole = required.IAMRole
+	}
+
+	if len(required.AdditionalSecurityGroupIDs) > 0 {
+		a.AdditionalSecurityGroupIDs = required.AdditionalSecurityGroupIDs
 	}
 }
 

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -56,7 +56,7 @@ func validateSecurityGroups(platform *aws.Platform, p *aws.MachinePool, fldPath 
 	allErrs := field.ErrorList{}
 
 	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.Subnets) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("additionalSecurityGroupID"), "subnets must be provided for security groups"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("platform.subnets"), "subnets must be provided when additional security groups are present"))
 	}
 	return allErrs
 }

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -47,6 +47,17 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("authentication"), p.EC2Metadata.Authentication, "must be either Required or Optional"))
 	}
 
+	allErrs = append(allErrs, validateSecurityGroups(platform, p, fldPath)...)
+
+	return allErrs
+}
+
+func validateSecurityGroups(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.Subnets) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("additionalSecurityGroupID"), "subnets must be provided for security groups"))
+	}
 	return allErrs
 }
 

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -141,6 +141,43 @@ func TestValidateMachinePool(t *testing.T) {
 	}
 }
 
+func Test_ValdidateSecurityGroups(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform *aws.Platform
+		pool     *aws.MachinePool
+		err      string
+	}{{
+		name: "valid security group config",
+		platform: &aws.Platform{
+			Region:  "us-east-1",
+			Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
+		},
+		pool: &aws.MachinePool{
+			AdditionalSecurityGroupIDs: []string{
+				"sg-valid-security-group",
+			},
+		},
+	}, {
+		name:     "invalid security group config",
+		platform: &aws.Platform{Region: "us-east-1"},
+		pool:     &aws.MachinePool{AdditionalSecurityGroupIDs: []string{"sg-valid-security-group"}},
+		err:      "test-path.additionalSecurityGroupID: Required value: subnets must be provided for security groups",
+	},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSecurityGroups(tc.platform, tc.pool, field.NewPath("test-path")).ToAggregate()
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.err, err)
+			}
+		})
+	}
+}
+
 func Test_validateAMIID(t *testing.T) {
 	cases := []struct {
 		platform *aws.Platform

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -162,7 +162,7 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		name:     "invalid security group config",
 		platform: &aws.Platform{Region: "us-east-1"},
 		pool:     &aws.MachinePool{AdditionalSecurityGroupIDs: []string{"sg-valid-security-group"}},
-		err:      "test-path.additionalSecurityGroupID: Required value: subnets must be provided for security groups",
+		err:      "test-path.platform.subnets: Required value: subnets must be provided when additional security groups are present",
 	},
 	}
 


### PR DESCRIPTION
Updates support [CORS-2631](https://issues.redhat.com//browse/CORS-2631) and [CORS-2632](https://issues.redhat.com//browse/CORS-2632)

- [x] Add install config option for additionalSecurityGroupIDs
- [x] Validate Security Groups - check that subnet ids exist
- [x] Custom Security Group Install config validation by querying API
- [x] Tag User Supplied Security Groups with Shared
- [x] Add (sorted) list of Security Group IDs provided by the user for compute node(s)
- [x] Add (sorted) list of Security Group IDs provided by the user for control plane node(s)
