### PR TITLE
OCPBUGS-14565: Replace with govc docker image and fix ibmcli folder permission issue

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -10,11 +10,14 @@ COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.10:cli as cli
+FROM quay.io/ocp-splat/govc:v0.29.0 as govc
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
+
+COPY --from=govc /govc /bin/govc
 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo' && \
@@ -68,7 +71,6 @@ ENV IGNITION_PROVIDER_VERSION=v2.1.0
 RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     mv terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64/terraform-provider-ignition /bin/terraform-provider-ignition
-RUN curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /bin -xvzf - govc
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install -b /bin && \
@@ -87,7 +89,7 @@ RUN mkdir /output && HOME=/output && \
     ibmcloud version && \
     ibmcloud plugin list
 
-RUN chown 1000:1000 /output && chmod -R g=u "$HOME/.bluemix/"
+RUN chown 1000:1000 /output && chmod -R g=u "/output/.bluemix/"
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output


### PR DESCRIPTION
update upi-installer image on rhel8 container
1.  remove downloading 'govc' and replace with govc docker image, sync with change in `Dockerfile.upi.ci` https://github.com/openshift/installer/blob/master/images/installer/Dockerfile.upi.ci#L13
2.  fix ibmcli folder permission issue detected in https://github.com/openshift/release/pull/39991, should be https://github.com/openshift/installer/blob/master/images/installer/Dockerfile.upi.ci#L96 
```
 [3/3] STEP 26/32: RUN chown 1000:1000 /output && chmod -R g=u "$HOME/.bluemix/"
chmod: cannot access '/root/.bluemix/': No such file or directory
error: build error: building at STEP "RUN chown 1000:1000 /output && chmod -R g=u "$HOME/.bluemix/"": while running runtime: exit status 1
```