### PR TITLE
AGENT-596: use agent-installer-utils for agent-tui extraction

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -100,7 +100,7 @@ metadata:
   name: openshift-was not built correctly
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.13
+  releaseImage: registry.ci.openshift.org/origin/release:4.14
 status: {}
 -- expected/infraenv.yaml --
 metadata:

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -78,7 +78,7 @@ func (a *AgentImage) fetchAgentTuiFiles(releaseImage string, pullSecret string, 
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {
-		extracted, err := release.ExtractFile("agent-installer-node-agent", srcFile)
+		extracted, err := release.ExtractFile("agent-installer-utils", srcFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.13"
+	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.14"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
Since `agent-installer-utils` image is now shipped within the release payload, it's then possible to start using it (instead of the temporary solution provided by `agent-installer-node-agent`) for extracting the agent-tui related artifacts