### PR TITLE
OCPBUGS-13108: Log additional host info at warning level

### DIFF
--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -224,7 +224,7 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 			(*clusterMetadata.Status == models.ClusterStatusInstallingPendingUserAction) {
 			for _, host := range clusterMetadata.Hosts {
 				if *host.Status == models.ClusterStatusInstallingPendingUserAction {
-					logrus.Debugf("Host %s %s", host.RequestedHostname, *host.StatusInfo)
+					logrus.Warningf("Host %s %s", host.RequestedHostname, *host.StatusInfo)
 				}
 			}
 		}

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -32,7 +32,6 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 				lastErrOnExit = err
 				cancel()
 			} else {
-				logrus.Info(err)
 				if err.Error() != lastErrStr {
 					logrus.Info(err)
 					lastErrStr = err.Error()


### PR DESCRIPTION
When the host fails to boot due to pending-user-action (this can occur when the disk boot order is set incorrectly) log the message at Warning level instead of Debug to make it obvious.

This also removes an additional spurious info message that was being logged.