### PR TITLE
OCPBUGS-13628: Revert "remove special cases for featureset in rendering"

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -92,6 +92,9 @@ then
 	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
 		ADDITIONAL_FLAGS+=("--cloud-provider-config-input-file=/assets/manifests/cloud-provider-config.yaml")
 	fi
+	{{- if .FeatureSet }}
+	ADDITIONAL_FLAGS+=("--feature-set={{.FeatureSet}}")
+	{{- end}}
 
 	bootkube_podman_run \
 		--name config-render \
@@ -103,6 +106,7 @@ then
 		--config-output-file=/assets/config-bootstrap/config \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/config-bootstrap \
+		--featuregate-manifest=/assets/manifests/99_feature-gate.yaml \
 		--rendered-manifest-files=/assets/manifests \
 		--payload-version=$VERSION \
 		"${ADDITIONAL_FLAGS[@]}"


### PR DESCRIPTION
Reverts openshift/installer#7158, tracked by OCPBUGS-13628

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get  payloads flowing again.

Since this landed, all installs are failing.  See https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-05-12-064129 for example jobs.

It looks like https://github.com/openshift/library-go/pull/1528 plus a revendor in cluster-config-operator is needed for this to work.  If possible please try the relevant PR's together perhaps using cluster-bot to prove this change doesn't break.


CC: @deads2k, @patrickdillon 