### PR TITLE
OCPBUGS-15238: GCP: ic: improve project validation

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -39,6 +39,7 @@ type API interface {
 	GetEnabledServices(ctx context.Context, project string) ([]string, error)
 	GetCredentials() *googleoauth.Credentials
 	GetProjectPermissions(ctx context.Context, project string, permissions []string) (sets.Set[string], error)
+	GetProjectByID(ctx context.Context, project string) (*cloudresourcemanager.Project, error)
 	ValidateServiceAccountHasPermissions(ctx context.Context, project string, permissions []string) (bool, error)
 }
 
@@ -260,6 +261,19 @@ func (c *Client) GetProjects(ctx context.Context) (map[string]string, error) {
 		return nil, err
 	}
 	return projects, nil
+}
+
+// GetProjectByID retrieves the project specified by its ID.
+func (c *Client) GetProjectByID(ctx context.Context, project string) (*cloudresourcemanager.Project, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	svc, err := c.getCloudResourceService(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc.Projects.Get(project).Context(ctx).Do()
 }
 
 // GetRegions gets the regions that are valid for the project. An error is returned when unsuccessful

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	google "golang.org/x/oauth2/google"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	compute "google.golang.org/api/compute/v1"
 	dns "google.golang.org/api/dns/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
@@ -125,6 +126,21 @@ func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*com
 func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockAPI)(nil).GetNetwork), ctx, network, project)
+}
+
+// GetProjectByID mocks base method.
+func (m *MockAPI) GetProjectByID(ctx context.Context, project string) (*cloudresourcemanager.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjectByID", ctx, project)
+	ret0, _ := ret[0].(*cloudresourcemanager.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjectByID indicates an expected call of GetProjectByID.
+func (mr *MockAPIMockRecorder) GetProjectByID(ctx, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectByID", reflect.TypeOf((*MockAPI)(nil).GetProjectByID), ctx, project)
 }
 
 // GetProjectPermissions mocks base method.

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -209,12 +209,12 @@ func validateProject(client API, ic *types.InstallConfig, fieldPath *field.Path)
 	allErrs := field.ErrorList{}
 
 	if ic.GCP.ProjectID != "" {
-		projects, err := client.GetProjects(context.TODO())
+		_, err := client.GetProjectByID(context.TODO(), ic.GCP.ProjectID)
 		if err != nil {
+			if IsNotFound(err) {
+				return append(allErrs, field.Invalid(fieldPath.Child("project"), ic.GCP.ProjectID, "invalid project ID"))
+			}
 			return append(allErrs, field.InternalError(fieldPath.Child("project"), err))
-		}
-		if _, found := projects[ic.GCP.ProjectID]; !found {
-			return append(allErrs, field.Invalid(fieldPath.Child("project"), ic.GCP.ProjectID, "invalid project ID"))
 		}
 	}
 
@@ -225,12 +225,12 @@ func validateNetworkProject(client API, ic *types.InstallConfig, fieldPath *fiel
 	allErrs := field.ErrorList{}
 
 	if ic.GCP.NetworkProjectID != "" {
-		projects, err := client.GetProjects(context.TODO())
+		_, err := client.GetProjectByID(context.TODO(), ic.GCP.NetworkProjectID)
 		if err != nil {
+			if IsNotFound(err) {
+				return append(allErrs, field.Invalid(fieldPath.Child("networkProjectID"), ic.GCP.NetworkProjectID, "invalid project ID"))
+			}
 			return append(allErrs, field.InternalError(fieldPath.Child("networkProjectID"), err))
-		}
-		if _, found := projects[ic.GCP.NetworkProjectID]; !found {
-			return append(allErrs, field.Invalid(fieldPath.Child("networkProjectID"), ic.GCP.NetworkProjectID, "invalid project ID"))
 		}
 	}
 


### PR DESCRIPTION
If we want to know if a project is valid, we can use the API to `Get` it directly, instead of `List`ing all projects and then filtering the one we want. Listing can be problematic for accounts with many associated projects.