### PR TITLE
Allow CustomNoUpgrade features via install-config

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1932,9 +1932,18 @@ spec:
             - Passthrough
             - Manual
             type: string
+          featureGates:
+            description: 'FeatureGates enables a set of custom feature gates. May
+              only be used in conjunction with FeatureSet "CustomNoUpgrade". Features
+              may be enabled or disabled by providing a true or false value for the
+              feature gate. E.g. "featureGates": ["FeatureGate1=true", "FeatureGate2=false"].'
+            items:
+              type: string
+            type: array
           featureSet:
             description: FeatureSet enables features that are not part of the default
-              feature set.
+              feature set. Valid values are "Default", "TechPreviewNoUpgrade" and
+              "CustomNoUpgrade". When omitted, the "Default" feature set is used.
             type: string
           fips:
             default: false

--- a/pkg/asset/manifests/featuregate.go
+++ b/pkg/asset/manifests/featuregate.go
@@ -2,6 +2,8 @@ package manifests
 
 import (
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +57,18 @@ func (f *FeatureGate) Generate(dependencies asset.Parents) error {
 		},
 	}
 
+	if len(installConfig.Config.FeatureGates) > 0 {
+		if installConfig.Config.FeatureSet != configv1.CustomNoUpgrade {
+			return errors.Errorf("custom features can only be used with the CustomNoUpgrade feature set")
+		}
+
+		customFeatures, err := generateCustomFeatures(installConfig.Config.FeatureGates)
+		if err != nil {
+			return errors.Wrapf(err, "failed to generate custom features")
+		}
+		f.Config.Spec.CustomNoUpgrade = customFeatures
+	}
+
 	configData, err := yaml.Marshal(f.Config)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %s manifests from InstallConfig", f.Name())
@@ -78,4 +92,46 @@ func (f *FeatureGate) Files() []*asset.File {
 // Load loads the already-rendered files back from disk.
 func (f *FeatureGate) Load(ff asset.FileFetcher) (bool, error) {
 	return false, nil
+}
+
+// generateCustomFeatures generates the custom feature gates from the install config.
+func generateCustomFeatures(features []string) (*configv1.CustomFeatureGates, error) {
+	customFeatures := &configv1.CustomFeatureGates{}
+
+	for _, feature := range features {
+		featureName, enabled, err := parseCustomFeatureGate(feature)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse custom feature %s", feature)
+		}
+
+		if enabled {
+			customFeatures.Enabled = append(customFeatures.Enabled, featureName)
+		} else {
+			customFeatures.Disabled = append(customFeatures.Disabled, featureName)
+		}
+	}
+
+	return customFeatures, nil
+}
+
+// parseCustomFeatureGates parses the custom feature gate string into the feature name and whether it is enabled.
+// The expected format is <FeatureName>=<Enabled>.
+func parseCustomFeatureGate(rawFeature string) (configv1.FeatureGateName, bool, error) {
+	var featureName string
+	var enabled bool
+
+	featureParts := strings.Split(rawFeature, "=")
+	if len(featureParts) != 2 {
+		return "", false, errors.Errorf("feature not in expected format %s", rawFeature)
+	}
+
+	featureName = featureParts[0]
+
+	var err error
+	enabled, err = strconv.ParseBool(featureParts[1])
+	if err != nil {
+		return "", false, errors.Wrapf(err, "feature not in expected format %s, could not parse boolean value", rawFeature)
+	}
+
+	return configv1.FeatureGateName(featureName), enabled, nil
 }

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -57,8 +57,11 @@ func Test_PrintFields(t *testing.T) {
  There are three possible values for this field, but the valid values are dependent upon the platform being used. "Mint": create new credentials with a subset of the overall permissions for each CredentialsRequest "Passthrough": copy the credentials with all of the overall permissions for each CredentialsRequest "Manual": CredentialsRequests must be handled manually by the user 
  For each of the following platforms, the field can set to the specified values. For all other platforms, the field must not be set. AWS: "Mint", "Passthrough", "Manual" Azure: "Passthrough", "Manual" AzureStack: "Manual" GCP: "Mint", "Passthrough", "Manual" IBMCloud: "Manual" AlibabaCloud: "Manual" PowerVS: "Manual" Nutanix: "Manual"
 
+    featureGates <[]string>
+      FeatureGates enables a set of custom feature gates. May only be used in conjunction with FeatureSet "CustomNoUpgrade". Features may be enabled or disabled by providing a true or false value for the feature gate. E.g. "featureGates": ["FeatureGate1=true", "FeatureGate2=false"].
+
     featureSet <string>
-      FeatureSet enables features that are not part of the default feature set.
+      FeatureSet enables features that are not part of the default feature set. Valid values are "Default", "TechPreviewNoUpgrade" and "CustomNoUpgrade". When omitted, the "Default" feature set is used.
 
     fips <boolean>
       Default: false

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -201,8 +201,17 @@ type InstallConfig struct {
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
 
 	// FeatureSet enables features that are not part of the default feature set.
+	// Valid values are "Default", "TechPreviewNoUpgrade" and "CustomNoUpgrade".
+	// When omitted, the "Default" feature set is used.
 	// +optional
 	FeatureSet configv1.FeatureSet `json:"featureSet,omitempty"`
+
+	// FeatureGates enables a set of custom feature gates.
+	// May only be used in conjunction with FeatureSet "CustomNoUpgrade".
+	// Features may be enabled or disabled by providing a true or false value for the feature gate.
+	// E.g. "featureGates": ["FeatureGate1=true", "FeatureGate2=false"].
+	// +optional
+	FeatureGates []string `json:"featureGates,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.


### PR DESCRIPTION
To promote developers to use custom feature sets to develop their new features, we need the openshift installer to support custom features and custom feature sets. To do this, this PR adds a `customFeatures` field to the install config which accepts a list of `<name>=<bool>` feature names, that will then go into the generation of the feature gate manifest during the manifest generation stage.