### PR TITLE
OCPBUGS-6639: pkg/types/azure/validation: validate resource groups

### DIFF
--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -70,6 +70,9 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 			allErrs = append(allErrs, field.Required(fldPath.Child("networkResourceGroupName"), "must provide a network resource group when a virtual network is specified"))
 		}
 	}
+	if p.BaseDomainResourceGroupName != "" && p.NetworkResourceGroupName != "" && strings.ToUpper(p.BaseDomainResourceGroupName) == strings.ToUpper(p.NetworkResourceGroupName) {
+		allErrs = append(allErrs, field.Required(fldPath.Child("baseDomainResourceGroupname"), "baseDomainResourceGroupName cannot be the same as networkResourceGroupName"))
+	}
 	if (p.ComputeSubnet != "" || p.ControlPlaneSubnet != "") && (p.VirtualNetwork == "" || p.NetworkResourceGroupName == "") {
 		if p.VirtualNetwork == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("virtualNetwork"), "must provide a virtual network when supplying subnets"))


### PR DESCRIPTION
Validate that baseDomainResourceGroup is not the same as networkResourceGroupName. networkResourceGroupName needs to be a separate resource group so that the created resources can be tracked outside of existing vnet resources.

https://issues.redhat.com/browse/OCPBUGS-6639