### PR TITLE
AGENT-648: Remove validation check limiting None platform to SNO

### DIFF
--- a/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
@@ -61,6 +61,7 @@ spec:
     networkType: OVNKubernetes
     serviceNetwork:
     - 172.30.0.0/16
+    userManagedNetworking: true
   platformType: None
   provisionRequirements:
     controlPlaneAgents: 1

--- a/cmd/openshift-install/testdata/agent/image/configurations/none_ha.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/none_ha.txt
@@ -1,20 +1,22 @@
-! exec openshift-install agent create image --dir $WORK
+# Verify a default configuration for the HA topology
 
-stderr 'Total number of Compute.Replicas must be 0 when ControlPlane.Replicas is 1 for none platform. Found 1'
+exec openshift-install agent create image --dir $WORK
 
-! exists $WORK/agent.x86_64.iso
-! exists $WORK/auth/kubeconfig
-! exists $WORK/auth/kubeadmin-password
+stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
 
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
 controlPlane: 
   name: master
-  replicas: 1
+  replicas: 3
 compute: 
 - name: worker
-  replicas: 1
+  replicas: 2
 metadata:
   namespace: cluster0
   name: ostest

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -62,6 +62,7 @@ spec:
     networkType: OVNKubernetes
     serviceNetwork:
     - 172.30.0.0/16
+    userManagedNetworking: true
   platformType: None
   provisionRequirements:
     controlPlaneAgents: 1

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible
 	github.com/go-openapi/errors v0.20.2
 	github.com/go-openapi/strfmt v0.21.2
+	github.com/go-openapi/swag v0.22.3
 	github.com/go-playground/validator/v10 v10.2.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/mock v1.7.0-rc.1
@@ -141,7 +142,6 @@ require (
 	github.com/go-openapi/loads v0.21.1 // indirect
 	github.com/go-openapi/runtime v0.23.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
-	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -133,29 +133,21 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 		workers = workers + int(*worker.Replicas)
 	}
 
-	//  platform None always imply SNO cluster
-	if installConfig.Platform.Name() == none.Name {
-		if installConfig.Networking.NetworkType != "OVNKubernetes" {
-			fieldPath = field.NewPath("Networking", "NetworkType")
-			allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Networking.NetworkType, "Only OVNKubernetes network type is allowed for Single Node OpenShift (SNO) cluster"))
-		}
-
-		if *installConfig.ControlPlane.Replicas != 1 {
-			fieldPath = field.NewPath("ControlPlane", "Replicas")
-			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("ControlPlane.Replicas must be 1 for %s platform. Found %v", none.Name, *installConfig.ControlPlane.Replicas)))
-		}
-
-		if workers != 0 {
+	if installConfig.ControlPlane != nil && *installConfig.ControlPlane.Replicas == 1 {
+		if workers == 0 {
+			if installConfig.Platform.Name() == none.Name && installConfig.Networking.NetworkType != "OVNKubernetes" {
+				fieldPath = field.NewPath("Networking", "NetworkType")
+				allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Networking.NetworkType, "Only OVNKubernetes network type is allowed for Single Node OpenShift (SNO) cluster"))
+			}
+			if installConfig.Platform.Name() != none.Name {
+				fieldPath = field.NewPath("Platform")
+				allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("Only platform %s supports 1 ControlPlane and 0 Compute nodes", none.Name)))
+			}
+		} else {
 			fieldPath = field.NewPath("Compute", "Replicas")
-			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("Total number of Compute.Replicas must be 0 for %s platform. Found %v", none.Name, workers)))
+			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("Total number of Compute.Replicas must be 0 when ControlPlane.Replicas is 1 for %s platform. Found %v", none.Name, workers)))
 		}
 	}
-
-	if installConfig.ControlPlane != nil && *installConfig.ControlPlane.Replicas == 1 && workers == 0 && installConfig.Platform.Name() != none.Name {
-		fieldPath = field.NewPath("Platform")
-		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("Platform should be set to %s if the ControlPlane.Replicas is %d and total number of Compute.Replicas is %d", none.Name, *installConfig.ControlPlane.Replicas, workers)))
-	}
-
 	return allErrs
 }
 

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-openapi/swag"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -155,6 +156,11 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 			},
 		}
 
+		if installConfig.Config.Platform.Name() == none.Name {
+			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", none.Name)
+			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
+		}
+
 		icOverridden := false
 		icOverrides := agentClusterInstallInstallConfigOverrides{}
 		if installConfig.Config.FIPS {
@@ -272,6 +278,10 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 		agentClusterInstall.Spec.PlatformType = hiveext.BareMetalPlatformType
 	case none.Name:
 		agentClusterInstall.Spec.PlatformType = hiveext.NonePlatformType
+		if agentClusterInstall.Spec.Networking.UserManagedNetworking != swag.Bool(true) {
+			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", none.Name)
+			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
+		}
 	case vsphere.Name:
 		agentClusterInstall.Spec.PlatformType = hiveext.VSpherePlatformType
 	}


### PR DESCRIPTION
- For none platform with only one master and zero workers, only the network type `OVNKubernetes` is allowed.
- none platform can now have ControlPlane.Replicas>1 and workers>0
- Set UserManagedNetworking to true for none platform
- Remove redundant integration test when supporting non-SNO cluster topologies for none platform