### PR TITLE
OCPBUGS-13547: Ensure --payload-version is set for MCO on bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -352,6 +352,7 @@ then
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
 			--release-image="${RELEASE_IMAGE_DIGEST}" \
 			--image-references=assets/image-references \
+			--payload-version="${VERSION}" \
 			${ADDITIONAL_FLAGS}
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to


### PR DESCRIPTION
In tandem with https://github.com/openshift/machine-config-operator/pull/3701 and working towards https://github.com/openshift/machine-config-operator/pull/3688, I am introducing a `--payload-version` requirement for the render command for MCO, so that it can read feature gates on bootstrap.

/hold 

I want to prove with cluster-bot that this works before merging