### PR TITLE
OCPBUGS-12890: Add Ignition Stub for proxy data to GCP

### DIFF
--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -175,3 +175,9 @@ variable "gcp_create_bootstrap_sa" {
   default = false
   description = "Whether a service account should be created to sign the ignition URL."
 }
+
+variable "gcp_bootstrap_proxy_ignition_stub" {
+  type = string
+  default = ""
+  description = "Ignition stub for the bootstrap process containing proxy information."
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -471,6 +471,11 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
 
+		shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy("", installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
+		if err != nil {
+			return err
+		}
+
 		img := streamArch.Images.Gcp
 		if img == nil {
 			return fmt.Errorf("%s: No GCP build found", st.FormatPrefix(archName))
@@ -481,16 +486,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		imageURL := fmt.Sprintf("https://storage.googleapis.com/rhcos/rhcos/%s.tar.gz", img.Name)
 		data, err := gcptfvars.TFVars(
 			gcptfvars.TFVarsSources{
-				Auth:                auth,
-				MasterConfigs:       masterConfigs,
-				WorkerConfigs:       workerConfigs,
-				CreateFirewallRules: createFirewallRules,
-				ImageURI:            imageURL,
-				ImageLicenses:       installConfig.Config.GCP.Licenses,
-				PreexistingNetwork:  preexistingnetwork,
-				PublicZoneName:      publicZoneName,
-				PrivateZoneName:     privateZoneName,
-				PublishStrategy:     installConfig.Config.Publish,
+				Auth:                       auth,
+				MasterConfigs:              masterConfigs,
+				WorkerConfigs:              workerConfigs,
+				CreateFirewallRules:        createFirewallRules,
+				ImageURI:                   imageURL,
+				ImageLicenses:              installConfig.Config.GCP.Licenses,
+				PreexistingNetwork:         preexistingnetwork,
+				PublicZoneName:             publicZoneName,
+				PrivateZoneName:            privateZoneName,
+				PublishStrategy:            installConfig.Config.Publish,
+				BootstrapProxyIgnitionStub: string(shim),
 			},
 		)
 		if err != nil {

--- a/pkg/asset/ignition/bootstrap/bootstrap_ignition.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap_ignition.go
@@ -50,6 +50,14 @@ func GenerateIgnitionShimWithCertBundleAndProxy(bootstrapConfigURL string, userC
 		},
 	}
 
+	if bootstrapConfigURL != "" {
+		ign.Ignition.Config = igntypes.IgnitionConfig{
+			Replace: igntypes.Resource{
+				Source: ignutil.StrToPtr(bootstrapConfigURL),
+			},
+		}
+	}
+
 	carefs, err := parseCertificateBundle([]byte(userCA))
 	if err != nil {
 		return nil, err

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -22,46 +22,48 @@ type Auth struct {
 }
 
 type config struct {
-	Auth                      `json:",inline"`
-	Region                    string   `json:"gcp_region,omitempty"`
-	BootstrapInstanceType     string   `json:"gcp_bootstrap_instance_type,omitempty"`
-	CreateBootstrapSA         bool     `json:"gcp_create_bootstrap_sa"`
-	CreateFirewallRules       bool     `json:"gcp_create_firewall_rules"`
-	MasterInstanceType        string   `json:"gcp_master_instance_type,omitempty"`
-	MasterAvailabilityZones   []string `json:"gcp_master_availability_zones"`
-	ImageURI                  string   `json:"gcp_image_uri,omitempty"`
-	Image                     string   `json:"gcp_image,omitempty"`
-	PreexistingImage          bool     `json:"gcp_preexisting_image"`
-	InstanceServiceAccount    string   `json:"gcp_instance_service_account,omitempty"`
-	ImageLicenses             []string `json:"gcp_image_licenses,omitempty"`
-	VolumeType                string   `json:"gcp_master_root_volume_type"`
-	VolumeSize                int64    `json:"gcp_master_root_volume_size"`
-	VolumeKMSKeyLink          string   `json:"gcp_root_volume_kms_key_link"`
-	PublicZoneName            string   `json:"gcp_public_zone_name,omitempty"`
-	PrivateZoneName           string   `json:"gcp_private_zone_name,omitempty"`
-	PublishStrategy           string   `json:"gcp_publish_strategy,omitempty"`
-	PreexistingNetwork        bool     `json:"gcp_preexisting_network,omitempty"`
-	ClusterNetwork            string   `json:"gcp_cluster_network,omitempty"`
-	ControlPlaneSubnet        string   `json:"gcp_control_plane_subnet,omitempty"`
-	ComputeSubnet             string   `json:"gcp_compute_subnet,omitempty"`
-	ControlPlaneTags          []string `json:"gcp_control_plane_tags,omitempty"`
-	SecureBoot                string   `json:"gcp_master_secure_boot,omitempty"`
-	OnHostMaintenance         string   `json:"gcp_master_on_host_maintenance,omitempty"`
-	EnableConfidentialCompute string   `json:"gcp_master_confidential_compute,omitempty"`
+	Auth                       `json:",inline"`
+	Region                     string   `json:"gcp_region,omitempty"`
+	BootstrapInstanceType      string   `json:"gcp_bootstrap_instance_type,omitempty"`
+	CreateBootstrapSA          bool     `json:"gcp_create_bootstrap_sa"`
+	CreateFirewallRules        bool     `json:"gcp_create_firewall_rules"`
+	MasterInstanceType         string   `json:"gcp_master_instance_type,omitempty"`
+	MasterAvailabilityZones    []string `json:"gcp_master_availability_zones"`
+	ImageURI                   string   `json:"gcp_image_uri,omitempty"`
+	Image                      string   `json:"gcp_image,omitempty"`
+	PreexistingImage           bool     `json:"gcp_preexisting_image"`
+	InstanceServiceAccount     string   `json:"gcp_instance_service_account,omitempty"`
+	ImageLicenses              []string `json:"gcp_image_licenses,omitempty"`
+	VolumeType                 string   `json:"gcp_master_root_volume_type"`
+	VolumeSize                 int64    `json:"gcp_master_root_volume_size"`
+	VolumeKMSKeyLink           string   `json:"gcp_root_volume_kms_key_link"`
+	PublicZoneName             string   `json:"gcp_public_zone_name,omitempty"`
+	PrivateZoneName            string   `json:"gcp_private_zone_name,omitempty"`
+	PublishStrategy            string   `json:"gcp_publish_strategy,omitempty"`
+	PreexistingNetwork         bool     `json:"gcp_preexisting_network,omitempty"`
+	ClusterNetwork             string   `json:"gcp_cluster_network,omitempty"`
+	ControlPlaneSubnet         string   `json:"gcp_control_plane_subnet,omitempty"`
+	ComputeSubnet              string   `json:"gcp_compute_subnet,omitempty"`
+	ControlPlaneTags           []string `json:"gcp_control_plane_tags,omitempty"`
+	SecureBoot                 string   `json:"gcp_master_secure_boot,omitempty"`
+	OnHostMaintenance          string   `json:"gcp_master_on_host_maintenance,omitempty"`
+	EnableConfidentialCompute  string   `json:"gcp_master_confidential_compute,omitempty"`
+	BootstrapProxyIgnitionStub string   `json:"gcp_bootstrap_proxy_ignition_stub,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	Auth                Auth
-	CreateFirewallRules bool
-	ImageURI            string
-	ImageLicenses       []string
-	MasterConfigs       []*machineapi.GCPMachineProviderSpec
-	WorkerConfigs       []*machineapi.GCPMachineProviderSpec
-	PublicZoneName      string
-	PrivateZoneName     string
-	PublishStrategy     types.PublishingStrategy
-	PreexistingNetwork  bool
+	Auth                       Auth
+	CreateFirewallRules        bool
+	ImageURI                   string
+	ImageLicenses              []string
+	MasterConfigs              []*machineapi.GCPMachineProviderSpec
+	WorkerConfigs              []*machineapi.GCPMachineProviderSpec
+	PublicZoneName             string
+	PrivateZoneName            string
+	PublishStrategy            types.PublishingStrategy
+	PreexistingNetwork         bool
+	BootstrapProxyIgnitionStub string
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
@@ -74,28 +76,29 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	}
 
 	cfg := &config{
-		Auth:                      sources.Auth,
-		Region:                    masterConfig.Region,
-		BootstrapInstanceType:     masterConfig.MachineType,
-		CreateFirewallRules:       sources.CreateFirewallRules,
-		MasterInstanceType:        masterConfig.MachineType,
-		MasterAvailabilityZones:   masterAvailabilityZones,
-		VolumeType:                masterConfig.Disks[0].Type,
-		VolumeSize:                masterConfig.Disks[0].SizeGB,
-		ImageURI:                  sources.ImageURI,
-		Image:                     masterConfig.Disks[0].Image,
-		ImageLicenses:             sources.ImageLicenses,
-		PublicZoneName:            sources.PublicZoneName,
-		PrivateZoneName:           sources.PrivateZoneName,
-		PublishStrategy:           string(sources.PublishStrategy),
-		ClusterNetwork:            masterConfig.NetworkInterfaces[0].Network,
-		ControlPlaneSubnet:        masterConfig.NetworkInterfaces[0].Subnetwork,
-		ComputeSubnet:             workerConfig.NetworkInterfaces[0].Subnetwork,
-		PreexistingNetwork:        sources.PreexistingNetwork,
-		ControlPlaneTags:          masterConfig.Tags,
-		SecureBoot:                string(masterConfig.ShieldedInstanceConfig.SecureBoot),
-		EnableConfidentialCompute: string(masterConfig.ConfidentialCompute),
-		OnHostMaintenance:         string(masterConfig.OnHostMaintenance),
+		Auth:                       sources.Auth,
+		Region:                     masterConfig.Region,
+		BootstrapInstanceType:      masterConfig.MachineType,
+		CreateFirewallRules:        sources.CreateFirewallRules,
+		MasterInstanceType:         masterConfig.MachineType,
+		MasterAvailabilityZones:    masterAvailabilityZones,
+		VolumeType:                 masterConfig.Disks[0].Type,
+		VolumeSize:                 masterConfig.Disks[0].SizeGB,
+		ImageURI:                   sources.ImageURI,
+		Image:                      masterConfig.Disks[0].Image,
+		ImageLicenses:              sources.ImageLicenses,
+		PublicZoneName:             sources.PublicZoneName,
+		PrivateZoneName:            sources.PrivateZoneName,
+		PublishStrategy:            string(sources.PublishStrategy),
+		ClusterNetwork:             masterConfig.NetworkInterfaces[0].Network,
+		ControlPlaneSubnet:         masterConfig.NetworkInterfaces[0].Subnetwork,
+		ComputeSubnet:              workerConfig.NetworkInterfaces[0].Subnetwork,
+		PreexistingNetwork:         sources.PreexistingNetwork,
+		ControlPlaneTags:           masterConfig.Tags,
+		SecureBoot:                 string(masterConfig.ShieldedInstanceConfig.SecureBoot),
+		EnableConfidentialCompute:  string(masterConfig.ConfidentialCompute),
+		OnHostMaintenance:          string(masterConfig.OnHostMaintenance),
+		BootstrapProxyIgnitionStub: sources.BootstrapProxyIgnitionStub,
 	}
 
 	cfg.PreexistingImage = true


### PR DESCRIPTION
** bootstrap process was missing proxy data in the ignition file. Create a a proxy stub and merge the new ignition file with the original file in terraform.