### PR TITLE
[release-4.13] OCPBUGS-13765: Support /dev/disk/by-path root device hints

### DIFF
--- a/pkg/types/baremetal/rootdevice.go
+++ b/pkg/types/baremetal/rootdevice.go
@@ -5,6 +5,7 @@ package baremetal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
@@ -62,7 +63,11 @@ func (source *RootDeviceHints) MakeHintMap() map[string]string {
 	}
 
 	if source.DeviceName != "" {
-		hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		if strings.HasPrefix(source.DeviceName, "/dev/disk/by-path/") {
+			hints["by_path"] = fmt.Sprintf("s== %s", source.DeviceName)
+		} else {
+			hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		}
 	}
 	if source.HCTL != "" {
 		hints["hctl"] = fmt.Sprintf("s== %s", source.HCTL)


### PR DESCRIPTION
In baremetal IPI, we should support /dev/disk/by-path root device hints in the install-config to match the implementation in Metal³.