### PR TITLE
CORS-2645: AWS Cross-Account Private Hosted Zone: Add Further Validations

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2289,7 +2289,7 @@ spec:
                       create the hosted zone on your behalf.
                     type: string
                   hostedZoneRole:
-                    description: HostedZoneRole is the ARN of a role to be assumed
+                    description: HostedZoneRole is the ARN of an IAM role to be assumed
                       when performing operations on the provided HostedZone. HostedZoneRole
                       can be used in a shared VPC scenario when the private hosted
                       zone belongs to a different account than the rest of the cluster

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -32,6 +32,12 @@ const (
 	// PermissionDeleteSharedInstanceRole is a set of permissions required when the installer destroys resources from a
 	// cluster with user-supplied IAM roles for instances.
 	PermissionDeleteSharedInstanceRole PermissionGroup = "delete-shared-instance-role"
+
+	// PermissionCreateHostedZone is a set of permissions required when the installer creates a route53 hosted zone.
+	PermissionCreateHostedZone PermissionGroup = "create-hosted-zone"
+
+	// PermissionDeleteHostedZone is a set of permissions required when the installer destroys a route53 hosted zone.
+	PermissionDeleteHostedZone PermissionGroup = "delete-hosted-zone"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -131,8 +137,6 @@ var permissions = map[PermissionGroup][]string{
 		// Route53 related perms
 		"route53:ChangeResourceRecordSets",
 		"route53:ChangeTagsForResource",
-		"route53:CreateHostedZone",
-		"route53:DeleteHostedZone",
 		"route53:GetChange",
 		"route53:GetHostedZone",
 		"route53:ListHostedZones",
@@ -232,6 +236,12 @@ var permissions = map[PermissionGroup][]string{
 	// Permissions required for deleting a cluster with shared instance roles
 	PermissionDeleteSharedInstanceRole: {
 		"iam:UntagRole",
+	},
+	PermissionCreateHostedZone: {
+		"route53:CreateHostedZone",
+	},
+	PermissionDeleteHostedZone: {
+		"route53:DeleteHostedZone",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -55,9 +55,14 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	case aws.Name:
 		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase}
 		usingExistingVPC := len(ic.Config.AWS.Subnets) != 0
+		usingExistingPrivateZone := len(ic.Config.AWS.HostedZone) != 0
 
 		if !usingExistingVPC {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking)
+		}
+
+		if !usingExistingPrivateZone {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateHostedZone)
 		}
 
 		// Add delete permissions for non-C2S installs.
@@ -67,6 +72,9 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedNetworking)
 			} else {
 				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteNetworking)
+			}
+			if !usingExistingPrivateZone {
+				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteHostedZone)
 			}
 		}
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -138,13 +137,10 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	}
 
 	if o.HostedZoneRole != "" {
-		creds := stscreds.NewCredentials(awsSession, o.HostedZoneRole)
+		cfg := awssession.GetR53ClientCfg(awsSession, o.HostedZoneRole)
 		// This client is specifically for finding route53 zones,
-		// so it needs to use the "global" us-east-1 region.
-		cfg := &aws.Config{
-			Credentials: creds,
-			Region:      aws.String(endpoints.UsEast1RegionID),
-		}
+		// so it needs to use the global us-east-1 region.
+		cfg.Region = aws.String(endpoints.UsEast1RegionID)
 		tagClients = append(tagClients, resourcegroupstaggingapi.New(awsSession, cfg))
 	}
 

--- a/pkg/destroy/aws/shared.go
+++ b/pkg/destroy/aws/shared.go
@@ -206,14 +206,13 @@ func (o *ClusterUninstaller) cleanSharedRoute53(ctx context.Context, session *se
 }
 
 func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, session *session.Session, id string, logger logrus.FieldLogger) error {
-	publicClient := route53.New(session)
-
 	// The private hosted zone (phz) may belong to a different account,
 	// in which case we need a separate client.
-	phzClient := publicClient
+	publicZoneClient := route53.New(session)
+	privateZoneClient := route53.New(session)
 	if o.HostedZoneRole != "" {
 		creds := stscreds.NewCredentials(session, o.HostedZoneRole)
-		phzClient = route53.New(session, &aws.Config{Credentials: creds})
+		privateZoneClient = route53.New(session, &aws.Config{Credentials: creds})
 		logger.Infof("Assuming role %s to destroy records in private hosted zone", o.HostedZoneRole)
 	}
 
@@ -223,13 +222,13 @@ func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, session 
 	}
 	dottedClusterDomain := o.ClusterDomain + "."
 
-	publicZoneID, err := findAncestorPublicRoute53(ctx, publicClient, dottedClusterDomain, logger)
+	publicZoneID, err := findAncestorPublicRoute53(ctx, publicZoneClient, dottedClusterDomain, logger)
 	if err != nil {
 		return err
 	}
 
 	var lastError error
-	err = phzClient.ListResourceRecordSetsPagesWithContext(
+	err = privateZoneClient.ListResourceRecordSetsPagesWithContext(
 		ctx,
 		&route53.ListResourceRecordSetsInput{HostedZoneId: aws.String(id)},
 		func(results *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
@@ -246,7 +245,7 @@ func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, session 
 				// delete any matching record sets in the public hosted zone
 				if publicZoneID != "" {
 					publicZoneLogger := logger.WithField("id", publicZoneID)
-					if err := deleteMatchingRecordSetInPublicZone(ctx, publicClient, publicZoneID, recordSet, publicZoneLogger); err != nil {
+					if err := deleteMatchingRecordSetInPublicZone(ctx, publicZoneClient, publicZoneID, recordSet, publicZoneLogger); err != nil {
 						if lastError != nil {
 							publicZoneLogger.Debug(lastError)
 						}
@@ -258,7 +257,7 @@ func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, session 
 					publicZoneLogger.WithFields(recordsetFields).Debug("Deleted from public zone")
 				}
 				// delete the record set
-				if err := deleteRoute53RecordSet(ctx, phzClient, id, recordSet, logger); err != nil {
+				if err := deleteRoute53RecordSet(ctx, privateZoneClient, id, recordSet, logger); err != nil {
 					if lastError != nil {
 						logger.Debug(lastError)
 					}

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -157,7 +157,7 @@ func Test_PrintFields(t *testing.T) {
       HostedZone is the ID of an existing hosted zone into which to add DNS records for the cluster's internal API. An existing hosted zone can only be used when also using existing subnets. The hosted zone must be associated with the VPC containing the subnets. Leave the hosted zone unset to have the installer create the hosted zone on your behalf.
 
     hostedZoneRole <string>
-      HostedZoneRole is the ARN of a role to be assumed when performing operations on the provided HostedZone. HostedZoneRole can be used in a shared VPC scenario when the private hosted zone belongs to a different account than the rest of the cluster resources. If HostedZoneRole is set, HostedZone must also be set.
+      HostedZoneRole is the ARN of an IAM role to be assumed when performing operations on the provided HostedZone. HostedZoneRole can be used in a shared VPC scenario when the private hosted zone belongs to a different account than the rest of the cluster resources. If HostedZoneRole is set, HostedZone must also be set.
 
     lbType <string>
       LBType is an optional field to specify a load balancer type. 

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -41,7 +41,7 @@ type Platform struct {
 	// +optional
 	HostedZone string `json:"hostedZone,omitempty"`
 
-	// HostedZoneRole is the ARN of a role to be assumed when performing
+	// HostedZoneRole is the ARN of an IAM role to be assumed when performing
 	// operations on the provided HostedZone. HostedZoneRole can be used
 	// in a shared VPC scenario when the private hosted zone belongs to a
 	// different account than the rest of the cluster resources.

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
@@ -26,7 +27,7 @@ var openshiftNamespaceRegex = regexp.MustCompile(`^([^/]*\.)?openshift.io/`)
 const userTagLimit = 25
 
 // ValidatePlatform checks that the specified platform is valid.
-func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
+func ValidatePlatform(p *aws.Platform, cm types.CredentialsMode, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if p.Region == "" {
@@ -39,8 +40,15 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 		}
 	}
 
-	if p.HostedZoneRole != "" && p.HostedZone == "" {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostedZoneRole"), p.HostedZoneRole, "may not specify a role to assume for hosted zone operations without also specifying a hosted zone"))
+	if p.HostedZoneRole != "" {
+		if p.HostedZone == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostedZoneRole"), p.HostedZoneRole, "may not specify a role to assume for hosted zone operations without also specifying a hosted zone"))
+		}
+
+		if cm != types.ManualCredentialsMode && cm != types.PassthroughCredentialsMode {
+			errMsg := "when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified"
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsMode"), errMsg))
+		}
 	}
 
 	allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
@@ -49,6 +57,7 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
+
 	return allErrs
 }
 

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
@@ -17,6 +18,7 @@ func TestValidatePlatform(t *testing.T) {
 		name     string
 		platform *aws.Platform
 		expected string
+		credMode types.CredentialsMode
 	}{
 		{
 			name: "minimal",
@@ -176,7 +178,7 @@ func TestValidatePlatform(t *testing.T) {
 			expected: fmt.Sprintf(`^\Qtest-path.userTags: Too many: %d: must have at most %d items`, userTagLimit+1, userTagLimit),
 		},
 		{
-			name: "hosted zone role without hosted zone",
+			name: "hosted zone role without hosted zone should error",
 			platform: &aws.Platform{
 				Region:         "us-east-1",
 				HostedZoneRole: "test-hosted-zone-role",
@@ -184,7 +186,8 @@ func TestValidatePlatform(t *testing.T) {
 			expected: `^test-path\.hostedZoneRole: Invalid value: "test-hosted-zone-role": may not specify a role to assume for hosted zone operations without also specifying a hosted zone$`,
 		},
 		{
-			name: "hosted zone & role",
+			name:     "valid hosted zone & role should not throw an error",
+			credMode: types.PassthroughCredentialsMode,
 			platform: &aws.Platform{
 				Region:         "us-east-1",
 				Subnets:        []string{"test-subnet"},
@@ -192,14 +195,24 @@ func TestValidatePlatform(t *testing.T) {
 				HostedZoneRole: "test-hosted-zone-role",
 			},
 		},
+		{
+			name: "hosted zone role without credential mode should error",
+			platform: &aws.Platform{
+				Region:         "us-east-1",
+				Subnets:        []string{"test-subnet"},
+				HostedZone:     "test-hosted-zone",
+				HostedZoneRole: "test-hosted-zone-role",
+			},
+			expected: `^test-path\.hostedZoneRole: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidatePlatform(tc.platform, field.NewPath("test-path")).ToAggregate()
+			err := ValidatePlatform(tc.platform, tc.credMode, field.NewPath("test-path")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Regexp(t, tc.expected, err)
+				assert.Regexp(t, tc.credMode, err)
 			}
 		})
 	}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -723,7 +723,9 @@ func validatePlatform(platform *types.Platform, usingAgentMethod bool, fldPath *
 		})
 	}
 	if platform.AWS != nil {
-		validate(aws.Name, platform.AWS, func(f *field.Path) field.ErrorList { return awsvalidation.ValidatePlatform(platform.AWS, f) })
+		validate(aws.Name, platform.AWS, func(f *field.Path) field.ErrorList {
+			return awsvalidation.ValidatePlatform(platform.AWS, c.CredentialsMode, f)
+		})
 	}
 	if platform.Azure != nil {
 		validate(azure.Name, platform.Azure, func(f *field.Path) field.ErrorList {


### PR DESCRIPTION
Adds/refines validations for the cross-account private hosted zone use case:

- do not allow mint credential mode
- do not require unnecessary permissions when using an existing hosted zone
- require sts:AssumeRole permissions  

Also includes some refactoring that did not make it into the previous PR.

ccing previous reviewers:
/cc @barbacbd @r4f4 @mtulio @sadasu 