### PR TITLE
Update hack/go-test.sh to golang 1.20

### DIFF
--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.18 \
+    docker.io/golang:1.20 \
     ./hack/go-test.sh "${@}"
 fi


### PR DESCRIPTION
It was previously set to 1.18 and needed to be bumped to match move to golang 1.20.