### PR TITLE
OpenStack: enable IPv6 primary dual-stack cluster

### DIFF
--- a/data/data/openstack/masters/sg-master.tf
+++ b/data/data/openstack/masters/sg-master.tf
@@ -16,6 +16,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_mcs_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 22623
+  port_range_max    = 22623
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 # TODO(mandre) Explicitely enable egress
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
@@ -26,6 +38,19 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
   port_range_max = 0
   # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp_v6" {
+  count          = length(var.machine_v6_cidrs)
+  direction      = "ingress"
+  ethertype      = "IPv6"
+  protocol       = "ipv6-icmp"
+  port_range_min = 0
+  port_range_max = 0
+  # FIXME(mandre) AWS only allows ICMP from cidr_block
+  remote_ip_prefix  = "::/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -42,6 +67,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -54,6 +91,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -62,6 +111,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   port_range_min    = 53
   port_range_max    = 53
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -102,6 +163,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -114,6 +187,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -122,6 +207,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike" {
   port_range_min    = 500
   port_range_max    = 500
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 500
+  port_range_max    = 500
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -148,6 +245,16 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_esp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_esp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "esp"
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -156,6 +263,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
   port_range_min    = 6641
   port_range_max    = 6642
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 6641
+  port_range_max    = 6642
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -172,6 +291,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -180,6 +311,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp" {
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -196,6 +339,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler"
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 10259
+  port_range_max    = 10259
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller_manager" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -204,6 +359,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   port_range_min    = 10257
   port_range_max    = 10257
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller_manager_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 10257
+  port_range_max    = 10257
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -220,6 +387,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure"
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -228,6 +407,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
   port_range_min    = 2379
   port_range_max    = 2380
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 2379
+  port_range_max    = 2380
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -244,6 +435,19 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp_v6" {
+  count          = length(var.machine_v6_cidrs)
+  direction      = "ingress"
+  ethertype      = "IPv6"
+  protocol       = "tcp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "::/0"
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -256,6 +460,19 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp_v6" {
+  count          = length(var.machine_v6_cidrs)
+  direction      = "ingress"
+  ethertype      = "IPv6"
+  protocol       = "udp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "::/0"
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
   count     = length(var.machine_v4_cidrs)
   direction = "ingress"
@@ -264,6 +481,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
   # is disabled and it cannot identify a number by name.
   protocol          = "112"
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp_v6" {
+  count     = length(var.machine_v6_cidrs)
+  direction = "ingress"
+  ethertype = "IPv6"
+  # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
+  # is disabled and it cannot identify a number by name.
+  protocol          = "112"
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
@@ -324,6 +553,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_router" {
   port_range_min    = 1936
   port_range_max    = 1936
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_router_v6" {
+  count             = (var.masters_schedulable && length(var.machine_v6_cidrs) > 0) ? 1 : 0
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 1936
+  port_range_max    = 1936
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }

--- a/data/data/openstack/masters/sg-worker.tf
+++ b/data/data/openstack/masters/sg-worker.tf
@@ -18,6 +18,19 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp_v6" {
+  count          = length(var.machine_v6_cidrs)
+  direction      = "ingress"
+  ethertype      = "IPv6"
+  protocol       = "ipv6-icmp"
+  port_range_min = 0
+  port_range_max = 0
+  # FIXME(mandre) AWS only allows ICMP from cidr_block
+  remote_ip_prefix  = "::/0"
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -26,6 +39,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
   port_range_min    = 22
   port_range_max    = 22
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
@@ -88,6 +113,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_router" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_router_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 1936
+  port_range_max    = 1936
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -96,6 +133,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   port_range_min    = 4789
   port_range_max    = 4789
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
@@ -112,6 +161,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -120,6 +181,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike" {
   port_range_min    = 500
   port_range_max    = 500
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 500
+  port_range_max    = 500
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
@@ -146,6 +219,16 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_esp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_esp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "esp"
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -154,6 +237,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
@@ -170,6 +265,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -178,6 +285,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
   port_range_min    = 10250
   port_range_max    = 10250
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
@@ -194,6 +313,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   count             = length(var.machine_v4_cidrs)
   direction         = "ingress"
@@ -206,6 +337,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp_v6" {
+  count             = length(var.machine_v6_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "udp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
   count     = length(var.machine_v4_cidrs)
   direction = "ingress"
@@ -214,6 +357,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
   # is disabled and it cannot identify a number by name.
   protocol          = "112"
   remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp_v6" {
+  count     = length(var.machine_v6_cidrs)
+  direction = "ingress"
+  ethertype = "IPv6"
+  # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
+  # is disabled and it cannot identify a number by name.
+  protocol          = "112"
+  remote_ip_prefix  = element(var.machine_v6_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -265,6 +265,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 			// as well as on vSphere
 			allowV6Primary = true
 		case p.OpenStack != nil:
+			allowV6Primary = true
 		case p.Ovirt != nil:
 		case p.Nutanix != nil:
 		case p.None != nil:
@@ -535,9 +536,6 @@ func validateVIPsForPlatform(network *types.Networking, platform *types.Platform
 
 		allErrs = append(allErrs, validateAPIAndIngressVIPs(virtualIPs, newVIPsFields, false, false, network, fldPath.Child(nutanix.Name))...)
 	case platform.OpenStack != nil:
-		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.OpenStack.APIVIPs, fldPath.Child(openstack.Name, newVIPsFields.APIVIPs))...)
-		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.OpenStack.IngressVIPs, fldPath.Child(openstack.Name, newVIPsFields.IngressVIPs))...)
-
 		virtualIPs = vips{
 			API:     platform.OpenStack.APIVIPs,
 			Ingress: platform.OpenStack.IngressVIPs,


### PR DESCRIPTION
This commit removes the enforcement of the ordering IPv4 to api and ingress VIPs and adds IPv6 security group rules to allow ingress and egress traffic over IPv6.