### PR TITLE
AGENT-660 Display insert config image message to console

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-config-image-wait.sh
+++ b/data/data/agent/files/usr/local/bin/agent-config-image-wait.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+status_name=60-check-config-image
+set_mount_config_image_message() {
+    mkdir -p /etc/motd.d/
+    tee "/etc/issue.d/${status_name}.issue" | sed -e 's/\\e[{][^}]*[}]//g' | tee "/etc/motd.d/${status_name}" 1>&2
+    agetty --reload
+}
+
+rendezvous_host_env="/etc/assisted/rendezvous-host.env"
+while [ ! -f "${rendezvous_host_env}" ]; do
+    printf '\\e{lightred}Insert or mount config image to start cluster installation\\e{reset}\n' | set_mount_config_image_message
+    sleep 30
+done
+rm -f "/etc/issue.d/${status_name}.issue" "/etc/motd.d/${status_name}"
+agetty --reload

--- a/data/data/agent/systemd/units/agent-check-config-image.service
+++ b/data/data/agent/systemd/units/agent-check-config-image.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Displays message to console if config image has not been inserted or mounted in unconfigured-ignition environment
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=True
+ExecStart=/usr/local/bin/agent-config-image-wait.sh
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -182,6 +182,8 @@ func (a *UnconfiguredIgnition) Generate(dependencies asset.Parents) error {
 		config.Storage.Files = append(config.Storage.Files, manifestFile)
 	}
 
+	// the agent-check-config-image.service added only to the unconfigured ignition
+	enabledServices = append(enabledServices, "agent-check-config-image.service")
 	err = bootstrap.AddSystemdUnits(&config, "agent/systemd/units", agentTemplateData, enabledServices)
 	if err != nil {
 		return err

--- a/pkg/asset/agent/image/unconfigured_ignition_test.go
+++ b/pkg/asset/agent/image/unconfigured_ignition_test.go
@@ -21,16 +21,18 @@ func TestUnconfiguredIgnition_Generate(t *testing.T) {
 	nmStateConfig := getTestNMStateConfig()
 
 	cases := []struct {
-		name                                  string
-		overrideDeps                          []asset.Asset
-		expectedError                         string
-		expectedFiles                         []string
-		preNetworkManagerConfigServiceEnabled bool
+		name              string
+		overrideDeps      []asset.Asset
+		expectedError     string
+		expectedFiles     []string
+		serviceEnabledMap map[string]bool
 	}{
 		{
-			name:                                  "default-configs-and-no-nmstateconfigs",
-			expectedFiles:                         generatedFilesUnconfiguredIgnition("/usr/local/bin/pre-network-manager-config.sh"),
-			preNetworkManagerConfigServiceEnabled: false,
+			name:          "default-configs-and-no-nmstateconfigs",
+			expectedFiles: generatedFilesUnconfiguredIgnition("/usr/local/bin/pre-network-manager-config.sh"),
+			serviceEnabledMap: map[string]bool{
+				"pre-network-manager-config.service": false,
+				"agent-check-config-image.service":   true},
 		},
 		{
 			name: "with-mirror-configs",
@@ -56,7 +58,9 @@ func TestUnconfiguredIgnition_Generate(t *testing.T) {
 			},
 			expectedFiles: generatedFilesUnconfiguredIgnition(registriesConfPath,
 				registryCABundlePath, "/usr/local/bin/pre-network-manager-config.sh"),
-			preNetworkManagerConfigServiceEnabled: false,
+			serviceEnabledMap: map[string]bool{
+				"pre-network-manager-config.service": false,
+				"agent-check-config-image.service":   true},
 		},
 		{
 			name: "with-nmstateconfigs",
@@ -65,7 +69,9 @@ func TestUnconfiguredIgnition_Generate(t *testing.T) {
 			},
 			expectedFiles: generatedFilesUnconfiguredIgnition("/etc/assisted/network/host0/eth0.nmconnection",
 				"/etc/assisted/network/host0/mac_interface.ini", "/usr/local/bin/pre-network-manager-config.sh"),
-			preNetworkManagerConfigServiceEnabled: true,
+			serviceEnabledMap: map[string]bool{
+				"pre-network-manager-config.service": true,
+				"agent-check-config-image.service":   true},
 		},
 	}
 	for _, tc := range cases {
@@ -87,7 +93,7 @@ func TestUnconfiguredIgnition_Generate(t *testing.T) {
 
 				assertExpectedFiles(t, unconfiguredIgnitionAsset.Config, tc.expectedFiles, nil)
 
-				assertPreNetworkConfigServiceEnabled(t, unconfiguredIgnitionAsset.Config, tc.preNetworkManagerConfigServiceEnabled)
+				assertServiceEnabled(t, unconfiguredIgnitionAsset.Config, tc.serviceEnabledMap)
 			}
 		})
 	}


### PR DESCRIPTION
The new service will only be added to the unconfigured ignition.

The purpose is to give customers some indication that in order for the hosts to proceed with cluster installation the config image need to be inserted or mounted.