### PR TITLE
OCPBUGS-13960: update RHCOS 4.14 bootimage metadata to 414.92.202306141028-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.14",
   "metadata": {
-    "last-modified": "2023-05-10T19:39:20Z",
-    "generator": "plume cosa2stream f78ee0e"
+    "last-modified": "2023-06-14T17:23:18Z",
+    "generator": "plume cosa2stream 14982ae"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-aws.aarch64.vmdk.gz",
-                "sha256": "e2466e0b4a8d3ae73349812cfe4bef75a49bd66c7179feb694b812cc23014f96",
-                "uncompressed-sha256": "5685f3f279998c0807b4cb20e6750a9093981d955a9aad5eafb86db1cbcd0fc5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-aws.aarch64.vmdk.gz",
+                "sha256": "78812675ef808461a21ac6975df578abc854a7a524bc6cff16e6895f8b46f21b",
+                "uncompressed-sha256": "c73282d3aad2117703f7fc86b6a3542c7ffd82c2fd8b593a729fbc5c72a0bb61"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-azure.aarch64.vhd.gz",
-                "sha256": "1e0933b3148d7917238f1466219595ba477333720a256b504bfc84b62320c0e5",
-                "uncompressed-sha256": "3d5c3254f362308d82db576f32df04b70e51e687f34e4b903a97c261387cc96b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-azure.aarch64.vhd.gz",
+                "sha256": "797da16ebeedcc29b0e4162c67bc2c85c524536513492146db3e8195058a9936",
+                "uncompressed-sha256": "aa02205dc12f51b0702d6797c00c148c6f04dd483ae5ef6ceb2d165e9de0c045"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-metal4k.aarch64.raw.gz",
-                "sha256": "3f035b4f3d7bfa09641b4c740a3310be4481f5a6147256aebd61751657ae59dd",
-                "uncompressed-sha256": "c23ffa6622042d78e4f3e3e9e9643731fc547d3589b5fb548c7df2e1638e2416"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-metal4k.aarch64.raw.gz",
+                "sha256": "4c36f8e41ba0c07e3b200cf642dd932fce8d82fdd0f94fbe3695bf46b2097c28",
+                "uncompressed-sha256": "0d280133e350dcf904ac60a07876e1dab3ecf072b136eeaca1d2a5a2b5c77f90"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-live.aarch64.iso",
-                "sha256": "1fbb68e84c938e3a3c79a5a591bf08bb6ef455149920761b9a453d62052fce3f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-live.aarch64.iso",
+                "sha256": "53a6163f1269b19f1ec0a220e57d08655e35084042dc02d0a3d1604768061dca"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-live-kernel-aarch64",
-                "sha256": "8c413251b04da4f39d2f95832985ead9b7615bbb01afbf5501b281256d25e38c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-live-kernel-aarch64",
+                "sha256": "dc2ee7d57358622c28708e533d3ed6df6c50cbdd98ff576dc0c2e148deb2bbf4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-live-initramfs.aarch64.img",
-                "sha256": "3042ef0256b244f63877e22d67aed501b2c79fb48e76336d08ad093fc440a603"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-live-initramfs.aarch64.img",
+                "sha256": "4b34fb24e2fd1b69f5b014f4fe8d1f643d3ed2be3f436f15057233e07df4c9a3"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-live-rootfs.aarch64.img",
-                "sha256": "43ee26292533ccf6027534c73fc4557e62be62e2e2867f36e18c2385ba7889d5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-live-rootfs.aarch64.img",
+                "sha256": "484fadce97c132159cb8b3b8423a214db9e94a66563cbca40c09e8756660ab78"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-metal.aarch64.raw.gz",
-                "sha256": "3ad10eea3ed49d3796aeaf056bf2339fbd59dc953583ca4513d80fe4d10d34c0",
-                "uncompressed-sha256": "4807f657727fcd3a27c05ef7abd0f5fde4d54fe4e40fac010d26b25f309eeadf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-metal.aarch64.raw.gz",
+                "sha256": "24c53acfb981a3aa759238be8821be56ec77cb8d38d50b98bec2fdd57acfc0bf",
+                "uncompressed-sha256": "8b3e45c412b72894578a4aca174f2394e34a34ec0f045ae46ee2aa6312eb6820"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-openstack.aarch64.qcow2.gz",
-                "sha256": "7aeba0e85523d3c1636f7580746dec891af5bbd31c55acb7b4343196e96a459f",
-                "uncompressed-sha256": "7cc6877973ef9a949acb5de3ed51cd29b3ffd7b13d1872990f87c25f3e8044c2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-openstack.aarch64.qcow2.gz",
+                "sha256": "8e02f3c84db946afb3d73634279fc34a6cfe391dfb2c83cf1a4d9a57d844a738",
+                "uncompressed-sha256": "fe1386005edb293ba3fa15a651511d53d23ec12b942be7d89056114aed122e79"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/aarch64/rhcos-414.92.202305090606-0-qemu.aarch64.qcow2.gz",
-                "sha256": "73fb1d6facb4a878afad9bcbac9da6bcfec1a7566bf543e1e5157559b0ff902b",
-                "uncompressed-sha256": "9946ed09d9d213ae0d0094ea1b4781084c652e3bb49428bf08734e259f511e00"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/aarch64/rhcos-414.92.202306141028-0-qemu.aarch64.qcow2.gz",
+                "sha256": "0089cd5a0f9ec09f15be31a47c0b68c0f1b3520951ed972b00907fda9aaaa2a1",
+                "uncompressed-sha256": "839d1304552f61754aa880ac00dea53607de43f029d043068f659743a11069f3"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0b88341a122bb04ca"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0a255b9c0c1d59440"
             },
             "ap-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e2f5f077b43fbe14"
+              "release": "414.92.202306141028-0",
+              "image": "ami-075d57fea3832cb98"
             },
             "ap-northeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0a90c121fe0e81ba1"
+              "release": "414.92.202306141028-0",
+              "image": "ami-06a6a2d39cfeb5308"
             },
             "ap-northeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0d95fd25152aa1304"
+              "release": "414.92.202306141028-0",
+              "image": "ami-043b2c0243d35c2c8"
             },
             "ap-northeast-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0dc6a4432a19fa692"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0949bfd53b9fd2423"
             },
             "ap-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0b8f5c96afee7f63b"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0b570679c136ea8eb"
             },
             "ap-south-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-041d0799045a08474"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0c581f7d94ea70999"
             },
             "ap-southeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e79212bfcea3f3a6"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0ad3ca201a2d10100"
             },
             "ap-southeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-06a8b1686b7d09fb3"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0f2f6f7505f82a21f"
             },
             "ap-southeast-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-01ebacefba962ca37"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0d17b946fa467bf29"
             },
             "ap-southeast-4": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0d2cc93cc1964e441"
+              "release": "414.92.202306141028-0",
+              "image": "ami-00a376b1f56332ca0"
             },
             "ca-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0bb1a8c85112f36ed"
+              "release": "414.92.202306141028-0",
+              "image": "ami-093f8340cac832ae7"
             },
             "eu-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e031dbd7b045a68b"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0289fbde46a8a15eb"
             },
             "eu-central-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-06f047d8d20292903"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0718df3e52af54382"
             },
             "eu-north-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-06bcae139614fc9cb"
+              "release": "414.92.202306141028-0",
+              "image": "ami-05b41bb758cdfd461"
             },
             "eu-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-02cbf21336b453aa1"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0a18acdb73901c9e0"
             },
             "eu-south-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0c28d87d6dbe733c2"
+              "release": "414.92.202306141028-0",
+              "image": "ami-081996c8e0c703a01"
             },
             "eu-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0afe368e69bb51819"
+              "release": "414.92.202306141028-0",
+              "image": "ami-01e01a640ec0e186c"
             },
             "eu-west-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0947bbde35a3e0874"
+              "release": "414.92.202306141028-0",
+              "image": "ami-045aec6c22a0cdd58"
             },
             "eu-west-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-048093c04c76b3cce"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0bdc0b62d3b220532"
             },
             "me-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-088c1e7ea2a38af21"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0fe4c6a9a99dfd5c3"
             },
             "me-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-06ce1b777dccc9f1e"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0659c353e3aa1570e"
             },
             "sa-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-01e6929ecbe306a4d"
+              "release": "414.92.202306141028-0",
+              "image": "ami-05e52b67c504dcb17"
             },
             "us-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-03b27b456fa289718"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0ce36bf731a0ed808"
             },
             "us-east-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e510e43e631b5ceb"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0b1364f0ab861014e"
             },
             "us-gov-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0b61deedc00fa0416"
+              "release": "414.92.202306141028-0",
+              "image": "ami-019ab973d149bd3d5"
             },
             "us-gov-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-00e98cf4a71129ab3"
+              "release": "414.92.202306141028-0",
+              "image": "ami-066604817f32395fd"
             },
             "us-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-022682087b45214d0"
+              "release": "414.92.202306141028-0",
+              "image": "ami-028baf134cf2e165f"
             },
             "us-west-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0be51b7bb4993f9f9"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0b13040fca21bdece"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202305090606-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202305090606-0-azure.aarch64.vhd"
+          "release": "414.92.202306141028-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202306141028-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-metal4k.ppc64le.raw.gz",
-                "sha256": "ec9b34cfcafc80676ec9c6a38cdc9b25c83bfe1dbe56004e0ddb0a4db9607e88",
-                "uncompressed-sha256": "8af3de38797f05e78a5dba75093b1d0576ca3f32683986cb2d0a6f5e486ca30d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-metal4k.ppc64le.raw.gz",
+                "sha256": "d60b1ea743c43ee27d65f042d52b856e81e562b471a8059304f74a62242d3c85",
+                "uncompressed-sha256": "de8ac718f8e4a27b6c4a773e5f129b34f740bf2b385e593565306954f85ae870"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-live.ppc64le.iso",
-                "sha256": "a9886d0a61297626581d9dbb54701016ac73d47c0c4715b2752fa82df512e31a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-live.ppc64le.iso",
+                "sha256": "e47193e7e2be48eab203f2b12f2d25261b8d40368ae5b6e33d6071ee2e75efde"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-live-kernel-ppc64le",
-                "sha256": "d51d94534a2f638cc78f59e802d7ad722bf3e10123ed05023186bbcd48595060"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-live-kernel-ppc64le",
+                "sha256": "ac2ab6e28da0d20200663b0b81b7397f8e783208bdc32d80c9bfa9e0597a3b39"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-live-initramfs.ppc64le.img",
-                "sha256": "22b8c029697f386b94af9dfbd3cdfd19bf96b5cf7df1efa3e090d572be83a02b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-live-initramfs.ppc64le.img",
+                "sha256": "ae21e87a9b3cd4ce340df35ec1dbade09e0a5d0b012a6001730293007411868a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-live-rootfs.ppc64le.img",
-                "sha256": "522b17f657b818e549d67a9078065476abd17bcc6a530169361a88c4a0368429"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-live-rootfs.ppc64le.img",
+                "sha256": "9b0afc1fb737bda6215087b65175e53f42e5e3b86cdff6e72dc356aa7567d1b4"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-metal.ppc64le.raw.gz",
-                "sha256": "efb47588791b63a6ce7b8b82410b082e94257b45525fdd5e03b0a0b0dac18673",
-                "uncompressed-sha256": "6eadc472e526deac661552e7d040dc233cec1c6e34ed73d74b785fc7bdfd9f6e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-metal.ppc64le.raw.gz",
+                "sha256": "ebf28e68f632e26d81f6949c73dbe59b13cd4f52cf016f6d3f97cbdb33e5cf13",
+                "uncompressed-sha256": "1dfeda01cc4956b59fcaba922409011859603ba16228124211f9e573881a2623"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "28f8128e8278e8cebe9a78b1550dd866d3a968b1189baedac7f50533ac26fac5",
-                "uncompressed-sha256": "38a9403efc0e0848deb546e13bd951e05a46fff1a8407db75147edf889448580"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "1f970cc7d678fb87baf70f6756d894eb1c4f0bb21a1f9cd625d231b8e3c1ca8f",
+                "uncompressed-sha256": "26909f51605518e00195532194dd961f11060c605fca6782e6861479b8356106"
               }
             }
           }
         },
         "powervs": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-powervs.ppc64le.ova.gz",
-                "sha256": "8584ea7e569557282aeaa03d4f12a7204ac0b9ab23d1861779312988e4d791c6",
-                "uncompressed-sha256": "74b3b95bbb16f9619759c1f43af91c0f511561e4e69bc97a4efe0df856b7ebf9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-powervs.ppc64le.ova.gz",
+                "sha256": "05e0c2b814d8717c9c576a169054c3266bb32652284ed5d1282f72bd7e30432f",
+                "uncompressed-sha256": "9ced006e62bcba74423d0e71567726dcebc3a1753c5761fdc68fe2d13566d6d5"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/ppc64le/rhcos-414.92.202305090606-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "53a3d15ce3b2de9b6dc7dc9171dbffc2f867bd2a43ca0f20987f616ad81944c3",
-                "uncompressed-sha256": "8a6a472f4a1db894fb54f3dfeebcd5e8818ec8d3d55db1c05d0c9cdc17115cf5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/ppc64le/rhcos-414.92.202306141028-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "cac8f3d6bdd1ebace0e24536175e6640cb34ed6ddd70fc04cc93804e66dcf1f5",
+                "uncompressed-sha256": "76057e2ae390edf83d8c82516b6d9aba4a476a0889853def8686d0638454b865"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "414.92.202305090606-0",
-              "object": "rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202306141028-0",
+              "object": "rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202305090606-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202306141028-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "fc0f708bdf0cda2246542e7f841ac2c7ec3534ab925cbf0f514cd0b5360bda73",
-                "uncompressed-sha256": "d06b21fb3c1cd90e0b823071ca9f6d187288c1b2ac0eeb221c275cad26fc4496"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "f8e711972c47f3324f16dfb39ca5f96c24d735d2986580b9453d8f24a588097b",
+                "uncompressed-sha256": "0232952df1a7fe8434bd85e75bfc7eaad711f0c09813b8265d952ad8ac43f188"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-metal4k.s390x.raw.gz",
-                "sha256": "174527658406d0a0ec5dd4004f12618cbb476c34247693531abedebadd0155e0",
-                "uncompressed-sha256": "acd9da49117149c8197f92af3b6bd21dd387201fc5349fa82a50f425d23e97b8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-metal4k.s390x.raw.gz",
+                "sha256": "09983ed3ceb038d0257deed0d5d8903c5ad4817f4eb761e248bfbb774c00d900",
+                "uncompressed-sha256": "494c12939cb8513e1b071ac4cf874fa022a867e6f4928e4a0b8f0022ccd1cc9f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-live.s390x.iso",
-                "sha256": "fd0485bd53522cd0fc3711676e9b8f4b0352b9d355adb2d2b560e3229a55b30e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-live.s390x.iso",
+                "sha256": "9688ce6febac4bebd45e686dc6e1bdfa96de25d0ff2c87aba1700d94344a2179"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-live-kernel-s390x",
-                "sha256": "dd1d7dd7706c59d17681392bf2e230aff3d2e62618546d3065b7d877a268cc28"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-live-kernel-s390x",
+                "sha256": "45ff4160612acda062f4406221742f15216edfb469fadc1393495d093802fa8b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-live-initramfs.s390x.img",
-                "sha256": "66198605eb455d28be4117f7091c5944464fdbdb78b08e71a621122d2dcc496e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-live-initramfs.s390x.img",
+                "sha256": "c102b9322a3f758ba0c0b98ed78e63c292b94a2013baa8ba394bcecb30cb9197"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-live-rootfs.s390x.img",
-                "sha256": "9fdebcd1114ca6f82e5c90de660f947dd665fd2f7257f2e92fdcd248111fd16d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-live-rootfs.s390x.img",
+                "sha256": "2cd121330af3a943570d846e8bd284c3dea1ae00f286f471b38897947a17b1b4"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-metal.s390x.raw.gz",
-                "sha256": "6a7af7ed42821ca2a765d7c1674203333c97cca73ef4b59f2d458f8871ee631a",
-                "uncompressed-sha256": "0143456c076799dee8e6251fdf4790acfdd373b588c206ec6af2e34d74600e1e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-metal.s390x.raw.gz",
+                "sha256": "a9e257953ee2a1eabb3ac7c7d77afb36cdea94a13dafe790ca9e018e1d451073",
+                "uncompressed-sha256": "eda3da400e260a0b9c85db03a2bdda4cbebb5ccd9f8104ed9d373f7f86ddd1f5"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-openstack.s390x.qcow2.gz",
-                "sha256": "8d1553558371bf7977c791344ef9d00cec64a75a01d31a29911b6d2e2a94c135",
-                "uncompressed-sha256": "2eb19af222af8ededeb13c103e023ea8d28b4ede6208cd85df5a21a6599fb89c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-openstack.s390x.qcow2.gz",
+                "sha256": "ee41f621e9d41d5df571ae20b4fb8b8a60a8cbd8ce448b97d5752fb97f97be8c",
+                "uncompressed-sha256": "1cb8c95e065e1db5c2a8126ce44667811af619ef9be6b650f4196af33deea419"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-qemu.s390x.qcow2.gz",
-                "sha256": "3b410e0ee24d8e593a939c618cde376c9b19aea23712d1a9d2da116e821a31b4",
-                "uncompressed-sha256": "c9b862ecb7e25ebc839df41ad2e6a66e8609701319b47a431d40b6670460b7c8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-qemu.s390x.qcow2.gz",
+                "sha256": "9d105e148a59532dcfa107b9496bd94bf00013a4e123c168a2c4c6e4e66d3a04",
+                "uncompressed-sha256": "b96f456c8aa114a4ba6f841041d93356922b21dd901edfa13a7a2f53eece7182"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/s390x/rhcos-414.92.202305090606-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "1f5ede04f3d262770ddfdae3ae6a6c820516debe8a447013a628fdd1ba35c896",
-                "uncompressed-sha256": "9e4528c559985bae00bcc2e5e41f623f40d50207cf66d7cba18a589050b54399"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/s390x/rhcos-414.92.202306141028-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "44aae5a6793035efc8e32f85e47c2f6762c9908fe79afd9c4e96bc33da5cac1d",
+                "uncompressed-sha256": "1381f19e70e6b4e4ac7e830be9a8414c74c9461cb79805160911715f8d09e335"
               }
             }
           }
@@ -458,169 +458,169 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "29189bb9e22e2584b8bacd6a63aa3278ee14cad0a21f3a8a02a2f2c1dd097b01",
-                "uncompressed-sha256": "13ad8414e5e5b32993dcc2205335727c4eb80766b15058d8c298856e24d27441"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "491ca1d5b4466ae3b6de1a27f0a4b0b1145c4783249cb439d6c3959d6d9f8ddc",
+                "uncompressed-sha256": "f3ce6fdaef8cef9c5e8e4224690b1aa0ddf962e7b8a8d002b6a24f5911be11c2"
               }
             }
           }
         },
         "aws": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-aws.x86_64.vmdk.gz",
-                "sha256": "1e241c50a0c1b84a1d2d6501734ef3f4663a75cca234650f9294491425a18b07",
-                "uncompressed-sha256": "22d4a67250b7ee78bfcf35455389f4eb8fb2bac46056d8a0bce69f29f1f0977d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-aws.x86_64.vmdk.gz",
+                "sha256": "b922b8598b2f40cd56f659a34924f556f9e003064694e06c145e4baf2d5b63ed",
+                "uncompressed-sha256": "e23e03581aad9bb289c8d47681bf2c220f7ad2d327da3252511e1596866acf8f"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-azure.x86_64.vhd.gz",
-                "sha256": "23c69c5f371de1a4d931e42d6f9b4f132fa65ba8d1fabd1f618e3b3ca5ead3c6",
-                "uncompressed-sha256": "b9edf5d844f2f967de6e06b7fcb4bf824a7faa258353a05acf204b73fb7c1a2b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-azure.x86_64.vhd.gz",
+                "sha256": "b0cfc460dc881f4c9f72bc1b36ccbc28d3d5c0e1a9f1a7711ad2bda10aae29ea",
+                "uncompressed-sha256": "9d03ff196a846a8ec376b1c793a3d0faa37d75d9d18978eeb45f6953e194a6b9"
               }
             }
           }
         },
         "azurestack": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-azurestack.x86_64.vhd.gz",
-                "sha256": "6a06d53401ab807b339ed05a8bccc23547d4af51ad450a7742d1e1a40c7980be",
-                "uncompressed-sha256": "605d8dc95dd64fa2ada948b9c69f610055968c5853904cef37b2761112a02503"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-azurestack.x86_64.vhd.gz",
+                "sha256": "6bf619366085b4c57027afe8ee6b71f9e04ce32d752120099062e2913a783f7c",
+                "uncompressed-sha256": "0524435f2337881ae8a94452a165295b8f3f4daf1b6e1922f4ca405ff52e8e38"
               }
             }
           }
         },
         "gcp": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-gcp.x86_64.tar.gz",
-                "sha256": "863157679b3328401144729d29fa76c730597919f07a177f4687e96e67f4b754",
-                "uncompressed-sha256": "14ea2330e46e6b73923aeabda98fee9e1666926888298706418a9911a23c263a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-gcp.x86_64.tar.gz",
+                "sha256": "9236c485984354a240974885f01af4835f24e807dfa0baf3684aab148ec8fc61",
+                "uncompressed-sha256": "672dde6d20c410a8c282abbc50c28ae8371f56dfbec8abc5438dfd731986eb12"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "504b95c9c2bbd77aeccb8618b19a04fccd23998973011286211ecb222a4d72d2",
-                "uncompressed-sha256": "779c5093bb658e009cc0a014feb2b30ccf540af702cf87f2778f89db4052e0db"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "5c4b87510fcb0f8b6ad9f0b610123eceb8c89b3afa947c112a37b472157e6b66",
+                "uncompressed-sha256": "a8a0c685ff03f405a4d8ac5e400900eb26dca7149eafa2b017ab47cdd803bdb9"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-kubevirt.x86_64.ociarchive",
-                "sha256": "41dd21b5f32980139e4d8c236f91bb7fcbfdcfaf35a43c3474ab9caa237b81ca"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-kubevirt.x86_64.ociarchive",
+                "sha256": "b46012430f2178cf321b87f356ef46cff3263f7c8a2697b7152f9bbd4b461164"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-metal4k.x86_64.raw.gz",
-                "sha256": "2b9b3dbdddb4c51d786617788c30f0603e0d461d0bb2ec9a596ca01352ea941c",
-                "uncompressed-sha256": "63f5fd7fe5c68fe9b7daecc5c27ebe997bec4ce6aa3053f7bff02f60c9cb4cee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-metal4k.x86_64.raw.gz",
+                "sha256": "698b57644184ffd55be0f22dc93b5d964138de982cb04dc4e02de4e3819f5506",
+                "uncompressed-sha256": "20de462fd96f79e582ec377dae79232c430d69bfdc08f5d017fcb50f82f24c60"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-live.x86_64.iso",
-                "sha256": "d0199a977f709156b51961d22b1390be6bd50614d26c528960ba9d535c683b6f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-live.x86_64.iso",
+                "sha256": "42ed52b81c5fc46052878bbf5ea6ba639d31c4c2a643089fa67f5693760449c2"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-live-kernel-x86_64",
-                "sha256": "cd0ec3f82549062461998ac50855f275e42b675f759351df843b6668c8c9bd0c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-live-kernel-x86_64",
+                "sha256": "cd596c50ec0988c0324318ca56f6af1658fe3a8f09d7d9da70afa65ac0086c6e"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-live-initramfs.x86_64.img",
-                "sha256": "809f23caeb2beeaaa871cea821d61293738d9ad7becd28c7cf026d53d24dd987"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-live-initramfs.x86_64.img",
+                "sha256": "d096fc2818b547287b928a5c70f793fa941bbc0284cf40ddcb7d959565ad10ab"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-live-rootfs.x86_64.img",
-                "sha256": "2257921f7e2911a5197cae0c986333274c50ab46434cc2d4edce8536badb65f1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-live-rootfs.x86_64.img",
+                "sha256": "dcdadc76300fa9f85b41c769a34a0d34cf8cfc6653a609045ec2f0a1cca57168"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-metal.x86_64.raw.gz",
-                "sha256": "e416a527d1abc587b61bbdd86884ece09968b6bf218f9fccccaed7b2fd08268d",
-                "uncompressed-sha256": "884e87180812646bb8e17df3749facd3e57b256c3daf5ff8017dc174628742e3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-metal.x86_64.raw.gz",
+                "sha256": "728816b1f0f2d63b8f0c1cc97523102a0fc7f6a09de8ed7f0718e42bd1500002",
+                "uncompressed-sha256": "1876d993a20e144de5b70a893aedcb6d9e6954395a96656c9ec6d1d7be4a1e1f"
               }
             }
           }
         },
         "nutanix": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-nutanix.x86_64.qcow2",
-                "sha256": "8ab9497d3388670b97df4f3d4b65eb20936f91322cda99e685af45c1c27d5757"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-nutanix.x86_64.qcow2",
+                "sha256": "3f841ee39d4c8a2cd439bc7d568efbba5ab953eba14060a8d72c5afecfb16286"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-openstack.x86_64.qcow2.gz",
-                "sha256": "e1ebe044f668dddae924de03147d4d6b58cfeab2fdd78932667d5fb6335a4967",
-                "uncompressed-sha256": "d65e3bade94def962036ef9945b8e68f666d6e81973046ff8d80ced75941f506"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-openstack.x86_64.qcow2.gz",
+                "sha256": "6bfe1e925260cbdf770f3664eaf50a2acc23ddb3ed4dba086bbc3ddf1940e0b4",
+                "uncompressed-sha256": "de4be5797a446b3b94accac9209bfffd25a31ba4560edac43c72173894f0fb98"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-qemu.x86_64.qcow2.gz",
-                "sha256": "a28ccb411a2c66696459aa8d76e7c8f7c214f2024146793ab471196b17d363e2",
-                "uncompressed-sha256": "c2d87931d4b50dd440917101e947459355e4ea491dcb74551d80444e83a52b28"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-qemu.x86_64.qcow2.gz",
+                "sha256": "8ea51c4b46a61d6101c7ed0f135049f66ccb5bcde02ac519bb9c8d7a87b9d9d8",
+                "uncompressed-sha256": "090e6f7a214a30cfe812056a1397ffba29cf1b53cbf269558af9c4dfa1696153"
               }
             }
           }
         },
         "vmware": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202305090606-0/x86_64/rhcos-414.92.202305090606-0-vmware.x86_64.ova",
-                "sha256": "9499acf8ed8c60e86398fec56ae3af2c48ac8ef9f5587d74850476bd760e5682"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202306141028-0/x86_64/rhcos-414.92.202306141028-0-vmware.x86_64.ova",
+                "sha256": "4ae2aa13872bf3ee4b8a56c9bc6a0d5151bec84a5f91f4b092b28c91e1537183"
               }
             }
           }
@@ -630,254 +630,258 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-6we1eksloqvohl7hsdn2"
+              "release": "414.92.202306141028-0",
+              "image": "m-6wejbsky2njtym87wo5l"
             },
             "ap-northeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "m-mj7cv759lyz6dljk3kno"
+              "release": "414.92.202306141028-0",
+              "image": "m-mj7a78t7qa7ln7tgu7y2"
             },
             "ap-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-a2d296d8d81kqimxgeb4"
+              "release": "414.92.202306141028-0",
+              "image": "m-a2ddyzdycmlazcakeenz"
             },
             "ap-southeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-t4nic7330wntoamejb0k"
+              "release": "414.92.202306141028-0",
+              "image": "m-t4nik9rlgd2v00kshau0"
             },
             "ap-southeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "m-p0w2x9fokwyxopq6lv6s"
+              "release": "414.92.202306141028-0",
+              "image": "m-p0wf2yycs0ou6i49jiuz"
             },
             "ap-southeast-3": {
-              "release": "414.92.202305090606-0",
-              "image": "m-8pse4tbvuqcuq10swfhs"
+              "release": "414.92.202306141028-0",
+              "image": "m-8ps7kflnjxigv0ai2lwx"
             },
             "ap-southeast-5": {
-              "release": "414.92.202305090606-0",
-              "image": "m-k1ad9myb3xz133vrypst"
+              "release": "414.92.202306141028-0",
+              "image": "m-k1a2vaomndkmh3pk0c1d"
             },
             "ap-southeast-6": {
-              "release": "414.92.202305090606-0",
-              "image": "m-5ts5plq6z4ozy0zn7x8o"
+              "release": "414.92.202306141028-0",
+              "image": "m-5tsje7kh18v0gq1pya35"
             },
             "ap-southeast-7": {
-              "release": "414.92.202305090606-0",
-              "image": "m-0jo2vwykwdw8solqyyq4"
+              "release": "414.92.202306141028-0",
+              "image": "m-0joiu22a7pi6ujba5wfw"
             },
             "cn-beijing": {
-              "release": "414.92.202305090606-0",
-              "image": "m-2zeb7h5vm6bzbp6qn07u"
+              "release": "414.92.202306141028-0",
+              "image": "m-2ze7g2ho9wfhnor7d5c5"
             },
             "cn-chengdu": {
-              "release": "414.92.202305090606-0",
-              "image": "m-2vc45cf1d9de9e7am6at"
+              "release": "414.92.202306141028-0",
+              "image": "m-2vc1xqd5xvvfhjsh41s5"
             },
             "cn-fuzhou": {
-              "release": "414.92.202305090606-0",
-              "image": "m-gw0itw54dntkgmpnujlk"
+              "release": "414.92.202306141028-0",
+              "image": "m-gw05jtzknjy00lmm7560"
             },
             "cn-guangzhou": {
-              "release": "414.92.202305090606-0",
-              "image": "m-7xv8p8qxpbzcixob149s"
+              "release": "414.92.202306141028-0",
+              "image": "m-7xvg5uvwiv5378s7pebh"
             },
             "cn-hangzhou": {
-              "release": "414.92.202305090606-0",
-              "image": "m-bp16ob85di5crwcdzver"
+              "release": "414.92.202306141028-0",
+              "image": "m-bp1j72loi5v65dktv7ye"
             },
             "cn-heyuan": {
-              "release": "414.92.202305090606-0",
-              "image": "m-f8zey1uows0ull5pbst3"
+              "release": "414.92.202306141028-0",
+              "image": "m-f8zfyblxzeyq8kgrsdmk"
             },
             "cn-hongkong": {
-              "release": "414.92.202305090606-0",
-              "image": "m-j6cab1h2be8x7snnjnam"
+              "release": "414.92.202306141028-0",
+              "image": "m-j6c2govcms4khu30s2ly"
             },
             "cn-huhehaote": {
-              "release": "414.92.202305090606-0",
-              "image": "m-hp3bviipywmm7grqvrv2"
+              "release": "414.92.202306141028-0",
+              "image": "m-hp3drajptbsrlcmjzejn"
             },
             "cn-nanjing": {
-              "release": "414.92.202305090606-0",
-              "image": "m-gc79g286p2e955m13lz1"
+              "release": "414.92.202306141028-0",
+              "image": "m-gc7dblbdqnnd0nstb6ta"
             },
             "cn-qingdao": {
-              "release": "414.92.202305090606-0",
-              "image": "m-m5e0a4iiua1f7gg65xc6"
+              "release": "414.92.202306141028-0",
+              "image": "m-m5ec6ijy7pm6kzvax17h"
             },
             "cn-shanghai": {
-              "release": "414.92.202305090606-0",
-              "image": "m-uf6c4isurxx55l4z8gzy"
+              "release": "414.92.202306141028-0",
+              "image": "m-uf6fgidgyd1r88ix9xfs"
             },
             "cn-shenzhen": {
-              "release": "414.92.202305090606-0",
-              "image": "m-wz9gyhwkjzwkjyh1hw2g"
+              "release": "414.92.202306141028-0",
+              "image": "m-wz913qax89uetgt2796k"
             },
             "cn-wulanchabu": {
-              "release": "414.92.202305090606-0",
-              "image": "m-0jlam46g5poknvz38otg"
+              "release": "414.92.202306141028-0",
+              "image": "m-0jlbwmaa4tkr5jswz8fi"
             },
             "cn-zhangjiakou": {
-              "release": "414.92.202305090606-0",
-              "image": "m-8vb3vii4ympy6uncguxo"
+              "release": "414.92.202306141028-0",
+              "image": "m-8vb97s8v8ophvbp1pfia"
             },
             "eu-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-gw8516f8qk2c9v6j9kli"
+              "release": "414.92.202306141028-0",
+              "image": "m-gw898s0j9e1fs0w96acy"
             },
             "eu-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-d7oi9sbpf6z2487r2422"
+              "release": "414.92.202306141028-0",
+              "image": "m-d7o2kicthf11x6danogi"
+            },
+            "me-central-1": {
+              "release": "414.92.202306141028-0",
+              "image": "m-l4va549dwf07ukl57x48"
             },
             "me-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-eb3dig6h7aehz57wyv98"
+              "release": "414.92.202306141028-0",
+              "image": "m-eb355363mjuuh2l15jcs"
             },
             "us-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-0xi5to3bh2a8mplasqcn"
+              "release": "414.92.202306141028-0",
+              "image": "m-0xifhcadlq8e8rjxsda4"
             },
             "us-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "m-rj92ekk59r1fp4i86j0d"
+              "release": "414.92.202306141028-0",
+              "image": "m-rj97ly79h5pzjsbnxbnd"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-045e31bc4bc76aa8c"
+              "release": "414.92.202306141028-0",
+              "image": "ami-05836f253d9367a84"
             },
             "ap-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-07ef50b1fa91b4a23"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0e591ec13d2f14c34"
             },
             "ap-northeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e4ecac6f2dbf9261"
+              "release": "414.92.202306141028-0",
+              "image": "ami-05bf01ffd58a085cf"
             },
             "ap-northeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0f209c73c01f18b6a"
+              "release": "414.92.202306141028-0",
+              "image": "ami-03991dbdd63a042b4"
             },
             "ap-northeast-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-03a5e48110bee96a8"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0a4e638d55227d5d9"
             },
             "ap-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-04516b4caba0b98c8"
+              "release": "414.92.202306141028-0",
+              "image": "ami-047810cf698d277e7"
             },
             "ap-south-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-00dba9c332149f167"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0f081533b237aef47"
             },
             "ap-southeast-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-08f081925ed857987"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0fc9048b86d06ce1f"
             },
             "ap-southeast-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0536624055de66179"
+              "release": "414.92.202306141028-0",
+              "image": "ami-045d7f628b11775e4"
             },
             "ap-southeast-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-061adee9d39ad585d"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0322ddc01032e7641"
             },
             "ap-southeast-4": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0a41e48f0cd4d716b"
+              "release": "414.92.202306141028-0",
+              "image": "ami-00a2a7bd9c6d1f38c"
             },
             "ca-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-097964bdd23d75afc"
+              "release": "414.92.202306141028-0",
+              "image": "ami-02f2bccd2842e5023"
             },
             "eu-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0bfacea2b38972d56"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0eff2d81c4acf6696"
             },
             "eu-central-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0aba62116cdc16573"
+              "release": "414.92.202306141028-0",
+              "image": "ami-003beae67fa582721"
             },
             "eu-north-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-05956babd3192b4d4"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0512a0d1f76e810a9"
             },
             "eu-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0dab1431846a7d291"
+              "release": "414.92.202306141028-0",
+              "image": "ami-03800fae66fa4f88f"
             },
             "eu-south-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0c6aac329d094b782"
+              "release": "414.92.202306141028-0",
+              "image": "ami-07f98b520881bf22f"
             },
             "eu-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0f3ec988eb4542eb3"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0f55d946fc10309f6"
             },
             "eu-west-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-03d8e201ee2536393"
+              "release": "414.92.202306141028-0",
+              "image": "ami-067e8386327b508eb"
             },
             "eu-west-3": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0246c0d3b16e65f7a"
+              "release": "414.92.202306141028-0",
+              "image": "ami-07883fab66bb009ad"
             },
             "me-central-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0abd182979b1197cc"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0ab3921462f8346f8"
             },
             "me-south-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-09ebb87c0d1a121b6"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0621a46460ba11683"
             },
             "sa-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-09bff1e11dee130d8"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0d0cad42d61719ebe"
             },
             "us-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-01735c4f217bf0ae4"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0e8b36c7affdb2e40"
             },
             "us-east-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0881b931e9e0e0a06"
+              "release": "414.92.202306141028-0",
+              "image": "ami-00688d1139b67ce50"
             },
             "us-gov-east-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0e4a567a3cdba04f1"
+              "release": "414.92.202306141028-0",
+              "image": "ami-009e72de816e95474"
             },
             "us-gov-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-0c95c80838ecda27a"
+              "release": "414.92.202306141028-0",
+              "image": "ami-034f00a1eb7b3e820"
             },
             "us-west-1": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-07421b452dc2ed137"
+              "release": "414.92.202306141028-0",
+              "image": "ami-0336cc8119fabc998"
             },
             "us-west-2": {
-              "release": "414.92.202305090606-0",
-              "image": "ami-03bff0fea00897308"
+              "release": "414.92.202306141028-0",
+              "image": "ami-01bfc200595c748a1"
             }
           }
         },
         "gcp": {
-          "release": "414.92.202305090606-0",
+          "release": "414.92.202306141028-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-414-92-202305090606-0-gcp-x86-64"
+          "name": "rhcos-414-92-202306141028-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "414.92.202305090606-0",
-          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.14-9.2-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ba2d624b78fff140a255baa17c5713b07316a1c809f922717ed014128d6ac85"
+          "release": "414.92.202306141028-0",
+          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+          "digest-ref": ""
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202305090606-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202305090606-0-azure.x86_64.vhd"
+          "release": "414.92.202306141028-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202306141028-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.14 boot image metadata and includes fixes for:

OCPBUGS-8081 - Agent based installer will always fail to install 3 node cluster with BareMetal (HPE ProLiant BL460c Gen9) with SAN storage.

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name 4.14-9.2                    \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=414.92.202306141028-0                                      \
    aarch64=414.92.202306141028-0                                     \
    s390x=414.92.202306141028-0                                       \
    ppc64le=414.92.202306141028-0
```