### PR TITLE
OCPBUGS-14818: disable oVirt provider

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -18,7 +18,6 @@ import (
 	libvirtconfig "github.com/openshift/installer/pkg/asset/installconfig/libvirt"
 	nutanixconfig "github.com/openshift/installer/pkg/asset/installconfig/nutanix"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
-	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	vsphereconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types"
@@ -101,10 +100,7 @@ func (a *platform) Generate(asset.Parents) error {
 			return err
 		}
 	case ovirt.Name:
-		a.Ovirt, err = ovirtconfig.Platform()
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("platform oVirt is no longer supported")
 	case vsphere.Name:
 		a.VSphere, err = vsphereconfig.Platform()
 		if err != nil {

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -42,7 +42,6 @@ var (
 		ibmcloud.Name,
 		nutanix.Name,
 		openstack.Name,
-		ovirt.Name,
 		powervs.Name,
 		vsphere.Name,
 	}

--- a/pkg/types/ovirt/validation/platform.go
+++ b/pkg/types/ovirt/validation/platform.go
@@ -1,105 +1,20 @@
 package validation
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/ovirt"
-	"github.com/openshift/installer/pkg/validate"
 )
 
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *ovirt.Platform, fldPath *field.Path, c *types.InstallConfig) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if err := validate.UUID(p.ClusterID); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("ovirt_cluster_id"), p.ClusterID, err.Error()))
-	}
-	if err := validate.UUID(p.StorageDomainID); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("ovirt_storage_domain_id"), p.StorageDomainID, err.Error()))
-	}
-	if p.VNICProfileID != "" {
-		if err := validate.UUID(p.VNICProfileID); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("vnicProfileID"), p.VNICProfileID, err.Error()))
-		}
-	}
-	if p.AffinityGroups != nil {
-		allErrs = append(allErrs, validateAffinityGroupFields(p, fldPath.Child("affinityGroups"))...)
-		allErrs = append(allErrs, validateAffinityGroupDuplicate(p.AffinityGroups)...)
-	}
-	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
-	}
-
-	// Platform fields only allowed in TechPreviewNoUpgrade
-	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
-		if c.Ovirt.LoadBalancer != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("loadBalancer"), "load balancer is not supported in this feature set"))
-		}
-	}
-
-	if c.Ovirt.LoadBalancer != nil {
-		if !validateLoadBalancer(c.Ovirt.LoadBalancer.Type) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancer", "type"), c.Ovirt.LoadBalancer.Type, "invalid load balancer type"))
-		}
-	}
-
-	return allErrs
-}
-
-func validateAffinityGroupFields(platform *ovirt.Platform, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	for _, ag := range platform.AffinityGroups {
-		if ag.Name == "" {
-			allErrs = append(
-				allErrs,
-				field.Required(fldPath,
-					fmt.Sprintf("Invalid affinity group %v: name must be not empty", ag.Name)))
-		}
-		if ag.Priority < 0 || ag.Priority > 5 {
-			allErrs = append(
-				allErrs,
-				field.Invalid(fldPath, ag,
-					fmt.Sprintf(
-						"Invalid affinity group %v: priority value must be between 0-5 found priority %v",
-						ag.Name,
-						ag.Priority)))
-		}
-	}
-	return allErrs
-}
-
-// validateAffinityGroupDuplicate checks that there is no duplicated affinity group with different fields
-func validateAffinityGroupDuplicate(agList []ovirt.AffinityGroup) field.ErrorList {
-	allErrs := field.ErrorList{}
-	for i, ag1 := range agList {
-		for _, ag2 := range agList[i+1:] {
-			if ag1.Name == ag2.Name {
-				if ag1.Priority != ag2.Priority ||
-					ag1.Description != ag2.Description ||
-					ag1.Enforcing != ag2.Enforcing {
-					allErrs = append(
-						allErrs,
-						&field.Error{
-							Type: field.ErrorTypeDuplicate,
-							BadValue: errors.Errorf("Error validating affinity groups: found same "+
-								"affinity group defined twice with different fields %v anf %v", ag1, ag2)})
-				}
-			}
-		}
-	}
-	return allErrs
-}
-
-// validateLoadBalancer returns an error if the load balancer is not valid.
-func validateLoadBalancer(lbType configv1.PlatformLoadBalancerType) bool {
-	switch lbType {
-	case configv1.LoadBalancerTypeOpenShiftManagedDefault, configv1.LoadBalancerTypeUserManaged:
-		return true
-	default:
-		return false
+	return field.ErrorList{
+		&field.Error{
+			Type:     field.ErrorTypeForbidden,
+			Field:    fldPath.String(),
+			BadValue: "Unsupported platform",
+			Detail:   "Platform oVirt is no longer supported",
+		},
 	}
 }

--- a/pkg/types/ovirt/validation/platform_test.go
+++ b/pkg/types/ovirt/validation/platform_test.go
@@ -32,11 +32,6 @@ func TestValidatePlatform(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:     "minimal",
-			platform: validPlatform(),
-			valid:    true,
-		},
-		{
 			name:     "forbidden load balancer field",
 			platform: validPlatform(),
 			config: &types.InstallConfig{
@@ -51,107 +46,7 @@ func TestValidatePlatform(t *testing.T) {
 				},
 			},
 			valid:         false,
-			expectedError: `^test-path\.loadBalancer: Forbidden: load balancer is not supported in this feature set`,
-		},
-		{
-			name:     "allowed load balancer field with OpenShift managed default",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				FeatureSet: configv1.TechPreviewNoUpgrade,
-				Platform: types.Platform{
-					Ovirt: func() *ovirt.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.OvirtPlatformLoadBalancer{
-							Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
-						}
-						return p
-					}(),
-				},
-			},
-			valid: true,
-		},
-		{
-			name:     "allowed load balancer field with user-managed",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				FeatureSet: configv1.TechPreviewNoUpgrade,
-				Platform: types.Platform{
-					Ovirt: func() *ovirt.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.OvirtPlatformLoadBalancer{
-							Type: configv1.LoadBalancerTypeUserManaged,
-						}
-						return p
-					}(),
-				},
-			},
-			valid: true,
-		},
-		{
-			name:     "allowed load balancer field invalid type",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				FeatureSet: configv1.TechPreviewNoUpgrade,
-				Platform: types.Platform{
-					Ovirt: func() *ovirt.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.OvirtPlatformLoadBalancer{
-							Type: "FooBar",
-						}
-						return p
-					}(),
-				},
-			},
-			expectedError: `^test-path\.loadBalancer.type: Invalid value: "FooBar": invalid load balancer type`,
-			valid:         false,
-		},
-		{
-			name: "invalid when empty cluster ID",
-			platform: func() *ovirt.Platform {
-				p := validPlatform()
-				p.ClusterID = ""
-				return p
-			}(),
-			expectedError: `^test-path.ovirt_cluster_id: Invalid value: "": invalid UUID length: 0`,
-			valid:         false,
-		},
-		{
-			name: "invalid when empty storage ID",
-			platform: func() *ovirt.Platform {
-				p := validPlatform()
-				p.StorageDomainID = ""
-				return p
-			}(),
-			expectedError: `^test-path.ovirt_storage_domain_id: Invalid value: "": invalid UUID length: 0`,
-			valid:         false,
-		},
-		{
-			name: "malformed vnic profile id",
-			platform: func() *ovirt.Platform {
-				p := validPlatform()
-				p.VNICProfileID = "abcd-sdf"
-				return p
-			}(),
-			expectedError: `^test-path.vnicProfileID: Invalid value: "abcd-sdf": invalid UUID length: 8`,
-			valid:         false,
-		},
-		{
-			name: "valid empty vnic profile id",
-			platform: func() *ovirt.Platform {
-				p := validPlatform()
-				p.VNICProfileID = ""
-				return p
-			}(),
-			valid: true,
-		},
-		{
-			name: "valid machine pool",
-			platform: func() *ovirt.Platform {
-				p := validPlatform()
-				p.DefaultMachinePlatform = &ovirt.MachinePool{}
-				return p
-			}(),
-			valid: true,
+			expectedError: `^test-path: Forbidden: Platform oVirt is no longer supported`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -26,7 +25,6 @@ import (
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/nutanix"
 	"github.com/openshift/installer/pkg/types/openstack"
-	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/openshift/installer/pkg/types/powervs"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
@@ -285,15 +283,6 @@ func validDualStackNetworkingConfig() *types.Networking {
 				HostPrefix: 64,
 			},
 		},
-	}
-}
-
-func validOvirtPlatform() *ovirt.Platform {
-	return &ovirt.Platform{
-		ClusterID:       uuid.NewRandom().String(),
-		StorageDomainID: uuid.NewRandom().String(),
-		APIVIPs:         []string{"10.0.1.1"},
-		IngressVIPs:     []string{"10.0.1.3"},
 	}
 }
 
@@ -590,7 +579,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform = types.Platform{}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: "": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, ovirt, powervs, vsphere\)$`,
+			expectedError: `^platform: Invalid value: "": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
 		},
 		{
 			name: "multiple platforms",
@@ -621,7 +610,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, ovirt, powervs, vsphere\)$`,
+			expectedError: `^platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
 		},
 		{
 			name: "invalid libvirt platform",
@@ -633,7 +622,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.Libvirt.URI = ""
 				return c
 			}(),
-			expectedError: `^\[platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, ovirt, powervs, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
+			expectedError: `^\[platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
 		},
 		{
 			name: "valid none platform",
@@ -1388,17 +1377,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: `Invalid value: "ffd1::/48": subnet size for IPv6 service network should be /112`,
 		},
-
-		{
-			name: "valid ovirt platform",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					Ovirt: validOvirtPlatform(),
-				}
-				return c
-			}(),
-		},
 		{
 			name: "architecture is not supported",
 			installConfig: func() *types.InstallConfig {
@@ -2079,33 +2057,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: "platform.nutanix.apiVIPs: Invalid value: \"foobar\": \"foobar\" is not a valid IP",
-		},
-		{
-			name: "should return error on missing vips on Ovirt if not set (vips are required on Ovirt)",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					Ovirt: validOvirtPlatform(),
-				}
-				c.Platform.Ovirt.DeprecatedAPIVIP = ""
-				c.Platform.Ovirt.APIVIPs = []string{}
-
-				return c
-			}(),
-			expectedError: "platform.ovirt.api_vips: Required value: must specify at least one VIP for the API",
-		},
-		{
-			name: "should validate vips on Ovirt (vips are required on Ovirt)",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					Ovirt: validOvirtPlatform(),
-				}
-				c.Platform.Ovirt.APIVIPs = []string{"foobar"}
-
-				return c
-			}(),
-			expectedError: "platform.ovirt.api_vips: Invalid value: \"foobar\": \"foobar\" is not a valid IP",
 		},
 		{
 			name: "should return error if only API VIP is set",


### PR DESCRIPTION
This PR disables oVirt as a supported platform by 
- removing it as an option from the interactive install
- and returning an validation error when using an `install-config.yaml`