### PR TITLE
docs: Add note about not configuring allowed address pairs for day 2 manila configuration

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -60,13 +60,17 @@ In addition, it covers the installation with the default CNI (OVNKubernetes), as
 - [Troubleshooting your cluster](troubleshooting.md)
 - [Customizing your install](customization.md)
 - [Installing OpenShift on OpenStack User-Provisioned Infrastructure](install_upi.md)
-- [Learn about the OpenShift on OpenStack networking infrastructure design](../../design/openstack/networking-infrastructure.md)
 - [Deploying OpenShift bare-metal workers](deploy_baremetal_workers.md)
 - [Deploying OpenShift single root I/O virtualization (SRIOV) workers](deploy_sriov_workers.md)
 - [Deploying OpenShift with OVS-DPDK](ovs-dpdk.md)
 - [Deploying OpenShift with an external load balancer](external_load_balancer.md)
 - [Provider Networks](provider_networks.md)
 - [Migrate the Image Registry from Cinder to Swift](image-registry-storage-swift.md)
+- [Image Registry With A Custom PVC Backend](image_registry_with_custom_pvc_backends.md)
+- [Adding Worker Nodes By Hand](add_worker_nodes_by_hand.md)
+- [Connecting workers nodes and pods to an IPv6 network](connect_nodes_to_ipv6_network.md)
+- [Connecting worker nodes to a dedicated Manila network](connect_nodes_to_manila_network.md)
+- [Learn about the OpenShift on OpenStack networking infrastructure design](../../design/openstack/networking-infrastructure.md)
 
 ## OpenStack Requirements
 

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -106,8 +106,9 @@ For a successful installation it is required:
 - Depending on the type of [image registry backend](#image-registry-requirements) either 1 Swift container or an additional 100 GB volume.
 - OpenStack resource tagging
 
-> **NOTE:**
-> The installer will check OpenStack quota limits to make sure that the requested resources can be created. Note that it won't check for resource availability in the cloud, but only on the quotas.
+> **Note**
+> The installer will check OpenStack quota limits to make sure that the requested resources can be created.
+> Note that it won't check for resource availability in the cloud, but only on the quotas.
 
 You may need to increase the security group related quotas from their default values. For example (as an OpenStack administrator):
 
@@ -147,7 +148,12 @@ openstack role add --user <user> --project <project> swiftoperator
 
 If Swift is not available, the [PVC](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) storage is used as the backend. For this purpose, a persistent volume of 100 GB will be created in Cinder and mounted to the image registry pod during the installation.
 
-**Note:** If you are deploying a cluster in an Availability Zone where Swift isn't available but where Cinder is, it is recommended to deploy the Image Registry with Cinder backend. It will try to schedule the volume into the same AZ as the Nova zone where the PVC is located; otherwise it'll pick the default availability zone. If needed, the Image registry can be moved to another availability zone by a day 2 operation.
+> **Note**
+> If you are deploying a cluster in an Availability Zone where Swift isn't available but where Cinder is,
+> it is recommended to deploy the Image Registry with Cinder backend.
+> It will try to schedule the volume into the same AZ as the Nova zone where the PVC is located;
+> otherwise it'll pick the default availability zone.
+> If needed, the Image registry can be moved to another availability zone by a day 2 operation.
 
 If you want to force Cinder to be used as a backend for the Image Registry, you need to remove the `swiftoperator` permissions. As an OpenStack administrator:
 
@@ -155,7 +161,9 @@ If you want to force Cinder to be used as a backend for the Image Registry, you 
 openstack role remove --user <user> --project <project> swiftoperator
 ```
 
-**Note:** Since Cinder supports only [ReadWriteOnce](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) access mode, it's not possible to have more than one replica of the image registry pod.
+> **Note**
+> Since Cinder supports only [ReadWriteOnce](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) access mode,
+> it's not possible to have more than one replica of the image registry pod.
 
 ### Disk Requirements
 
@@ -222,8 +230,9 @@ openstack network list --long -c ID -c Name -c "Router Type"
 +--------------------------------------+----------------+-------------+
 ```
 
-> **NOTE:**
-> If the Neutron `trunk` service plug-in is enabled, trunk port will be created by default. For more information, please refer to [neutron trunk port](https://wiki.openstack.org/wiki/Neutron/TrunkPort).
+> **Note**
+> If the Neutron `trunk` service plug-in is enabled, trunk port will be created by default.
+> For more information, please refer to [neutron trunk port](https://wiki.openstack.org/wiki/Neutron/TrunkPort).
 
 ### Nova Metadata Service
 
@@ -348,8 +357,12 @@ openstack floating ip create --description "Ingress <cluster name>.<base domain>
 # => <ingressFloatingIP>
 ```
 
-> **NOTE:**
-> These IP addresses will **not** show up attached to any particular server (e.g. when running `openstack server list`). Similarly, the API and Ingress ports will always be in the `DOWN` state. This is because the ports are not attached to the servers directly. Instead, their fixed IP addresses are managed by keepalived. This has no record in Neutron's database and as such, is not visible to OpenStack.
+> **Note**
+> These IP addresses will **not** show up attached to any particular server (e.g. when running `openstack server list`).
+> Similarly, the API and Ingress ports will always be in the `DOWN` state.
+> This is because the ports are not attached to the servers directly.
+> Instead, their fixed IP addresses are managed by keepalived.
+> This has no record in Neutron's database and as such, is not visible to OpenStack.
 
 *The network traffic will flow through even though the IPs and ports do not show up in the servers*.
 
@@ -588,8 +601,10 @@ In order to use Availability Zones, create one MachineSet per target
 Availability Zone, and set the Availability Zone in the `availabilityZone`
 property of the MachineSet.
 
-> **NOTE:**
-> When deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it. In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider, all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
+> **Note**
+> When deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it.
+> In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider,
+> all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
 
 [server-group-docs]: https://docs.openstack.org/api-ref/compute/?expanded=create-server-group-detail#create-server-group
 
@@ -604,7 +619,8 @@ Add the following external facing services to your new load balancer:
 - The master nodes serve the OpenShift API on port 6443 using TCP.
 - The apps hosted on the worker nodes are served on ports 80, and 443. They are both served using TCP.
 
-Note: Make sure the instance that your new load balancer is running on has security group rules that allow TCP traffic over these ports.
+> **Note**
+> Make sure the instance that your new load balancer is running on has security group rules that allow TCP traffic over these ports.
 
 #### HAProxy Example Load Balancer Config
 
@@ -667,7 +683,8 @@ Result:
 }
 ```
 
-Note: The versions in the sample output may differ from your own. As long as you get a JSON payload response, the API is accessible.
+> **Note**
+> The versions in the sample output may differ from your own. As long as you get a JSON payload response, the API is accessible.
 
 #### Verifying that Apps Reachable
 
@@ -705,8 +722,9 @@ If you need to update the OpenStack cloud provider configuration you can edit th
 oc edit configmap -n openshift-config cloud-provider-config
 ```
 
-> **NOTE:**
-> It can take a while to reconfigure the cluster depending on the size of it. The reconfiguration is completed once no node is getting `SchedulingDisabled` taint anymore.
+> **Note**
+> It can take a while to reconfigure the cluster depending on the size of it.
+> The reconfiguration is completed once no node is getting `SchedulingDisabled` taint anymore.
 
 There are several things you can change:
 

--- a/docs/user/openstack/connect_nodes_to_ipv6_network.md
+++ b/docs/user/openstack/connect_nodes_to_ipv6_network.md
@@ -15,17 +15,20 @@ compute:
 ...
 ```
 
-**Note**: To use Stateful IPv6 Networks, the arg `ip=dhcp,dhcpv6` needs to be included in the kernal args of the Worker nodes, otherwise the Nodes won't get an IPv6 address due to a [bug][dhcpv6-bug]. Use the [procedure][add-kernel-args] to add kernel argument to the Nodes.
+> **Note**
+> To use Stateful IPv6 Networks, the arg `ip=dhcp,dhcpv6` needs to be included in the kernel args of the Worker nodes,
+> otherwise the Nodes won't get an IPv6 address due to a [bug][dhcpv6-bug].
+> Use the [procedure][add-kernel-args] to add kernel argument to the Nodes.
 
-## Enable connectivity to the Pods
+## Enable connectivity to the pods
 
-To enable connectivity between Pods with additional Network on different Nodes, the Port security needs to be disabled for the IPv6 Port of the Server. This way it's possible to avoid adding an allowed-address-pairs with an IP and MAC address in the Server's IPv6 Port whenever a new Pod gets created.
+To enable connectivity between pods with additional Network on different Nodes, the Port security needs to be disabled for the IPv6 Port of the Server. This way it's possible to avoid adding an allowed-address-pairs with an IP and MAC address in the Server's IPv6 Port whenever a new pod gets created.
 
 ```sh
 openstack port set --no-security-group --disable-port-security <worker-ipv6-port>
 ```
 
-## Add IPv6 connectivity to Pods
+## Add IPv6 connectivity to pods
 
 Create a file named `network.yaml` and specify [the desired CNI config][configuring-an-additional-network]. Here is an example of CNI config used for slaac address mode with macvlan:
 
@@ -40,7 +43,10 @@ spec:
 
 The node's interface specified in the Network attachment `master` field may differ from `ens4` when more additional networks are configured or when a different Kernel driver is used.
 
-**Note**: When using Stateful address mode, specify the `ipam` section in the CNI config, otherwise no address is configured in the additional interface of the Pod. Also, note that DHCPv6 is not yet supported by [Multus][dhcpv6-multus].
+> **Note**
+> When using Stateful address mode, specify the `ipam` section in the CNI config,
+> otherwise no address is configured in the additional interface of the pod.
+> Also, note that DHCPv6 is not yet supported by [Multus][dhcpv6-multus].
 
 then run:
 
@@ -48,15 +54,16 @@ then run:
 oc patch network.operator cluster --patch "$(cat network.yaml)" --type=merge
 ```
 
-It takes a while for the the network definition to be enforce, you can check with the following command:
+It takes a while for the network definition to be enforced.
+You can check with the following command:
 
 ```sh
 oc get network-attachment-definitions -A
 ```
 
-## Create Pods with IPv6 network
+## Create pods with IPv6 network
 
-To create Pods with IPv6 network make sure to create them on the same Namespace specified in the `additionalNetworks`
+To create pods with IPv6 network make sure to create them on the same Namespace specified in the `additionalNetworks`
 and specify the following annotation `k8s.v1.cni.cncf.io/networks: <additional-network-name>`.
 
 [dhcpv6-bug]: https://issues.redhat.com/browse/OCPBUGS-2104

--- a/docs/user/openstack/connect_nodes_to_ipv6_network.md
+++ b/docs/user/openstack/connect_nodes_to_ipv6_network.md
@@ -1,4 +1,4 @@
-# Connect workers nodes and Pods to IPv6 network
+# Connecting worker nodes and pods to an IPv6 network
 
 To connect your workers at the time of installation you can use [additionalNetworkIDs](https://github.com/openshift/installer/blob/master/docs/user/openstack/customization.md#additional-networks) parameter in the install config and set IPv6 network ID there:
 

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -51,9 +51,11 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * `zones` (optional list of strings): The names of the availability zones you want to install your root volumes on. If unset, the installer will use your default volume zone.
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
-**NOTE:** The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool.
+> **Note**
+> The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool.
 
-**NOTE:** Note when deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it. In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider, all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
+> **Note**
+> Note when deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it. In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider, all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
 
 
 ## Examples
@@ -127,9 +129,11 @@ parameter field in the install config to point to that location.   The install p
 then use that mirrored image.
 In all other respects the process will be consistent with the default.
 
-**NOTE:** For this to work, the parameter value must be a valid http(s) URL.
+> **Note**
+> For this to work, the parameter value must be a valid http(s) URL.
 
-**NOTE:** The optional `sha256` query parameter can be attached to the URL. This will force the installer to check the uncompressed image file checksum before uploading it into Glance.
+> **Note**
+> The optional `sha256` query parameter can be attached to the URL. This will force the installer to check the uncompressed image file checksum before uploading it into Glance.
 
 Example:
 
@@ -203,9 +207,11 @@ controlPlane:
       - fa806b2f-ac49-4bce-b9db-124bc64209bf
 ```
 
-**NOTES:**
-* Allowed address pairs won't be created for the additional networks.
-* The additional networks attached to the Control Plane machine will also be attached to the bootstrap node.
+> **Note**
+> Allowed address pairs won't be created for the additional networks.
+
+> **Note**
+> The additional networks attached to the Control Plane machine will also be attached to the bootstrap node.
 
 ## Additional Security Groups
 
@@ -236,7 +242,8 @@ controlPlane:
       - 7ee219f3-d2e9-48a1-96c2-e7429f1b0da7
 ```
 
-**NOTE:** The additional security groups attached to the Control Plane machine will also be attached to the bootstrap node.
+> **Note**
+> The additional security groups attached to the Control Plane machine will also be attached to the bootstrap node.
 
 ## Cloud Provider configuration
 

--- a/docs/user/openstack/image_registry_with_custom_pvc_backends.md
+++ b/docs/user/openstack/image_registry_with_custom_pvc_backends.md
@@ -20,7 +20,8 @@ EOF
 storageclass.storage.k8s.io/custom-csi-storageclass created
 ```
 
-**Note**: OpenShift doesn't check that the availability zone exists. So, users must verify that they have entered the correct value.
+> **Note**
+> OpenShift doesn't check that the availability zone exists. So, users must verify that they have entered the correct value.
 
 2. Create a pvc using the storageclass in `openshift-image-registry-namespace`, change the size of the volume if necessary.
 
@@ -45,7 +46,8 @@ EOF
 persistentvolumeclaim/csi-pvc-imageregistry created
 ```
 
-**Note**: Setting the `imageregistry.openshift.io` annotation is important, because otherwise Cluster Image Registry Operator won't be able to consume this PVC.
+> **Note**
+> Setting the `imageregistry.openshift.io` annotation is important, because otherwise Cluster Image Registry Operator won't be able to consume this PVC.
 
 3. Replace the original volume claim in the image registry config.
 

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -63,7 +63,9 @@ of this method of installation.
 ## Prerequisites
 
 The file `inventory.yaml` contains the variables most likely to need customization.
-**NOTE**: some of the default pods (e.g. the `openshift-router`) require at least two nodes so that is the effective minimum.
+
+> **Note**
+> Some of the default pods (e.g. the `openshift-router`) require at least two nodes so that is the effective minimum.
 
 The requirements for UPI are broadly similar to the [ones for OpenStack IPI][ipi-reqs]:
 
@@ -201,7 +203,8 @@ $ gunzip rhcos-${RHCOSVERSION}-openstack.x86_64.qcow2.gz
 
 Next step is to create a Glance image.
 
-**NOTE:** *This document* will use `rhcos-${CLUSTER_NAME}` as the Glance image name. The name of the Glance image must be the one configured as `os_image_rhcos` in `inventory.yaml`.
+> **Note**
+> This document will use `rhcos-${CLUSTER_NAME}` as the Glance image name. The name of the Glance image must be the one configured as `os_image_rhcos` in `inventory.yaml`.
 
 <!--- e2e-openstack-upi: INCLUDE START --->
 ```sh
@@ -209,7 +212,9 @@ $ openstack image create --container-format=bare --disk-format=qcow2 --file rhco
 ```
 <!--- e2e-openstack-upi: INCLUDE END --->
 
-**NOTE:** Depending on your OpenStack environment you can upload the RHCOS image as `raw` or `qcow2`. See [Disk and container formats for images](https://docs.openstack.org/image-guide/introduction.html#disk-and-container-formats-for-images) for more information.
+> **Note**
+> Depending on your OpenStack environment you can upload the RHCOS image as `raw` or `qcow2`.
+> See [Disk and container formats for images](https://docs.openstack.org/image-guide/introduction.html#disk-and-container-formats-for-images) for more information.
 
 [qemu_guest_agent]: https://docs.openstack.org/nova/latest/admin/configuration/hypervisor-kvm.html
 If the RHCOS image being used supports it,  the [KVM Qemu Guest Agent][qemu_guest_agent] may be used to enable optional
@@ -234,7 +239,11 @@ $ openstack image show "rhcos-${CLUSTER_NAME}"
 
 If the variables `os_api_fip`, `os_ingress_fip` and `os_bootstrap_fip` are found in `inventory.yaml`, the corresponding floating IPs will be attached to the API load balancer, to the worker nodes load balancer and to the temporary machine used for the install process, respectively. Note that `os_external_network` is a requirement for those.
 
-**NOTE**: throughout this document, we will use `203.0.113.23` as the public IP address for the OpenShift API endpoint and `203.0.113.19` as the public IP for the ingress (`*.apps`) endpoint. `203.0.113.20` will be the public IP used for the bootstrap machine.
+> **Note**
+> Throughout this document, we will use `203.0.113.23` as the public IP address
+> for the OpenShift API endpoint and `203.0.113.19` as the public IP for the
+> ingress (`*.apps`) endpoint. `203.0.113.20` will be the public IP used for
+> the bootstrap machine.
 
 ```sh
 $ openstack floating ip create --description "OpenShift API" <external>
@@ -359,8 +368,9 @@ if "ingressVIP" in data["platform"]["openstack"]:
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 ```
 
-**NOTE**: All the scripts in this guide work with Python 3 as well as Python 2. You can also choose to edit the
-`install-config.yaml` file by hand.
+> **Note**
+> All the scripts in this guide work with Python 3 as well as Python 2.
+> You can also choose to edit the `install-config.yaml` file by hand.
 
 ### Empty Compute Pools
 
@@ -540,7 +550,8 @@ openshift-qlvwv-bootstrap
 
 **`/opt/openshift/tls/cloud-ca-cert.pem`** (if applicable).
 
-**NOTE**: We recommend you back up the Ignition files before making any changes!
+> **Note**
+> We recommend you back up the Ignition files before making any changes!
 
 You can edit the Ignition file manually or run this Python script:
 
@@ -626,7 +637,8 @@ $ openstack image create --disk-format=raw --container-format=bare --file bootst
 ```
 <!--- e2e-openstack-upi: INCLUDE END --->
 
-**NOTE**: Make sure the created image has `active` status.
+> **Note**
+> Make sure the created image has `active` status.
 
 Copy and save `file` value of the output, it should look like `/v2/images/<image_id>/file`.
 
@@ -787,7 +799,8 @@ If you look inside, you will see that they contain very little. In fact, most of
 
 You can make your own changes here.
 
-**NOTE**: The worker nodes do not require any changes to their Ignition, but you can make your own by editing `worker.ign`.
+> **Note**
+> The worker nodes do not require any changes to their Ignition, but you can make your own by editing `worker.ign`.
 
 ## Network Topology
 
@@ -816,7 +829,8 @@ Outside connectivity will be provided by attaching the floating IP addresses (IP
 
 ### Subnet DNS (optional)
 
-**NOTE**: This step is optional and only necessary if you want to control the default resolvers your Nova servers will use.
+> **Note**
+> This step is optional and only necessary if you want to control the default resolvers your Nova servers will use.
 
 During deployment, the OpenShift nodes will need to be able to resolve public name records to download the OpenShift images and so on. They will also need to resolve the OpenStack API endpoint.
 
@@ -912,7 +926,8 @@ $ oc get nodes
 $ oc get pods -A
 ```
 
-**NOTE**: Only the API will be up at this point. The OpenShift UI will run on the compute nodes.
+> **Note**
+> Only the API will be up at this point. The OpenShift UI will run on the compute nodes.
 
 ### Delete the Bootstrap Resources
 <!--- e2e-openstack-upi: INCLUDE START --->
@@ -1085,8 +1100,9 @@ $ ansible-playbook -i inventory.yaml  \
 
 The playbook `down-load-balancers.yaml` idempotently deletes the load balancers created by the Kuryr installation, if any.
 
-**NOTE:** The deletion of load balancers with `provisioning_status` `PENDING-*` is skipped. Make sure to retry the
-`down-load-balancers.yaml` playbook once the load balancers have transitioned to `ACTIVE`.
+> **Note**
+> The deletion of load balancers with `provisioning_status` `PENDING-*` is skipped.
+> Make sure to retry the `down-load-balancers.yaml` playbook once the load balancers have transitioned to `ACTIVE`.
 
 Delete the RHCOS image if it's no longer useful.
 

--- a/docs/user/openstack/kuryr.md
+++ b/docs/user/openstack/kuryr.md
@@ -51,7 +51,8 @@ As highlighted in the minimum quota recommendations, when using Kuryr SDN, there
 openstack quota set --secgroups 250 --secgroup-rules 1000 --ports 1500 --subnets 250 --networks 250 <project>
 ```
 
-**NOTE:** Each Amphora Load Balancer creates a VM. Even if that VM is not part of the user quota, the OpenStack cluster must have enough capacity to allocate those VMs too. A standard OpenShift installation ends up with more that 50 Amphora Load Balancers.
+> **Note**
+> Each Amphora Load Balancer creates a VM. Even if that VM is not part of the user quota, the OpenStack cluster must have enough capacity to allocate those VMs too. A standard OpenShift installation ends up with more that 50 Amphora Load Balancers.
 
 ## Neutron Configuration
 
@@ -63,12 +64,13 @@ In addition, if the default ML2/OVS Neutron driver is used, the firewall must be
 
 Kuryr SDN uses OpenStack Octavia LBaaS to implement OpenShift services. Thus the OpenStack environment must have Octavia components installed and configured if Kuryr SDN is used.
 
-**NOTE:** Depending on your OpenStack environment Octavia may not support UDP listeners, which means there is no support for UDP services if Kuryr SDN is used.
+> **Note**
+> Depending on your OpenStack environment Octavia may not support UDP listeners, which means there is no support for UDP services if Kuryr SDN is used.
 
 ### The Octavia OVN Driver
 
 Octavia supports multiple provider drivers through the Octavia API.
-￼
+
 To see all available Octavia provider drivers, on a command line, enter:
 
 ```yaml
@@ -81,15 +83,15 @@ $ openstack loadbalancer provider list
 | ovn     | Octavia OVN driver.                             |
 +---------+-------------------------------------------------+
 ```
-￼
+
 Beginning with OpenStack Train, the Octavia OVN provider driver (`ovn`) is supported.
 `ovn` is an integration driver for the load balancing that Octavia and OVN provide.
 It supports basic load balancing capabilities, and is based on OpenFlow rules.
-￼
+
 The Amphora provider driver is the default driver. If `ovn` is enabled,
 however, Kuryr uses it.￼
 If Kuryr uses `ovn` instead of Amphora, it offers the following benefits:
-￼
+
 * Decreased resource requirements. Kuryr does not require a load balancer VM
 for each Service.
 * Reduced network latency.
@@ -110,7 +112,8 @@ networking:
   ...
 ```
 
-**NOTE:** If your environment doesn't support trunks or OpenStack Octavia service isn't available, Kuryr SDN will not properly work, as trunks are needed to connect the pods to the OpenStack network and Octavia to create the OpenShift services.
+> **Note**
+> If your environment doesn't support trunks or OpenStack Octavia service isn't available, Kuryr SDN will not properly work, as trunks are needed to connect the pods to the OpenStack network and Octavia to create the OpenShift services.
 
 ### Known limitations of installing with Kuryr SDN
 

--- a/docs/user/openstack/provider_networks.md
+++ b/docs/user/openstack/provider_networks.md
@@ -65,8 +65,9 @@ on a tenant network:
 
     openstack subnet create --dhcp --host-route destination=169.254.169.254/32,gateway=$ROUTER_IP" (...)
 
-**Note:** We're working on removing the nova-metadata requirement but for now it is strongly required to be
-          enabled in the cloud and reachable from the provider network.
+> **Note**
+> We're working on removing the nova-metadata requirement but for now it is
+> mandatory and must be reachable from the provider network.
 
 
 ## Deploying cluster with primary interface on a provider network with IPI
@@ -81,10 +82,9 @@ on a tenant network:
     - Set `platform.openstack.machinesSubnet` to the subnet ID of the provider network subnet.
     - Set `networking.machineNetwork.cidr` to the CIDR of the provider network subnet.
 
-**Note:**
-
-`platform.openstack.apiVIP` and `platform.openstack.ingressVIP` both need to be an unassigned IP
-address on the `networking.machineNetwork.cidr`.
+    > **Note**
+    > `platform.openstack.apiVIP` and `platform.openstack.ingressVIP` both need to
+    > be an unassigned IP address on the `networking.machineNetwork.cidr`.
 
     Example:
 

--- a/docs/user/openstack/troubleshooting.md
+++ b/docs/user/openstack/troubleshooting.md
@@ -33,7 +33,8 @@ The operation can take up to 5 minutes, during which time the machine will be gr
 
 A new worker machine for the cluster will soon be created automatically by the [machine-api-operator](https://github.com/openshift/machine-api-operator).
 
-**NOTE**: in future versions of OpenShift all broken machines will be automatically deleted and recovered by the machine-api-operator.
+> **Note**
+> In future versions of OpenShift all broken machines will be automatically deleted and recovered by the machine-api-operator.
 
 ## SSH access to the instances
 


### PR DESCRIPTION
Add a note suggesting users disable allowed address pairs when adding a manila network as a day 2 network.

While we're here, also address some other nits with the docs by adding missing entries to the "Reference doc" ToC in the main README, and fixing formatting for some admonitions.

Commits:

- `docs: Improve Manila document`
- `docs: Add missing refs to OpenStack README ToC`
- `docs: Use GHFM for OpenStack doc notes`
