### PR TITLE
OCPBUGS-14932: specify azure cli version

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -25,7 +25,7 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-      azure-cli \
+      azure-cli-2.49.0-1.el8 \
       gettext \
       google-cloud-cli \
       gzip \


### PR DESCRIPTION
API version issue when using az 2.50.0 to install upi
```
Creating 'api' record in public zone for IP 52.152.61.10
ERROR: (NoRegisteredProviderFound) No registered resource provider found for location 'global' and API version '2023-07-01-preview' for type 'dnszones/A'. The supported api-versions are '2015-05-04-preview, 2016-04-01, 2017-09-01, 2017-09-15-preview, 2017-10-01, 2018-03-01-preview, 2018-05-01'. The supported locations are ', global'.
Code: NoRegisteredProviderFound
Message: No registered resource provider found for location 'global' and API version '2023-07-01-preview' for type 'dnszones/A'. The supported api-versions are '2015-05-04-preview, 2016-04-01, 2017-09-01, 2017-09-15-preview, 2017-10-01, 2018-03-01-preview, 2018-05-01'. The supported locations are ', global'.
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2023-07-05T09:32:52Z"}
error: failed to execute wrapped command: exit status 1 
```
This is know issue on azure cli: https://github.com/Azure/azure-cli/issues/23985

specify azure cli version to 2.49.0 which we have already verified to avoid such issue.