### PR TITLE
remove special cases for featureset in rendering

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -92,9 +92,6 @@ then
 	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
 		ADDITIONAL_FLAGS+=("--cloud-provider-config-input-file=/assets/manifests/cloud-provider-config.yaml")
 	fi
-	{{- if .FeatureSet }}
-	ADDITIONAL_FLAGS+=("--feature-set={{.FeatureSet}}")
-	{{- end}}
 
 	bootkube_podman_run \
 		--name config-render \
@@ -106,7 +103,6 @@ then
 		--config-output-file=/assets/config-bootstrap/config \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/config-bootstrap \
-		--featuregate-manifest=/assets/manifests/99_feature-gate.yaml \
 		--rendered-manifest-files=/assets/manifests \
 		--payload-version=$VERSION \
 		"${ADDITIONAL_FLAGS[@]}"


### PR DESCRIPTION
This completes the reset for rendering featureset sensitive manifests based on the FeatureGate manifest provided by the cluster-config-operator.