### PR TITLE
OCPCLOUD-2036: introduce External platform type

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2502,6 +2502,18 @@ spec:
                 required:
                 - hosts
                 type: object
+              external:
+                description: External is the configuration used when installing on
+                  an external cloud provider.
+                properties:
+                  platformName:
+                    default: Unknown
+                    description: PlatformName holds the arbitrary string representing
+                      the infrastructure provider name, expected to be set at the
+                      installation time. This field is solely for informational and
+                      reporting purposes and is not expected to be used for decision-making.
+                    type: string
+                type: object
               gcp:
                 description: GCP is the configuration used when installing on Google
                   Cloud Platform.

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -27,6 +27,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -99,7 +100,7 @@ func (m *Metadata) Generate(parents asset.Parents) (err error) {
 		metadata.ClusterPlatformMetadata.AlibabaCloud = alibabacloud.Metadata(installConfig.Config)
 	case powervstypes.Name:
 		metadata.ClusterPlatformMetadata.PowerVS = powervs.Metadata(installConfig.Config, installConfig.PowerVS)
-	case nonetypes.Name:
+	case externaltypes.Name, nonetypes.Name:
 	case nutanixtypes.Name:
 		metadata.ClusterPlatformMetadata.Nutanix = nutanix.Metadata(installConfig.Config)
 	default:

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -138,7 +139,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 	platform := installConfig.Config.Platform.Name()
 	switch platform {
-	case none.Name:
+	case external.Name, none.Name:
 		return errors.Errorf("cannot create the cluster because %q is a UPI platform", platform)
 	}
 

--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -92,6 +93,8 @@ func (a *platform) Generate(asset.Parents) error {
 		if err != nil {
 			return err
 		}
+	case external.Name:
+		a.External = &external.Platform{}
 	case none.Name:
 		a.None = &none.Platform{}
 	case openstack.Name:

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -88,7 +89,7 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "creating OpenStack session")
 		}
-	case baremetal.Name, libvirt.Name, none.Name, vsphere.Name, nutanix.Name:
+	case baremetal.Name, libvirt.Name, external.Name, none.Name, vsphere.Name, nutanix.Name:
 		// no creds to check
 	case azure.Name:
 		azureSession, err := ic.Azure.Session()

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -107,7 +108,7 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case azure.Name, baremetal.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name, vsphere.Name, alibabacloud.Name, nutanix.Name:
+	case azure.Name, baremetal.Name, libvirt.Name, external.Name, none.Name, openstack.Name, ovirt.Name, vsphere.Name, alibabacloud.Name, nutanix.Name:
 		// no permissions to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -147,7 +148,7 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case libvirt.Name, none.Name:
+	case external.Name, libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:
 		err := nutanixconfig.ValidateForProvisioning(ic.Config)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -51,6 +51,7 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	azuredefaults "github.com/openshift/installer/pkg/types/azure/defaults"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -477,7 +478,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err := powervs.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish); err != nil {
 			return errors.Wrap(err, "failed to to configure master machine objects")
 		}
-	case nonetypes.Name:
+	case externaltypes.Name, nonetypes.Name:
 	case nutanixtypes.Name:
 		mpool := defaultNutanixMachinePoolPlatform()
 		mpool.NumCPUs = 8

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -52,6 +52,7 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	azuredefaults "github.com/openshift/installer/pkg/types/azure/defaults"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -640,7 +641,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			for _, set := range sets {
 				machineSets = append(machineSets, set)
 			}
-		case nonetypes.Name:
+		case externaltypes.Name, nonetypes.Name:
 		case nutanixtypes.Name:
 			mpool := defaultNutanixMachinePoolPlatform()
 			mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -26,6 +26,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -93,7 +94,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	}
 
 	switch installConfig.Config.Platform.Name() {
-	case libvirttypes.Name, nonetypes.Name, baremetaltypes.Name, ovirttypes.Name:
+	case libvirttypes.Name, externaltypes.Name, nonetypes.Name, baremetaltypes.Name, ovirttypes.Name:
 		return nil
 	case awstypes.Name:
 		// Store the additional trust bundle in the ca-bundle.pem key if the cluster is being installed on a C2S region.

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -22,6 +22,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -213,7 +214,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 		config.Spec.PrivateZone = &configv1.DNSZone{
 			ID: zoneID,
 		}
-	case libvirttypes.Name, openstacktypes.Name, baremetaltypes.Name, nonetypes.Name, vspheretypes.Name, ovirttypes.Name, nutanixtypes.Name:
+	case libvirttypes.Name, openstacktypes.Name, baremetaltypes.Name, externaltypes.Name, nonetypes.Name, vspheretypes.Name, ovirttypes.Name, nutanixtypes.Name:
 	default:
 		return errors.New("invalid Platform")
 	}

--- a/pkg/asset/manifests/external/infrastructure.go
+++ b/pkg/asset/manifests/external/infrastructure.go
@@ -1,0 +1,24 @@
+package external
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+)
+
+// GetInfraPlatformSpec constructs ExternalPlatformSpec for the infrastructure spec.
+func GetInfraPlatformSpec(ic *installconfig.InstallConfig) *configv1.ExternalPlatformSpec {
+	icPlatformSpec := ic.Config.External
+
+	return &configv1.ExternalPlatformSpec{
+		PlatformName: icPlatformSpec.PlatformName,
+	}
+}
+
+// GetInfraPlatformStatus constructs ExternalPlatformSpec for the infrastructure spec.
+func GetInfraPlatformStatus() *configv1.ExternalPlatformStatus {
+	return &configv1.ExternalPlatformStatus{
+		CloudControllerManager: configv1.CloudControllerManagerStatus{
+			State: configv1.CloudControllerManagerExternal,
+		},
+	}
+}

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -13,6 +13,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	externalinfra "github.com/openshift/installer/pkg/asset/manifests/external"
 	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	vsphereinfra "github.com/openshift/installer/pkg/asset/manifests/vsphere"
 	"github.com/openshift/installer/pkg/types"
@@ -20,6 +21,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -202,6 +204,10 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		}
 	case libvirt.Name:
 		config.Spec.PlatformSpec.Type = configv1.LibvirtPlatformType
+	case external.Name:
+		config.Spec.PlatformSpec.Type = configv1.ExternalPlatformType
+		config.Spec.PlatformSpec.External = externalinfra.GetInfraPlatformSpec(installConfig)
+		config.Status.PlatformStatus.External = externalinfra.GetInfraPlatformStatus()
 	case none.Name:
 		config.Spec.PlatformSpec.Type = configv1.NonePlatformType
 	case openstack.Name:

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -26,6 +26,7 @@ import (
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	typesgcp "github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -174,7 +175,7 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 				return errors.Wrap(err, "failed to meet the prerequisite of one DHCP service per Power VS instance")
 			}
 		}
-	case alibabacloud.Name, azure.Name, baremetal.Name, ibmcloud.Name, libvirt.Name, none.Name, ovirt.Name, vsphere.Name, nutanix.Name:
+	case alibabacloud.Name, azure.Name, baremetal.Name, ibmcloud.Name, libvirt.Name, external.Name, none.Name, ovirt.Name, vsphere.Name, nutanix.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -196,6 +197,8 @@ func osImage(config *types.InstallConfig) (string, error) {
 		}
 
 		return "", fmt.Errorf("%s: No Power VS build found", st.FormatPrefix(archName))
+	case external.Name:
+		return "", nil
 	case none.Name:
 		return "", nil
 	case nutanix.Name:

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -118,6 +118,9 @@ func Test_PrintFields(t *testing.T) {
     baremetal <object>
       BareMetal is the configuration used when installing on bare metal.
 
+    external <object>
+      External is the configuration used when installing on an external cloud provider.
+
     gcp <object>
       GCP is the configuration used when installing on Google Cloud Platform.
 

--- a/pkg/terraform/stages/platform/stages.go
+++ b/pkg/terraform/stages/platform/stages.go
@@ -20,6 +20,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -62,6 +63,9 @@ func StagesForPlatform(platform string) []terraform.Stage {
 		return vsphere.PlatformStages
 	case nonetypes.Name:
 		// terraform is not used when the platform is "none"
+		return []terraform.Stage{}
+	case externaltypes.Name:
+		// terraform is not used when the platform is "external"
 		return []terraform.Stage{}
 	default:
 		panic(fmt.Sprintf("unsupported platform %q", platform))

--- a/pkg/types/external/defaults/platform.go
+++ b/pkg/types/external/defaults/platform.go
@@ -1,0 +1,8 @@
+package defaults
+
+import "github.com/openshift/installer/pkg/types/external"
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *external.Platform) {
+	p.PlatformName = "Unknown"
+}

--- a/pkg/types/external/doc.go
+++ b/pkg/types/external/doc.go
@@ -1,0 +1,6 @@
+// Package none contains generic structures for installer
+// configuration and management.
+package external
+
+// Name is name for the External platform.
+const Name string = "external"

--- a/pkg/types/external/platform.go
+++ b/pkg/types/external/platform.go
@@ -1,0 +1,12 @@
+package external
+
+// Platform stores configuration related to external cloud providers.
+type Platform struct {
+	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
+	// This field is solely for informational and reporting purposes and is not expected to be used for decision-making.
+	// +kubebuilder:default:="Unknown"
+	// +default="Unknown"
+	// +kubebuilder:validation:XValidation:rule="oldSelf == 'Unknown' || self == oldSelf",message="platform name cannot be changed once set"
+	// +optional
+	PlatformName string `json:"platformName,omitempty"`
+}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -50,6 +51,7 @@ var (
 	// to the user in the interactive wizard.
 	HiddenPlatformNames = []string{
 		baremetal.Name,
+		external.Name,
 		none.Name,
 	}
 
@@ -286,6 +288,10 @@ type Platform struct {
 	// platform.
 	None *none.Platform `json:"none,omitempty"`
 
+	// External is the configuration used when installing on
+	// an external cloud provider.
+	External *external.Platform `json:"external,omitempty"`
+
 	// OpenStack is the configuration used when installing on OpenStack.
 	// +optional
 	OpenStack *openstack.Platform `json:"openstack,omitempty"`
@@ -330,6 +336,8 @@ func (p *Platform) Name() string {
 		return libvirt.Name
 	case p.None != nil:
 		return none.Name
+	case p.External != nil:
+		return external.Name
 	case p.OpenStack != nil:
 		return openstack.Name
 	case p.VSphere != nil:

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -258,6 +258,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		case p.Ovirt != nil:
 		case p.Nutanix != nil:
 		case p.None != nil:
+		case p.External != nil:
 		default:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "DualStack", "dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address"))
 		}
@@ -289,6 +290,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		case p.Ovirt != nil:
 		case p.Nutanix != nil:
 		case p.None != nil:
+		case p.External != nil:
 		case p.Azure != nil && p.Azure.CloudName == azure.StackCloud:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "IPv6", "Azure Stack does not support IPv6"))
 		default:

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -579,7 +579,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform = types.Platform{}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: "": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
+			expectedError: `^platform: Invalid value: "": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, external, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
 		},
 		{
 			name: "multiple platforms",
@@ -610,7 +610,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
+			expectedError: `^platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, external, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\)$`,
 		},
 		{
 			name: "invalid libvirt platform",
@@ -622,7 +622,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.Libvirt.URI = ""
 				return c
 			}(),
-			expectedError: `^\[platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
+			expectedError: `^\[platform: Invalid value: "libvirt": must specify one of the platforms \(alibabacloud, aws, azure, baremetal, external, gcp, ibmcloud, none, nutanix, openstack, powervs, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
 		},
 		{
 			name: "valid none platform",


### PR DESCRIPTION
The intent of this pull request is to allow the definition of the external platform type so that partners are able to more easily integrate with the installer and other components that recognize the external platform type.

cc: @elmiko 