### PR TITLE
CORS-2719: Remove service account user permission

### DIFF
--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -37,13 +37,6 @@ resource "google_project_iam_member" "master-storage-admin" {
   member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
-resource "google_project_iam_member" "master-service-account-user" {
-  count   = var.service_account == "" ? 1 : 0
-  project = var.project_id
-  role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
-}
-
 resource "google_compute_instance" "master" {
   count       = var.instance_count
   description = local.description


### PR DESCRIPTION
** Removed the addition of the service account user permission for control plane nodes in terraform.

The service account user permission is passed to MAO as it is needed by that operator to access specific resources. It is not needed during the creation of master/control plane nodes. 