### PR TITLE
OCPBUGS-15041: Pass releaseImageMirror to assisted if mirror defined

### DIFF
--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -59,13 +59,13 @@ func TestIgnition_getTemplateData(t *testing.T) {
 			},
 		},
 	}
-	releaseImage := "quay.io:443/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64"
-	releaseImageMirror := "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+	releaseImage := clusterImageSet.Spec.ReleaseImage
+	releaseImageMirror := "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image:4.10.0-rc.1-x86_64"
 	infraEnvID := "random-infra-env-id"
 	haveMirrorConfig := true
 	publicContainerRegistries := "quay.io,registry.ci.openshift.org"
 
-	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, "x86_64")
+	releaseImageList, err := releaseImageList(releaseImageMirror, "x86_64")
 	assert.NoError(t, err)
 
 	arch := "x86_64"


### PR DESCRIPTION
In https://github.com/openshift/assisted-service/pull/5102 a new assisted-service validation was added to check DNS for the releaseImage. This fails in a disconnected environment when the releaseImage is the source.  If a mirror is defined, pass in the releaseImage set to the mirror.

Note that an assisted-service bug for the failure in a disconnected environment was created - https://issues.redhat.com/browse/MGMT-15056. If a fix for that merges we can revert this change.