### PR TITLE
OCPBUGS-13764: Support /dev/disk/by-path root device hints

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/types/agent"
 	"github.com/openshift/installer/pkg/types/agent/conversion"
+	"github.com/openshift/installer/pkg/types/baremetal/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
 
@@ -247,15 +248,16 @@ func (a *AgentConfig) validateHostInterfaces(hostPath *field.Path, host agent.Ho
 }
 
 func (a *AgentConfig) validateHostRootDeviceHints(hostPath *field.Path, host agent.Host) field.ErrorList {
-	var allErrs field.ErrorList
+	rdhPath := hostPath.Child("rootDeviceHints")
+	allErrs := validation.ValidateHostRootDeviceHints(&host.RootDeviceHints, rdhPath)
 
 	if host.RootDeviceHints.WWNWithExtension != "" {
 		allErrs = append(allErrs, field.Forbidden(
-			hostPath.Child("RootDeviceHints", "WWNWithExtension"), "WWN extensions are not supported in root device hints"))
+			rdhPath.Child("wwnWithExtension"), "WWN extensions are not supported in root device hints"))
 	}
 
 	if host.RootDeviceHints.WWNVendorExtension != "" {
-		allErrs = append(allErrs, field.Forbidden(hostPath.Child("RootDeviceHints", "WWNVendorExtension"), "WWN vendor extensions are not supported in root device hints"))
+		allErrs = append(allErrs, field.Forbidden(rdhPath.Child("wwnVendorExtension"), "WWN vendor extensions are not supported in root device hints"))
 	}
 
 	return allErrs

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -153,6 +153,24 @@ hosts:
 			expectedError: "invalid Agent Config configuration: Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
 		},
 		{
+			name: "unsupported device name root device hint",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: agent-config-cluster0
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:01
+    rootDeviceHints:
+      deviceName: "/dev/disk/by-id/wwn-0x600508e000000000ce506dc50ab0ad05"`,
+
+			expectedFound: false,
+			expectedError: "invalid Agent Config configuration: Hosts[0].rootDeviceHints.deviceName: Invalid value: \"/dev/disk/by-id/wwn-0x600508e000000000ce506dc50ab0ad05\": Device Name of root device hint must be path in /dev/ or /dev/disk/by-path/",
+		},
+		{
 			name: "unsupported wwn extension root device hint",
 			data: `
 apiVersion: v1beta1
@@ -168,7 +186,7 @@ hosts:
       wwnWithExtension: "wwn-with-extension-value"`,
 
 			expectedFound: false,
-			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNWithExtension: Forbidden: WWN extensions are not supported in root device hints",
+			expectedError: "invalid Agent Config configuration: Hosts[0].rootDeviceHints.wwnWithExtension: Forbidden: WWN extensions are not supported in root device hints",
 		},
 		{
 			name: "unsupported wwn vendor extension root device hint",
@@ -186,7 +204,7 @@ hosts:
       wwnVendorExtension: "wwn-with-vendor-extension-value"`,
 
 			expectedFound: false,
-			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
+			expectedError: "invalid Agent Config configuration: Hosts[0].rootDeviceHints.wwnVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
 		},
 		{
 			name: "node-hostname-and-role-are-not-required",

--- a/pkg/types/baremetal/rootdevice.go
+++ b/pkg/types/baremetal/rootdevice.go
@@ -5,6 +5,7 @@ package baremetal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
@@ -62,7 +63,11 @@ func (source *RootDeviceHints) MakeHintMap() map[string]string {
 	}
 
 	if source.DeviceName != "" {
-		hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		if strings.HasPrefix(source.DeviceName, "/dev/disk/by-path/") {
+			hints["by_path"] = fmt.Sprintf("s== %s", source.DeviceName)
+		} else {
+			hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		}
 	}
 	if source.HCTL != "" {
 		hints["hctl"] = fmt.Sprintf("s== %s", source.HCTL)

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -359,6 +359,62 @@ interfaces:
 	}
 }
 
+func TestValidateHostRootDeviceHints(t *testing.T) {
+	cases := []struct {
+		name            string
+		rootDeviceHints *baremetal.RootDeviceHints
+		expectedSuccess bool
+	}{
+		{
+			name:            "nil hints",
+			expectedSuccess: true,
+		},
+		{
+			name:            "no hints",
+			rootDeviceHints: &baremetal.RootDeviceHints{},
+			expectedSuccess: true,
+		},
+		{
+			name: "non /dev path",
+			rootDeviceHints: &baremetal.RootDeviceHints{
+				DeviceName: "sda",
+			},
+		},
+		{
+			name: "/dev path",
+			rootDeviceHints: &baremetal.RootDeviceHints{
+				DeviceName: "/dev/sda",
+			},
+			expectedSuccess: true,
+		},
+		{
+			name: "by-path path",
+			rootDeviceHints: &baremetal.RootDeviceHints{
+				DeviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0",
+			},
+			expectedSuccess: true,
+		},
+		{
+			name: "by-id path",
+			rootDeviceHints: &baremetal.RootDeviceHints{
+				DeviceName: "/dev/disk/by-id/wwn-0x600508e000000000ce506dc50ab0ad05",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateHostRootDeviceHints(tc.rootDeviceHints, field.NewPath("rootDeviceHints"))
+
+			if tc.expectedSuccess {
+				assert.Empty(t, errs)
+			} else {
+				assert.NotEmpty(t, errs)
+			}
+		})
+	}
+}
+
 func TestValidateProvisioning(t *testing.T) {
 	//Used for url validations
 	imagesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Update the installer/terraform implementation to match the Metal³ changes in [OCPBUGS-13080](https://issues.redhat.com/browse/OCPBUGS-13080) so that control plane and worker machines will have equivalent functionality.

This includes accepting /by-path/ paths and adding validation to ensure that invalid paths that can't ever match are rejected immediately. The code to construct the HardwareDetails for the status annotation of the control plane hosts runs in the baremetal-operator container so it always matches and no changes are needed here.