### PR TITLE
CFE-829: Remove Azure Tags TechPreview only indicators and checks

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2508,9 +2508,7 @@ spec:
                     description: UserTags has additional keys and values that the
                       installer will add as tags to all resources that it creates
                       on AzurePublicCloud alone. Resources created by the cluster
-                      itself may not include these tags. This is a TechPreview feature
-                      and requires setting featureSet to TechPreviewNoUpgrade to configure
-                      the tags.
+                      itself may not include these tags.
                     type: object
                   virtualNetwork:
                     description: VirtualNetwork specifies the name of an existing

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -222,7 +222,7 @@ func Test_PrintFields(t *testing.T) {
       ResourceGroupName is the name of an already existing resource group where the cluster should be installed. This resource group should only be used for this specific cluster and the cluster components will assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster. If empty, a new resource group will created for the cluster.
 
     userTags <object>
-      UserTags has additional keys and values that the installer will add as tags to all resources that it creates on AzurePublicCloud alone. Resources created by the cluster itself may not include these tags. This is a TechPreview feature and requires setting featureSet to TechPreviewNoUpgrade to configure the tags.
+      UserTags has additional keys and values that the installer will add as tags to all resources that it creates on AzurePublicCloud alone. Resources created by the cluster itself may not include these tags.
 
     virtualNetwork <string>
       VirtualNetwork specifies the name of an existing VNet for the installer to use`,

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -90,8 +90,6 @@ type Platform struct {
 	// UserTags has additional keys and values that the installer will add
 	// as tags to all resources that it creates on AzurePublicCloud alone.
 	// Resources created by the cluster itself may not include these tags.
-	// This is a TechPreview feature and requires setting featureSet to
-	// TechPreviewNoUpgrade to configure the tags.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1045,10 +1045,6 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
 		errMsg := "the TechPreviewNoUpgrade feature set must be enabled to use this field"
 
-		if c.Azure != nil && len(c.Azure.UserTags) > 0 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "azure", "userTags"), errMsg))
-		}
-
 		if c.AWS != nil {
 			if len(c.AWS.HostedZoneRole) > 0 {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "aws", "hostedZoneRole"), errMsg))


### PR DESCRIPTION
Support for user defined tags for Azure resources was TechPreview only in openshift-4.13 which will be made GA in openshift-4.14. And the changes in this PR are for removing the indications on TechPreview and the featureSet check.