### PR TITLE
OCPBUGS-11799: update RHCOS 4.13 bootimage metadata to 413.92.202305021736-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-04-13T19:38:53Z",
+    "last-modified": "2023-05-02T23:08:39Z",
     "generator": "plume cosa2stream 7a1f61e"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-aws.aarch64.vmdk.gz",
-                "sha256": "596fdccc1b226ab18a5e4e705a1a928ff6c17aac3fa74360912142eee9ac74c9",
-                "uncompressed-sha256": "7dfa48ef70b4c96caf1fed8a7c66ea673fbdd73ff22925dfda7f116c03de5fc4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-aws.aarch64.vmdk.gz",
+                "sha256": "bc262bb9da4fea5d9a243acb845781a4e5e1cfe8e3a3de1649f0adc98bb5bb54",
+                "uncompressed-sha256": "6c90b44f218723a680fd659045624243124cedd41da91f434c5c6e1ed6d916ae"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-azure.aarch64.vhd.gz",
-                "sha256": "a7755b005f8c48d95f312a7e966c8e4db07d3ff44520b1af108e38d29b508107",
-                "uncompressed-sha256": "f21a92579d7cdea8509879a691499cd03669c5d928dd79580b5a4fb96864961d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-azure.aarch64.vhd.gz",
+                "sha256": "1670e82e0fdb273ebdfaed3ded4e52ba5f37172daaf35cc138c71fce7eed85ef",
+                "uncompressed-sha256": "273085880b79490f1a4fc0de9e44d8c0caac09f3891bc1f38dae2e49f6d9a8ce"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-metal4k.aarch64.raw.gz",
-                "sha256": "3aeade4dce31025d6a9c897fc9565518d3441ae20d280bda7fa3dc437f4572a4",
-                "uncompressed-sha256": "00c9fbcb246e369ba5c4ebe79146604669f4264c1b2af2357c27ba71ef66efbd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-metal4k.aarch64.raw.gz",
+                "sha256": "b9e9da2e0819262a11684cf13b07948b29ac0ecf50c47244231706bc71b0b15d",
+                "uncompressed-sha256": "75a99d87904c5853ceb6719f29b3e328ba497881844bad11a21f131ac623aaa7"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live.aarch64.iso",
-                "sha256": "6786dc55f751391e0e8bfce4e739d4163bb83000d40095cc57ab32d9c788bcbc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live.aarch64.iso",
+                "sha256": "518eea069fea853b42db5452cbae7590347f2e6114df79ecff704e8ea07f73b4"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-kernel-aarch64",
-                "sha256": "9e44cafd61f5ce4c9c8af8c912c200ff59210b2d239798b21e6ef89a20b8f2dc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-kernel-aarch64",
+                "sha256": "8c413251b04da4f39d2f95832985ead9b7615bbb01afbf5501b281256d25e38c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-initramfs.aarch64.img",
-                "sha256": "f6e87e4d82fca59e8807a6c833a950d51129b4d5dac328cc88b6a4061dba9d37"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-initramfs.aarch64.img",
+                "sha256": "292b75831e817e316ef5ad68ec67320cc8020608025613f2be2c1d722c95fb05"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-live-rootfs.aarch64.img",
-                "sha256": "f36d134acfd958e5c69224cfb52f83954f4f0f5b2a2f6516010c94b9c2d1a24a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-rootfs.aarch64.img",
+                "sha256": "eb187a24fc72986b4dd680f875a8c4097f847caa8f78ef3133f552417c4eeb85"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-metal.aarch64.raw.gz",
-                "sha256": "5a5864addc018c3faf471037dae4aafa1fe67e834494e7b942cb8829f814566b",
-                "uncompressed-sha256": "1ffd5f5112843e0694ca3d3cb00a35805c2e4ce2c18360c8e22f6238fe5d7981"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-metal.aarch64.raw.gz",
+                "sha256": "6fdaabbddf0f11ec770acc808f294d7287e80ac5e60d1a16e55857ebb290e5fa",
+                "uncompressed-sha256": "c844827988f5b411cc450f9330a6484f24d96568c49d65b4dc4b7b3e948324b1"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-openstack.aarch64.qcow2.gz",
-                "sha256": "025cd6bdf94e51fbe40d3e0352c1045aad154fe2e026e6b3b9bfe2001f2bc03f",
-                "uncompressed-sha256": "a1548f02f2c996055efed9118c44257d9e4e6b21b799ba93cd6b5bf1e5b2b057"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-openstack.aarch64.qcow2.gz",
+                "sha256": "9acb5ca338face7711aa24e19d0d536df4956a7a446cd4e0751aa5fb42603867",
+                "uncompressed-sha256": "4c21e56d1b5500d1536cd18fc3bbe1fd8f97b89b0683e22f592c813eb2ceda7a"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/aarch64/rhcos-413.92.202304131328-0-qemu.aarch64.qcow2.gz",
-                "sha256": "ca7d574b2c28d01f415ae69a45ad0cb053a51e2ad7c021fa06de8269499b6539",
-                "uncompressed-sha256": "17981760ec1f0a71a2acc43d374307a72a2614528b160d39745b7463cf09f71a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-qemu.aarch64.qcow2.gz",
+                "sha256": "8f600b7145fd8b00d28ed6442b5e1336c9035c5bfec1df82bb87b8062092c82d",
+                "uncompressed-sha256": "396a07ee8dc0c11e0c7eaec554d1f9ae1a6aa6c4cabdc0c23c861b795303e515"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0bb65810adc5ca543"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0d684ca7c09e6f5fc"
             },
             "ap-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-012f26a2a97f6c452"
+              "release": "413.92.202305021736-0",
+              "image": "ami-01b0e1c24d180fe5d"
             },
             "ap-northeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0bd791e17565439ad"
+              "release": "413.92.202305021736-0",
+              "image": "ami-06439c626e2663888"
             },
             "ap-northeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0dc21a63bb0952a91"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0a19d3bed3a2854e3"
             },
             "ap-northeast-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-013f8a2af201ba65c"
+              "release": "413.92.202305021736-0",
+              "image": "ami-08b8fa76fd46b5c58"
             },
             "ap-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-091851be5f00c09d0"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0ec6463b788929a6a"
             },
             "ap-south-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0432a8d5529538f9f"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0f5077b6d7e1b10a5"
             },
             "ap-southeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-035767797f8b055f2"
+              "release": "413.92.202305021736-0",
+              "image": "ami-081a6c6a24e2ee453"
             },
             "ap-southeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0b51d82fe56befe0a"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0a70049ac02157a02"
             },
             "ap-southeast-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0aa543cf2707622ca"
+              "release": "413.92.202305021736-0",
+              "image": "ami-065fd6311a9d7e6a6"
             },
             "ap-southeast-4": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0cae5ad273ecc7983"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0105993dc2508c4f4"
             },
             "ca-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0c51f1d44900be6e5"
+              "release": "413.92.202305021736-0",
+              "image": "ami-04582d73d5aad9a85"
             },
             "eu-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0f65d93e29628b78a"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0f72c8b59213f628e"
             },
             "eu-central-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0df5a72495111fd66"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0647f43516c31119c"
             },
             "eu-north-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0fa9a849f34ad48a9"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0d155ca6a531f5f72"
             },
             "eu-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-07adde5e5568a745f"
+              "release": "413.92.202305021736-0",
+              "image": "ami-02f8d2794a663dbd0"
             },
             "eu-south-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0859c02ad7be51b79"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0427659985f520cae"
             },
             "eu-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0dcff52b004380bff"
+              "release": "413.92.202305021736-0",
+              "image": "ami-04e9944a8f9761c3e"
             },
             "eu-west-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0506763e6b3ea4a91"
+              "release": "413.92.202305021736-0",
+              "image": "ami-09c701f11d9a7b167"
             },
             "eu-west-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0f6de799bad717ba9"
+              "release": "413.92.202305021736-0",
+              "image": "ami-02cd8181243610e0d"
             },
             "me-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-00f5b8abb7023fcfa"
+              "release": "413.92.202305021736-0",
+              "image": "ami-03008d03f133e6ec0"
             },
             "me-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-030071ed9776932f8"
+              "release": "413.92.202305021736-0",
+              "image": "ami-096bc3b4ec0faad76"
             },
             "sa-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-02ded16bdde6f1e37"
+              "release": "413.92.202305021736-0",
+              "image": "ami-01f9b5a4f7b8c50a1"
             },
             "us-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-028daadbb014b7680"
+              "release": "413.92.202305021736-0",
+              "image": "ami-09ea6f8f7845792e1"
             },
             "us-east-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0415c3c5a2d24606d"
+              "release": "413.92.202305021736-0",
+              "image": "ami-039cdb2bf3b5178da"
             },
             "us-gov-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-07c9c2218eb2af040"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0fed54a5ab75baed0"
             },
             "us-gov-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-077f449c4d42271a7"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0fc5be5af4bb1d79f"
             },
             "us-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-09d0aa8c2c3785abc"
+              "release": "413.92.202305021736-0",
+              "image": "ami-018e5407337da1062"
             },
             "us-west-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0b43bbeeb2032c8fb"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0c0c67ef81b80e8eb"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202304131328-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202304131328-0-azure.aarch64.vhd"
+          "release": "413.92.202305021736-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202305021736-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-metal4k.ppc64le.raw.gz",
-                "sha256": "e4d91f86d37064a6c4be40b6f1c9b3b606a2dfb5818bafc7296a98b389196434",
-                "uncompressed-sha256": "94077e622acbeb01ab34797741a3bdf35e16c10ef772f2b16d5b3f981fab0be6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-metal4k.ppc64le.raw.gz",
+                "sha256": "73fef57e12a76ffa302155ef1c5740de3e59e811dc1aa9ecf7a839dcd276a93b",
+                "uncompressed-sha256": "3e9ce068791fb773040e282bc43c7b9aba3ddaf6e6042d203896790a9632fa01"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live.ppc64le.iso",
-                "sha256": "f9682339b0cf1f4b28fd8d64558d50ac849a6c0a3d71a515c9786ca91dd377b9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live.ppc64le.iso",
+                "sha256": "a7c819d1dccb3b46ea87b078874f9c2283c7fe509b0ece935cabb3cbf9c2c68b"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-kernel-ppc64le",
-                "sha256": "8b77fb7e10f6d1cbedc0dfb397495cd4d5a3060053116b4761984137cb328962"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-kernel-ppc64le",
+                "sha256": "d51d94534a2f638cc78f59e802d7ad722bf3e10123ed05023186bbcd48595060"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-initramfs.ppc64le.img",
-                "sha256": "89ae5202f65a7cda98417f8b8b95dc6f09fb818f68725fc629f9c4bd4186bd22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-initramfs.ppc64le.img",
+                "sha256": "dcdb3c1cb61c6e8dd91fb3a56277778ded9a9f648409042428d04a683a4fa195"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-live-rootfs.ppc64le.img",
-                "sha256": "75797bad27fe509693dabfd616b88a6591e3ff6f5531fc8e33814bb47f5b4ed2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-rootfs.ppc64le.img",
+                "sha256": "37412d2fd885dd52471e8ff99fec47316791722074c5da3732e80bb5a21f1a9a"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-metal.ppc64le.raw.gz",
-                "sha256": "f7413e3ad98af952a3c28598f363d854cb613ac22f7bfc554a2dd66f6718ff2f",
-                "uncompressed-sha256": "a3b2bc2fc9ab524267af1bc04b6938bb2c2313b37bbe7631e4540244390cf764"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-metal.ppc64le.raw.gz",
+                "sha256": "5babf59eb0bc9d7dec6e640b83ea60184ddc6aaf8599071145964043abc3a3ae",
+                "uncompressed-sha256": "55c66b4c93c40708dbc2b95b77bfb382d95ac0d36391ea0b0515ff9c36fe9935"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "e60bc7f4042bb6d58eb0fa23aab2e77116aab4ff2df22b6991c89e159fe1616a",
-                "uncompressed-sha256": "c68eb03a27efdd0cfafbe37bb8cf0888d4f1da590193bc223d927088c5b466d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "1994294808e4ea10fc927b5b4114dc359c7928ad02569d6fbc72e3ad2c0ecf62",
+                "uncompressed-sha256": "eb69cc641d9184afd293fb0d0e20ee5c63ae86f4212a206b511ae93824938005"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-powervs.ppc64le.ova.gz",
-                "sha256": "eda197f829ac354a8b711964064864ff3e350bcfcf893ea822e254a48e026039",
-                "uncompressed-sha256": "b3d02e8d120958d511a1f17771d91607730e84be259c23161b211d0ad41769dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-powervs.ppc64le.ova.gz",
+                "sha256": "1f2b64a332ac18ca0836c80c02f3c8a4ced01031d40df7654a4d6b4281d8d754",
+                "uncompressed-sha256": "5c35575f3830b9c1fdd324bb2fec6135f33a60798b39f73ef7a29e70be565cb1"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/ppc64le/rhcos-413.92.202304131328-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "32b2acc26af0fbcbf0b72965417ee0de16e92424e135a33ceb341b8a67d4cb46",
-                "uncompressed-sha256": "f29224c9efdf703b79506e0483816a9f7c6abc89084a3871d5eff3a20c5ec08c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "03a982b2908271d90427d100eb5b2416947ffb3adb3ceec7c583fda783bfe745",
+                "uncompressed-sha256": "8124552a68a2a9ed3b624105f58fb7adf9cc3e467ad59a2930dec2a725108939"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.92.202304131328-0",
-              "object": "rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202305021736-0",
+              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202304131328-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "4b3799f78eb57448eb165d805c0db3d02024c9d6c906020bdf447be1551f1dfa",
-                "uncompressed-sha256": "c55f416866db7484d211da6dfef026c272d4bd823babd0f3ac6a143e35ecbd56"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "21605bca4acc676532ec29fe15c773f7c729508295755d7f1c96392887e5a0ec",
+                "uncompressed-sha256": "8143defef36d5c860b6438481de66123995fa004398f08c7185cf2cb4ce7bb8d"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-metal4k.s390x.raw.gz",
-                "sha256": "0cdb5172c8e719716869f88e4239e1dce0578d8b17ee977cd380d4ec8b0a055c",
-                "uncompressed-sha256": "baf53441c19672e67870a9addea9a76a499846eebf5af26b47c1d38e14bf3bcf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-metal4k.s390x.raw.gz",
+                "sha256": "35b2c32a3b4344fbc66fd1b60e99deb5629adc5521880cc453b070f363e49143",
+                "uncompressed-sha256": "733c80fb4cbc72ea58bd59813479befef0e002f512782954ef24e9739e8110fc"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live.s390x.iso",
-                "sha256": "52cf4c012c5f69b9575b66c6942a4ec3e1ab822dc7de4c33b158ee5c923079ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live.s390x.iso",
+                "sha256": "8c43a00c91c45d6166ee51d0e3089c3c191291d539f30e7071ab4297125910ff"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-kernel-s390x",
-                "sha256": "b126f4a81df5d7be59a9a7a6249e0498611774c3458cc62f863b3b36a61bf1f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-kernel-s390x",
+                "sha256": "dd1d7dd7706c59d17681392bf2e230aff3d2e62618546d3065b7d877a268cc28"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-initramfs.s390x.img",
-                "sha256": "fc2702f42ed282874e61bb9f7893a1054b9566f3620a9137d122b939d4932e22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-initramfs.s390x.img",
+                "sha256": "f73ecf730a782ad95916f949343661e69cc0a68a480c4b3447388e5d31856ad1"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-live-rootfs.s390x.img",
-                "sha256": "e3a81a19c02b36a5cfc8126a6bd216655138a7391e201a6f756e03e522e4c9d6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-rootfs.s390x.img",
+                "sha256": "ab03b8a69f03f7579fceee0eb7b9c5b8b841d48ce67c1caf6552e6517d00b18d"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-metal.s390x.raw.gz",
-                "sha256": "b14d3acceebb5e4e95073f6b71fcc23fcd4b43e161bbd13b110fc326f0589a45",
-                "uncompressed-sha256": "a58d5c8eee0e634711abc262c01a1ad046838e0d4693132cd3af5a05cd48c662"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-metal.s390x.raw.gz",
+                "sha256": "63922508ab7e863909d2ca445849c4e3d3b1bee38a73b95571184de97a2ea1c2",
+                "uncompressed-sha256": "b90ab55c6eeb14f8dedc47c0f427156822c3a923ecf5a6cee95922ecc2cba540"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-openstack.s390x.qcow2.gz",
-                "sha256": "ac9ce852418217c1d9295d05197b6ded417e3bcaf97ecd2a91589e5b78d02ccb",
-                "uncompressed-sha256": "7fa844069039e96aa00001c1e3ae58bfb1d384e2616ddf6d7d307b75a1ef0ff0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-openstack.s390x.qcow2.gz",
+                "sha256": "29eaef172be4384e025ddc3fec11ac8685ea14284a69338a177804698a060eb9",
+                "uncompressed-sha256": "2582cff6dc1992e68b647f0c59bcae34eefec541eb38c843f7a6727ae833f498"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-qemu.s390x.qcow2.gz",
-                "sha256": "8de5edf59adfa5306e1dc6a7b8062851228820456f6927a22bfe4af8a096ad23",
-                "uncompressed-sha256": "d101884e6cb0c0f4ee96a0ff3d9a4ee6d678c18c437354f473437b46eff816f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-qemu.s390x.qcow2.gz",
+                "sha256": "8e96c7ca3d922a9e8daf0bd963053935b63d08e2dc709bf81509f14142802e4d",
+                "uncompressed-sha256": "78fdd3c54187c912ddfe5bf66ee3229e97ac135d3d8b5d46f5fca54900d8ad5a"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/s390x/rhcos-413.92.202304131328-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "f08d26bea3371d05fc1fd29603a08b66b78ac6f748825cba2c86572cbff27ad5",
-                "uncompressed-sha256": "b593e13cc3b8b7fa9ca15302feb77ad79de30f359b9a6980ee2df15f03fdc733"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "8012cf28e0f7b69cae58de00e5ecc62b51d8d19891aab52b50921503545e1338",
+                "uncompressed-sha256": "a2f92153cce26f6f2f5009f6ae5845ba17bfad22817416bb4ab48964b0096e5e"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "2e0c7ea191e3bfd1388231b1bcf83fa03638a02a603d7eb84b7ddb83e7dbc448",
-                "uncompressed-sha256": "6416c1db3c3a90d50b63c40d267990903f685a3066468b705c25acb05f444999"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "7282b1841600ec1e04cff54fb5befb52ef8c5d1586091dae9e09582bc7997f53",
+                "uncompressed-sha256": "48f69571d5dc57eb2cb9244dd959bbf9db5b2cb4253a7a8491a28697a68c5c67"
               }
             }
           }
         },
         "aws": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-aws.x86_64.vmdk.gz",
-                "sha256": "92c96bc8f728e59ef0c4c41b9a141efb47b70c149a228d6402468ca44b9d4a26",
-                "uncompressed-sha256": "520473de28e2180c6eab4a48d028ece2a6079d6ae6dd6ac3db7efa96f008f1fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-aws.x86_64.vmdk.gz",
+                "sha256": "f2a0a9a9caf3a58d31cb2491544583e937b881374db3293688f4928ae84175df",
+                "uncompressed-sha256": "b4b1dbd5439931b9a072d299354cfe4e7d7914d41d1aa6ea2292b31aca07a520"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-azure.x86_64.vhd.gz",
-                "sha256": "b92ff80fb8ab81252f958992e0e68cbc6b78f1ca6d10ee52e6dea62f123ecbba",
-                "uncompressed-sha256": "f06e265dcdaaa030379540780fa5dc9ca6bcded6a84c0808916766ab426b628f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-azure.x86_64.vhd.gz",
+                "sha256": "83aca9a5ac49324e0e1d062a7bc43e21238e2316a358b7b817128bbc947e13db",
+                "uncompressed-sha256": "3683ef6d0d5ac584d5cd3eb30206e578580297abbb4251ed4df6ddb3a9349439"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-azurestack.x86_64.vhd.gz",
-                "sha256": "4cbb522d68562bb931b9417b57b19fd848e6a6b04d42b80b70d8424c8a4279e2",
-                "uncompressed-sha256": "4660aacf740307c242f51e3ab27374c01470aeb2990ebb1356a04e472aaf4198"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-azurestack.x86_64.vhd.gz",
+                "sha256": "f967ec657a6882478ae3d923f3f3414d9154bebf262fc27c22d0d673fc6590e4",
+                "uncompressed-sha256": "fa2a4e97cb92087d78871ff21989916c2e5d92168a972013c805046f5af6f016"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-gcp.x86_64.tar.gz",
-                "sha256": "1968dcb443ee88594363043170460fd0871ba12e1fc3782a242bba27a3052a41",
-                "uncompressed-sha256": "a4a7a228fdf85321f02b2c4a4c6f76da38201c4f2c8491fe993ba8a8e46c801d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-gcp.x86_64.tar.gz",
+                "sha256": "50446ea637e88f42a7f0dedcf5b9f56286dfadfa6c4f6af9e10b36509ffb08f6",
+                "uncompressed-sha256": "b168b94c9e9dfb6a8001dcbb621aa28e68d60eef4f86457341bdc57ec454d2bf"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "cc823bb7466a17a61b0a8aaecbeac091014bc8a5bddcfcef50b5107841360ff5",
-                "uncompressed-sha256": "ca3a5ed1bd147581a03652971d86f77eec03e374c20b2c8f71cb63461107d0f1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "1b910bbf84587058c51d397cf0b2ed3871c1cbbb9f0998477e7f0dd401400ed7",
+                "uncompressed-sha256": "222abce547c1bbf32723676f4977a3721c8a3788f0b7b6b3496b79999e8c60b3"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-metal4k.x86_64.raw.gz",
-                "sha256": "a3c2ab728d1b86982f4f844d1faade74b292f26a7fb9f5907e366d8b19d1bb5e",
-                "uncompressed-sha256": "cf6aff927138d881e6b43f648ca929e9d2cbe2bd6274e41524f8fcbcafde700f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-metal4k.x86_64.raw.gz",
+                "sha256": "c58e77b7cfa9eaad7d2f3e84e99d47f3d2a4bc0bdd3671d2287f8fad6ceca2dd",
+                "uncompressed-sha256": "f1381ec2f6ccb94b6d9af1233940517bbb2e2ec075a89d16d150aa48007c29b2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live.x86_64.iso",
-                "sha256": "c16edd4c7a43401a2203e2d19631795c0598160f9cdd884292e4c7eafd3fc1d5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live.x86_64.iso",
+                "sha256": "ed9411c23534f6fcac4ab986f9850418312896f8f46fb77213030dbc454d44b7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-kernel-x86_64",
-                "sha256": "833e29fcfde19f8fff62ce3c07ef883042eb476c2468405599eb000da813629d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-kernel-x86_64",
+                "sha256": "cd0ec3f82549062461998ac50855f275e42b675f759351df843b6668c8c9bd0c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-initramfs.x86_64.img",
-                "sha256": "4dec2f088edd4e8e7fa637783cb8cacebdddd637699fdb0c05da56edfef71f4d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-initramfs.x86_64.img",
+                "sha256": "c721debe2d8e88727455d9ed7221f4a6e1d51f42d9a557238f6f092ce30bb06c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-live-rootfs.x86_64.img",
-                "sha256": "e8d3b0dfda5cc73f88d7a33af8b1c1cfdf8770b782e5d78b3ae0e3a241329d76"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-rootfs.x86_64.img",
+                "sha256": "f504ebb72bb3541565a49d2f87c5aa63c54091100920feb413d3566232ff82c9"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-metal.x86_64.raw.gz",
-                "sha256": "a65a33d3601cad1a5dd7ef249e5f10e4dc0d77c79c1169567cb3e0e40d8b7117",
-                "uncompressed-sha256": "8a87af3edc9b0b3abf5bef3164585f394e64e1c9a18118075d0f26290e064a2c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-metal.x86_64.raw.gz",
+                "sha256": "37f8bc614604dc985754fc2be69bc3f119866b74b96542b5d3b482dcf2132d38",
+                "uncompressed-sha256": "43e36022f451e8498521225e0fdea6909176a6bc4f84b6796d5c918d27e91dd6"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-nutanix.x86_64.qcow2",
-                "sha256": "ee827471b3f0f72c840fb05dc068f00b0fdbc042c4adb2ed19d5539ae7d660ef"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-nutanix.x86_64.qcow2",
+                "sha256": "d0defcd6645f44d8d15e5bd2fc03ca6d6a2d1640a0507053b676e9d69adc70c0"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-openstack.x86_64.qcow2.gz",
-                "sha256": "18309a0bf2de258c89e76b82fbf7eafdf76b5ba568ecdea27cdf91da7ee368d3",
-                "uncompressed-sha256": "885e3973a03d60596a869949e9ee1fad4e5ace974508b5f6d76eb216d80c7e5b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-openstack.x86_64.qcow2.gz",
+                "sha256": "5c5ca88c6bf2cd06d936091efae254bcd877e709fe95f6fea2c3283faf05b53e",
+                "uncompressed-sha256": "e10860fa337d8468becf47fb8398709631b2d719b863872edd2cde7240de7b1d"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-qemu.x86_64.qcow2.gz",
-                "sha256": "f591e821bcc04552020a02c0131020db728570a91a4d10cab86ce7979900c04a",
-                "uncompressed-sha256": "de666ab498df922ba266a1ff230b520987875e4c546353a8cb08c165ccb71ec8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-qemu.x86_64.qcow2.gz",
+                "sha256": "cc15897f797548ae627a5880f7c496fc38205c9322f4ec8e822f0e26f324453b",
+                "uncompressed-sha256": "dec79efb470705174320ef502772489a67eeedac14457d0958fc541f635c4e28"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202304131328-0/x86_64/rhcos-413.92.202304131328-0-vmware.x86_64.ova",
-                "sha256": "c3e9e9e863309436855bd4553b1656ed02f14eba68df8d3cb76a05d6e86ff222"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-vmware.x86_64.ova",
+                "sha256": "0b0cf6b81a058f4016d442e57d917532f02dcbe1befceb9652cdc4532345fcc3"
               }
             }
           }
@@ -619,249 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-6we6sft8lefh54fnr1jw"
+              "release": "413.92.202305021736-0",
+              "image": "m-6we4x6nuds9vssarjv0g"
             },
             "ap-northeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "m-mj775wbd0ntw4vfksrsz"
+              "release": "413.92.202305021736-0",
+              "image": "m-mj7ii98d3070rr7xuvxs"
             },
             "ap-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-a2d4b7plxce7w0nsmnbk"
+              "release": "413.92.202305021736-0",
+              "image": "m-a2dhjxtmedm2xz4xmdtb"
             },
             "ap-southeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-t4n9zne6aawpiduagrs1"
+              "release": "413.92.202305021736-0",
+              "image": "m-t4n2uj0enpjt7e34t4x2"
             },
             "ap-southeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "m-p0wcmhrnz37gnbo1z55y"
+              "release": "413.92.202305021736-0",
+              "image": "m-p0wisxc1ycreg7n9por2"
             },
             "ap-southeast-3": {
-              "release": "413.92.202304131328-0",
-              "image": "m-8psi54o0farwi5qstbzk"
+              "release": "413.92.202305021736-0",
+              "image": "m-8ps2kyhkrj3ti2r9lal7"
             },
             "ap-southeast-5": {
-              "release": "413.92.202304131328-0",
-              "image": "m-k1aatqxnd848ziagdq1f"
+              "release": "413.92.202305021736-0",
+              "image": "m-k1adbmvh1r2oxp2rmmj1"
             },
             "ap-southeast-6": {
-              "release": "413.92.202304131328-0",
-              "image": "m-5tsc0is76jl4awdweovm"
+              "release": "413.92.202305021736-0",
+              "image": "m-5ts7gtyipiygxu1ivpn5"
             },
             "ap-southeast-7": {
-              "release": "413.92.202304131328-0",
-              "image": "m-0joebex44r15d6sc1vvd"
+              "release": "413.92.202305021736-0",
+              "image": "m-0jo2ra36bjwjp3aoodda"
             },
             "cn-beijing": {
-              "release": "413.92.202304131328-0",
-              "image": "m-2zef091umjxs3nm25z3g"
+              "release": "413.92.202305021736-0",
+              "image": "m-2zehuzxdr25ufiijep0v"
             },
             "cn-chengdu": {
-              "release": "413.92.202304131328-0",
-              "image": "m-2vc5dgmgfcqyucz4zhm0"
+              "release": "413.92.202305021736-0",
+              "image": "m-2vc7njvnsm84959nez9f"
             },
             "cn-fuzhou": {
-              "release": "413.92.202304131328-0",
-              "image": "m-gw0ivkvqw7u1nz8gdqpv"
+              "release": "413.92.202305021736-0",
+              "image": "m-gw07wgj0ctvz6y4poaz0"
             },
             "cn-guangzhou": {
-              "release": "413.92.202304131328-0",
-              "image": "m-7xv3as0di5cerys82fa0"
+              "release": "413.92.202305021736-0",
+              "image": "m-7xvdyeffe7qrnnshxsmn"
             },
             "cn-hangzhou": {
-              "release": "413.92.202304131328-0",
-              "image": "m-bp14yq8pqzx5t73z1twt"
+              "release": "413.92.202305021736-0",
+              "image": "m-bp1ivkw5ddglsgui2pb9"
             },
             "cn-heyuan": {
-              "release": "413.92.202304131328-0",
-              "image": "m-f8zce08slb14ct1sbvd2"
+              "release": "413.92.202305021736-0",
+              "image": "m-f8zfls7i2k5jxfb4weut"
             },
             "cn-hongkong": {
-              "release": "413.92.202304131328-0",
-              "image": "m-j6c4482d659aq3kf812x"
+              "release": "413.92.202305021736-0",
+              "image": "m-j6ceptfg1yxdxv0euqar"
             },
             "cn-huhehaote": {
-              "release": "413.92.202304131328-0",
-              "image": "m-hp3jdu6sts43i0w0mdkd"
+              "release": "413.92.202305021736-0",
+              "image": "m-hp39z79mkgle86esl4ai"
             },
             "cn-nanjing": {
-              "release": "413.92.202304131328-0",
-              "image": "m-gc7165thk05axefqlno3"
+              "release": "413.92.202305021736-0",
+              "image": "m-gc7iibcg8mvkrg2gnpgq"
             },
             "cn-qingdao": {
-              "release": "413.92.202304131328-0",
-              "image": "m-m5eddrru28t2ab1m7rmg"
+              "release": "413.92.202305021736-0",
+              "image": "m-m5ec2qfwezphfr660aoc"
             },
             "cn-shanghai": {
-              "release": "413.92.202304131328-0",
-              "image": "m-uf6crk739nql90ad2yw0"
+              "release": "413.92.202305021736-0",
+              "image": "m-uf69l882scy28zvejfht"
             },
             "cn-shenzhen": {
-              "release": "413.92.202304131328-0",
-              "image": "m-wz925oz0glj75vlh4q35"
+              "release": "413.92.202305021736-0",
+              "image": "m-wz9a5diq7hze93a5k6ys"
             },
             "cn-wulanchabu": {
-              "release": "413.92.202304131328-0",
-              "image": "m-0jlj1bbn1zk31w66t29m"
+              "release": "413.92.202305021736-0",
+              "image": "m-0jl8awxohyxmlp2irz00"
             },
             "cn-zhangjiakou": {
-              "release": "413.92.202304131328-0",
-              "image": "m-8vb3d38l2pqmkapkkntw"
+              "release": "413.92.202305021736-0",
+              "image": "m-8vbhrb3uqwooszgi4nh5"
             },
             "eu-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-gw822ez51zqq7hizj5b3"
+              "release": "413.92.202305021736-0",
+              "image": "m-gw8dsm7azykgh5pc11sx"
             },
             "eu-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-d7obpolokx813qvoxjmp"
+              "release": "413.92.202305021736-0",
+              "image": "m-d7ocb9acwsann20xay4d"
             },
             "me-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-eb37o5ejhjzak25z2kmd"
+              "release": "413.92.202305021736-0",
+              "image": "m-eb3d5ybedqqg41e6v87s"
             },
             "us-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-0xihajgqbixg5sagyxpr"
+              "release": "413.92.202305021736-0",
+              "image": "m-0xi2l8aeug6mbilc936t"
             },
             "us-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "m-rj990s7tn5umpkg102lk"
+              "release": "413.92.202305021736-0",
+              "image": "m-rj9dk1uxn0vjcjga805e"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0a27a19561c494289"
+              "release": "413.92.202305021736-0",
+              "image": "ami-052b3e6b060b5595d"
             },
             "ap-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-03039b6b4fd63f5e4"
+              "release": "413.92.202305021736-0",
+              "image": "ami-09c502968481ee218"
             },
             "ap-northeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-08b05213421ac1a62"
+              "release": "413.92.202305021736-0",
+              "image": "ami-06b1dbe049e3c1d23"
             },
             "ap-northeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0bc30b044ecf6ea73"
+              "release": "413.92.202305021736-0",
+              "image": "ami-08add6eb5aa1c8639"
             },
             "ap-northeast-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-06d6a7d0a15f4a889"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0af4dfc64506fe20e"
             },
             "ap-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0d4f43f96250ddd54"
+              "release": "413.92.202305021736-0",
+              "image": "ami-09b1532dd3d63fdc0"
             },
             "ap-south-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0340cea17be8877d3"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0a915cedf8558e600"
             },
             "ap-southeast-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-031ff0026f2f2c931"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0c914fd7a50130c9e"
             },
             "ap-southeast-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0cdc8fbb99f5c30bc"
+              "release": "413.92.202305021736-0",
+              "image": "ami-04b54199f4be0ec9d"
             },
             "ap-southeast-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-07cba44f2cca22e6c"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0be3ee78b9a3fdf07"
             },
             "ap-southeast-4": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-001ab4772243af582"
+              "release": "413.92.202305021736-0",
+              "image": "ami-00a44d7d5054bb5f8"
             },
             "ca-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0524c96b60b5765d6"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0bb1fd49820ea09ae"
             },
             "eu-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-045ea69599b03cf00"
+              "release": "413.92.202305021736-0",
+              "image": "ami-03d9cb166a11c9b8a"
             },
             "eu-central-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-092330d200e659be2"
+              "release": "413.92.202305021736-0",
+              "image": "ami-089865c640f876630"
             },
             "eu-north-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0220cdf67c21e544b"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0e94d896e72eeae0d"
             },
             "eu-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0619eacd0693f738f"
+              "release": "413.92.202305021736-0",
+              "image": "ami-04df4e2850dce0721"
             },
             "eu-south-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0581ea608220a233c"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0d80de3a5ba722545"
             },
             "eu-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-03bac910dd6bef9d0"
+              "release": "413.92.202305021736-0",
+              "image": "ami-066f2d86026ef97a8"
             },
             "eu-west-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-02e0abc0367daa3bc"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0f1c0b26b1c99499d"
             },
             "eu-west-3": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0426f858e1b17f150"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0f639505a9c74d9a2"
             },
             "me-central-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0bd95efcd6ea97dd6"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0fbb2ece8478f1402"
             },
             "me-south-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0947f72bf80e4825f"
+              "release": "413.92.202305021736-0",
+              "image": "ami-01507551558853852"
             },
             "sa-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0c87a19515f5c7ca2"
+              "release": "413.92.202305021736-0",
+              "image": "ami-097132aa0da53c981"
             },
             "us-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-0d17184a4270b8a35"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0624891c612b5eaa0"
             },
             "us-east-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-047898836dfc05f97"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0dc6c4d1bd5161f13"
             },
             "us-gov-east-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-009696dcd1c0f050a"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0bab20368b3b9b861"
             },
             "us-gov-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-09a1a9bc37fc8c0e8"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0fe8299f8e808e720"
             },
             "us-west-1": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-02cd5e46fa8bdc4a7"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0c03b7e5954f10f9b"
             },
             "us-west-2": {
-              "release": "413.92.202304131328-0",
-              "image": "ami-021596e74e41d905a"
+              "release": "413.92.202305021736-0",
+              "image": "ami-0f4cdfd74e4a3fc29"
             }
           }
         },
         "gcp": {
-          "release": "413.92.202304131328-0",
+          "release": "413.92.202305021736-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-92-202304131328-0-gcp-x86-64"
+          "name": "rhcos-413-92-202305021736-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202304131328-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202304131328-0-azure.x86_64.vhd"
+          "release": "413.92.202305021736-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202305021736-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 bootimage metadata which include fixes for the following:
OCPBUGS-11791 - RHCOS missing udev rules for GCE PD NVMe disks in initrd

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --name 4.13-9.2 --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=413.92.202305021736-0 aarch64=413.92.202305021736-0 s390x=413.92.202305021736-0 ppc64le=413.92.202305021736-0
```