### PR TITLE
OCPBUGS-13552: vSphere Add ova sha query; additional debugging

### DIFF
--- a/pkg/tfvars/internal/cache/cache.go
+++ b/pkg/tfvars/internal/cache/cache.go
@@ -146,10 +146,14 @@ func cacheFile(reader io.Reader, filePath string, sha256Checksum string) (err er
 		reader = io.TeeReader(reader, hasher)
 	}
 
-	_, err = io.Copy(file, reader)
+	written, err := io.Copy(file, reader)
 	if err != nil {
 		return err
 	}
+
+	// Let's find out how much data was written
+	// for future troubleshooting
+	logrus.Debugf("writing the RHCOS image was %d bytes", written)
 
 	err = file.Close()
 	if err != nil {
@@ -204,12 +208,14 @@ func (u *urlWithIntegrity) download(dataType string) (string, error) {
 		return "", err
 	}
 
-	// Send a request
 	resp, err := http.Get(u.location.String())
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
+
+	// Let's find the content length for future debugging
+	logrus.Debugf("image download content length: %d", resp.ContentLength)
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
We have been experiencing issues with OVA
corruption for quite a while. In investigating
this issue it seems the provided sha256 for the OVA
was being left unused. This PR adds `sha256` query
so that upon download of the OVA the integrity
will be checked.

In addition the content length of the body GET
along with the io.Copy bytes written is outputted
when debugging is enabled.

Further debugging was added to the vsphereprivate
resource if and when parsing of the OVF descriptor
fails. It checks the SHA256 and provides the size of
the OVA for additional checking.