### PR TITLE
OCPBUGS-13662: Ignore CPUPartitioning for ABI

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -387,4 +387,9 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		fieldPath := field.NewPath("BootstrapInPlace", "InstallationDisk")
 		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.BootstrapInPlace.InstallationDisk))
 	}
+
+	if installConfig.CPUPartitioning != "None" {
+		fieldPath := field.NewPath("CPUPartitioning")
+		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.CPUPartitioning))
+	}
 }


### PR DESCRIPTION
Print a warning if `CPUPartitioning` is set to a non-default value.