### PR TITLE
CORS-2656: Remove context from cluster uninstaller struct

### DIFF
--- a/pkg/destroy/gcp/address.go
+++ b/pkg/destroy/gcp/address.go
@@ -1,6 +1,8 @@
 package gcp
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -8,17 +10,17 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
-func (o *ClusterUninstaller) listAddresses() ([]cloudResource, error) {
-	return o.listAddressesWithFilter("items(name,region,addressType),nextPageToken", o.clusterIDFilter(), nil)
+func (o *ClusterUninstaller) listAddresses(ctx context.Context) ([]cloudResource, error) {
+	return o.listAddressesWithFilter(ctx, "items(name,region,addressType),nextPageToken", o.clusterIDFilter(), nil)
 }
 
 // listAddressesWithFilter lists addresses in the project that satisfy the filter criteria.
 // The fields parameter specifies which fields should be returned in the result, the filter string contains
 // a filter string passed to the API to filter results. The filterFunc is a client-side filtering function
 // that determines whether a particular result should be returned or not.
-func (o *ClusterUninstaller) listAddressesWithFilter(fields string, filter string, filterFunc func(*compute.Address) bool) ([]cloudResource, error) {
+func (o *ClusterUninstaller) listAddressesWithFilter(ctx context.Context, fields string, filter string, filterFunc func(*compute.Address) bool) ([]cloudResource, error) {
 	o.Logger.Debugf("Listing addresses")
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	result := []cloudResource{}
 	req := o.computeSvc.Addresses.List(o.ProjectID, o.Region).Fields(googleapi.Field(fields))
@@ -58,9 +60,9 @@ func (o *ClusterUninstaller) listAddressesWithFilter(fields string, filter strin
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteAddress(item cloudResource) error {
+func (o *ClusterUninstaller) deleteAddress(ctx context.Context, item cloudResource) error {
 	o.Logger.Debugf("Deleting address %s", item.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Addresses.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
@@ -81,14 +83,14 @@ func (o *ClusterUninstaller) deleteAddress(item cloudResource) error {
 
 // destroyAddresses removes all address resources that have a name prefixed
 // with the cluster's infra ID.
-func (o *ClusterUninstaller) destroyAddresses() error {
-	found, err := o.listAddresses()
+func (o *ClusterUninstaller) destroyAddresses(ctx context.Context) error {
+	found, err := o.listAddresses(ctx)
 	if err != nil {
 		return err
 	}
 	items := o.insertPendingItems("address", found)
 	for _, item := range items {
-		err := o.deleteAddress(item)
+		err := o.deleteAddress(ctx, item)
 		if err != nil {
 			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}

--- a/pkg/destroy/gcp/bucket.go
+++ b/pkg/destroy/gcp/bucket.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -13,17 +14,17 @@ var (
 	multiDashes = regexp.MustCompile(`-{2,}`)
 )
 
-func (o *ClusterUninstaller) listBuckets() ([]cloudResource, error) {
-	return o.listBucketsWithFilter("items(name),nextPageToken", o.ClusterID+"-", nil)
+func (o *ClusterUninstaller) listBuckets(ctx context.Context) ([]cloudResource, error) {
+	return o.listBucketsWithFilter(ctx, "items(name),nextPageToken", o.ClusterID+"-", nil)
 }
 
 // listBucketsWithFilter lists buckets in the project that satisfy the filter criteria.
 // The fields parameter specifies which fields should be returned in the result, the filter string contains
 // a prefix string passed to the API to filter results. The filterFunc is a client-side filtering function
 // that determines whether a particular result should be returned or not.
-func (o *ClusterUninstaller) listBucketsWithFilter(fields string, prefix string, filterFunc func(*storage.Bucket) bool) ([]cloudResource, error) {
+func (o *ClusterUninstaller) listBucketsWithFilter(ctx context.Context, fields string, prefix string, filterFunc func(*storage.Bucket) bool) ([]cloudResource, error) {
 	o.Logger.Debug("Listing storage buckets")
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	result := []cloudResource{}
 	req := o.storageSvc.Buckets.List(o.ProjectID).Fields(googleapi.Field(fields))
@@ -50,9 +51,9 @@ func (o *ClusterUninstaller) listBucketsWithFilter(fields string, prefix string,
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteBucket(item cloudResource) error {
+func (o *ClusterUninstaller) deleteBucket(ctx context.Context, item cloudResource) error {
 	o.Logger.Debugf("Deleting storate bucket %s", item.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	err := o.storageSvc.Buckets.Delete(item.name).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
@@ -65,25 +66,25 @@ func (o *ClusterUninstaller) deleteBucket(item cloudResource) error {
 
 // destroyBuckets finds all gcs buckets that have a name prefixed
 // with the cluster's infra ID. It then removes all the objects in each bucket and deletes it.
-func (o *ClusterUninstaller) destroyBuckets() error {
-	found, err := o.listBuckets()
+func (o *ClusterUninstaller) destroyBuckets(ctx context.Context) error {
+	found, err := o.listBuckets(ctx)
 	if err != nil {
 		return err
 	}
 	items := o.insertPendingItems("bucket", found)
 	for _, item := range items {
-		foundObjects, err := o.listBucketObjects(item)
+		foundObjects, err := o.listBucketObjects(ctx, item)
 		if err != nil {
 			return err
 		}
 		objects := o.insertPendingItems("bucketobject", foundObjects)
 		for _, object := range objects {
-			err = o.deleteBucketObject(item, object)
+			err = o.deleteBucketObject(ctx, item, object)
 			if err != nil {
 				o.errorTracker.suppressWarning(object.key, err, o.Logger)
 			}
 		}
-		err = o.deleteBucket(item)
+		err = o.deleteBucket(ctx, item)
 		if err != nil {
 			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}

--- a/pkg/destroy/gcp/bucketobject.go
+++ b/pkg/destroy/gcp/bucketobject.go
@@ -1,13 +1,15 @@
 package gcp
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	storage "google.golang.org/api/storage/v1"
 )
 
-func (o *ClusterUninstaller) listBucketObjects(bucket cloudResource) ([]cloudResource, error) {
+func (o *ClusterUninstaller) listBucketObjects(ctx context.Context, bucket cloudResource) ([]cloudResource, error) {
 	o.Logger.Debugf("Listing objects for storage bucket %s", bucket.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	result := []cloudResource{}
 	req := o.storageSvc.Objects.List(bucket.name).Fields("items(name),nextPageToken")
@@ -28,9 +30,9 @@ func (o *ClusterUninstaller) listBucketObjects(bucket cloudResource) ([]cloudRes
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteBucketObject(bucket cloudResource, item cloudResource) error {
+func (o *ClusterUninstaller) deleteBucketObject(ctx context.Context, bucket cloudResource, item cloudResource) error {
 	o.Logger.Debugf("Deleting storate object %s/%s", bucket.name, item.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	err := o.storageSvc.Objects.Delete(bucket.name, item.name).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -1,22 +1,24 @@
 package gcp
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
-func (o *ClusterUninstaller) listNetworks() ([]cloudResource, error) {
-	return o.listNetworksWithFilter("items(name,selfLink),nextPageToken", o.clusterIDFilter(), nil)
+func (o *ClusterUninstaller) listNetworks(ctx context.Context) ([]cloudResource, error) {
+	return o.listNetworksWithFilter(ctx, "items(name,selfLink),nextPageToken", o.clusterIDFilter(), nil)
 }
 
 // listNetworksWithFilter lists addresses in the project that satisfy the filter criteria.
 // The fields parameter specifies which fields should be returned in the result, the filter string contains
 // a filter string passed to the API to filter results. The filterFunc is a client-side filtering function
 // that determines whether a particular result should be returned or not.
-func (o *ClusterUninstaller) listNetworksWithFilter(fields string, filter string, filterFunc func(*compute.Network) bool) ([]cloudResource, error) {
+func (o *ClusterUninstaller) listNetworksWithFilter(ctx context.Context, fields string, filter string, filterFunc func(*compute.Network) bool) ([]cloudResource, error) {
 	o.Logger.Debugf("Listing networks")
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	result := []cloudResource{}
 	req := o.computeSvc.Networks.List(o.ProjectID).Fields(googleapi.Field(fields))
@@ -43,9 +45,9 @@ func (o *ClusterUninstaller) listNetworksWithFilter(fields string, filter string
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteNetwork(item cloudResource) error {
+func (o *ClusterUninstaller) deleteNetwork(ctx context.Context, item cloudResource) error {
 	o.Logger.Debugf("Deleting network %s", item.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Networks.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
@@ -66,26 +68,26 @@ func (o *ClusterUninstaller) deleteNetwork(item cloudResource) error {
 
 // destroyNetworks removes all vpc network resources prefixed
 // with the cluster's infra ID, and deletes all of the routes.
-func (o *ClusterUninstaller) destroyNetworks() error {
-	found, err := o.listNetworks()
+func (o *ClusterUninstaller) destroyNetworks(ctx context.Context) error {
+	found, err := o.listNetworks(ctx)
 	if err != nil {
 		return err
 	}
 	items := o.insertPendingItems("network", found)
 	for _, item := range items {
-		foundRoutes, err := o.listNetworkRoutes(item.url)
+		foundRoutes, err := o.listNetworkRoutes(ctx, item.url)
 		if err != nil {
 			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 			continue
 		}
 		routes := o.insertPendingItems("route", foundRoutes)
 		for _, route := range routes {
-			err := o.deleteRoute(route)
+			err := o.deleteRoute(ctx, route)
 			if err != nil {
 				o.errorTracker.suppressWarning(route.key, err, o.Logger)
 			}
 		}
-		err = o.deleteNetwork(item)
+		err = o.deleteNetwork(ctx, item)
 		if err != nil {
 			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}

--- a/pkg/destroy/gcp/policybinding.go
+++ b/pkg/destroy/gcp/policybinding.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -9,9 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func (o *ClusterUninstaller) getProjectIAMPolicy() (*resourcemanager.Policy, error) {
+func (o *ClusterUninstaller) getProjectIAMPolicy(ctx context.Context) (*resourcemanager.Policy, error) {
 	o.Logger.Debug("Fetching project IAM policy")
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	req := &resourcemanager.GetIamPolicyRequest{}
 	policy, err := o.rmSvc.Projects.GetIamPolicy(o.ProjectID, req).Context(ctx).Do()
@@ -21,9 +22,9 @@ func (o *ClusterUninstaller) getProjectIAMPolicy() (*resourcemanager.Policy, err
 	return policy, nil
 }
 
-func (o *ClusterUninstaller) setProjectIAMPolicy(policy *resourcemanager.Policy) error {
+func (o *ClusterUninstaller) setProjectIAMPolicy(ctx context.Context, policy *resourcemanager.Policy) error {
 	o.Logger.Debug("Setting project IAM policy")
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	req := &resourcemanager.SetIamPolicyRequest{Policy: policy}
 	_, err := o.rmSvc.Projects.SetIamPolicy(o.ProjectID, req).Context(ctx).Do()

--- a/pkg/destroy/gcp/serviceaccount.go
+++ b/pkg/destroy/gcp/serviceaccount.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -12,11 +13,11 @@ import (
 
 // listServiceAccounts retrieves all service accounts with a display name prefixed with the cluster's
 // infra ID. Filtering is done client side because the API doesn't offer filtering for service accounts.
-func (o *ClusterUninstaller) listServiceAccounts() ([]cloudResource, error) {
+func (o *ClusterUninstaller) listServiceAccounts(ctx context.Context) ([]cloudResource, error) {
 	o.Logger.Debugf("Listing service accounts")
 
 	result := []cloudResource{}
-	sas, err := o.listClusterServiceAccount()
+	sas, err := o.listClusterServiceAccount(ctx)
 	if err != nil {
 		errors.Wrapf(err, "failed to fetch service accounts for the cluster")
 	}
@@ -39,8 +40,8 @@ func (o *ClusterUninstaller) listServiceAccounts() ([]cloudResource, error) {
 	return result, nil
 }
 
-func (o *ClusterUninstaller) listClusterServiceAccount() ([]*iam.ServiceAccount, error) {
-	ctx, cancel := o.contextWithTimeout()
+func (o *ClusterUninstaller) listClusterServiceAccount(ctx context.Context) ([]*iam.ServiceAccount, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	result := []*iam.ServiceAccount{}
 	req := o.iamSvc.Projects.ServiceAccounts.List(fmt.Sprintf("projects/%s", o.ProjectID)).Fields("accounts(name,displayName,email),nextPageToken")
@@ -58,9 +59,9 @@ func (o *ClusterUninstaller) listClusterServiceAccount() ([]*iam.ServiceAccount,
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteServiceAccount(item cloudResource) error {
+func (o *ClusterUninstaller) deleteServiceAccount(ctx context.Context, item cloudResource) error {
 	o.Logger.Debugf("Deleting service account %s", item.name)
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	_, err := o.iamSvc.Projects.ServiceAccounts.Delete(item.name).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
@@ -73,8 +74,8 @@ func (o *ClusterUninstaller) deleteServiceAccount(item cloudResource) error {
 
 // destroyServiceAccounts removes service accounts with a display name prefixed
 // with the cluster's infra ID.
-func (o *ClusterUninstaller) destroyServiceAccounts() error {
-	found, err := o.listServiceAccounts()
+func (o *ClusterUninstaller) destroyServiceAccounts(ctx context.Context) error {
+	found, err := o.listServiceAccounts(ctx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 	}
 
 	// Remove service accounts from project policy
-	policy, err := o.getProjectIAMPolicy()
+	policy, err := o.getProjectIAMPolicy(ctx)
 	if err != nil {
 		return err
 	}
@@ -93,7 +94,7 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 		emails.Insert(item.url)
 	}
 	if o.clearIAMPolicyBindings(policy, emails, o.Logger) {
-		err = o.setProjectIAMPolicy(policy)
+		err = o.setProjectIAMPolicy(ctx, policy)
 		if err != nil {
 			o.errorTracker.suppressWarning("iampolicy", err, o.Logger)
 			return errors.Errorf("%d items pending", len(items))
@@ -102,7 +103,7 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 	}
 
 	for _, item := range items {
-		err := o.deleteServiceAccount(item)
+		err := o.deleteServiceAccount(ctx, item)
 		if err != nil {
 			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}


### PR DESCRIPTION
** context structs should not be stored in another struct. Removed from GCP and altered the gcp destroy functionality to pass around the base context to all destroy functions and each will create a child off of the context.