### PR TITLE
OCPBUGS-14762: Use the same names for public LB in IPI and UPI Azure

### DIFF
--- a/upi/azure/03_infra.json
+++ b/upi/azure/03_infra.json
@@ -31,7 +31,7 @@
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "masterPublicIpAddressName" : "[concat(parameters('baseName'), '-master-pip')]",
     "masterPublicIpAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('masterPublicIpAddressName'))]",
-    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
+    "masterLoadBalancerName" : "[parameters('baseName')]",
     "masterLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('masterLoadBalancerName'))]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "internalLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('internalLoadBalancerName'))]",
@@ -67,7 +67,7 @@
       "properties" : {
         "frontendIPConfigurations" : [
           {
-            "name" : "public-lb-ip",
+            "name" : "public-lb-ip-v4",
             "properties" : {
               "publicIPAddress" : {
                 "id" : "[variables('masterPublicIpAddressID')]"
@@ -77,7 +77,7 @@
         ],
         "backendAddressPools" : [
           {
-            "name" : "public-lb-backend"
+            "name" : "[variables('masterLoadBalancerName')]"
           }
         ],
         "loadBalancingRules" : [
@@ -85,10 +85,10 @@
             "name" : "api-internal",
             "properties" : {
               "frontendIPConfiguration" : {
-                "id" :"[concat(variables('masterLoadBalancerID'), '/frontendIPConfigurations/public-lb-ip')]"
+                "id" :"[concat(variables('masterLoadBalancerID'), '/frontendIPConfigurations/public-lb-ip-v4')]"
               },
               "backendAddressPool" : {
-                "id" : "[concat(variables('masterLoadBalancerID'), '/backendAddressPools/public-lb-backend')]"
+                "id" : "[concat(variables('masterLoadBalancerID'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
               },
               "protocol" : "Tcp",
               "loadDistribution" : "Default",

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -55,7 +55,7 @@
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
     "masterSubnetName" : "[concat(if(not(empty(parameters('vnetBaseName'))), parameters('vnetBaseName'), parameters('baseName')), '-master-subnet')]",
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
-    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
+    "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
@@ -104,7 +104,7 @@
               },
               "loadBalancerBackendAddressPools" : [
                 {
-                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/public-lb-backend')]"
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
                 },
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -77,7 +77,7 @@
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
     "masterSubnetName" : "[concat(if(not(empty(parameters('vnetBaseName'))), parameters('vnetBaseName'), parameters('baseName')), '-master-subnet')]",
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
-    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
+    "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
@@ -112,7 +112,7 @@
               },
               "loadBalancerBackendAddressPools" : [
                 {
-                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/public-lb-backend')]"
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
                 },
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"


### PR DESCRIPTION
The CCM/KCM in OpenShift is configured to look for a load balancer name of `${CLUSTER_ID}`. In UPI we have been creating a load balancer called `${CLUSTER_ID}-public` to fill the same purpose.

When the KCM/CCM starts up, it notices the lack of the LB and creates a new load balancer, however, it doesn't move the master nodes across from the old LB, as it assumes they are supposed to be attached to the other LB. In this case, for UPI clusters, the master node membership is never reconciled and any service that uses a load balancer will never route through the master nodes.

```
I0704 12:31:39.379256       1 azure_standard.go:878] Node "jspeedtest3-xl52m-master-0" has already been added to LB "jspeedtest3-xl52m-public-lb", omit adding it to a new one
I0704 12:31:39.379304       1 azure_standard.go:878] Node "jspeedtest3-xl52m-master-1" has already been added to LB "jspeedtest3-xl52m-public-lb", omit adding it to a new one
I0704 12:31:39.394029       1 azure_standard.go:878] Node "jspeedtest3-xl52m-master-2" has already been added to LB "jspeedtest3-xl52m-public-lb", omit adding it to a new one
```

We should fix this by creating the correctly named LB. This PR updates the load balancer creation scripts for UPI to create the load balancer with the same naming as the terraform created load balancer for IPI.