### PR TITLE
OCPBUGS-13718: ic: azure: validate diskTypes in AzureStack

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -43,6 +43,9 @@ func Validate(client API, ic *types.InstallConfig) error {
 
 	allErrs = append(allErrs, validateNetworks(client, ic.Azure, ic.Networking.MachineNetwork, field.NewPath("platform").Child("azure"))...)
 	allErrs = append(allErrs, validateRegion(client, field.NewPath("platform").Child("azure").Child("region"), ic.Azure)...)
+	if ic.Azure.CloudName == aztypes.StackCloud {
+		allErrs = append(allErrs, validateAzureStackDiskType(client, ic)...)
+	}
 	allErrs = append(allErrs, validateInstanceTypes(client, ic)...)
 	if ic.Azure.CloudName == aztypes.StackCloud && ic.Azure.ClusterOSImage != "" {
 		StorageEndpointSuffix, err := client.GetStorageEndpointSuffix(context.TODO())
@@ -650,5 +653,41 @@ func validateMarketplaceImage(client API, installConfig *types.InstallConfig) fi
 				fmt.Sprintf("could not determine if the license terms for the marketplace image have been accepted: %v", err)))
 		}
 	}
+	return allErrs
+}
+
+func validateAzureStackDiskType(_ API, installConfig *types.InstallConfig) field.ErrorList {
+	var allErrs field.ErrorList
+
+	supportedTypes := sets.New("Premium_LRS", "Standard_LRS")
+	errMsg := fmt.Sprintf("disk format not supported. Must be one of %v", sets.List(supportedTypes))
+
+	defaultDiskType := aztypes.DefaultDiskType
+	if installConfig.Azure.DefaultMachinePlatform != nil &&
+		installConfig.Azure.DefaultMachinePlatform.DiskType != "" {
+		defaultDiskType = installConfig.Azure.DefaultMachinePlatform.DiskType
+	}
+
+	diskType := defaultDiskType
+	if installConfig.ControlPlane != nil &&
+		installConfig.ControlPlane.Platform.Azure != nil &&
+		installConfig.ControlPlane.Platform.Azure.DiskType != "" {
+		diskType = installConfig.ControlPlane.Platform.Azure.DiskType
+	}
+	if !supportedTypes.Has(diskType) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("controlPlane", "platform", "azure", "OSDisk", "diskType"), diskType, errMsg))
+	}
+
+	for idx, compute := range installConfig.Compute {
+		fieldPath := field.NewPath("compute").Index(idx)
+		diskType := defaultDiskType
+		if compute.Platform.Azure != nil && compute.Platform.Azure.DiskType != "" {
+			diskType = compute.Platform.Azure.DiskType
+		}
+		if !supportedTypes.Has(diskType) {
+			allErrs = append(allErrs, field.Invalid(fieldPath.Child("platform", "azure", "OSDisk", "diskType"), diskType, errMsg))
+		}
+	}
+
 	return allErrs
 }

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -1007,3 +1007,84 @@ func TestAzureUltraSSDCapability(t *testing.T) {
 		})
 	}
 }
+
+func TestAzureStackDiskType(t *testing.T) {
+	const unsupportedDiskType = "StandardSSD_LRS"
+
+	validDefaultDiskType := func(ic *types.InstallConfig) {
+		ic.Azure.DefaultMachinePlatform.DiskType = "Premium_LRS"
+	}
+	invalidDefaultDiskType := func(ic *types.InstallConfig) {
+		ic.Azure.DefaultMachinePlatform.DiskType = unsupportedDiskType
+	}
+	validControlPlaneDiskType := func(ic *types.InstallConfig) {
+		ic.ControlPlane.Platform.Azure.DiskType = "Standard_LRS"
+	}
+	invalidControlPlaneDiskType := func(ic *types.InstallConfig) {
+		ic.ControlPlane.Platform.Azure.DiskType = unsupportedDiskType
+	}
+	validComputeDiskType := func(ic *types.InstallConfig) {
+		ic.Compute[0].Platform.Azure.DiskType = "Standard_LRS"
+	}
+	invalidComputeDiskType := func(ic *types.InstallConfig) {
+		ic.Compute[0].Platform.Azure.DiskType = unsupportedDiskType
+	}
+
+	cases := []struct {
+		name     string
+		edits    editFunctions
+		errorMsg string
+	}{
+		{
+			name:     "Valid defaultMachinePlatform DiskType",
+			edits:    editFunctions{validDefaultDiskType},
+			errorMsg: "",
+		},
+		{
+			name:     "Invalid defaultMachinePlatform DiskType",
+			edits:    editFunctions{invalidDefaultDiskType},
+			errorMsg: `\[controlPlane.platform.azure.OSDisk.diskType: Invalid value: "StandardSSD_LRS": disk format not supported. Must be one of \[Premium_LRS Standard_LRS\] compute\[0\].platform.azure.OSDisk.diskType: Invalid value: "StandardSSD_LRS": disk format not supported. Must be one of \[Premium_LRS Standard_LRS\]\]`,
+		},
+		{
+			name:     "Valid controlPlane DiskType",
+			edits:    editFunctions{validControlPlaneDiskType},
+			errorMsg: "",
+		},
+		{
+			name:     "Invalid controlPlane DiskType",
+			edits:    editFunctions{invalidControlPlaneDiskType},
+			errorMsg: `\[controlPlane.platform.azure.OSDisk.diskType: Invalid value: "StandardSSD_LRS": disk format not supported. Must be one of \[Premium_LRS Standard_LRS\]\]`,
+		},
+		{
+			name:     "Valid compute DiskType",
+			edits:    editFunctions{validComputeDiskType},
+			errorMsg: "",
+		},
+		{
+			name:     "Invalid compute DiskType",
+			edits:    editFunctions{invalidComputeDiskType},
+			errorMsg: `\[compute\[0\].platform.azure.OSDisk.diskType: Invalid value: "StandardSSD_LRS": disk format not supported. Must be one of \[Premium_LRS Standard_LRS\]\]`,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	azureClient := mock.NewMockAPI(mockCtrl)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+
+			aggregatedErrors := validateAzureStackDiskType(azureClient, editedInstallConfig)
+			if tc.errorMsg != "" {
+				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
+			} else {
+				assert.NoError(t, aggregatedErrors.ToAggregate())
+			}
+		})
+	}
+}


### PR DESCRIPTION
"StandardSSD_LRS" is not a supported disk type and will result in the following failure:
```
level=error msg=Error: expected storage_os_disk.0.managed_disk_type to be one of [Premium_LRS Standard_LRS], got StandardSSD_LRS
level=error
level=error msg=  with azurestack_virtual_machine.bootstrap,
level=error msg=  on main.tf line 107, in resource "azurestack_virtual_machine" "bootstrap":
level=error msg= 107: resource "azurestack_virtual_machine" "bootstrap" {
level=error
```
Let's make sure that only Premium_LRS or Standard_LRS can be specified for AzureStack.