### PR TITLE
OCPBUGS-9435: terraform: aws: secret regions now support ALIAS record

### DIFF
--- a/data/data/aws/cluster/route53/base.tf
+++ b/data/data/aws/cluster/route53/base.tf
@@ -5,7 +5,7 @@ locals {
   // So publish_strategy serves an coordinated proxy for that decision.
   public_endpoints = var.publish_strategy == "External" ? true : false
 
-  use_cname = contains(["us-gov-west-1", "us-gov-east-1", "us-iso-east-1"], var.region)
+  use_cname = contains(["us-gov-west-1", "us-gov-east-1"], var.region)
   use_alias = ! local.use_cname
 }
 


### PR DESCRIPTION
Switching to use a CNAME instead of an ALIAS record is no longer needed on C2S regions. Both TC2S and SC2S support ALIAS records now.