### PR TITLE
OCPBUGS-14869: Add timezone info in installer logs

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -365,8 +365,9 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config) *cluster
 	apiTimeout := 20 * time.Minute
 
 	untilTime := time.Now().Add(apiTimeout)
-	logrus.Infof("Waiting up to %v (until %v) for the Kubernetes API at %s...",
-		apiTimeout, untilTime.Format(time.Kitchen), config.Host)
+	timezone, _ := untilTime.Zone()
+	logrus.Infof("Waiting up to %v (until %v %s) for the Kubernetes API at %s...",
+		apiTimeout, untilTime.Format(time.Kitchen), timezone, config.Host)
 
 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
@@ -431,8 +432,9 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
 	}
 
 	untilTime := time.Now().Add(timeout)
-	logrus.Infof("Waiting up to %v (until %v) for bootstrapping to complete...",
-		timeout, untilTime.Format(time.Kitchen))
+	timezone, _ := untilTime.Zone()
+	logrus.Infof("Waiting up to %v (until %v %s) for bootstrapping to complete...",
+		timeout, untilTime.Format(time.Kitchen), timezone)
 
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -486,8 +488,9 @@ func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 	}
 
 	untilTime := time.Now().Add(timeout)
-	logrus.Infof("Waiting up to %v (until %v) for the cluster at %s to initialize...",
-		timeout, untilTime.Format(time.Kitchen), config.Host)
+	timezone, _ := untilTime.Zone()
+	logrus.Infof("Waiting up to %v (until %v %s) for the cluster at %s to initialize...",
+		timeout, untilTime.Format(time.Kitchen), timezone, config.Host)
 	cc, err := configclient.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a config client")


### PR DESCRIPTION
- Add timezone info - `until <time> <timezone>`
```
openshift-install wait-for install-complete --dir=install-dir
[...]
INFO Waiting up to 1h0m0s (until 4:52PM UTC) for the cluster at https://api.ocp.example.local:6443 to initialize...
[...]
```
```
TZ=Asia/Kolkata openshift-install wait-for install-complete --dir=install-dir
[...]
INFO Waiting up to 1h0m0s (until 5:55PM IST) for the cluster at https://api.ocp.example.local:6443 to initialize...
[...]
```

Fixes ocpbugs-14869
