### PR TITLE
OCPBUGS-14757: images: installer: add xz to the container

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -37,7 +37,8 @@ RUN yum update -y && \
       python2-pyyaml \
       python3-pyyaml \
       bind-utils \
-      util-linux && \
+      util-linux \
+      xz && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd


### PR DESCRIPTION
It was installed by default in RHEL-7 and is needed by some steps in CI.