### PR TITLE
PowerVS: Replace deprecated key_id attribute with name for ibm_pi_key resource

### DIFF
--- a/data/data/powervs/bootstrap/main.tf
+++ b/data/data/powervs/bootstrap/main.tf
@@ -20,7 +20,7 @@ module "vm" {
 
   resource_group        = var.powervs_resource_group
   cluster_id            = var.cluster_id
-  ssh_key_id            = var.cluster_key_id
+  ssh_key_name          = var.cluster_key_name
   cos_bucket_location   = var.powervs_vpc_region
   cos_instance_location = var.powervs_cos_instance_location
   cos_storage_class     = var.powervs_cos_storage_class

--- a/data/data/powervs/bootstrap/variables.tf
+++ b/data/data/powervs/bootstrap/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster_key_id" { type = string }
+variable "cluster_key_name" { type = string }
 variable "dhcp_network_id" { type = string }
 variable "dhcp_id" { type = string }
 variable "vpc_id" { type = string }

--- a/data/data/powervs/bootstrap/vm/main.tf
+++ b/data/data/powervs/bootstrap/vm/main.tf
@@ -56,7 +56,7 @@ resource "ibm_pi_instance" "bootstrap" {
     OBJECT_NAME = ibm_cos_bucket_object.ignition.key
     IAM_TOKEN   = data.ibm_iam_auth_token.iam_token.iam_access_token
   }))
-  pi_key_pair_name = var.ssh_key_id
+  pi_key_pair_name = var.ssh_key_name
   pi_health_status = "WARNING"
 }
 

--- a/data/data/powervs/bootstrap/vm/variables.tf
+++ b/data/data/powervs/bootstrap/vm/variables.tf
@@ -42,9 +42,9 @@ variable "cluster_id" {
   description = "The ID created by the installer to uniquely identify the created cluster."
 }
 
-variable "ssh_key_id" {
+variable "ssh_key_name" {
   type        = string
-  description = "The SSH Key ID."
+  description = "The SSH Key name."
 }
 
 variable "cos_instance_location" {

--- a/data/data/powervs/cluster/bootstrap/variables.tf
+++ b/data/data/powervs/cluster/bootstrap/variables.tf
@@ -48,9 +48,9 @@ variable "cluster_id" {
   description = "The ID created by the installer to uniquely identify the created cluster."
 }
 
-variable "ssh_key_id" {
+variable "ssh_key_name" {
   type        = string
-  description = "The SSH Key ID."
+  description = "The SSH Key name."
 }
 
 variable "cos_instance_location" {

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -73,7 +73,7 @@ module "master" {
   ignition            = var.ignition_master
   sys_type            = var.powervs_sys_type
   proc_type           = var.powervs_proc_type
-  ssh_key_id          = ibm_pi_key.cluster_key.key_id
+  ssh_key_name        = ibm_pi_key.cluster_key.name
   image_id            = ibm_pi_image.boot_image.image_id
   dhcp_network_id     = module.pi_network.dhcp_network_id
   dhcp_id             = module.pi_network.dhcp_id

--- a/data/data/powervs/cluster/master/main.tf
+++ b/data/data/powervs/cluster/master/main.tf
@@ -28,7 +28,7 @@ module "vm" {
   cloud_instance_id = var.cloud_instance_id
   resource_group    = var.resource_group
   ignition          = var.ignition
-  ssh_key_id        = var.ssh_key_id
+  ssh_key_name      = var.ssh_key_name
   dhcp_id           = var.dhcp_id
   dhcp_network_id   = var.dhcp_network_id
 }

--- a/data/data/powervs/cluster/master/variables.tf
+++ b/data/data/powervs/cluster/master/variables.tf
@@ -68,9 +68,9 @@ variable "ignition" {
   description = "The ignition file."
 }
 
-variable "ssh_key_id" {
+variable "ssh_key_name" {
   type        = string
-  description = "The SSH Key ID."
+  description = "The SSH Key Name."
 }
 
 variable "image_id" {

--- a/data/data/powervs/cluster/master/vm/main.tf
+++ b/data/data/powervs/cluster/master/vm/main.tf
@@ -12,7 +12,7 @@ resource "ibm_pi_instance" "master" {
     network_id = var.dhcp_network_id
   }
   pi_user_data     = base64encode(var.ignition)
-  pi_key_pair_name = var.ssh_key_id
+  pi_key_pair_name = var.ssh_key_name
   pi_health_status = "WARNING"
 }
 

--- a/data/data/powervs/cluster/master/vm/variables.tf
+++ b/data/data/powervs/cluster/master/vm/variables.tf
@@ -47,9 +47,9 @@ variable "cluster_id" {
   description = "The ID created by the installer to uniquely identify the created cluster."
 }
 
-variable "ssh_key_id" {
+variable "ssh_key_name" {
   type        = string
-  description = "The SSH Key ID."
+  description = "The SSH Key Name."
 }
 
 variable "dhcp_id" {

--- a/data/data/powervs/cluster/outputs.tf
+++ b/data/data/powervs/cluster/outputs.tf
@@ -2,8 +2,8 @@ output "control_plane_ips" {
   value = module.master.master_ips
 }
 
-output "cluster_key_id" {
-  value = ibm_pi_key.cluster_key.key_id
+output "cluster_key_name" {
+  value = ibm_pi_key.cluster_key.name
 }
 
 output "boot_image_id" {


### PR DESCRIPTION
The output from ibm_pi_key resource, namely key_id has been deprecated and replaced by name attribute.

JIRA: https://issues.redhat.com/browse/MULTIARCH-3675
Reference: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_key#attribute-reference