### PR TITLE
MULTIARCH-3664: enable multipath for powervs

### DIFF
--- a/pkg/asset/machines/machineconfig/multipath.go
+++ b/pkg/asset/machines/machineconfig/multipath.go
@@ -1,0 +1,46 @@
+package machineconfig
+
+import (
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/asset/ignition"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+// ForMultipathEnabled creates the MachineConfig to enable multipath.
+func ForMultipathEnabled(role string) (*mcfgv1.MachineConfig, error) {
+	var (
+		kernelArgsMultipath = []string{"rd.multipath=default", "root=/dev/disk/by-label/dm-mpath-root"}
+	)
+
+	ignConfig := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+	}
+
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-multipath", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config:          rawExt,
+			KernelArguments: kernelArgsMultipath,
+		},
+	}, nil
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -528,6 +528,14 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 		machineConfigs = append(machineConfigs, ignFIPS)
 	}
+	if ic.Platform.Name() == powervstypes.Name {
+		// always enable multipath for powervs.
+		ignMultipath, err := machineconfig.ForMultipathEnabled("master")
+		if err != nil {
+			return errors.Wrap(err, "failed to create ignition for Multipath enabled for master machines")
+		}
+		machineConfigs = append(machineConfigs, ignMultipath)
+	}
 
 	m.MachineConfigFiles, err = machineconfig.Manifests(machineConfigs, "master", directory)
 	if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -280,6 +280,15 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 			machineConfigs = append(machineConfigs, ignFIPS)
 		}
+		if ic.Platform.Name() == powervstypes.Name {
+			// always enable multipath for powervs.
+			ignMultipath, err := machineconfig.ForMultipathEnabled("worker")
+			if err != nil {
+				return errors.Wrap(err, "failed to create ignition for multipath enabled for worker machines")
+			}
+			machineConfigs = append(machineConfigs, ignMultipath)
+		}
+
 		switch ic.Platform.Name() {
 		case alibabacloudtypes.Name:
 			client, err := installConfig.AlibabaCloud.Client()


### PR DESCRIPTION
Since IBM Power Virtual Servers environment supports multipath for disks including root, we need to enable multipath by default on this environment. Whenever anyone installs a cluster on PowerVS multipath becomes mandatory.
This will be used for running PowerVS CSI driver which again uses multipath.

JIRA: https://issues.redhat.com/browse/MULTIARCH-3664