### PR TITLE
OCPBUGS-9378: vSphere set bootstrap/master efi

### DIFF
--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -24,6 +24,7 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
   tags                        = var.tags
+  firmware                    = "efi"
 
   network_interface {
     network_id = var.template[0].network_interfaces.0.network_id

--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -45,6 +45,7 @@ resource "vsphere_virtual_machine" "vm_master" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
   tags                        = var.tags
+  firmware                    = "efi"
 
   network_interface {
     network_id = local.template_map[var.vsphere_control_planes[count.index].template].network_interfaces.0.network_id


### PR DESCRIPTION
This commit forces the `firmware` to only use
EFI.