### PR TITLE
CORS-2658: azure: multi-zonal NAT gateways support 

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -145,7 +145,7 @@ resource "azurerm_network_interface" "bootstrap" {
     content {
       primary                       = ip_configuration.value.primary
       name                          = ip_configuration.value.name
-      subnet_id                     = var.master_subnet_id
+      subnet_id                     = var.master_subnet_id[0]
       private_ip_address_version    = ip_configuration.value.ip_address_version
       private_ip_address_allocation = "Dynamic"
       public_ip_address_id          = ip_configuration.value.public_ip_id
@@ -179,7 +179,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "internal_
   count = var.use_ipv4 ? 1 : 0
 
   network_interface_id    = azurerm_network_interface.bootstrap.id
-  backend_address_pool_id = var.ilb_backend_pool_v4_id
+  backend_address_pool_id = var.ilb_backend_pool_v4_id[0]
   ip_configuration_name   = local.bootstrap_nic_ip_v4_configuration_name
 }
 
@@ -187,7 +187,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "internal_
   count = var.use_ipv6 ? 1 : 0
 
   network_interface_id    = azurerm_network_interface.bootstrap.id
-  backend_address_pool_id = var.ilb_backend_pool_v6_id
+  backend_address_pool_id = var.ilb_backend_pool_v6_id[0]
   ip_configuration_name   = local.bootstrap_nic_ip_v6_configuration_name
 }
 

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -11,19 +11,19 @@ variable "elb_backend_pool_v6_id" {
 }
 
 variable "ilb_backend_pool_v4_id" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "The internal load balancer bakend pool id. used to attach the bootstrap NIC"
 }
 
 variable "ilb_backend_pool_v6_id" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "The internal load balancer bakend pool id for ipv6. used to attach the bootstrap NIC"
 }
 
 variable "master_subnet_id" {
-  type        = string
+  type        = list(string)
   description = "The subnet ID for the bootstrap node."
 }
 

--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -32,7 +32,7 @@ resource "azurerm_private_dns_a_record" "apiint_internal" {
   zone_name           = azurerm_private_dns_zone.private.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  records             = [var.internal_lb_ipaddress_v4]
+  records             = var.internal_lb_ipaddress_v4
   tags                = var.azure_extra_tags
 }
 
@@ -43,7 +43,7 @@ resource "azurerm_private_dns_aaaa_record" "apiint_internal_v6" {
   zone_name           = azurerm_private_dns_zone.private.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  records             = [var.internal_lb_ipaddress_v6]
+  records             = var.internal_lb_ipaddress_v6
   tags                = var.azure_extra_tags
 }
 
@@ -54,7 +54,7 @@ resource "azurerm_private_dns_a_record" "api_internal" {
   zone_name           = azurerm_private_dns_zone.private.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  records             = [var.internal_lb_ipaddress_v4]
+  records             = var.internal_lb_ipaddress_v4
   tags                = var.azure_extra_tags
 }
 
@@ -65,7 +65,7 @@ resource "azurerm_private_dns_aaaa_record" "api_internal_v6" {
   zone_name           = azurerm_private_dns_zone.private.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  records             = [var.internal_lb_ipaddress_v6]
+  records             = var.internal_lb_ipaddress_v6
   tags                = var.azure_extra_tags
 }
 

--- a/data/data/azure/cluster/dns/variables.tf
+++ b/data/data/azure/cluster/dns/variables.tf
@@ -43,12 +43,12 @@ variable "external_lb_fqdn_v6" {
 
 variable "internal_lb_ipaddress_v4" {
   description = "External API's LB IP v4 address"
-  type = string
+  type = list(string)
 }
 
 variable "internal_lb_ipaddress_v6" {
   description = "External API's LB IP v6 address"
-  type = string
+  type = list(string)
 }
 
 variable "virtual_network_id" {

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -47,7 +47,6 @@ module "master" {
   vm_image_offer             = var.azure_marketplace_image_offer
   vm_image_sku               = var.azure_marketplace_image_sku
   vm_image_version           = var.azure_marketplace_image_version
-  master_subnet_zone_map     = var.master_subnet_zone_map
 
   security_encryption_type            = var.azure_master_security_encryption_type
   secure_vm_disk_encryption_set_id    = var.azure_master_secure_vm_disk_encryption_set_id

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -47,6 +47,7 @@ module "master" {
   vm_image_offer             = var.azure_marketplace_image_offer
   vm_image_sku               = var.azure_marketplace_image_sku
   vm_image_version           = var.azure_marketplace_image_version
+  master_subnet_zone_map     = var.master_subnet_zone_map
 
   security_encryption_type            = var.azure_master_security_encryption_type
   secure_vm_disk_encryption_set_id    = var.azure_master_secure_vm_disk_encryption_set_id

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -90,7 +90,7 @@ resource "azurerm_linux_virtual_machine" "master" {
   name     = "${var.cluster_id}-master-${count.index}"
   location = var.region
   // The VM zone has to be the same as the subnet's it is associated with when using NAT gateway
-  zone                  = var.outbound_type == "NatGateway" ? var.master_subnet_zone_map[azurerm_network_interface.master[count.index].ip_configuration[0].subnet_id] : var.availability_zones[count.index] != "" ? var.availability_zones[count.index] : null
+  zone                  = var.availability_zones[count.index] != "" ? var.availability_zones[count.index] : null
   resource_group_name   = var.resource_group_name
   network_interface_ids = [element(azurerm_network_interface.master.*.id, count.index)]
   size                  = var.vm_size

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -80,11 +80,11 @@ variable "elb_backend_pool_v6_id" {
 }
 
 variable "ilb_backend_pool_v4_id" {
-  type = string
+  type = list(string)
 }
 
 variable "ilb_backend_pool_v6_id" {
-  type = string
+  type = list(string)
 }
 
 variable "ignition_master" {
@@ -98,8 +98,8 @@ variable "kubeconfig_content" {
 }
 
 variable "subnet_id" {
-  type        = string
-  description = "The subnet to attach the masters to."
+  type        = list(string)
+  description = "The subnets to attach the masters to."
 }
 
 variable "os_volume_type" {
@@ -206,4 +206,9 @@ variable "virtualized_trusted_platform_module" {
   type = string
   default = ""
   description = "Defines whether vTPM should be enabled on the virtual machine."
+}
+
+variable "master_subnet_zone_map" {
+  type = map
+  description = "Mapping of subnet ID and its availability zone"
 }

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -207,8 +207,3 @@ variable "virtualized_trusted_platform_module" {
   default = ""
   description = "Defines whether vTPM should be enabled on the virtual machine."
 }
-
-variable "master_subnet_zone_map" {
-  type = map
-  description = "Mapping of subnet ID and its availability zone"
-}

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -11,13 +11,13 @@ variable "elb_backend_pool_v6_id" {
 }
 
 variable "ilb_backend_pool_v4_id" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "The internal load balancer bakend pool id. used to attach the bootstrap NIC"
 }
 
 variable "ilb_backend_pool_v6_id" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "The internal load balancer bakend pool id for ipv6. used to attach the bootstrap NIC"
 }
@@ -33,12 +33,12 @@ variable "public_lb_pip_v6_fqdn" {
 }
 
 variable "internal_lb_ip_v4_address" {
-  type    = string
+  type    = list(string)
   default = null
 }
 
 variable "internal_lb_ip_v6_address" {
-  type    = string
+  type    = list(string)
   default = null
 }
 
@@ -48,7 +48,7 @@ variable "virtual_network_id" {
 }
 
 variable "master_subnet_id" {
-  type        = string
+  type        = list(string)
   description = "The subnet ID for the bootstrap node."
 }
 
@@ -86,4 +86,9 @@ completely and therefore the `vnet/public-lb.tf`
 conditional need to be recreated. See
 https://github.com/hashicorp/terraform/issues/12570
 EOF
+}
+
+variable "master_subnet_zone_map" {
+  type = map
+  description = "Mapping of subnet ID and its availability zone"
 }

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -87,8 +87,3 @@ conditional need to be recreated. See
 https://github.com/hashicorp/terraform/issues/12570
 EOF
 }
-
-variable "master_subnet_zone_map" {
-  type = map
-  description = "Mapping of subnet ID and its availability zone"
-}

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -283,3 +283,9 @@ variable "azure_master_virtualized_trusted_platform_module" {
   description = "Defines whether the instance should have vTPM enabled."
   default     = ""
 }
+
+variable "azure_worker_availability_zones" {
+  type        = list(string)
+  description = "The availability zones in which to create the workers. The length of this list must match worker_count."
+  default     = []
+}

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -166,13 +166,13 @@ variable "azure_virtual_network" {
 }
 
 variable "azure_control_plane_subnet" {
-  type        = string
-  description = "The name of the subnet for the control plane, either existing or to be created."
+  type        = list(string)
+  description = "The name of the subnets for the control plane, either existing or to be created."
 }
 
 variable "azure_compute_subnet" {
-  type        = string
-  description = "The name of the subnet for worker nodes, either existing or to be created"
+  type        = list(string)
+  description = "The name of the subnets for worker nodes, either existing or to be created"
 }
 
 variable "azure_private" {

--- a/data/data/azure/vnet/common.tf
+++ b/data/data/azure/vnet/common.tf
@@ -6,7 +6,7 @@ data "azurerm_subnet" "preexisting_master_subnet" {
 
   resource_group_name  = var.azure_network_resource_group_name
   virtual_network_name = var.azure_virtual_network
-  name                 = var.azure_control_plane_subnet
+  name                 = var.azure_control_plane_subnet[0]
 }
 
 data "azurerm_subnet" "preexisting_worker_subnet" {
@@ -14,7 +14,7 @@ data "azurerm_subnet" "preexisting_worker_subnet" {
 
   resource_group_name  = var.azure_network_resource_group_name
   virtual_network_name = var.azure_virtual_network
-  name                 = var.azure_compute_subnet
+  name                 = var.azure_compute_subnet[0]
 }
 
 data "azurerm_virtual_network" "preexisting_virtual_network" {
@@ -26,15 +26,21 @@ data "azurerm_virtual_network" "preexisting_virtual_network" {
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  master_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 0) : null  #master subnet is a smaller subnet within the vnet. i.e from /16 to /17
-  master_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 0) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  subnet_count = var.azure_outbound_routing_type == "NatGateway" ? max(length(var.azure_master_availability_zones), 1) : 1
 
-  worker_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 1) : null  #node subnet is a smaller subnet within the vnet. i.e from /16 to /17
-  worker_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 1) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  master_subnet_cidr_v4       = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 0) : null  #master subnet is a smaller subnet within the vnet. i.e from /16 to /17
+  master_subnet_cidr_v6       = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 0) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  master_subnet_cidr_v4_zonal = [for i in range(local.subnet_count) : cidrsubnet(local.master_subnet_cidr_v4, ceil(log(local.subnet_count, 2)), i)]
 
-  master_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[0].id : azurerm_subnet.master_subnet[0].id
-  worker_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[0].id : azurerm_subnet.worker_subnet[0].id
+  worker_subnet_cidr_v4       = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 1) : null  #node subnet is a smaller subnet within the vnet. i.e from /16 to /17
+  worker_subnet_cidr_v6       = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 1) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  worker_subnet_cidr_v4_zonal = [for i in range(local.subnet_count) : cidrsubnet(local.worker_subnet_cidr_v4, ceil(log(local.subnet_count, 2)), i)]
+
+  master_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[*].id : azurerm_subnet.master_subnet[*].id
+  worker_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[*].id : azurerm_subnet.worker_subnet[*].id
 
   virtual_network    = var.azure_preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].name : azurerm_virtual_network.cluster_vnet[0].name
   virtual_network_id = var.azure_preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].id : azurerm_virtual_network.cluster_vnet[0].id
+
+  master_subnet_zone_map = { for i in range(local.subnet_count) : local.master_subnet_id[i] => element(var.azure_master_availability_zones, i) }
 }

--- a/data/data/azure/vnet/common.tf
+++ b/data/data/azure/vnet/common.tf
@@ -26,21 +26,24 @@ data "azurerm_virtual_network" "preexisting_virtual_network" {
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  subnet_count = var.azure_outbound_routing_type == "NatGateway" ? max(length(var.azure_master_availability_zones), 1) : 1
+  cluster_zones     = distinct(compact(concat(var.azure_master_availability_zones, var.azure_worker_availability_zones)))
+  nat_gateway_count = var.azure_outbound_routing_type == "NatGateway" ? max(length(local.cluster_zones), 1) : 0
 
+  master_zones                = distinct(compact(var.azure_master_availability_zones))
+  master_subnet_count         = var.azure_outbound_routing_type == "NatGateway" ? max(length(local.master_zones), 1) : 1
   master_subnet_cidr_v4       = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 0) : null  #master subnet is a smaller subnet within the vnet. i.e from /16 to /17
   master_subnet_cidr_v6       = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 0) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
-  master_subnet_cidr_v4_zonal = [for i in range(local.subnet_count) : cidrsubnet(local.master_subnet_cidr_v4, ceil(log(local.subnet_count, 2)), i)]
+  master_subnet_cidr_v4_zonal = [for i in range(local.master_subnet_count) : cidrsubnet(local.master_subnet_cidr_v4, ceil(log(local.master_subnet_count, 2)), i)]
 
+  worker_zones                = distinct(compact(var.azure_worker_availability_zones))
+  worker_subnet_count         = var.azure_outbound_routing_type == "NatGateway" ? max(length(local.worker_zones), 1) : 1
   worker_subnet_cidr_v4       = var.use_ipv4 ? cidrsubnet(var.machine_v4_cidrs[0], 1, 1) : null  #node subnet is a smaller subnet within the vnet. i.e from /16 to /17
   worker_subnet_cidr_v6       = var.use_ipv6 ? cidrsubnet(var.machine_v6_cidrs[0], 16, 1) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
-  worker_subnet_cidr_v4_zonal = [for i in range(local.subnet_count) : cidrsubnet(local.worker_subnet_cidr_v4, ceil(log(local.subnet_count, 2)), i)]
+  worker_subnet_cidr_v4_zonal = [for i in range(local.worker_subnet_count) : cidrsubnet(local.worker_subnet_cidr_v4, ceil(log(local.worker_subnet_count, 2)), i)]
 
   master_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[*].id : azurerm_subnet.master_subnet[*].id
   worker_subnet_id = var.azure_preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[*].id : azurerm_subnet.worker_subnet[*].id
 
   virtual_network    = var.azure_preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].name : azurerm_virtual_network.cluster_vnet[0].name
   virtual_network_id = var.azure_preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].id : azurerm_virtual_network.cluster_vnet[0].id
-
-  master_subnet_zone_map = { for i in range(local.subnet_count) : local.master_subnet_id[i] => element(var.azure_master_availability_zones, i) }
 }

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -1,6 +1,22 @@
 locals {
   internal_lb_frontend_ip_v4_configuration_name = "internal-lb-ip-v4"
   internal_lb_frontend_ip_v6_configuration_name = "internal-lb-ip-v6"
+  internal_lb_frontend_ip_v4_configuration = [for idx in range(length(local.master_subnet_id)) : {
+    name : "${local.internal_lb_frontend_ip_v4_configuration_name}-${idx}",
+    ipv6 : false,
+    include : var.use_ipv4,
+    subnet_id : local.master_subnet_id[idx]
+    private_ip_address : null
+    zones : var.azure_outbound_routing_type == "NatGateway" ? [local.master_subnet_zone_map[local.master_subnet_id[idx]]] : null
+  }]
+  internal_lb_frontend_ip_v6_configuration = [for idx in range(length(local.master_subnet_id)) : {
+    name : "${local.internal_lb_frontend_ip_v6_configuration_name}-${idx}",
+    ipv6 : true,
+    include : var.use_ipv6,
+    subnet_id : local.master_subnet_id[idx]
+    private_ip_address : var.use_ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2 - idx) : null
+    zones : var.azure_outbound_routing_type == "NatGateway" ? [local.master_subnet_zone_map[local.master_subnet_id[idx]]] : null
+  }]
 }
 
 resource "azurerm_lb" "internal" {
@@ -10,24 +26,21 @@ resource "azurerm_lb" "internal" {
   location            = var.azure_region
 
   dynamic "frontend_ip_configuration" {
-    for_each = [for ip in [
-      { name : local.internal_lb_frontend_ip_v4_configuration_name, ipv6 : false, include : var.use_ipv4 },
-      { name : local.internal_lb_frontend_ip_v6_configuration_name, ipv6 : true, include : var.use_ipv6 },
-      ] : {
-      name : ip.name
-      ipv6 : ip.ipv6
-      include : ip.include
-      } if ip.include
+    for_each = [for ip in flatten([
+      local.internal_lb_frontend_ip_v4_configuration,
+      local.internal_lb_frontend_ip_v6_configuration,
+      ]) : ip if ip.include
     ]
 
     content {
       name                       = frontend_ip_configuration.value.name
-      subnet_id                  = local.master_subnet_id
+      subnet_id                  = frontend_ip_configuration.value.subnet_id
       private_ip_address_version = frontend_ip_configuration.value.ipv6 ? "IPv6" : "IPv4"
       # WORKAROUND: Allocate a high ipv6 internal LB address to avoid the race with NIC allocation (a master and the LB
       #   were being assigned the same IP dynamically). Issue is being tracked as a support ticket to Azure.
       private_ip_address_allocation = frontend_ip_configuration.value.ipv6 ? "Static" : "Dynamic"
-      private_ip_address            = frontend_ip_configuration.value.ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2) : null
+      private_ip_address            = frontend_ip_configuration.value.private_ip_address
+      zones                         = frontend_ip_configuration.value.zones
     }
   }
 
@@ -35,29 +48,31 @@ resource "azurerm_lb" "internal" {
 }
 
 resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v4" {
-  count = var.use_ipv4 ? 1 : 0
+  count = var.use_ipv4 ? length(local.internal_lb_frontend_ip_v4_configuration) : 0
 
   loadbalancer_id = azurerm_lb.internal.id
-  name            = var.cluster_id
+  // WORKAROUND: the cloud provider is not happy when we change the name for private clusters
+  name = count.index > 0 ? "${var.cluster_id}-${count.index}" : "${var.cluster_id}"
 }
 
 resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v6" {
-  count = var.use_ipv6 ? 1 : 0
+  count = var.use_ipv6 ? length(local.internal_lb_frontend_ip_v6_configuration) : 0
 
   loadbalancer_id = azurerm_lb.internal.id
-  name            = "${var.cluster_id}-IPv6"
+  // WORKAROUND: the cloud provider is not happy when we change the name for private clusters
+  name = count.index > 0 ? "${var.cluster_id}-IPv6-${count.index}" : "${var.cluster_id}-IPv6"
 }
 
 resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v4" {
-  count = var.use_ipv4 ? 1 : 0
+  count = var.use_ipv4 ? length(local.internal_lb_frontend_ip_v4_configuration) : 0
 
-  name                           = "api-internal-v4"
+  name                           = "api-internal-v4-${count.index}"
   protocol                       = "Tcp"
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id]
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[count.index].id]
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 6443
   backend_port                   = 6443
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration[count.index].name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
@@ -65,15 +80,15 @@ resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v4" {
 }
 
 resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v6" {
-  count = var.use_ipv6 ? 1 : 0
+  count = var.use_ipv6 ? length(local.internal_lb_frontend_ip_v6_configuration) : 0
 
-  name                           = "api-internal-v6"
+  name                           = "api-internal-v6-${count.index}"
   protocol                       = "Tcp"
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id]
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[count.index].id]
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 6443
   backend_port                   = 6443
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration[count.index].name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
@@ -81,15 +96,15 @@ resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v6" {
 }
 
 resource "azurerm_lb_rule" "internal_lb_rule_sint_v4" {
-  count = var.use_ipv4 ? 1 : 0
+  count = var.use_ipv4 ? length(local.internal_lb_frontend_ip_v4_configuration) : 0
 
-  name                           = "sint-v4"
+  name                           = "sint-v4-${count.index}"
   protocol                       = "Tcp"
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id]
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[count.index].id]
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 22623
   backend_port                   = 22623
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration[count.index].name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
@@ -97,15 +112,15 @@ resource "azurerm_lb_rule" "internal_lb_rule_sint_v4" {
 }
 
 resource "azurerm_lb_rule" "internal_lb_rule_sint_v6" {
-  count = var.use_ipv6 ? 1 : 0
+  count = var.use_ipv6 ? length(local.internal_lb_frontend_ip_v6_configuration) : 0
 
-  name                           = "sint-v6"
+  name                           = "sint-v6-${count.index}"
   protocol                       = "Tcp"
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id]
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[count.index].id]
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 22623
   backend_port                   = 22623
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration[count.index].name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -7,7 +7,7 @@ locals {
     include : var.use_ipv4,
     subnet_id : local.master_subnet_id[idx]
     private_ip_address : null
-    zones : var.azure_outbound_routing_type == "NatGateway" ? [local.master_subnet_zone_map[local.master_subnet_id[idx]]] : null
+    zones : (var.azure_outbound_routing_type == "NatGateway" && var.azure_master_availability_zones[idx] != "") ? [var.azure_master_availability_zones[idx]] : null
   }]
   internal_lb_frontend_ip_v6_configuration = [for idx in range(length(local.master_subnet_id)) : {
     name : "${local.internal_lb_frontend_ip_v6_configuration_name}-${idx}",
@@ -15,7 +15,7 @@ locals {
     include : var.use_ipv6,
     subnet_id : local.master_subnet_id[idx]
     private_ip_address : var.use_ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2 - idx) : null
-    zones : var.azure_outbound_routing_type == "NatGateway" ? [local.master_subnet_zone_map[local.master_subnet_id[idx]]] : null
+    zones : (var.azure_outbound_routing_type == "NatGateway" && var.azure_master_availability_zones[idx] != "") ? [var.azure_master_availability_zones[idx]] : null
   }]
 }
 

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -6,14 +6,14 @@ resource "azurerm_network_security_group" "cluster" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "master" {
-  count = var.azure_preexisting_network ? 0 : local.subnet_count
+  count = var.azure_preexisting_network ? 0 : local.master_subnet_count
 
   subnet_id                 = azurerm_subnet.master_subnet[count.index].id
   network_security_group_id = azurerm_network_security_group.cluster.id
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {
-  count = var.azure_preexisting_network ? 0 : local.subnet_count
+  count = var.azure_preexisting_network ? 0 : local.worker_subnet_count
 
   subnet_id                 = azurerm_subnet.worker_subnet[count.index].id
   network_security_group_id = azurerm_network_security_group.cluster.id

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -6,16 +6,16 @@ resource "azurerm_network_security_group" "cluster" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "master" {
-  count = var.azure_preexisting_network ? 0 : 1
+  count = var.azure_preexisting_network ? 0 : local.subnet_count
 
-  subnet_id                 = azurerm_subnet.master_subnet[0].id
+  subnet_id                 = azurerm_subnet.master_subnet[count.index].id
   network_security_group_id = azurerm_network_security_group.cluster.id
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {
-  count = var.azure_preexisting_network ? 0 : 1
+  count = var.azure_preexisting_network ? 0 : local.subnet_count
 
-  subnet_id                 = azurerm_subnet.worker_subnet[0].id
+  subnet_id                 = azurerm_subnet.worker_subnet[count.index].id
   network_security_group_id = azurerm_network_security_group.cluster.id
 }
 

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -7,11 +7,11 @@ output "elb_backend_pool_v6_id" {
 }
 
 output "ilb_backend_pool_v4_id" {
-  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id : null
+  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[*].id : null
 }
 
 output "ilb_backend_pool_v6_id" {
-  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id : null
+  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[*].id : null
 }
 
 output "public_lb_pip_v4_fqdn" {
@@ -23,11 +23,11 @@ output "public_lb_pip_v6_fqdn" {
 }
 
 output "internal_lb_ip_v4_address" {
-  value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
+  value = var.use_ipv4 ? chunklist(azurerm_lb.internal.private_ip_addresses, length(local.master_subnet_id))[0] : null
 }
 
 output "internal_lb_ip_v6_address" {
-  value = var.use_ipv6 ? azurerm_lb.internal.private_ip_addresses[1] : null
+  value = var.use_ipv6 ? chunklist(azurerm_lb.internal.private_ip_addresses, length(local.master_subnet_id))[var.use_ipv4 ? 1 : 0] : null
 }
 
 output "nsg_name" {
@@ -40,6 +40,10 @@ output "virtual_network_id" {
 
 output "master_subnet_id" {
   value = local.master_subnet_id
+}
+
+output "master_subnet_zone_map" {
+  value = local.master_subnet_zone_map
 }
 
 output "worker_subnet_id" {

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -42,10 +42,6 @@ output "master_subnet_id" {
   value = local.master_subnet_id
 }
 
-output "master_subnet_zone_map" {
-  value = local.master_subnet_zone_map
-}
-
 output "worker_subnet_id" {
   value = local.worker_subnet_id
 }

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -54,7 +54,7 @@ data "azurerm_public_ip" "cluster_public_ip_v6" {
 }
 
 resource "azurerm_public_ip" "nat_gw_public_ip_v4" {
-  count = local.need_nat_gw ? local.subnet_count : 0
+  count = local.need_nat_gw ? local.nat_gateway_count : 0
 
   sku                 = "Standard"
   location            = var.azure_region
@@ -62,11 +62,11 @@ resource "azurerm_public_ip" "nat_gw_public_ip_v4" {
   resource_group_name = data.azurerm_resource_group.main.name
   allocation_method   = "Static"
   tags                = var.azure_extra_tags
-  zones               = length(var.azure_master_availability_zones) > 0 ? [var.azure_master_availability_zones[count.index]] : null
+  zones               = length(local.cluster_zones) > 0 ? [element(local.cluster_zones, count.index)] : null
 }
 
 data "azurerm_public_ip" "nat_gw_public_ip_v4" {
-  count = local.need_nat_gw ? local.subnet_count : 0
+  count = local.need_nat_gw ? local.nat_gateway_count : 0
 
   name                = azurerm_public_ip.nat_gw_public_ip_v4[count.index].name
   resource_group_name = data.azurerm_resource_group.main.name
@@ -203,7 +203,7 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
 }
 
 resource "azurerm_nat_gateway" "nat_gw" {
-  count = local.need_nat_gw ? local.subnet_count : 0
+  count = local.need_nat_gw ? local.nat_gateway_count : 0
 
   name                    = "${var.cluster_id}-natgw-${count.index}"
   location                = var.azure_region
@@ -217,7 +217,7 @@ resource "azurerm_nat_gateway" "nat_gw" {
 }
 
 data "azurerm_nat_gateway" "nat_gw" {
-  count = local.need_nat_gw ? local.subnet_count : 0
+  count = local.need_nat_gw ? local.nat_gateway_count : 0
 
   name                = azurerm_nat_gateway.nat_gw[count.index].name
   resource_group_name = data.azurerm_resource_group.main.name
@@ -226,7 +226,7 @@ data "azurerm_nat_gateway" "nat_gw" {
 // NAT Gateways can only be associated with IPv4 addresses
 // https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview#nat-gateway-configurations
 resource "azurerm_nat_gateway_public_ip_association" "nat_ip_assoc" {
-  count = local.need_nat_gw ? local.subnet_count : 0
+  count = local.need_nat_gw ? local.nat_gateway_count : 0
 
   nat_gateway_id       = azurerm_nat_gateway.nat_gw[count.index].id
   public_ip_address_id = azurerm_public_ip.nat_gw_public_ip_v4[count.index].id

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -9,37 +9,37 @@ resource "azurerm_virtual_network" "cluster_vnet" {
 }
 
 resource "azurerm_subnet" "master_subnet" {
-  count = var.azure_preexisting_network ? 0 : 1
+  count = var.azure_preexisting_network ? 0 : local.subnet_count
 
   resource_group_name = data.azurerm_resource_group.main.name
   address_prefixes = [for cidr in [
-    { value : local.master_subnet_cidr_v4, include : var.use_ipv4 },
+    { value : local.master_subnet_cidr_v4_zonal[count.index], include : var.use_ipv4 },
     { value : local.master_subnet_cidr_v6, include : var.use_ipv6 }
   ] : cidr.value if cidr.include]
   virtual_network_name = local.virtual_network
-  name                 = var.azure_control_plane_subnet
+  name                 = var.azure_control_plane_subnet[count.index]
 }
 
 resource "azurerm_subnet" "worker_subnet" {
-  count = var.azure_preexisting_network ? 0 : 1
+  count = var.azure_preexisting_network ? 0 : local.subnet_count
 
   resource_group_name = data.azurerm_resource_group.main.name
   address_prefixes = [for cidr in [
-    { value : local.worker_subnet_cidr_v4, include : var.use_ipv4 },
+    { value : local.worker_subnet_cidr_v4_zonal[count.index], include : var.use_ipv4 },
     { value : local.worker_subnet_cidr_v6, include : var.use_ipv6 }
   ] : cidr.value if cidr.include]
   virtual_network_name = local.virtual_network
-  name                 = var.azure_compute_subnet
+  name                 = var.azure_compute_subnet[count.index]
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat_master_assoc" {
-  count          = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
-  subnet_id      = local.master_subnet_id
-  nat_gateway_id = azurerm_nat_gateway.nat_gw[0].id
+  count          = var.azure_outbound_routing_type == "NatGateway" ? local.subnet_count : 0
+  subnet_id      = local.master_subnet_id[count.index]
+  nat_gateway_id = azurerm_nat_gateway.nat_gw[count.index].id
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat_worker_assoc" {
-  count          = var.azure_outbound_routing_type == "NatGateway" ? 1 : 0
-  subnet_id      = local.worker_subnet_id
-  nat_gateway_id = azurerm_nat_gateway.nat_gw[0].id
+  count          = var.azure_outbound_routing_type == "NatGateway" ? local.subnet_count : 0
+  subnet_id      = local.worker_subnet_id[count.index]
+  nat_gateway_id = azurerm_nat_gateway.nat_gw[count.index].id
 }

--- a/data/data/azurestack/vnet/common.tf
+++ b/data/data/azurestack/vnet/common.tf
@@ -6,7 +6,7 @@ data "azurestack_subnet" "preexisting_master_subnet" {
 
   resource_group_name  = var.azure_network_resource_group_name
   virtual_network_name = var.azure_virtual_network
-  name                 = var.azure_control_plane_subnet
+  name                 = var.azure_control_plane_subnet[0]
 }
 
 data "azurestack_subnet" "preexisting_worker_subnet" {
@@ -14,7 +14,7 @@ data "azurestack_subnet" "preexisting_worker_subnet" {
 
   resource_group_name  = var.azure_network_resource_group_name
   virtual_network_name = var.azure_virtual_network
-  name                 = var.azure_compute_subnet
+  name                 = var.azure_compute_subnet[0]
 }
 
 data "azurestack_virtual_network" "preexisting_virtual_network" {

--- a/data/data/azurestack/vnet/vnet.tf
+++ b/data/data/azurestack/vnet/vnet.tf
@@ -13,7 +13,7 @@ resource "azurestack_subnet" "master_subnet" {
   resource_group_name       = data.azurestack_resource_group.main.name
   address_prefix            = local.master_subnet_cidr_v4
   virtual_network_name      = local.virtual_network
-  name                      = var.azure_control_plane_subnet
+  name                      = var.azure_control_plane_subnet[0]
   network_security_group_id = azurestack_network_security_group.cluster.id
 }
 
@@ -23,6 +23,6 @@ resource "azurestack_subnet" "worker_subnet" {
   resource_group_name       = data.azurestack_resource_group.main.name
   address_prefix            = local.worker_subnet_cidr_v4
   virtual_network_name      = local.virtual_network
-  name                      = var.azure_compute_subnet
+  name                      = var.azure_compute_subnet[0]
   network_security_group_id = azurestack_network_security_group.cluster.id
 }

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2710,7 +2710,8 @@ spec:
                   outboundType:
                     default: Loadbalancer
                     description: OutboundType is a strategy for how egress from cluster
-                      is achieved. When not specified default is "Loadbalancer".
+                      is achieved. When not specified default is "Loadbalancer". "NatGateway"
+                      is only available in TechPreview.
                     enum:
                     - ""
                     - Loadbalancer

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -232,6 +232,16 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 
 	ultraSSDCapability := machineapi.AzureUltraSSDCapabilityState(mpool.UltraSSDCapability)
 
+	subnetIdx := 0
+	if platform.OutboundType == azure.NatGatewayOutboundType {
+		// There are as many subnets as AZs when using NAT gateways
+		subnetIdx = *azIdx
+	}
+	// Don't change the subnet name if it's been specified by the user
+	if platform.VirtualNetwork == "" {
+		subnet = fmt.Sprintf("%s-%d", subnet, subnetIdx)
+	}
+
 	spec := &machineapi.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -222,7 +222,7 @@ func Test_PrintFields(t *testing.T) {
     outboundType <string>
       Default: "Loadbalancer"
       Valid Values: "","Loadbalancer","NatGateway","UserDefinedRouting"
-      OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+      OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer". "NatGateway" is only available in TechPreview.
 
     region <string> -required-
       Region specifies the Azure region where the cluster will be created.

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -67,10 +67,11 @@ type config struct {
 	UseMarketplaceImage                     bool              `json:"azure_use_marketplace_image"`
 	MarketplaceImageHasPlan                 bool              `json:"azure_marketplace_image_has_plan"`
 	OSImage                                 `json:",inline"`
-	SecurityEncryptionType                  string `json:"azure_master_security_encryption_type,omitempty"`
-	SecureVirtualMachineDiskEncryptionSetID string `json:"azure_master_secure_vm_disk_encryption_set_id,omitempty"`
-	SecureBoot                              string `json:"azure_master_secure_boot,omitempty"`
-	VirtualizedTrustedPlatformModule        string `json:"azure_master_virtualized_trusted_platform_module,omitempty"`
+	SecurityEncryptionType                  string   `json:"azure_master_security_encryption_type,omitempty"`
+	SecureVirtualMachineDiskEncryptionSetID string   `json:"azure_master_secure_vm_disk_encryption_set_id,omitempty"`
+	SecureBoot                              string   `json:"azure_master_secure_boot,omitempty"`
+	VirtualizedTrustedPlatformModule        string   `json:"azure_master_virtualized_trusted_platform_module,omitempty"`
+	WorkerAvailabilityZones                 []string `json:"azure_worker_availability_zones,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -104,6 +105,11 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterAvailabilityZones := make([]string, len(sources.MasterConfigs))
 	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = to.String(c.Zone)
+	}
+
+	workerAvailabilityZones := make([]string, len(sources.WorkerConfigs))
+	for i, c := range sources.WorkerConfigs {
+		workerAvailabilityZones[i] = to.String(c.Zone)
 	}
 
 	environment, err := environment(sources.CloudName)
@@ -200,6 +206,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		SecureVirtualMachineDiskEncryptionSetID: masterConfig.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet.ID,
 		SecureBoot:                              secureBoot,
 		VirtualizedTrustedPlatformModule:        virtualizedTrustedPlatformModule,
+		WorkerAvailabilityZones:                 workerAvailabilityZones,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -79,6 +79,7 @@ type Platform struct {
 	CloudName CloudEnvironment `json:"cloudName,omitempty"`
 
 	// OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+	// "NatGateway" is only available in TechPreview.
 	//
 	// +kubebuilder:default=Loadbalancer
 	// +optional

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
@@ -46,7 +47,7 @@ var (
 const maxUserTagLimit = 10
 
 // ValidatePlatform checks that the specified platform is valid.
-func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPath *field.Path) field.ErrorList {
+func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPath *field.Path, ic *types.InstallConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region should be set to one of the supported Azure regions"))
@@ -88,9 +89,14 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	if p.OutboundType == azure.UserDefinedRoutingOutboundType && p.VirtualNetwork == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is only allowed when installing to pre-existing network", azure.UserDefinedRoutingOutboundType)))
 	}
-	if p.OutboundType == azure.NatGatewayOutboundType && p.VirtualNetwork != "" {
-		// For now, BYO network and NAT gateways are not compatible
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is not allowed when installing to pre-existing network", azure.NatGatewayOutboundType)))
+	if p.OutboundType == azure.NatGatewayOutboundType {
+		if ic.FeatureSet != configv1.TechPreviewNoUpgrade {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "not supported in this feature set"))
+		}
+		if p.VirtualNetwork != "" {
+			// For now, BYO network and NAT gateways are not compatible
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is not allowed when installing to pre-existing network", azure.NatGatewayOutboundType)))
+		}
 	}
 
 	// support for Azure user-defined tags made available through

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -208,8 +208,11 @@ func validateAzureStack(p *azure.Platform, fldPath *field.Path) field.ErrorList 
 	if p.ARMEndpoint == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("armEndpoint"), "ARM endpoint must be set when installing on Azure Stack"))
 	}
-	if p.OutboundType == azure.UserDefinedRoutingOutboundType {
+	switch p.OutboundType {
+	case azure.UserDefinedRoutingOutboundType:
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "Azure Stack does not support user-defined routing"))
+	case azure.NatGatewayOutboundType:
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "Azure Stack does not support NAT routing currently"))
 	}
 	return allErrs
 }

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -151,14 +151,24 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			expected: `^test-path\.outboundType: Invalid value: "UserDefinedRouting": UserDefinedRouting is only allowed when installing to pre-existing network$`,
 		},
+		{
+			name: "invalid nat gateway",
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.OutboundType = azure.NatGatewayOutboundType
+				return p
+			}(),
+			expected: `^test-path\.outboundType: Invalid value: "NatGateway": not supported in this feature set$`,
+		},
 	}
+	ic := types.InstallConfig{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.wantSkip != nil && tc.wantSkip(tc.platform) {
 				t.Skip()
 			}
 
-			err := ValidatePlatform(tc.platform, types.ExternalPublishingStrategy, field.NewPath("test-path")).ToAggregate()
+			err := ValidatePlatform(tc.platform, types.ExternalPublishingStrategy, field.NewPath("test-path"), &ic).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -731,7 +731,7 @@ func validatePlatform(platform *types.Platform, usingAgentMethod bool, fldPath *
 	}
 	if platform.Azure != nil {
 		validate(azure.Name, platform.Azure, func(f *field.Path) field.ErrorList {
-			return azurevalidation.ValidatePlatform(platform.Azure, c.Publish, f)
+			return azurevalidation.ValidatePlatform(platform.Azure, c.Publish, f, c)
 		})
 	}
 	if platform.GCP != nil {


### PR DESCRIPTION
Add multi-zone support for Azure NAT gateways. This means that there are
as many NAT gateways and subnets for controlPlane and compute machines
as there are availability zones.

Depends on https://github.com/openshift/installer/pull/6933