### PR TITLE
Use the correct image name for agent-tui extraction

### DIFF
--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -73,7 +73,7 @@ func (a *AgentArtifacts) fetchAgentTuiFiles(releaseImage string, pullSecret stri
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {
-		extracted, err := release.ExtractFile("agent-installer-node-agent", srcFile)
+		extracted, err := release.ExtractFile("agent-installer-utils", srcFile)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Apparently the patch applied in PR [7185](https://github.com/openshift/installer/commit/9888256c5ce4a8b97061a136acd6a13d5a08b571#diff-4ba63e2557dcff8b6d8c998632f13630e766c5a4ccba4a77e41acc66ceaa692aL81) silently overwrote the image name (introduced in PR [7212](https://github.com/openshift/installer/commit/fa3a3141f18faf8970741e71de4f672e9606203d)).
It's currently working because the agent-tui related code has not yet been removed from `agent-installer-node-agent` (but it will be in the immediate future as part of the epic https://issues.redhat.com/browse/AGENT-508)