### PR TITLE
update RHCOS 4.13 bootimage metadata to 413.92.202306140611-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-05-02T23:08:39Z",
-    "generator": "plume cosa2stream 7a1f61e"
+    "last-modified": "2023-06-14T20:10:53Z",
+    "generator": "plume cosa2stream 14982ae"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-aws.aarch64.vmdk.gz",
-                "sha256": "bc262bb9da4fea5d9a243acb845781a4e5e1cfe8e3a3de1649f0adc98bb5bb54",
-                "uncompressed-sha256": "6c90b44f218723a680fd659045624243124cedd41da91f434c5c6e1ed6d916ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-aws.aarch64.vmdk.gz",
+                "sha256": "d57b16651fe0d336224c279c3655e4d7411bfea3d91d403d433dd3d91fb609b2",
+                "uncompressed-sha256": "f837339fa896e4a881a5cce20862d980d4a95310c52215624e91921f5ab0682e"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-azure.aarch64.vhd.gz",
-                "sha256": "1670e82e0fdb273ebdfaed3ded4e52ba5f37172daaf35cc138c71fce7eed85ef",
-                "uncompressed-sha256": "273085880b79490f1a4fc0de9e44d8c0caac09f3891bc1f38dae2e49f6d9a8ce"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-azure.aarch64.vhd.gz",
+                "sha256": "3611d26975c5542a93112d280c9d900f9c26d3408456f0cb0decdfc35073368e",
+                "uncompressed-sha256": "c49f0faf1f77417dbf7de13676fe61b89bda483ee7d6567ffd0bb5397ea86c28"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-metal4k.aarch64.raw.gz",
-                "sha256": "b9e9da2e0819262a11684cf13b07948b29ac0ecf50c47244231706bc71b0b15d",
-                "uncompressed-sha256": "75a99d87904c5853ceb6719f29b3e328ba497881844bad11a21f131ac623aaa7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-metal4k.aarch64.raw.gz",
+                "sha256": "4657c9728433ad726c585b15bc33bc8457bb9435bcf6c5455897a89127d7d1ff",
+                "uncompressed-sha256": "ea1dbea7ada0eec5860a1203114497c13d9cefc8b5123676381885c4f3e6ed01"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live.aarch64.iso",
-                "sha256": "518eea069fea853b42db5452cbae7590347f2e6114df79ecff704e8ea07f73b4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-live.aarch64.iso",
+                "sha256": "79c7928ce2b79ec3005372c5ec6ee6bc4f88264c8b323ee84ad105fdf1342c7a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-kernel-aarch64",
-                "sha256": "8c413251b04da4f39d2f95832985ead9b7615bbb01afbf5501b281256d25e38c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-live-kernel-aarch64",
+                "sha256": "dc2ee7d57358622c28708e533d3ed6df6c50cbdd98ff576dc0c2e148deb2bbf4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-initramfs.aarch64.img",
-                "sha256": "292b75831e817e316ef5ad68ec67320cc8020608025613f2be2c1d722c95fb05"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-live-initramfs.aarch64.img",
+                "sha256": "95b55fd07075ef160564b053c7c3182dbebc97d12d4d21eb9895efc93949297f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-live-rootfs.aarch64.img",
-                "sha256": "eb187a24fc72986b4dd680f875a8c4097f847caa8f78ef3133f552417c4eeb85"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-live-rootfs.aarch64.img",
+                "sha256": "19497d1d3878fb15c45040276b2f54610d6c04e1c0788b84ec244b6d276cddb8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-metal.aarch64.raw.gz",
-                "sha256": "6fdaabbddf0f11ec770acc808f294d7287e80ac5e60d1a16e55857ebb290e5fa",
-                "uncompressed-sha256": "c844827988f5b411cc450f9330a6484f24d96568c49d65b4dc4b7b3e948324b1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-metal.aarch64.raw.gz",
+                "sha256": "818b67f2f2071f73173a3cdd94d9718da7d3e6ea5af9823698e3f89f70ac955f",
+                "uncompressed-sha256": "dcabfa51ada363d7e93ab33686b34679bf341069002da31d9411ab6e105ac269"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-openstack.aarch64.qcow2.gz",
-                "sha256": "9acb5ca338face7711aa24e19d0d536df4956a7a446cd4e0751aa5fb42603867",
-                "uncompressed-sha256": "4c21e56d1b5500d1536cd18fc3bbe1fd8f97b89b0683e22f592c813eb2ceda7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-openstack.aarch64.qcow2.gz",
+                "sha256": "1385e0df7da8bc389a5a23bb5d93358ba9af1f9a154abea570f1075e1927f1ba",
+                "uncompressed-sha256": "d33596d5f2a65aa5d2e412b58ae687ffe5ece524c070c2df8774dcb47306b804"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/aarch64/rhcos-413.92.202305021736-0-qemu.aarch64.qcow2.gz",
-                "sha256": "8f600b7145fd8b00d28ed6442b5e1336c9035c5bfec1df82bb87b8062092c82d",
-                "uncompressed-sha256": "396a07ee8dc0c11e0c7eaec554d1f9ae1a6aa6c4cabdc0c23c861b795303e515"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/aarch64/rhcos-413.92.202306140611-0-qemu.aarch64.qcow2.gz",
+                "sha256": "2ee260080c39bedb882abdd0d7fabc0ab107f0af0d7437e2efb6d394f4d6b781",
+                "uncompressed-sha256": "971d5d356df49ef6654ac0ef6491e1fd6697bbd780837cc243be06cc3587e66c"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0d684ca7c09e6f5fc"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c6fb555330c7907e"
             },
             "ap-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-01b0e1c24d180fe5d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c1d62f52a813b76e"
             },
             "ap-northeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-06439c626e2663888"
+              "release": "413.92.202306140611-0",
+              "image": "ami-007c72853ebd3e32a"
             },
             "ap-northeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0a19d3bed3a2854e3"
+              "release": "413.92.202306140611-0",
+              "image": "ami-055739e3a9dcb0350"
             },
             "ap-northeast-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-08b8fa76fd46b5c58"
+              "release": "413.92.202306140611-0",
+              "image": "ami-02526b6a782d4877f"
             },
             "ap-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0ec6463b788929a6a"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0664b2cf203796697"
             },
             "ap-south-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0f5077b6d7e1b10a5"
+              "release": "413.92.202306140611-0",
+              "image": "ami-00402d462cc4f4c5b"
             },
             "ap-southeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-081a6c6a24e2ee453"
+              "release": "413.92.202306140611-0",
+              "image": "ami-033092941092f1732"
             },
             "ap-southeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0a70049ac02157a02"
+              "release": "413.92.202306140611-0",
+              "image": "ami-03af30b6837edc0a6"
             },
             "ap-southeast-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-065fd6311a9d7e6a6"
+              "release": "413.92.202306140611-0",
+              "image": "ami-04b55e0cca668766e"
             },
             "ap-southeast-4": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0105993dc2508c4f4"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0bf39a15bdaf3d576"
             },
             "ca-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-04582d73d5aad9a85"
+              "release": "413.92.202306140611-0",
+              "image": "ami-04bb6921206fc4035"
             },
             "eu-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0f72c8b59213f628e"
+              "release": "413.92.202306140611-0",
+              "image": "ami-02cb1240328565f2a"
             },
             "eu-central-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0647f43516c31119c"
+              "release": "413.92.202306140611-0",
+              "image": "ami-056829dc79e3e981c"
             },
             "eu-north-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0d155ca6a531f5f72"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0b1b5a4ce841151e0"
             },
             "eu-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-02f8d2794a663dbd0"
+              "release": "413.92.202306140611-0",
+              "image": "ami-07fa7237f797b68cb"
             },
             "eu-south-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0427659985f520cae"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0b3232a94b9c64318"
             },
             "eu-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-04e9944a8f9761c3e"
+              "release": "413.92.202306140611-0",
+              "image": "ami-033bba573fc0ec603"
             },
             "eu-west-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-09c701f11d9a7b167"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0bbd3bcec98d03faa"
             },
             "eu-west-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-02cd8181243610e0d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-068c21071f52e45fc"
             },
             "me-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-03008d03f133e6ec0"
+              "release": "413.92.202306140611-0",
+              "image": "ami-01488889353d1b4c3"
             },
             "me-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-096bc3b4ec0faad76"
+              "release": "413.92.202306140611-0",
+              "image": "ami-063ffdd073ce690e7"
             },
             "sa-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-01f9b5a4f7b8c50a1"
+              "release": "413.92.202306140611-0",
+              "image": "ami-06dcbe8ec4eafb3fb"
             },
             "us-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-09ea6f8f7845792e1"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c5f29f1266c93f19"
             },
             "us-east-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-039cdb2bf3b5178da"
+              "release": "413.92.202306140611-0",
+              "image": "ami-011a679890fbe6984"
             },
             "us-gov-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0fed54a5ab75baed0"
+              "release": "413.92.202306140611-0",
+              "image": "ami-09fcf2ad11694f905"
             },
             "us-gov-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0fc5be5af4bb1d79f"
+              "release": "413.92.202306140611-0",
+              "image": "ami-03584d6e521871fc3"
             },
             "us-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-018e5407337da1062"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0ae25be91fa19e213"
             },
             "us-west-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0c0c67ef81b80e8eb"
+              "release": "413.92.202306140611-0",
+              "image": "ami-077dc29b75a501aa3"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202305021736-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202305021736-0-azure.aarch64.vhd"
+          "release": "413.92.202306140611-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202306140611-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-metal4k.ppc64le.raw.gz",
-                "sha256": "73fef57e12a76ffa302155ef1c5740de3e59e811dc1aa9ecf7a839dcd276a93b",
-                "uncompressed-sha256": "3e9ce068791fb773040e282bc43c7b9aba3ddaf6e6042d203896790a9632fa01"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-metal4k.ppc64le.raw.gz",
+                "sha256": "a138c3f78dff8125d5b2a685828dbcd5adbed1b7b7d5b3edf8df34425479266c",
+                "uncompressed-sha256": "bd80b9342b5bddea4dd0c1b4a8b2ed98f768a621601decd3cce49051c71e70b7"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live.ppc64le.iso",
-                "sha256": "a7c819d1dccb3b46ea87b078874f9c2283c7fe509b0ece935cabb3cbf9c2c68b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-live.ppc64le.iso",
+                "sha256": "3942f065fcdd62b6e58c0a9e67c4bdff501dad0f85235959b318c24c9d216331"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-kernel-ppc64le",
-                "sha256": "d51d94534a2f638cc78f59e802d7ad722bf3e10123ed05023186bbcd48595060"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-live-kernel-ppc64le",
+                "sha256": "ac2ab6e28da0d20200663b0b81b7397f8e783208bdc32d80c9bfa9e0597a3b39"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-initramfs.ppc64le.img",
-                "sha256": "dcdb3c1cb61c6e8dd91fb3a56277778ded9a9f648409042428d04a683a4fa195"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-live-initramfs.ppc64le.img",
+                "sha256": "2d8ac38e488ba2a491177b61543830c1196217ec5b591c1a17bec6b2adcee40d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-live-rootfs.ppc64le.img",
-                "sha256": "37412d2fd885dd52471e8ff99fec47316791722074c5da3732e80bb5a21f1a9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-live-rootfs.ppc64le.img",
+                "sha256": "4b98c474bdf0d45122e8d1571f41d92e248cc6c3d52c8dc193467dd408bb72b5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-metal.ppc64le.raw.gz",
-                "sha256": "5babf59eb0bc9d7dec6e640b83ea60184ddc6aaf8599071145964043abc3a3ae",
-                "uncompressed-sha256": "55c66b4c93c40708dbc2b95b77bfb382d95ac0d36391ea0b0515ff9c36fe9935"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-metal.ppc64le.raw.gz",
+                "sha256": "4a49024df3d1b20eb2ad3ae39b5fce62fb02a9e35b679e2f6d8df2ba00877d6a",
+                "uncompressed-sha256": "860ed86ce4059a2ea218862580c169433f84e67a2e4df0d32ffa74486517fee8"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "1994294808e4ea10fc927b5b4114dc359c7928ad02569d6fbc72e3ad2c0ecf62",
-                "uncompressed-sha256": "eb69cc641d9184afd293fb0d0e20ee5c63ae86f4212a206b511ae93824938005"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "53ac73a31cd1a71c3d1c3b2e84a3d4a37d4c6e81a193522eea8e07196597b411",
+                "uncompressed-sha256": "5d1e47620e5b15066d62322ea86335adee18e051f18b99b31848694978774876"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-powervs.ppc64le.ova.gz",
-                "sha256": "1f2b64a332ac18ca0836c80c02f3c8a4ced01031d40df7654a4d6b4281d8d754",
-                "uncompressed-sha256": "5c35575f3830b9c1fdd324bb2fec6135f33a60798b39f73ef7a29e70be565cb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-powervs.ppc64le.ova.gz",
+                "sha256": "1208e516de2ae1564e42f13e6997a8739b445d7f1feaef01e7eed3bf0eb6af82",
+                "uncompressed-sha256": "593d5d07e7059c1edef8eaa8e32dadafcdf5a4d673b4b14b30be40dfc5538552"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/ppc64le/rhcos-413.92.202305021736-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "03a982b2908271d90427d100eb5b2416947ffb3adb3ceec7c583fda783bfe745",
-                "uncompressed-sha256": "8124552a68a2a9ed3b624105f58fb7adf9cc3e467ad59a2930dec2a725108939"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/ppc64le/rhcos-413.92.202306140611-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "0e72b85fd2d53b5d3bb32ea7e975f8ce022a25287816d685982e408e2be4463d",
+                "uncompressed-sha256": "bb21015a742d81c812c30597085abcddd5825c74a2faac18821d70d986f806ef"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.92.202305021736-0",
-              "object": "rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202306140611-0",
+              "object": "rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202305021736-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202306140611-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "21605bca4acc676532ec29fe15c773f7c729508295755d7f1c96392887e5a0ec",
-                "uncompressed-sha256": "8143defef36d5c860b6438481de66123995fa004398f08c7185cf2cb4ce7bb8d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "2b61f7281dea545785ba1e4867418204703829a2cfa0d8f5e90b58f91d6837d8",
+                "uncompressed-sha256": "74015045a7ca4064d30cc353bdb1f6c1f6227d343a9f27eba80a09c527d07bf0"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-metal4k.s390x.raw.gz",
-                "sha256": "35b2c32a3b4344fbc66fd1b60e99deb5629adc5521880cc453b070f363e49143",
-                "uncompressed-sha256": "733c80fb4cbc72ea58bd59813479befef0e002f512782954ef24e9739e8110fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-metal4k.s390x.raw.gz",
+                "sha256": "5ec30575484ef8c03ebb446b250f09381436c2689800635fcffa44cdc9a42c76",
+                "uncompressed-sha256": "855c7c667dab84056415e11ceb99a8f616f9709fe1391f79f1ca88d0986a3ae5"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live.s390x.iso",
-                "sha256": "8c43a00c91c45d6166ee51d0e3089c3c191291d539f30e7071ab4297125910ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-live.s390x.iso",
+                "sha256": "357af346340addb7e777c7a469642cd05c1a0921862a42850feaaff31559492c"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-kernel-s390x",
-                "sha256": "dd1d7dd7706c59d17681392bf2e230aff3d2e62618546d3065b7d877a268cc28"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-live-kernel-s390x",
+                "sha256": "45ff4160612acda062f4406221742f15216edfb469fadc1393495d093802fa8b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-initramfs.s390x.img",
-                "sha256": "f73ecf730a782ad95916f949343661e69cc0a68a480c4b3447388e5d31856ad1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-live-initramfs.s390x.img",
+                "sha256": "b10405d07c5eea251a31ee0d49feae6d88d0e8cc807b622062648e8f1a1d28f7"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-live-rootfs.s390x.img",
-                "sha256": "ab03b8a69f03f7579fceee0eb7b9c5b8b841d48ce67c1caf6552e6517d00b18d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-live-rootfs.s390x.img",
+                "sha256": "491d5b339e98f4239b5effcd32a5be0bd5225f4c59921cff772cc804ddceff17"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-metal.s390x.raw.gz",
-                "sha256": "63922508ab7e863909d2ca445849c4e3d3b1bee38a73b95571184de97a2ea1c2",
-                "uncompressed-sha256": "b90ab55c6eeb14f8dedc47c0f427156822c3a923ecf5a6cee95922ecc2cba540"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-metal.s390x.raw.gz",
+                "sha256": "0ddcd0d8d1a22e208aeb8937be3dd7e5e22ccfbe68695932516ab8ac5fd943f4",
+                "uncompressed-sha256": "fed643979643f12084afc416ba63de180e9c1bc4fc11055a3d43a4ac1f505d78"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-openstack.s390x.qcow2.gz",
-                "sha256": "29eaef172be4384e025ddc3fec11ac8685ea14284a69338a177804698a060eb9",
-                "uncompressed-sha256": "2582cff6dc1992e68b647f0c59bcae34eefec541eb38c843f7a6727ae833f498"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-openstack.s390x.qcow2.gz",
+                "sha256": "d218735fda147319102c13c3ad1d717d2cf691bd0ece45222e5f197d814f99a6",
+                "uncompressed-sha256": "b80f61ed48c7c53327080b59d58d4cdc189ff631478ad3fe3c7dcc5382567a43"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-qemu.s390x.qcow2.gz",
-                "sha256": "8e96c7ca3d922a9e8daf0bd963053935b63d08e2dc709bf81509f14142802e4d",
-                "uncompressed-sha256": "78fdd3c54187c912ddfe5bf66ee3229e97ac135d3d8b5d46f5fca54900d8ad5a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-qemu.s390x.qcow2.gz",
+                "sha256": "17d03c01fe7285c01ec3685da3ec14f064f73ba1f56f5a351efd382a7062c3ac",
+                "uncompressed-sha256": "090a66e9c6c7a1040dc70c8459765f5398fc7ab9ce514a497822311904976aad"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/s390x/rhcos-413.92.202305021736-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "8012cf28e0f7b69cae58de00e5ecc62b51d8d19891aab52b50921503545e1338",
-                "uncompressed-sha256": "a2f92153cce26f6f2f5009f6ae5845ba17bfad22817416bb4ab48964b0096e5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/s390x/rhcos-413.92.202306140611-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "c8f96411f5755c0d3679ed7fa7d39c570092461a505170cf828eb5762d0f3a77",
+                "uncompressed-sha256": "5b330d63359b84827f0baaa49675142e4160ccbd7341ac5f11938a509fe0b082"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "7282b1841600ec1e04cff54fb5befb52ef8c5d1586091dae9e09582bc7997f53",
-                "uncompressed-sha256": "48f69571d5dc57eb2cb9244dd959bbf9db5b2cb4253a7a8491a28697a68c5c67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "ef34e1267cebb66a83e3dd391e66e7092a712f82c5f550d0cf7dab4fc0bb0a6e",
+                "uncompressed-sha256": "5e834555f6afa3e4aff4dd46a87904bd0c715af5ef2aa781673fad56ad8bd12a"
               }
             }
           }
         },
         "aws": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-aws.x86_64.vmdk.gz",
-                "sha256": "f2a0a9a9caf3a58d31cb2491544583e937b881374db3293688f4928ae84175df",
-                "uncompressed-sha256": "b4b1dbd5439931b9a072d299354cfe4e7d7914d41d1aa6ea2292b31aca07a520"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-aws.x86_64.vmdk.gz",
+                "sha256": "5066923ea4eefe6cc91a76199405730b5ca37b07c2547ed2af6920eff2c9564b",
+                "uncompressed-sha256": "50c0f40f999a924989e318a43a3b6ffd4828d756af5213a6196a961a8c148a92"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-azure.x86_64.vhd.gz",
-                "sha256": "83aca9a5ac49324e0e1d062a7bc43e21238e2316a358b7b817128bbc947e13db",
-                "uncompressed-sha256": "3683ef6d0d5ac584d5cd3eb30206e578580297abbb4251ed4df6ddb3a9349439"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-azure.x86_64.vhd.gz",
+                "sha256": "65d4b23a37361907922b2f9258d98f6b68d4e9ff61c804315813a0f221262de1",
+                "uncompressed-sha256": "66e09a7ffb454868a1e1402cbb13f8aaa8557165a694ab6be94a9577db5b9ff9"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-azurestack.x86_64.vhd.gz",
-                "sha256": "f967ec657a6882478ae3d923f3f3414d9154bebf262fc27c22d0d673fc6590e4",
-                "uncompressed-sha256": "fa2a4e97cb92087d78871ff21989916c2e5d92168a972013c805046f5af6f016"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-azurestack.x86_64.vhd.gz",
+                "sha256": "fdfd244018bef0bc3cb960835999bb291c634e995ae3ea484e2a264a84ac8889",
+                "uncompressed-sha256": "d75b3efe402a9d994f206953aa22accc561fbb28c144a0855a2963418130591d"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-gcp.x86_64.tar.gz",
-                "sha256": "50446ea637e88f42a7f0dedcf5b9f56286dfadfa6c4f6af9e10b36509ffb08f6",
-                "uncompressed-sha256": "b168b94c9e9dfb6a8001dcbb621aa28e68d60eef4f86457341bdc57ec454d2bf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-gcp.x86_64.tar.gz",
+                "sha256": "8f6551ea7cb5aa1a0fa2931222d64f5c67e857d2757454826a2777c709e00b38",
+                "uncompressed-sha256": "3503f92cc4720a693c966cf54c6b3cf799f0cb2c8a5c48ee359a2107619876f1"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "1b910bbf84587058c51d397cf0b2ed3871c1cbbb9f0998477e7f0dd401400ed7",
-                "uncompressed-sha256": "222abce547c1bbf32723676f4977a3721c8a3788f0b7b6b3496b79999e8c60b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "bf516c91a3525c41344ff76b343cee5371c81bb7fc54a931ce4b45822f5d8d36",
+                "uncompressed-sha256": "c86c3df9b52b2d33ea2c7c9ca584a20cbc800faa4a0365c12eae055adf00d4b4"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-metal4k.x86_64.raw.gz",
-                "sha256": "c58e77b7cfa9eaad7d2f3e84e99d47f3d2a4bc0bdd3671d2287f8fad6ceca2dd",
-                "uncompressed-sha256": "f1381ec2f6ccb94b6d9af1233940517bbb2e2ec075a89d16d150aa48007c29b2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-metal4k.x86_64.raw.gz",
+                "sha256": "f412fbb0ffd479a3567cef44de89dfa7eb86d3c779c139ee805262223efbd921",
+                "uncompressed-sha256": "a8cd0d525156e7423c832be2532750624bdbe1287ea8b4445e26b76c8d145fa7"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live.x86_64.iso",
-                "sha256": "ed9411c23534f6fcac4ab986f9850418312896f8f46fb77213030dbc454d44b7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-live.x86_64.iso",
+                "sha256": "213148852e90efb96c82cb9d9d8ceb5b436549f1dfd20e3aa9fb9256f03da748"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-kernel-x86_64",
-                "sha256": "cd0ec3f82549062461998ac50855f275e42b675f759351df843b6668c8c9bd0c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-live-kernel-x86_64",
+                "sha256": "cd596c50ec0988c0324318ca56f6af1658fe3a8f09d7d9da70afa65ac0086c6e"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-initramfs.x86_64.img",
-                "sha256": "c721debe2d8e88727455d9ed7221f4a6e1d51f42d9a557238f6f092ce30bb06c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-live-initramfs.x86_64.img",
+                "sha256": "a21b85593c811173b66eba9424bdd30aa48e54d9b5c451e92dedfc6252a9b4b3"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-live-rootfs.x86_64.img",
-                "sha256": "f504ebb72bb3541565a49d2f87c5aa63c54091100920feb413d3566232ff82c9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-live-rootfs.x86_64.img",
+                "sha256": "d44887c5cbb9a655efe7fd01632b584c2308c877f282700ed37be1a7cb2ccf11"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-metal.x86_64.raw.gz",
-                "sha256": "37f8bc614604dc985754fc2be69bc3f119866b74b96542b5d3b482dcf2132d38",
-                "uncompressed-sha256": "43e36022f451e8498521225e0fdea6909176a6bc4f84b6796d5c918d27e91dd6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-metal.x86_64.raw.gz",
+                "sha256": "922a82a023bcc1b4044d0600e47f983878fd4c874bec7c8ac46797ebcfa61980",
+                "uncompressed-sha256": "70b25dec645ae95d53aa5d61cf4054f5747e7d7bc761a2d29b0c4a1534a58b31"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-nutanix.x86_64.qcow2",
-                "sha256": "d0defcd6645f44d8d15e5bd2fc03ca6d6a2d1640a0507053b676e9d69adc70c0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-nutanix.x86_64.qcow2",
+                "sha256": "ed4927952b845c6b7aab7b20bbceeb19fd041ede2047717b5b5aba8961daac7b"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-openstack.x86_64.qcow2.gz",
-                "sha256": "5c5ca88c6bf2cd06d936091efae254bcd877e709fe95f6fea2c3283faf05b53e",
-                "uncompressed-sha256": "e10860fa337d8468becf47fb8398709631b2d719b863872edd2cde7240de7b1d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-openstack.x86_64.qcow2.gz",
+                "sha256": "b58b1121cdff217289006dfa9d360e0638d961cf6f35d74baacd8408007fdac1",
+                "uncompressed-sha256": "c9f909ed09e7bb8133a9a2faabebb403a34704612c21028b45631c653115540e"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-qemu.x86_64.qcow2.gz",
-                "sha256": "cc15897f797548ae627a5880f7c496fc38205c9322f4ec8e822f0e26f324453b",
-                "uncompressed-sha256": "dec79efb470705174320ef502772489a67eeedac14457d0958fc541f635c4e28"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-qemu.x86_64.qcow2.gz",
+                "sha256": "9e71775e0538b27b73ebc03395a17cf61cf3e27a3f7819e4594fd842cdc5458e",
+                "uncompressed-sha256": "fa891a8b7289af96b081422c4921d8d790e823de392e4bcea1e3bb34bd225383"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202305021736-0/x86_64/rhcos-413.92.202305021736-0-vmware.x86_64.ova",
-                "sha256": "0b0cf6b81a058f4016d442e57d917532f02dcbe1befceb9652cdc4532345fcc3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202306140611-0/x86_64/rhcos-413.92.202306140611-0-vmware.x86_64.ova",
+                "sha256": "07b1359c9453f3d05986448db1eda559af70d32b6e37b26219cf484c4b39f92f"
               }
             }
           }
@@ -619,249 +619,253 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-6we4x6nuds9vssarjv0g"
+              "release": "413.92.202306140611-0",
+              "image": "m-6weh8q3f0zyjhb49xv9b"
             },
             "ap-northeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "m-mj7ii98d3070rr7xuvxs"
+              "release": "413.92.202306140611-0",
+              "image": "m-mj72vfp4griynx3qt9pc"
             },
             "ap-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-a2dhjxtmedm2xz4xmdtb"
+              "release": "413.92.202306140611-0",
+              "image": "m-a2ddyzdycmlb0tkefw00"
             },
             "ap-southeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-t4n2uj0enpjt7e34t4x2"
+              "release": "413.92.202306140611-0",
+              "image": "m-t4nf23eba5w0q1k9sapa"
             },
             "ap-southeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "m-p0wisxc1ycreg7n9por2"
+              "release": "413.92.202306140611-0",
+              "image": "m-p0w3hvin23xwrkioeph5"
             },
             "ap-southeast-3": {
-              "release": "413.92.202305021736-0",
-              "image": "m-8ps2kyhkrj3ti2r9lal7"
+              "release": "413.92.202306140611-0",
+              "image": "m-8ps6mar1u7lwd85sv4z0"
             },
             "ap-southeast-5": {
-              "release": "413.92.202305021736-0",
-              "image": "m-k1adbmvh1r2oxp2rmmj1"
+              "release": "413.92.202306140611-0",
+              "image": "m-k1a1kyq9ik91pfs981bu"
             },
             "ap-southeast-6": {
-              "release": "413.92.202305021736-0",
-              "image": "m-5ts7gtyipiygxu1ivpn5"
+              "release": "413.92.202306140611-0",
+              "image": "m-5tsg6k7vd9bjhyod4pkm"
             },
             "ap-southeast-7": {
-              "release": "413.92.202305021736-0",
-              "image": "m-0jo2ra36bjwjp3aoodda"
+              "release": "413.92.202306140611-0",
+              "image": "m-0joiiacghs9utf6drr4v"
             },
             "cn-beijing": {
-              "release": "413.92.202305021736-0",
-              "image": "m-2zehuzxdr25ufiijep0v"
+              "release": "413.92.202306140611-0",
+              "image": "m-2ze2ha85j0j8owcfo246"
             },
             "cn-chengdu": {
-              "release": "413.92.202305021736-0",
-              "image": "m-2vc7njvnsm84959nez9f"
+              "release": "413.92.202306140611-0",
+              "image": "m-2vcbguzqc8boot2i0mw7"
             },
             "cn-fuzhou": {
-              "release": "413.92.202305021736-0",
-              "image": "m-gw07wgj0ctvz6y4poaz0"
+              "release": "413.92.202306140611-0",
+              "image": "m-gw0el5m0k2rp13nmqzuc"
             },
             "cn-guangzhou": {
-              "release": "413.92.202305021736-0",
-              "image": "m-7xvdyeffe7qrnnshxsmn"
+              "release": "413.92.202306140611-0",
+              "image": "m-7xv12z1chuc16ionru8q"
             },
             "cn-hangzhou": {
-              "release": "413.92.202305021736-0",
-              "image": "m-bp1ivkw5ddglsgui2pb9"
+              "release": "413.92.202306140611-0",
+              "image": "m-bp19e0nii44vm9zvvm94"
             },
             "cn-heyuan": {
-              "release": "413.92.202305021736-0",
-              "image": "m-f8zfls7i2k5jxfb4weut"
+              "release": "413.92.202306140611-0",
+              "image": "m-f8zfyblxzeyqbb4bf4e5"
             },
             "cn-hongkong": {
-              "release": "413.92.202305021736-0",
-              "image": "m-j6ceptfg1yxdxv0euqar"
+              "release": "413.92.202306140611-0",
+              "image": "m-j6cfzbe54ww1mxpfpyx1"
             },
             "cn-huhehaote": {
-              "release": "413.92.202305021736-0",
-              "image": "m-hp39z79mkgle86esl4ai"
+              "release": "413.92.202306140611-0",
+              "image": "m-hp3bkhq8efk2iex5xmqe"
             },
             "cn-nanjing": {
-              "release": "413.92.202305021736-0",
-              "image": "m-gc7iibcg8mvkrg2gnpgq"
+              "release": "413.92.202306140611-0",
+              "image": "m-gc7a7nziyoc90wpxty03"
             },
             "cn-qingdao": {
-              "release": "413.92.202305021736-0",
-              "image": "m-m5ec2qfwezphfr660aoc"
+              "release": "413.92.202306140611-0",
+              "image": "m-m5eh82gfl240h0g8k266"
             },
             "cn-shanghai": {
-              "release": "413.92.202305021736-0",
-              "image": "m-uf69l882scy28zvejfht"
+              "release": "413.92.202306140611-0",
+              "image": "m-uf63c0os3vg2ym2bsdrr"
             },
             "cn-shenzhen": {
-              "release": "413.92.202305021736-0",
-              "image": "m-wz9a5diq7hze93a5k6ys"
+              "release": "413.92.202306140611-0",
+              "image": "m-wz9gjo7y5b8lxud4j6l6"
             },
             "cn-wulanchabu": {
-              "release": "413.92.202305021736-0",
-              "image": "m-0jl8awxohyxmlp2irz00"
+              "release": "413.92.202306140611-0",
+              "image": "m-0jl81g9psnhmvlpfamos"
             },
             "cn-zhangjiakou": {
-              "release": "413.92.202305021736-0",
-              "image": "m-8vbhrb3uqwooszgi4nh5"
+              "release": "413.92.202306140611-0",
+              "image": "m-8vbav94tu1ngbt8fpshf"
             },
             "eu-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-gw8dsm7azykgh5pc11sx"
+              "release": "413.92.202306140611-0",
+              "image": "m-gw801j6k5ndl8w31x2o8"
             },
             "eu-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-d7ocb9acwsann20xay4d"
+              "release": "413.92.202306140611-0",
+              "image": "m-d7o4zk0oqgn2k5q3v34k"
+            },
+            "me-central-1": {
+              "release": "413.92.202306140611-0",
+              "image": "m-l4v480quy0kdrrzq9zle"
             },
             "me-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-eb3d5ybedqqg41e6v87s"
+              "release": "413.92.202306140611-0",
+              "image": "m-eb355363mjuujr9jo859"
             },
             "us-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-0xi2l8aeug6mbilc936t"
+              "release": "413.92.202306140611-0",
+              "image": "m-0xiece4cpkn7mml59czu"
             },
             "us-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "m-rj9dk1uxn0vjcjga805e"
+              "release": "413.92.202306140611-0",
+              "image": "m-rj93370kf4o3ns9m5adm"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-052b3e6b060b5595d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c45f55ec0435e45d"
             },
             "ap-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-09c502968481ee218"
+              "release": "413.92.202306140611-0",
+              "image": "ami-08253af1bd7d33932"
             },
             "ap-northeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-06b1dbe049e3c1d23"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c5ee9382e21a1c1e"
             },
             "ap-northeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-08add6eb5aa1c8639"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c6899f9256329db9"
             },
             "ap-northeast-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0af4dfc64506fe20e"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0197346d7edc5b8b5"
             },
             "ap-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-09b1532dd3d63fdc0"
+              "release": "413.92.202306140611-0",
+              "image": "ami-02a3a4d84812e4bf4"
             },
             "ap-south-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0a915cedf8558e600"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0f55b84cfdd62146b"
             },
             "ap-southeast-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0c914fd7a50130c9e"
+              "release": "413.92.202306140611-0",
+              "image": "ami-016b9678a4c7cb429"
             },
             "ap-southeast-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-04b54199f4be0ec9d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0c5535d8d74b63436"
             },
             "ap-southeast-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0be3ee78b9a3fdf07"
+              "release": "413.92.202306140611-0",
+              "image": "ami-03b6fc492afb1f838"
             },
             "ap-southeast-4": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-00a44d7d5054bb5f8"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0ce75b69c7191b321"
             },
             "ca-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0bb1fd49820ea09ae"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0b7094ceaa6566839"
             },
             "eu-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-03d9cb166a11c9b8a"
+              "release": "413.92.202306140611-0",
+              "image": "ami-00d6d939dd4e438ba"
             },
             "eu-central-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-089865c640f876630"
+              "release": "413.92.202306140611-0",
+              "image": "ami-00435d96e40179a8c"
             },
             "eu-north-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0e94d896e72eeae0d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-02a749b7b17d73157"
             },
             "eu-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-04df4e2850dce0721"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0347e02470b63b5f6"
             },
             "eu-south-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0d80de3a5ba722545"
+              "release": "413.92.202306140611-0",
+              "image": "ami-066f3dd93bbffcc46"
             },
             "eu-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-066f2d86026ef97a8"
+              "release": "413.92.202306140611-0",
+              "image": "ami-02336c66133d55646"
             },
             "eu-west-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0f1c0b26b1c99499d"
+              "release": "413.92.202306140611-0",
+              "image": "ami-0e4b9abbd2fed8ab0"
             },
             "eu-west-3": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0f639505a9c74d9a2"
+              "release": "413.92.202306140611-0",
+              "image": "ami-08f0fd6f033a8d3f5"
             },
             "me-central-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0fbb2ece8478f1402"
+              "release": "413.92.202306140611-0",
+              "image": "ami-03746e3c9922d26bf"
             },
             "me-south-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-01507551558853852"
+              "release": "413.92.202306140611-0",
+              "image": "ami-00536ee85d7f0d9a1"
             },
             "sa-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-097132aa0da53c981"
+              "release": "413.92.202306140611-0",
+              "image": "ami-043097f934eb2e2dd"
             },
             "us-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0624891c612b5eaa0"
+              "release": "413.92.202306140611-0",
+              "image": "ami-03c7dfb29b8d70db7"
             },
             "us-east-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0dc6c4d1bd5161f13"
+              "release": "413.92.202306140611-0",
+              "image": "ami-085c2a9af03474b5a"
             },
             "us-gov-east-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0bab20368b3b9b861"
+              "release": "413.92.202306140611-0",
+              "image": "ami-06123403fc94ef8af"
             },
             "us-gov-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0fe8299f8e808e720"
+              "release": "413.92.202306140611-0",
+              "image": "ami-066646888033e457c"
             },
             "us-west-1": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0c03b7e5954f10f9b"
+              "release": "413.92.202306140611-0",
+              "image": "ami-001a7e2ce1a595450"
             },
             "us-west-2": {
-              "release": "413.92.202305021736-0",
-              "image": "ami-0f4cdfd74e4a3fc29"
+              "release": "413.92.202306140611-0",
+              "image": "ami-074364998a8e3a109"
             }
           }
         },
         "gcp": {
-          "release": "413.92.202305021736-0",
+          "release": "413.92.202306140611-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-92-202305021736-0-gcp-x86-64"
+          "name": "rhcos-413-92-202306140611-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202305021736-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202305021736-0-azure.x86_64.vhd"
+          "release": "413.92.202306140611-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202306140611-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 bootimage metadata which include fixes for the following:

OCPBUGS-13896 - Agent based installer will always fail to install
    3 node cluster with BareMetal (HPE ProLiant BL460c Gen9) with
    SAN storage.
OCPBUGS-13941 - RHCOS 4.12.3 and 4.12.10 on Z display the "swiotlb
    buffer is full" message during KVM cluster Secure Execution (SE)
    install boots for the bootstrap, master, worker nodes,
    elongating boot durations

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json \
--distro rhcos --no-signatures --name 4.13-9.2 \
--url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
x86_64=413.92.202306140611-0 \
aarch64=413.92.202306140611-0 \
s390x=413.92.202306140611-0 \
ppc64le=413.92.202306140611-0
```