### PR TITLE
CFE-687: Apply user defined labels on created gcp resources

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,10 +1,4 @@
 locals {
-  labels = merge(
-    {
-      "kubernetes-io-cluster-${var.cluster_id}" = "owned"
-    },
-    var.gcp_extra_labels,
-  )
   description = "Created By OpenShift Installer"
 
   public_endpoints = var.gcp_publish_strategy == "External" ? true : false
@@ -21,6 +15,7 @@ resource "google_storage_bucket" "ignition" {
   name                        = "${var.cluster_id}-bootstrap-ignition"
   location                    = var.gcp_region
   uniform_bucket_level_access = true
+  labels                      = var.gcp_extra_labels
 }
 
 resource "google_storage_bucket_object" "ignition" {
@@ -93,9 +88,10 @@ resource "google_compute_instance" "bootstrap" {
 
   boot_disk {
     initialize_params {
-      type  = var.gcp_master_root_volume_type
-      size  = var.gcp_master_root_volume_size
-      image = var.compute_image
+      type   = var.gcp_master_root_volume_type
+      size   = var.gcp_master_root_volume_size
+      image  = var.compute_image
+      labels = var.gcp_extra_labels
     }
     kms_key_self_link = var.gcp_root_volume_kms_key_link
   }
@@ -140,7 +136,7 @@ resource "google_compute_instance" "bootstrap" {
 
   tags = ["${var.cluster_id}-master", "${var.cluster_id}-bootstrap"]
 
-  labels = local.labels
+  labels = var.gcp_extra_labels
 
   lifecycle {
     # In GCP TF apply is run a second time to remove bootstrap node from LB.

--- a/data/data/gcp/cluster/dns/base.tf
+++ b/data/data/gcp/cluster/dns/base.tf
@@ -10,6 +10,7 @@ resource "google_dns_managed_zone" "int" {
   dns_name    = "${var.cluster_domain}."
   visibility  = "private"
   project     = var.project_id
+  labels      = var.gcp_extra_labels
 
   private_visibility_config {
     networks {

--- a/data/data/gcp/cluster/dns/variables.tf
+++ b/data/data/gcp/cluster/dns/variables.tf
@@ -42,3 +42,9 @@ variable "project_id" {
   type        = string
   description = "The target GCP project for the cluster."
 }
+
+variable "gcp_extra_labels" {
+  type        = map(string)
+  description = "GCP labels to be applied to created resources."
+  default     = {}
+}

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -1,11 +1,4 @@
 locals {
-  labels = merge(
-    {
-      "kubernetes-io-cluster-${var.cluster_id}" = "owned"
-    },
-    var.gcp_extra_labels,
-  )
-
   master_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 1, 0) #master subnet is a smaller subnet within the vnet. e.g., from /21 to /22
   worker_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 1, 1) #worker subnet is a smaller subnet within the vnet. e.g., from /21 to /22
   public_endpoints   = var.gcp_publish_strategy == "External" ? true : false
@@ -41,9 +34,9 @@ module "master" {
 
   confidential_compute = var.gcp_master_confidential_compute
   on_host_maintenance  = var.gcp_master_on_host_maintenance
+  gcp_extra_labels     = var.gcp_extra_labels
 
-  tags   = var.gcp_control_plane_tags
-  labels = local.labels
+  tags = var.gcp_control_plane_tags
 }
 
 module "iam" {
@@ -85,6 +78,7 @@ module "dns" {
   api_internal_lb_ip = module.network.cluster_ip
   public_endpoints   = local.public_endpoints
   project_id         = var.gcp_project_id
+  gcp_extra_labels   = var.gcp_extra_labels
 }
 
 resource "google_compute_image" "cluster" {
@@ -106,4 +100,5 @@ resource "google_compute_image" "cluster" {
   }
 
   licenses = var.gcp_image_licenses
+  labels   = var.gcp_extra_labels
 }

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -47,9 +47,10 @@ resource "google_compute_instance" "master" {
 
   boot_disk {
     initialize_params {
-      type  = var.root_volume_type
-      size  = var.root_volume_size
-      image = var.image
+      type   = var.root_volume_type
+      size   = var.root_volume_size
+      image  = var.image
+      labels = var.gcp_extra_labels
     }
     kms_key_self_link = var.root_volume_kms_key_link
   }
@@ -89,7 +90,7 @@ resource "google_compute_instance" "master" {
     var.tags,
   )
 
-  labels = var.labels
+  labels = var.gcp_extra_labels
 
   service_account {
     email  = var.service_account != "" ? var.service_account : google_service_account.master-node-sa[0].email

--- a/data/data/gcp/cluster/master/variables.tf
+++ b/data/data/gcp/cluster/master/variables.tf
@@ -23,7 +23,7 @@ variable "instance_count" {
   description = "The number of master instances to launch."
 }
 
-variable "labels" {
+variable "gcp_extra_labels" {
   type        = map(string)
   description = "GCP labels to be applied to created resources."
   default     = {}

--- a/data/data/gcp/post-bootstrap/main.tf
+++ b/data/data/gcp/post-bootstrap/main.tf
@@ -38,6 +38,7 @@ resource "google_compute_forwarding_rule" "api_internal" {
   ports           = ["6443", "22623"]
   subnetwork      = var.master_subnet
   network         = var.network
+  labels          = var.gcp_extra_labels
 
   load_balancing_scheme = "INTERNAL"
 }
@@ -61,4 +62,5 @@ resource "google_compute_forwarding_rule" "api" {
   ip_address = var.cluster_public_ip
   target     = google_compute_target_pool.api[0].self_link
   port_range = "6443"
+  labels     = var.gcp_extra_labels
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -505,6 +505,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				PublicZoneName:      publicZoneName,
 				PrivateZoneName:     privateZoneName,
 				PublishStrategy:     installConfig.Config.Publish,
+				InfrastructureName:  clusterID.InfraID,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -187,6 +187,10 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	if mpool.SecureBoot == string(machineapi.SecureBootPolicyEnabled) {
 		shieldedInstanceConfig.SecureBoot = machineapi.SecureBootPolicyEnabled
 	}
+	labels := make(map[string]string, len(platform.UserLabels))
+	for _, label := range platform.UserLabels {
+		labels[label.Key] = label.Value
+	}
 	return &machineapi.GCPMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",
@@ -200,6 +204,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			SizeGB:        mpool.OSDisk.DiskSizeGB,
 			Type:          mpool.OSDisk.DiskType,
 			Image:         osImage,
+			Labels:        labels,
 			EncryptionKey: encryptionKey,
 		}},
 		NetworkInterfaces: []*machineapi.GCPNetworkInterface{{
@@ -219,6 +224,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 		ShieldedInstanceConfig: shieldedInstanceConfig,
 		ConfidentialCompute:    machineapi.ConfidentialComputePolicy(mpool.ConfidentialCompute),
 		OnHostMaintenance:      machineapi.GCPHostMaintenanceType(mpool.OnHostMaintenance),
+		Labels:                 labels,
 	}, nil
 }
 


### PR DESCRIPTION
PR is for applying OCP default label ("kubernetes-io-cluster-${cluster_id}" = "owned") and user defined labels to all gcp resources created.