### PR TITLE
OCPBUGS-15238: GCP: ic: client: use a higher context timeout

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -52,9 +52,6 @@ type Client struct {
 
 // NewClient initializes a client with a session.
 func NewClient(ctx context.Context) (*Client, error) {
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	ssn, err := GetSession(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get session")
@@ -222,9 +219,6 @@ func (c *Client) GetSubnetworks(ctx context.Context, network, project, region st
 }
 
 func (c *Client) getComputeService(ctx context.Context) (*compute.Service, error) {
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	svc, err := compute.NewService(ctx, option.WithCredentials(c.ssn.Credentials))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create compute service")

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -101,7 +101,7 @@ func (c *Client) GetNetwork(ctx context.Context, network, project string) (*comp
 
 // GetPublicDomains returns all of the domains from among the project's public DNS zones.
 func (c *Client) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -127,7 +127,7 @@ func (c *Client) GetPublicDomains(ctx context.Context, project string) ([]string
 // GetDNSZoneByName returns a DNS zone matching the `zoneName` if the DNS zone exists
 // and can be seen (correct permissions for a private zone) in the project.
 func (c *Client) GetDNSZoneByName(ctx context.Context, project, zoneName string) (*dns.ManagedZone, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -179,7 +179,7 @@ func (c *Client) GetDNSZone(ctx context.Context, project, baseDomain string, isP
 
 // GetRecordSets returns all the records for a DNS zone.
 func (c *Client) GetRecordSets(ctx context.Context, project, zone string) ([]*dns.ResourceRecordSet, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -18,6 +18,8 @@ import (
 
 //go:generate mockgen -source=./client.go -destination=./mock/gcpclient_generated.go -package=mock
 
+const defaultTimeout = 2 * time.Minute
+
 var (
 	// RequiredBasePermissions is the list of permissions required for an installation.
 	// A list of valid permissions can be found at https://cloud.google.com/iam/docs/understanding-roles.
@@ -50,7 +52,7 @@ type Client struct {
 
 // NewClient initializes a client with a session.
 func NewClient(ctx context.Context) (*Client, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	ssn, err := GetSession(ctx)
@@ -71,7 +73,7 @@ func (c *Client) GetMachineType(ctx context.Context, project, zone, machineType 
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	req, err := svc.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
 	if err != nil {
@@ -88,7 +90,7 @@ func (c *Client) GetNetwork(ctx context.Context, network, project string) (*comp
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	res, err := svc.Networks.Get(project, network).Context(ctx).Do()
 	if err != nil {
@@ -99,7 +101,7 @@ func (c *Client) GetNetwork(ctx context.Context, network, project string) (*comp
 
 // GetPublicDomains returns all of the domains from among the project's public DNS zones.
 func (c *Client) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -125,7 +127,7 @@ func (c *Client) GetPublicDomains(ctx context.Context, project string) ([]string
 // GetDNSZoneByName returns a DNS zone matching the `zoneName` if the DNS zone exists
 // and can be seen (correct permissions for a private zone) in the project.
 func (c *Client) GetDNSZoneByName(ctx context.Context, project, zoneName string) (*dns.ManagedZone, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -137,12 +139,11 @@ func (c *Client) GetDNSZoneByName(ctx context.Context, project, zoneName string)
 		return nil, errors.Wrap(err, "failed to get DNS Zones")
 	}
 	return returnedZone, nil
-
 }
 
 // GetDNSZone returns a DNS zone for a basedomain.
 func (c *Client) GetDNSZone(ctx context.Context, project, baseDomain string, isPublic bool) (*dns.ManagedZone, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -178,7 +179,7 @@ func (c *Client) GetDNSZone(ctx context.Context, project, baseDomain string, isP
 
 // GetRecordSets returns all the records for a DNS zone.
 func (c *Client) GetRecordSets(ctx context.Context, project, zone string) ([]*dns.ResourceRecordSet, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getDNSService(ctx)
@@ -208,7 +209,7 @@ func (c *Client) GetSubnetworks(ctx context.Context, network, project, region st
 	req := svc.Subnetworks.List(project, region).Filter(filter)
 	var res []*compute.Subnetwork
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	if err := req.Pages(ctx, func(page *compute.SubnetworkList) error {
@@ -221,7 +222,7 @@ func (c *Client) GetSubnetworks(ctx context.Context, network, project, region st
 }
 
 func (c *Client) getComputeService(ctx context.Context) (*compute.Service, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := compute.NewService(ctx, option.WithCredentials(c.ssn.Credentials))
@@ -242,7 +243,7 @@ func (c *Client) getDNSService(ctx context.Context) (*dns.Service, error) {
 // GetProjects gets the list of project names and ids associated with the current user in the form
 // of a map whose keys are ids and values are names.
 func (c *Client) GetProjects(ctx context.Context) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getCloudResourceService(ctx)
@@ -265,7 +266,7 @@ func (c *Client) GetProjects(ctx context.Context) (map[string]string, error) {
 
 // GetProjectByID retrieves the project specified by its ID.
 func (c *Client) GetProjectByID(ctx context.Context, project string) (*cloudresourcemanager.Project, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getCloudResourceService(ctx)
@@ -283,7 +284,7 @@ func (c *Client) GetRegions(ctx context.Context, project string) ([]string, erro
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	gcpRegionsList, err := svc.Regions.List(project).Context(ctx).Do()
 	if err != nil {
@@ -311,7 +312,7 @@ func (c *Client) GetZones(ctx context.Context, project, filter string) ([]*compu
 	}
 
 	zones := []*compute.Zone{}
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	if err := req.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
@@ -335,7 +336,7 @@ func (c *Client) getCloudResourceService(ctx context.Context) (*cloudresourceman
 
 // GetEnabledServices gets the list of enabled services for a project.
 func (c *Client) GetEnabledServices(ctx context.Context, project string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	svc, err := c.getServiceUsageService(ctx)
@@ -374,7 +375,7 @@ func (c *Client) GetCredentials() *googleoauth.Credentials {
 }
 
 func (c *Client) getPermissions(ctx context.Context, project string, permissions []string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	service, err := c.getCloudResourceService(ctx)


### PR DESCRIPTION
We are probably being too optimistic with timeouts like 30s and 1min for API calls. If your account happens to have access to thousands of projects, the API calls can easily exceed that. Let's settle in 2min for now.

I also used the opportunity to fix a few instances where the context passed as parameter was being ignored.