### PR TITLE
OCPBUGS-14121: Convert Rendezvous IPv6 address to canonical format

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -498,8 +498,16 @@ func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 		logrus.Debug("RendezvousIP from the NMStateConfig ", rendezvousIP)
 	} else {
 		err = errors.New("missing rendezvousIP in agent-config or at least one NMStateConfig manifest")
+		return "", err
 	}
-	return rendezvousIP, err
+
+	// Convert IPv6 address to canonical to match host format for comparisons
+	addr := net.ParseIP(rendezvousIP)
+	if addr == nil {
+		err = errors.New(fmt.Sprintf("invalid rendezvous IP: %s", rendezvousIP))
+		return "", err
+	}
+	return addr.String(), err
 }
 
 func getPublicContainerRegistries(registriesConfig *mirror.RegistriesConf) string {

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -231,6 +231,32 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 			},
 			expectedError: "missing rendezvousIP in agent-config or at least one NMStateConfig manifest",
 		},
+		{
+			Name: "non-canonical-ipv6-address",
+			agentConfig: &agent.Config{
+				RendezvousIP: "fd2e:6f44:5dd8:c956:0000:0000:0000:0050",
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
+					},
+				},
+			},
+			expectedRendezvousIP: "fd2e:6f44:5dd8:c956::50",
+		},
+		{
+			Name: "invalid-ipv6-address",
+			agentConfig: &agent.Config{
+				RendezvousIP: "fd2e:6f44:5dd8:c956::0000::0050",
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
+					},
+				},
+			},
+			expectedError: "invalid rendezvous IP: fd2e:6f44:5dd8:c956::0000::0050",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
If the RendezvousIP is provided as a non-canonical (i.e. not compressed) IPv6 address then the IP comparison on the host will fail. Use ParseIp() address to convert this to canonical format. Note that this function will not affect the IPv4 address format.