### PR TITLE
OCPBUGS-13940: bump RHCOS 4.12 bootimage metadata to 412.86.202306132230-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.12",
   "metadata": {
-    "last-modified": "2023-05-04T22:48:45Z",
-    "generator": "plume cosa2stream 7a1f61e"
+    "last-modified": "2023-06-14T20:19:10Z",
+    "generator": "plume cosa2stream 14982ae"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-aws.aarch64.vmdk.gz",
-                "sha256": "27ab3965dbb5dd9153155c6c7e8e11167a473122f47ff6e2c70ec850516d3749",
-                "uncompressed-sha256": "72abb8a61de6a0ef22a31eea3c0b504391551d2400ef547e13f1433b262bb4d9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-aws.aarch64.vmdk.gz",
+                "sha256": "34faf22970acfbbe2325d927cae7c694fcb9fd481e8a54af09ad64af0c79d578",
+                "uncompressed-sha256": "7e90856cf8ab7d1e62320e916588756bf74a421648c26874ee0f790c43be9441"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-azure.aarch64.vhd.gz",
-                "sha256": "407bd22994266bd175f6b48b25d5edc2f287f607cd22cb7a393be84e17b01240",
-                "uncompressed-sha256": "da4a419f66b44d7ffbf1b579734997ee115896c41551cfa62ac4d7e302eda08d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-azure.aarch64.vhd.gz",
+                "sha256": "a69e39a7b8395cebbf2cb4a606f528d13a8b328eac383d1525e8283fb6159eec",
+                "uncompressed-sha256": "1ba973d29ded5fc51e59e5899139386f626799d0f0cb8110319a601c84068d76"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-metal4k.aarch64.raw.gz",
-                "sha256": "6f2d1cc782f61f4ce5fdfe4126bfe841d185fe7f00ea3609f5bb533e8a9cbd32",
-                "uncompressed-sha256": "f37901fdb179731016ef55865683b293399e25ebefb6ebb7ec7e440189be22a2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-metal4k.aarch64.raw.gz",
+                "sha256": "5dc0b7efd86943d5d2b2611991b90d4374e381366f1fc48af028d00329ab965d",
+                "uncompressed-sha256": "111471df2c98bf7165a57f46b53c0bd6d45db35190f8d18108889d4bb7e8e47d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-live.aarch64.iso",
-                "sha256": "f6bb9f11980056b29670eaaa260c56777919324ee5b3a292c412d208d0143180"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-live.aarch64.iso",
+                "sha256": "bde0b1a36324b6ebfe08a886e21635ffafd6ea2ac9830aa6d6fa48fb17e5045c"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-live-kernel-aarch64",
-                "sha256": "8a63d9cefa3cb8aab88b476226d33ee1310911f1ac2356ce290b2be129f56288"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-live-kernel-aarch64",
+                "sha256": "da93b565c22f7fc0b643bab92a4007ba673efdef85e71a5c65bf1af9e2d6b28f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-live-initramfs.aarch64.img",
-                "sha256": "9c9fbc7b3a9ae57149d3fe925e8a12be48db740b790420c9068fe0aa157e76a1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-live-initramfs.aarch64.img",
+                "sha256": "7e4cb64bfdefdb66ca2fbd291fc5208a672d0082476cfa27f3cbf9f9e728f325"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-live-rootfs.aarch64.img",
-                "sha256": "e395c125c057d6eac686172eeceb63c7e2651d216e56e967c573e8b9d58ce55e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-live-rootfs.aarch64.img",
+                "sha256": "91d1ec863378237a7ab4a2a3ac0da7ea2f4cd0669eb3cbd688117fe0d7edff1b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-metal.aarch64.raw.gz",
-                "sha256": "a16f33f1717b46d07474ba716a975d90ea462d0dee07c0f25d4dcb7153b09a81",
-                "uncompressed-sha256": "f43762410470ae4c74d44ac7400cb0a51fd6fe5ac2de0c89c39d9c0d88e90f49"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-metal.aarch64.raw.gz",
+                "sha256": "d8a7f47f790651ac0ff35924914216fa67d62cb57f4d0c8507c76e5ed0465233",
+                "uncompressed-sha256": "01f4741e9668aa4d92be8767999d9f6a80e1c44ad5f2edb9dfeb3747652ea065"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-openstack.aarch64.qcow2.gz",
-                "sha256": "d717a8fc4e2e1e69f28670cf0d04a46c53cde3155e00e4c66155b4988171430b",
-                "uncompressed-sha256": "6a50dc2a6dc978db19652db8f155f38a266907036dbc6fc8d3f912d4891a846d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-openstack.aarch64.qcow2.gz",
+                "sha256": "b87e0f3962e90e9ff38e1fb22d4487bfa2d8aee9ae97a471603d0b727f63cf5a",
+                "uncompressed-sha256": "599f7a1a91cfcec1fe7afa4a75576fd98b8b6045c1a2133f86e7976b694a3377"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/aarch64/rhcos-412.86.202305030814-0-qemu.aarch64.qcow2.gz",
-                "sha256": "3704c737a40a85af06e83c2c8c6bc7cad0c1dc46397dddc7bf61df0a7d4d44db",
-                "uncompressed-sha256": "ace833e91d53c9b584830cfc7970d057b11a7556f23b35d25d817a3d514384e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/aarch64/rhcos-412.86.202306132230-0-qemu.aarch64.qcow2.gz",
+                "sha256": "9da4b77f3504e9dd8b2d1a9bcc2bf46f124955d7d8a5d6b5816e3907722b78e4",
+                "uncompressed-sha256": "5d7892d3ab7bbe0240f1eece8b03ae84837977d836aad0ae3fbfe1a4c3d258bc"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-09aa15de4abefef3c"
+              "release": "412.86.202306132230-0",
+              "image": "ami-06bc7b39135309613"
             },
             "ap-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0307effed84ec9672"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0e219ccc9f6787c47"
             },
             "ap-northeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0d2da62676675a340"
+              "release": "412.86.202306132230-0",
+              "image": "ami-08c3ec92d0d210c72"
             },
             "ap-northeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0eeca6f3091d06f02"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a79cb00088376afb"
             },
             "ap-northeast-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-05363a929cef402cb"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0b1fa5eaecbd831e6"
             },
             "ap-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0648c46ca17060627"
+              "release": "412.86.202306132230-0",
+              "image": "ami-02b1988f5caa7b995"
             },
             "ap-south-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-02bc7dec1498308f7"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0aba3797d00bd6dc9"
             },
             "ap-southeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0ee8743a5c7d71153"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a52f64df0bd37f5a"
             },
             "ap-southeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0ef2e3cec3b4379a3"
+              "release": "412.86.202306132230-0",
+              "image": "ami-08ccf128828f50e1a"
             },
             "ap-southeast-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-02f18ec90b0fa4202"
+              "release": "412.86.202306132230-0",
+              "image": "ami-09b9749e96390af6b"
             },
             "ap-southeast-4": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0f4369ad6db32811b"
+              "release": "412.86.202306132230-0",
+              "image": "ami-022f7ba26adc2d91b"
             },
             "ca-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0d404b4090931e0d0"
+              "release": "412.86.202306132230-0",
+              "image": "ami-04324c5cf1c9b2061"
             },
             "eu-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-032f4435b9251dcd4"
+              "release": "412.86.202306132230-0",
+              "image": "ami-099b5468f27518bf3"
             },
             "eu-central-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-064e78d7dfbfb12fc"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0ea84cfc5b1a36f66"
             },
             "eu-north-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0c4790370dc09b1c8"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a588505a524981a3"
             },
             "eu-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-00ab54ec9a4eb95bc"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0e639e86bff0770a0"
             },
             "eu-south-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0f1ef8830abdd9189"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0e322b127615f58c0"
             },
             "eu-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-063386c1d14e7f232"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0bc7b1d9aeadea472"
             },
             "eu-west-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0561ef6f1845afd93"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a8e0910c72f9d437"
             },
             "eu-west-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0f69d8ed9801aa2b9"
+              "release": "412.86.202306132230-0",
+              "image": "ami-069ba0ad075807f9e"
             },
             "me-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0b0d1c80cb8ddf9c5"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0297d70798af9a03b"
             },
             "me-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0b7db292b94a700c5"
+              "release": "412.86.202306132230-0",
+              "image": "ami-022208d2379d44828"
             },
             "sa-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-02dfde51604b0edfc"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0b27e78964feb8a1d"
             },
             "us-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0c829cc66eca096b1"
+              "release": "412.86.202306132230-0",
+              "image": "ami-06dc872956cb333f7"
             },
             "us-east-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0e643133b944e8ab5"
+              "release": "412.86.202306132230-0",
+              "image": "ami-07bf459e69e2f4dbc"
             },
             "us-gov-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-09cfbbd1d84e9172a"
+              "release": "412.86.202306132230-0",
+              "image": "ami-01a5b1786c45de396"
             },
             "us-gov-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-03edf758064230cf3"
+              "release": "412.86.202306132230-0",
+              "image": "ami-03e69b3294645ab59"
             },
             "us-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-04a57b7169dc20369"
+              "release": "412.86.202306132230-0",
+              "image": "ami-08d31c6e973002694"
             },
             "us-west-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0da50730efa3994ff"
+              "release": "412.86.202306132230-0",
+              "image": "ami-098f9201de31c999f"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202305030814-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202305030814-0-azure.aarch64.vhd"
+          "release": "412.86.202306132230-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202306132230-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-metal4k.ppc64le.raw.gz",
-                "sha256": "51889e22a433539a3a55dd32ef8789861e262f26e869da4a147242fb0c041d80",
-                "uncompressed-sha256": "f113f19db60b3ffd16551821c915aa8a2cf4ba3902f276d1f6d1eefd51fde396"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-metal4k.ppc64le.raw.gz",
+                "sha256": "5ecb4499cbeef2571ece529947dee9e34dba33b589a2ed1a23ab1b8be8d6a0e3",
+                "uncompressed-sha256": "1826c7affd977a1ad4a522e0a530a05789b302908cf04b4fd9dfd1ce655e0538"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-live.ppc64le.iso",
-                "sha256": "ba87737875acc7837c7a91fbc49e31871dbb47e401caa0d7ca015e5c6f7842b7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-live.ppc64le.iso",
+                "sha256": "02af643bda773f851d90e65fd616ead9a7dd0d25c72ff02f9a976c8d8f1957da"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-live-kernel-ppc64le",
-                "sha256": "feebed6bbd23287feab35d19a133c8f02523e3065d34b24c6fb96d66d4f03883"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-live-kernel-ppc64le",
+                "sha256": "16985e088f70d06035d7bd058721b3206a6c4fafeb08109f3531712ec5415244"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-live-initramfs.ppc64le.img",
-                "sha256": "a5528266acbf81dec04b062cf05b4f99e247014029cbb11bfc3d2d31663d17ce"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-live-initramfs.ppc64le.img",
+                "sha256": "6ab101de291d144cfb4b1f1bbba496b6057f801c9e1fe3f5abf2251f9b6f5d08"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-live-rootfs.ppc64le.img",
-                "sha256": "38b01cc8705ae27a394ef02b18bad24997a4fb13498bf894a4ef86872e118b0f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-live-rootfs.ppc64le.img",
+                "sha256": "e59ce1c81e59b98a9aae56d747e3bf30a3a21f97e9b0883de5a54076b6476f1b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-metal.ppc64le.raw.gz",
-                "sha256": "f29344795fc1a884b5b6f2baf7a480b3943aa8e5d6bd6c9cef1b19eaa6acf7b6",
-                "uncompressed-sha256": "e789f8ab388c141f4c0795c63b47507393cdc01bab626389420841ba0e07d584"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-metal.ppc64le.raw.gz",
+                "sha256": "1ea550ce887ad87287e2ea280ab91bf2b91ecc62abe506fb1f83f0b2feef181f",
+                "uncompressed-sha256": "0d9ad433e3aceb125f2529233d5f833c096bcc290332548277d17ceb3c20a8d7"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "50b56c7a5f399ac169cef4c92e05ab53011381dbd2b4d4615161a2b7e037f180",
-                "uncompressed-sha256": "af2c48faa368fee53af1174a1930febc3954e2c0373610e19d3977b5af2b709a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "6c0288da3614ed207fcc6ebf607ba9400207fb51430587d680cd0fafa12d33f1",
+                "uncompressed-sha256": "7b5f4a28c564fed4d1ad76b2c34023ce7408db3959df40342aeb80e4245fbb71"
               }
             }
           }
         },
         "powervs": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-powervs.ppc64le.ova.gz",
-                "sha256": "dd593c426cc336c9aa210cb8e5a02c294025092da93fc1209b64880e5e8bac84",
-                "uncompressed-sha256": "37d5eafe019a4c905a7c12d569e8dffd74e7ab4d2a04f7d4114d1e1f78e8c350"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-powervs.ppc64le.ova.gz",
+                "sha256": "d492979397c81709b6046c826e82d54726cf78d499a55493c4b278afe1d61d82",
+                "uncompressed-sha256": "9b7a690bb02c622c2a792b1a58e6c557191ea4d0156a4e29509892360a73d70e"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/ppc64le/rhcos-412.86.202305030814-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "86d0b036aedbbff7c45187526f9a9c04ffea6457f76349f23b12accab3b8f43d",
-                "uncompressed-sha256": "cbf8079c708ca21f3b651807917c401e2e8cea2c46a2f2f73e2f080ede66653e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/ppc64le/rhcos-412.86.202306132230-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "0fa5ee5ff9ac6d71121e3b4f22f4e33d600f3be1d3f65dd1329d1a8d3fd0b98f",
+                "uncompressed-sha256": "1deead966482150626e0b273cb74dc388b6bd12297399fd9aba785eb4a1a6949"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "412.86.202305030814-0",
-              "object": "rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202306132230-0",
+              "object": "rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202305030814-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202306132230-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "9998d924b1a4f232415a0b0cd986ffa87d4a41c4c3d80d9eb51dd51ba04f8f9c",
-                "uncompressed-sha256": "8a7b7da8165abd0b69fb6474130fefb234d96069bb2d2dcf48ec456ff91745de"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "6f99d0d5fa222888fa09f90df5e5a90df9161c7ed1f4ad23ffaf1bf1b891bb65",
+                "uncompressed-sha256": "bcb4f9b354257065d7b56eabbab615fefd9c9dd683c63e0550b4269a04fcff7a"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-metal4k.s390x.raw.gz",
-                "sha256": "9a18d28e8ca4ee89309c8de8d1d92efabd6f5d7ebddca1d0c8b76f7da5dd3008",
-                "uncompressed-sha256": "990a301d245f92131b0e40ba7ab11ce089538457e288bf0e885b6434d7373411"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-metal4k.s390x.raw.gz",
+                "sha256": "aef7bc79f818eec20abed10169ac96379fe9c9fdebede68aa56cddc02b093051",
+                "uncompressed-sha256": "8a5eea277b7d8f2714e328249d2d19166ecc086dee42a7fd558f77d85d37454d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-live.s390x.iso",
-                "sha256": "0878469dbfd6b0b32effc2da6003143affd444244f370680bd7f72b2cf39582a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-live.s390x.iso",
+                "sha256": "a202d5a412a2abb2a8ac257663eb720e569b16603faa0a4e96ffcd39e61876f3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-live-kernel-s390x",
-                "sha256": "5cf743f077734a9dcb6c5a3ea8e958d78a7938f5dc8ea38e1cef05008a84d878"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-live-kernel-s390x",
+                "sha256": "c4be688b86a61d12b12c74450126cd9675df4a508f20911124c66818bc9704b8"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-live-initramfs.s390x.img",
-                "sha256": "4a91bb04d9193978a848caae2b085b68cebcf883801d1439289132b7b264b17b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-live-initramfs.s390x.img",
+                "sha256": "482e9ed3e22c8bcd23205fc806c21fa60d393070b4c05118ff73a797caaccec8"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-live-rootfs.s390x.img",
-                "sha256": "7fa84bc34ca72c870bdc0f660a42f6723ffb70ce1a9201e5d6deb8e154094a87"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-live-rootfs.s390x.img",
+                "sha256": "d5e46084e6e9e214929ff07add59e43a545dcce04edf0aea7170b70420ac107e"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-metal.s390x.raw.gz",
-                "sha256": "59ffe73f57dc9b7bc2c3846fd1339a4feb262a4594b0142736c2dffe0bb00d3a",
-                "uncompressed-sha256": "3f5fb808cc036eff394568613ebd6de7a0436448cbcedf642c9691f53c9f1ae7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-metal.s390x.raw.gz",
+                "sha256": "f1e29674500b597ad84e1e68f6c7ccdc90fb119168cdb1b61026db24baee321c",
+                "uncompressed-sha256": "a4bb84225199bfa051418bf89066c22c9ad0cc5f2bf4e638ddf24fbdac167c3a"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-openstack.s390x.qcow2.gz",
-                "sha256": "c30c16d412d00b8f3873b29fc78fefeaa58d325fef7de9f8edb674cd1428d6e3",
-                "uncompressed-sha256": "962f16a0b06d915d1eabf507d207f193744367525fdcbaafdaeda48c8c0c18cc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-openstack.s390x.qcow2.gz",
+                "sha256": "7d17186baf0f1863f6fc5fb7c0c064d03819e84926d60ef43d6fc504e09e0351",
+                "uncompressed-sha256": "2c4a96d15d5a206474feff12d03bc14ef898300e60bc9ece4a2eb884009bfcff"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-qemu.s390x.qcow2.gz",
-                "sha256": "82283e6c71f8b71be1d9156c0f0aabfd8fd44f9524f3b6da06b95054de3393f3",
-                "uncompressed-sha256": "f45d83ab3752b147e673e014c3f6713e55f4290b8f01d93951b60260d5bc054b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-qemu.s390x.qcow2.gz",
+                "sha256": "b65b33fb8a67c9d81ea819da11acddb5c36803bfdbc73a0d9ea8b2ba9e4b5e13",
+                "uncompressed-sha256": "f71a5cda797a199fc64bd8983a678f6bd9b918522f1248366489a62debe6e8bc"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/s390x/rhcos-412.86.202305030814-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "df74f47ec7e1594f2c6963609f04c544c8ec0d236433fbfed3f318c05f0c4624",
-                "uncompressed-sha256": "eea607afb82c1f5b1ba9e2d59bbc80baad21abcac282bb4f2c669f0432d19d1d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/s390x/rhcos-412.86.202306132230-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "f0dfe6b4da62afe75a35dff20a9104bde318cec28795f6b37c79c5259fdac3b7",
+                "uncompressed-sha256": "d963e7d198f725d0f9c3d70146f27942bd99e366d6c36b46f757ee4e050608a8"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "082b2e3ac63a9ffc88682c4d6af7736d7c3c7fe005223c63bcb2d33f857aa356",
-                "uncompressed-sha256": "08b8ce0f94a8e7d82fb6ab62294b0cab93dbca771d1f4a8cc5d6e5a97dc2f66e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "f2ce159c5abdb0ea37d7d1e432eebd39917bbac68d8c68a0808b5d2433e343f1",
+                "uncompressed-sha256": "351c5f7ad6454435f18785b15e50649ba1e427bdbf14ae5b38612142e3956aad"
               }
             }
           }
         },
         "aws": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-aws.x86_64.vmdk.gz",
-                "sha256": "b5173fbd4d72c86e4314a09a04cf87f894f36b4381436693fdfbf994b4c09f15",
-                "uncompressed-sha256": "7e04f5f951cab96ab91aeb4f3c84747b8833671e37b4586c6a6873ccb65924d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-aws.x86_64.vmdk.gz",
+                "sha256": "d5dafad4d767e680b2abeb13bcd22885f80588d237955d6084d7c501c89d110c",
+                "uncompressed-sha256": "48f8804866d4fc8e4306c301744103e5b158cbbd0283b23fdfa5f293e33082d0"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-azure.x86_64.vhd.gz",
-                "sha256": "983ba5787415e8b40e09aeab5c57545c07dcdff1c899a8eee2cc2a0045196b39",
-                "uncompressed-sha256": "e059e320db6b11e7ce77b9644c61b97b7b4ec9a4ebc4a2e6a5f912e125022102"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-azure.x86_64.vhd.gz",
+                "sha256": "e8403598ab52e8e89514fc3fa4c2be8baea3b0e2d4d1660a698eff8403cf1fe1",
+                "uncompressed-sha256": "a948afbe277d1f27eab9147f64d6840707ed9c819adf9d99d572c81c0b031cdc"
               }
             }
           }
         },
         "azurestack": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-azurestack.x86_64.vhd.gz",
-                "sha256": "29353636fb2ac6dd13dd117718ecad12e970d47160c9a6d413b744a7cd64ebcf",
-                "uncompressed-sha256": "b5db27427d6259d1d90a70d01c5f98a90749e91e732da2bcf4ffbedb5d1b9981"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-azurestack.x86_64.vhd.gz",
+                "sha256": "a633203d1e2d87f80530585025dbafad6292864f152d1f191deb9015393632a1",
+                "uncompressed-sha256": "31d0cffb324e934e3dfb489732dac55dcf217c16199d4b05ad8702a588b93010"
               }
             }
           }
         },
         "gcp": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-gcp.x86_64.tar.gz",
-                "sha256": "944cfdb3058e694ad2d09d8f517046556cc6872bda952ba4a31f487d35b212dc",
-                "uncompressed-sha256": "4f213bee63777770fe88fa12f5dd0402bc87f336305ec311039e0697b1898bdb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-gcp.x86_64.tar.gz",
+                "sha256": "71d4ae7dbfdc8f43a23c0d46e051c641e2f50a4c0e48517c47a5d7763cf0e455",
+                "uncompressed-sha256": "becda742fb323a1d500ed188f5d3996f54ef2b2a6762d2463155f81f6b97cabd"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "0e149b4d145b6474405bb898ceac73a88e06e01c42567a2f79babefeeaa5a9fe",
-                "uncompressed-sha256": "bb84c6fe219a7095dfe18b89bb804961c0bc60249da4bf376ce2073701f932e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "39a214651802e44991d1f0b9d61b1279e2fb11afaf67efc5608a7acdd73311fb",
+                "uncompressed-sha256": "1a06e7ae4f010e211f601dddc02817b7460d59145aeaa554998814dc009e9b21"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-metal4k.x86_64.raw.gz",
-                "sha256": "b92a94061c0d5e04d566dc0e7462e4ed7e450b7210890f0aef773e440ff1b77e",
-                "uncompressed-sha256": "3329cac2e727d3697d26c3ef7860bfc4aaca200067b62899360eddb3d9739770"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-metal4k.x86_64.raw.gz",
+                "sha256": "1d76e6445cc745528f221378c84814e53f63b498a16e70b4ae47add077ac9dfb",
+                "uncompressed-sha256": "4e5425cd8999b4e89e4c3e27247230dc19c3fd5280b5dcf1653712c7f5285d02"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-live.x86_64.iso",
-                "sha256": "da07c5be7e16c8fd254ffe60bbddb355834fe7ab0bd09e33df146da5a3203dde"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-live.x86_64.iso",
+                "sha256": "b4325231b117debb6b3290d094be874a4f9449248d0f833df3c2897922abd506"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-live-kernel-x86_64",
-                "sha256": "a8bef9cd5240db50d7fa56734f082411aff35c5ba689f7a1c0eb7b3e6aef677f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-live-kernel-x86_64",
+                "sha256": "734af7a980ace14296970b5fd635605dce3f3f93c4dfdd14b46de048338bec40"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-live-initramfs.x86_64.img",
-                "sha256": "151767175142b95d2a2baccf8d638d8b10af4840c0435f6d379e6da37d8d2b5d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-live-initramfs.x86_64.img",
+                "sha256": "91ef7c4f8adbdea7e00f452eed265dc7a9a3a9e1ee1d23802cdbfdc47735549b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-live-rootfs.x86_64.img",
-                "sha256": "fb0cf5cc840c79da08e3bea8a64dc76c0635861a2086dac6fd51a7e628b4eefa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-live-rootfs.x86_64.img",
+                "sha256": "d7ca9142317ac8857dc77dcfd104f4916dfc94bccfd1d1ceab67d8c556f22e38"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-metal.x86_64.raw.gz",
-                "sha256": "43b0248e303df7b85671c48830cf21800062feb2dce76f7a4089fe75776a9c08",
-                "uncompressed-sha256": "8fcb31b77896d0bfeafeb1e782dc33a848d25bf8e12284949d368aa8e5744043"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-metal.x86_64.raw.gz",
+                "sha256": "2002eeb916b6689ee38653419a83cb19b1f9145c3c5f75c685e24784e0b9cde5",
+                "uncompressed-sha256": "9f438b951cb2c943daa023870ebe165f1a92217ddcabda842f3d48926b517545"
               }
             }
           }
         },
         "nutanix": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-nutanix.x86_64.qcow2",
-                "sha256": "dfd1a09baa94621cf1a511084c06c01e8fb08b189745ad51fe38a0089fd5f6de"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-nutanix.x86_64.qcow2",
+                "sha256": "a0058a64d96c44519a6f8b9c63756fa465e3cd26ebcd328612a35fd54d5ef9ef"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-openstack.x86_64.qcow2.gz",
-                "sha256": "fcef7bec0aebdbde42e742bbc0efed3377ef0992f692fd501ce8aa27258e22ae",
-                "uncompressed-sha256": "f152651ce770bc6593889e7360c94767297ca784c1f2f2447b8a5fb91d342d39"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-openstack.x86_64.qcow2.gz",
+                "sha256": "94af58433e8da6fdf3efd7780868d31a125e2262410ec6646f41bba90775cfbc",
+                "uncompressed-sha256": "4f424253d5a116e8ab81a13c80d1abd222d39edeed95a3600eaf1fb1b745975d"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-qemu.x86_64.qcow2.gz",
-                "sha256": "d96caa2a78dc134f2068212a6ca8f171a036792c6afbc7a406c18c2978527585",
-                "uncompressed-sha256": "2403df724fa468cd52de5d16f08dea74b53ba167b1df1bb70c28cf55b7bfb058"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-qemu.x86_64.qcow2.gz",
+                "sha256": "99a0c1e0a5ad1285006cc17a65065b70319211a81a2c084507bde6df65526b39",
+                "uncompressed-sha256": "eb7e5c9b219bb55c0863a209175d2db36853ac0a19790bb2c422f69ede8c3723"
               }
             }
           }
         },
         "vmware": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202305030814-0/x86_64/rhcos-412.86.202305030814-0-vmware.x86_64.ova",
-                "sha256": "84451a1d5cd7d0a01d335c8d2814fe9e9d75f9b21ebe20303f7b3491ec257cba"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202306132230-0/x86_64/rhcos-412.86.202306132230-0-vmware.x86_64.ova",
+                "sha256": "9dbb6eefcce04027fc1220c0736623e03ded48bd4a635331a0ae551ce03e8a7f"
               }
             }
           }
@@ -619,249 +619,253 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-6we48itfxvy7duupsmio"
+              "release": "412.86.202306132230-0",
+              "image": "m-6we6j2upxs4d8xdbu32y"
             },
             "ap-northeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "m-mj7etr562erxaxe61c1v"
+              "release": "412.86.202306132230-0",
+              "image": "m-mj72vfp4griynbeeknz3"
             },
             "ap-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-a2ddzmggyfcbo0zzc43f"
+              "release": "412.86.202306132230-0",
+              "image": "m-a2d1zfc8rfwo63jna4ep"
             },
             "ap-southeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-t4nhze65r0kqjgvfdalq"
+              "release": "412.86.202306132230-0",
+              "image": "m-t4nfh3wm14wvubblnh4h"
             },
             "ap-southeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "m-p0wf5arwdm0bo0o9qk1q"
+              "release": "412.86.202306132230-0",
+              "image": "m-p0wiczw823xqokilz58p"
             },
             "ap-southeast-3": {
-              "release": "412.86.202305030814-0",
-              "image": "m-8pse59h8vl7ppu59btuw"
+              "release": "412.86.202306132230-0",
+              "image": "m-8ps7kflnjxigwpggkb5e"
             },
             "ap-southeast-5": {
-              "release": "412.86.202305030814-0",
-              "image": "m-k1ahlg0mqfhst5aedrnp"
+              "release": "412.86.202306132230-0",
+              "image": "m-k1a1kyq9ik91pjqbg5a3"
             },
             "ap-southeast-6": {
-              "release": "412.86.202305030814-0",
-              "image": "m-5ts7rnu95k4aztmysqn4"
+              "release": "412.86.202306132230-0",
+              "image": "m-5tsje7kh18v0ip2u0978"
             },
             "ap-southeast-7": {
-              "release": "412.86.202305030814-0",
-              "image": "m-0jo3mbfvg5ijqx0h2zry"
+              "release": "412.86.202306132230-0",
+              "image": "m-0joawe9khlws611f75ac"
             },
             "cn-beijing": {
-              "release": "412.86.202305030814-0",
-              "image": "m-2ze2z1shaair48gp8nuk"
+              "release": "412.86.202306132230-0",
+              "image": "m-2zeac9wdro5ivanymkpx"
             },
             "cn-chengdu": {
-              "release": "412.86.202305030814-0",
-              "image": "m-2vca4l24q16n5iftzpgo"
+              "release": "412.86.202306132230-0",
+              "image": "m-2vc3938cw1fv5fv8vtel"
             },
             "cn-fuzhou": {
-              "release": "412.86.202305030814-0",
-              "image": "m-gw03ypgot9ycxhrjnvkn"
+              "release": "412.86.202306132230-0",
+              "image": "m-gw0dwbgwsc2bx3bsyk03"
             },
             "cn-guangzhou": {
-              "release": "412.86.202305030814-0",
-              "image": "m-7xv39vi1i01kyisogy6p"
+              "release": "412.86.202306132230-0",
+              "image": "m-7xv6xadctb07g7g7jr3v"
             },
             "cn-hangzhou": {
-              "release": "412.86.202305030814-0",
-              "image": "m-bp1j1l05ijbfo2r0gnim"
+              "release": "412.86.202306132230-0",
+              "image": "m-bp1d84zkkrs8uxpucnio"
             },
             "cn-heyuan": {
-              "release": "412.86.202305030814-0",
-              "image": "m-f8z7gbq5uckgzanzcvoq"
+              "release": "412.86.202306132230-0",
+              "image": "m-f8zdz9xb90rt3m70weyd"
             },
             "cn-hongkong": {
-              "release": "412.86.202305030814-0",
-              "image": "m-j6c1p5gopm5zwhndtds8"
+              "release": "412.86.202306132230-0",
+              "image": "m-j6chcup3cdmuwx2h0cfq"
             },
             "cn-huhehaote": {
-              "release": "412.86.202305030814-0",
-              "image": "m-hp3arwss5bjg213crl60"
+              "release": "412.86.202306132230-0",
+              "image": "m-hp3add41svtis9037m4j"
             },
             "cn-nanjing": {
-              "release": "412.86.202305030814-0",
-              "image": "m-gc7gjy9pconu69jlqn8l"
+              "release": "412.86.202306132230-0",
+              "image": "m-gc75jtzknjy028tjksfd"
             },
             "cn-qingdao": {
-              "release": "412.86.202305030814-0",
-              "image": "m-m5ee7ekgpgmjm00ffgb5"
+              "release": "412.86.202306132230-0",
+              "image": "m-m5e4m7do3s12a9ph2w3p"
             },
             "cn-shanghai": {
-              "release": "412.86.202305030814-0",
-              "image": "m-uf6iqkx61lexvgqzp1iw"
+              "release": "412.86.202306132230-0",
+              "image": "m-uf60wqke3be83hqmdgum"
             },
             "cn-shenzhen": {
-              "release": "412.86.202305030814-0",
-              "image": "m-wz9492lnxeccbnog230l"
+              "release": "412.86.202306132230-0",
+              "image": "m-wz96pw3ankf6vu7qdmon"
             },
             "cn-wulanchabu": {
-              "release": "412.86.202305030814-0",
-              "image": "m-0jl0bwovjnd0asr5tjd3"
+              "release": "412.86.202306132230-0",
+              "image": "m-0jl81g9psnhmvhrd2iqj"
             },
             "cn-zhangjiakou": {
-              "release": "412.86.202305030814-0",
-              "image": "m-8vb5dtouzyojr9882012"
+              "release": "412.86.202306132230-0",
+              "image": "m-8vbbmwm1w6d1b2ob4cpq"
             },
             "eu-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-gw8dors7d26ytzryqu6w"
+              "release": "412.86.202306132230-0",
+              "image": "m-gw81x3ipsap6p6c19jsz"
             },
             "eu-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-d7oid17pqvtuyn8oj0ua"
+              "release": "412.86.202306132230-0",
+              "image": "m-d7ocyk9jl6pe5c79l40w"
+            },
+            "me-central-1": {
+              "release": "412.86.202306132230-0",
+              "image": "m-l4v480quy0kdshn4qp9v"
             },
             "me-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-eb31kvnda2wayjd1tshp"
+              "release": "412.86.202306132230-0",
+              "image": "m-eb3fxu5adk3dfp11zbiv"
             },
             "us-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-0xi4qbll39as4c1aolhg"
+              "release": "412.86.202306132230-0",
+              "image": "m-0xidhcyrfvd5imuivilr"
             },
             "us-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "m-rj9fxwgi5ru2m5mqroei"
+              "release": "412.86.202306132230-0",
+              "image": "m-rj9b4wcn8cqh8xfyby3u"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0948a99fa699103d0"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a21b3ac71edd1e0b"
             },
             "ap-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-098e58b615154d8e6"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0b4be6c13686b4b1b"
             },
             "ap-northeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-09ad3df5132191695"
+              "release": "412.86.202306132230-0",
+              "image": "ami-09958255d2f51fd1d"
             },
             "ap-northeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-08d4700134cfc1db2"
+              "release": "412.86.202306132230-0",
+              "image": "ami-067bef4157279b7c1"
             },
             "ap-northeast-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-079631f8957dcb842"
+              "release": "412.86.202306132230-0",
+              "image": "ami-00e038ac2ff8018ae"
             },
             "ap-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0c7fd1f4e4324c58d"
+              "release": "412.86.202306132230-0",
+              "image": "ami-02cf6f56b2109689a"
             },
             "ap-south-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0d0c187842a9a8708"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0d856f3be63b8f0e1"
             },
             "ap-southeast-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0b9eda681375fba2a"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a6eaba40efc33127"
             },
             "ap-southeast-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-075316accc8cf7950"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0b930c08b7f55148e"
             },
             "ap-southeast-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0a6c7a5604038c224"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0bc7b3959c508df3d"
             },
             "ap-southeast-4": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0428d17941fccb486"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0aea7fe00a04d0c81"
             },
             "ca-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0da07718221cf24a7"
+              "release": "412.86.202306132230-0",
+              "image": "ami-05e33216c59952858"
             },
             "eu-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-02a84ac3befad8793"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0875c396d98d54018"
             },
             "eu-central-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-05b23bc3c240b7acf"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0ab211986de76c3da"
             },
             "eu-north-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-03c9bcf474c4b6784"
+              "release": "412.86.202306132230-0",
+              "image": "ami-05331873a10422592"
             },
             "eu-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-045d751a71143972f"
+              "release": "412.86.202306132230-0",
+              "image": "ami-06464da2e98775bac"
             },
             "eu-south-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-03657078fb5870b9a"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0e1e165f35235b112"
             },
             "eu-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0621d1342d35e2653"
+              "release": "412.86.202306132230-0",
+              "image": "ami-049eb7be607aacfd0"
             },
             "eu-west-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0247f7b7c05e32a5a"
+              "release": "412.86.202306132230-0",
+              "image": "ami-079674eb173c169cb"
             },
             "eu-west-3": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0649c95aa69d7ef14"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0058d57781b7e4927"
             },
             "me-central-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0f7caeb48a70e9b85"
+              "release": "412.86.202306132230-0",
+              "image": "ami-088d9aae1af6bba4b"
             },
             "me-south-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0efefec801e9065ed"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0059bf30784d71aa4"
             },
             "sa-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-071150377fba5586b"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0e49f38d55097b4eb"
             },
             "us-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-0ccb85644951df8b3"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0bfd1a8e24b8f181f"
             },
             "us-east-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-04fa9a691e3fad742"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0b51136413570eba8"
             },
             "us-gov-east-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-06c66dc527ec78588"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0068b12def618a62d"
             },
             "us-gov-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-006b4b58e4b6ea862"
+              "release": "412.86.202306132230-0",
+              "image": "ami-0a3ffe2d1526a859d"
             },
             "us-west-1": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-004562d41f48a0a05"
+              "release": "412.86.202306132230-0",
+              "image": "ami-03260f4b6e0166045"
             },
             "us-west-2": {
-              "release": "412.86.202305030814-0",
-              "image": "ami-04ecfdca3a4142e8f"
+              "release": "412.86.202306132230-0",
+              "image": "ami-082b9bb7e4cff2b78"
             }
           }
         },
         "gcp": {
-          "release": "412.86.202305030814-0",
+          "release": "412.86.202306132230-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-412-86-202305030814-0-gcp-x86-64"
+          "name": "rhcos-412-86-202306132230-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202305030814-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202305030814-0-azure.x86_64.vhd"
+          "release": "412.86.202306132230-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202306132230-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.12 boot image metadata in the installer which includes the fixes for the following:

OCPBUGS-13942 - RHCOS 4.12.3 and 4.12.10 on Z display the "swiotlb
    buffer is full" message during KVM cluster Secure Execution (SE)
    install boots for the bootstrap, master, worker nodes, elongating
    boot durations

Changes generated with:
```
plume cosa2stream --target data/data/coreos/rhcos.json \
--distro rhcos --no-signatures \
--url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
x86_64=412.86.202306132230-0 \
aarch64=412.86.202306132230-0 \
s390x=412.86.202306132230-0 \
ppc64le=412.86.202306132230-0
```