### PR TITLE
SPLAT-1094: warn users about deprecation of Alibaba Cloud

### DIFF
--- a/pkg/asset/installconfig/alibabacloud/alibabacloud.go
+++ b/pkg/asset/installconfig/alibabacloud/alibabacloud.go
@@ -63,6 +63,11 @@ func Platform() (*alibabacloud.Platform, error) {
 		return nil, err
 	}
 
+	err = bypassDeprecation()
+	if err != nil {
+		return nil, err
+	}
+
 	region, err := selectRegion(client)
 	if err != nil {
 		return nil, err
@@ -135,4 +140,24 @@ func selectRegion(client *Client) (string, error) {
 		return "", err
 	}
 	return selectedRegion, nil
+}
+
+func bypassDeprecation() error {
+	confirmationMsg := "DEPRECATED. Alibaba Cloud is deprecated and will be " +
+		"removed in a future OpenShift version. Would you still like to continue?"
+
+	shouldContinue := false
+	prompt := &survey.Confirm{
+		Message: confirmationMsg,
+	}
+	err := survey.AskOne(prompt, &shouldContinue)
+	if err != nil {
+		return err
+	}
+
+	if !shouldContinue {
+		return errors.Errorf("deprecated platform")
+	}
+
+	return nil
 }

--- a/pkg/types/alibabacloud/validation/platform.go
+++ b/pkg/types/alibabacloud/validation/platform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -13,6 +14,8 @@ import (
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *alibabacloud.Platform, n *types.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	logrus.Warn("Alibaba Cloud is deprecated and will be removed in a future OpenShift version. Please reach out to your Red Hat Support or Technical Account Manager for more information.")
 
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region must be specified"))


### PR DESCRIPTION
The Alibaba Cloud provider is soon going to be removed. This PR introduces a warning to users about the deprecation and a request for confirmation before to proceed with an installation in that provider. Doesn't affect the UX of other providers.

![alibaba-deprecation-msg](https://github.com/openshift/installer/assets/158611/37471e41-90ed-48a0-b4f8-afa2dd100ab5)
