### PR TITLE
Default dataStore is returned the name instead the inventoryPath

### DIFF
--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -271,7 +271,7 @@ func getDataStore(ctx context.Context, path string, finder Finder, client *vim25
 	}
 	if len(dataStores) == 1 {
 		logrus.Infof("Defaulting to only available datastore: %s", dataStores[0].InventoryPath)
-		return dataStores[0].Name(), nil
+		return dataStores[0].InventoryPath, nil
 	}
 
 	dataStoreChoices := make([]string, 0, len(dataStores))


### PR DESCRIPTION
On version 4.13 if only one dataStore is detected, it sets the configuration to the name instead to the path

Example:
```
% ./openshift-install create install-config --dir vmware-cluster-install                  
? SSH Public Key 
? Platform vsphere
? vCenter portal.vc.opentlc.com
? Username sandbox-mzfsr@vc.opentlc.com
? Password [? for help] ************
INFO Connecting to vCenter portal.vc.opentlc.com  
INFO Defaulting to only available datacenter: SDDC-Datacenter 
INFO Defaulting to only available cluster: /SDDC-Datacenter/host/Cluster-1 
INFO Defaulting to only available datastore: /SDDC-Datacenter/datastore/WorkloadDatastore 
 INFO Defaulting to only available network: segment-sandbox-mzfsr 
? Virtual IP Address for API 192.168.13.201
? Virtual IP Address for Ingress 192.168.13.202
? Base Domain dynamic.opentlc.com
? Cluster Name mzfsr
? Pull Secret [? for help]
After that, I've got en error like:
FATAL failed to fetch Install Config: failed to generate asset "Install Config": invalid install config: platform.vsphere.failureDomains.topology.datastore: Invalid value: "WorkloadDatastore": full path of datastore must be provided in format /<datacenter/datastore/<datastore>
```