### PR TITLE
OSASINFRA-3181 - Volume Types for OpenStack CPMS

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -629,8 +629,16 @@ spec:
                                 gibibytes (GiB). Required
                               type: integer
                             type:
-                              description: Type defines the type of the volume. Required
+                              description: 'Type defines the type of the volume. Deprecated:
+                                Use Types instead.'
                               type: string
+                            types:
+                              description: Types is the list of the volume types of
+                                the root volumes. This is mutually exclusive with
+                                Type.
+                              items:
+                                type: string
+                              type: array
                             zones:
                               description: Zones is the list of availability zones
                                 where the root volumes should be deployed. If no zones
@@ -641,7 +649,7 @@ spec:
                               type: array
                           required:
                           - size
-                          - type
+                          - types
                           type: object
                         serverGroupPolicy:
                           description: ServerGroupPolicy will be used to create the
@@ -1381,8 +1389,15 @@ spec:
                               (GiB). Required
                             type: integer
                           type:
-                            description: Type defines the type of the volume. Required
+                            description: 'Type defines the type of the volume. Deprecated:
+                              Use Types instead.'
                             type: string
+                          types:
+                            description: Types is the list of the volume types of
+                              the root volumes. This is mutually exclusive with Type.
+                            items:
+                              type: string
+                            type: array
                           zones:
                             description: Zones is the list of availability zones where
                               the root volumes should be deployed. If no zones are
@@ -1393,7 +1408,7 @@ spec:
                             type: array
                         required:
                         - size
-                        - type
+                        - types
                         type: object
                       serverGroupPolicy:
                         description: ServerGroupPolicy will be used to create the
@@ -3152,8 +3167,15 @@ spec:
                               (GiB). Required
                             type: integer
                           type:
-                            description: Type defines the type of the volume. Required
+                            description: 'Type defines the type of the volume. Deprecated:
+                              Use Types instead.'
                             type: string
+                          types:
+                            description: Types is the list of the volume types of
+                              the root volumes. This is mutually exclusive with Type.
+                            items:
+                              type: string
+                            type: array
                           zones:
                             description: Zones is the list of availability zones where
                               the root volumes should be deployed. If no zones are
@@ -3164,7 +3186,7 @@ spec:
                             type: array
                         required:
                         - size
-                        - type
+                        - types
                         type: object
                       serverGroupPolicy:
                         description: ServerGroupPolicy will be used to create the

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -73,7 +73,7 @@ resource "openstack_blockstorage_volume_v3" "bootstrap_volume" {
   description = local.description
 
   size        = var.openstack_master_root_volume_size
-  volume_type = var.openstack_master_root_volume_type
+  volume_type = var.openstack_master_root_volume_types[0]
   image_id    = data.openstack_images_image_v2.base_image.id
 
   availability_zone = var.openstack_master_root_volume_availability_zones[0]

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -64,7 +64,7 @@ resource "openstack_blockstorage_volume_v3" "master_volume" {
   count = var.openstack_master_root_volume_size == null ? 0 : var.master_count
 
   size = var.openstack_master_root_volume_size
-  volume_type = var.openstack_master_root_volume_type
+  volume_type = var.openstack_master_root_volume_types[count.index]
   image_id = data.openstack_images_image_v2.base_image.id
 
   availability_zone = var.openstack_master_root_volume_availability_zones[count.index]

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -1,9 +1,3 @@
-variable "openstack_master_root_volume_type" {
-  type        = string
-  default     = null
-  description = "The type of volume for the root block device of master nodes."
-}
-
 variable "openstack_master_root_volume_size" {
   type        = number
   default     = null
@@ -387,6 +381,12 @@ variable "openstack_master_root_volume_availability_zones" {
   type        = list(string)
   default     = [""]
   description = "List of availability Zones to Schedule the masters root volumes on."
+}
+
+variable "openstack_master_root_volume_types" {
+  type        = list(string)
+  default     = [""]
+  description = "List of volume types used by the masters root volumes."
 }
 
 variable "openstack_worker_server_group_names" {

--- a/docs/user/openstack/control-plane-machine-set.md
+++ b/docs/user/openstack/control-plane-machine-set.md
@@ -322,3 +322,88 @@ spec:
 When reconciling the Machines, cluster-control-plane-machine-set-operator will match their spec against the template, after substituting `availabilityZone` and `rootVolume.availabilityZone` for each of them.
 
 The three Control plane Machines will all be provisioned on a different availability zone and have their `rootVolume` provisioned on a different availability zone.
+
+---
+
+## Example 5: three Compute availability zones, three Storage types
+
+The storage types apply to the root volume. The `providerSpec` must contain a `rootVolume` property.
+
+```yaml
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  creationTimestamp: null
+  labels:
+    machine.openshift.io/cluster-api-cluster: ocp1-2g2xs
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ocp1-2g2xs
+      machine.openshift.io/cluster-api-machine-role: master
+      machine.openshift.io/cluster-api-machine-type: master
+  state: Active
+  strategy: {}
+  template:
+    machineType: machines_v1beta1_machine_openshift_io
+    machines_v1beta1_machine_openshift_io:
+      failureDomains:
+        openstack:
+        - availabilityZone: nova-one
+          rootVolume:
+            volumeType: fastpool-1
+        - availabilityZone: nova-two
+          rootVolume:
+            volumeType: fastpool-2
+        - availabilityZone: nova-three
+          rootVolume:
+            volumeType: fastpool-3
+        platform: OpenStack
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ocp1-2g2xs
+          machine.openshift.io/cluster-api-machine-role: master
+          machine.openshift.io/cluster-api-machine-type: master
+      spec:
+        lifecycleHooks: {}
+        metadata: {}
+        providerSpec:
+          value: # <-- The OpenStack providerSpec
+            apiVersion: machine.openshift.io/v1alpha1
+            cloudName: openstack
+            cloudsSecret:
+              name: openstack-cloud-credentials
+              namespace: openshift-machine-api
+            flavor: m1.xlarge
+            image: ocp1-2g2xs-rhcos
+            kind: OpenstackProviderSpec
+            metadata:
+              creationTimestamp: null
+            networks:
+            - filter: {}
+              subnets:
+              - filter:
+                  name: ocp1-2g2xs-nodes
+                  tags: openshiftClusterID=ocp1-2g2xs
+            rootVolume:
+              diskSize: 30
+            securityGroups:
+            - filter: {}
+              name: ocp1-2g2xs-master
+            serverGroupName: ocp1-2g2xs-master
+            serverMetadata:
+              Name: ocp1-2g2xs-master
+              openshiftClusterID: ocp1-2g2xs
+            tags:
+            - openshiftClusterID=ocp1-2g2xs
+            trunk: true
+            userDataSecret:
+              name: master-user-data
+```
+
+When reconciling the Machines, cluster-control-plane-machine-set-operator will match their spec against the template, after substituting `availabilityZone` and `rootVolume.volumeType` for each of them.
+
+The three Control plane Machines will all be provisioned on a different availability zone and have their `rootVolume` provisioned with a different volume type.

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -47,7 +47,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
-  * `type` (required string): The volume pool to create the volume from.
+  * `type` (optional string): The volume pool to create the volume from. It was replaced by `types`.
+  * `types` (required list of strings): The volume pool to create the volume from. If compute `zones` are defined with more than one type, the number of zones must match the number of types.
   * `zones` (optional list of strings): The names of the availability zones you want to install your root volumes on. If unset, the installer will use your default volume zone.
     If compute `zones` contains at least one value, `rootVolume.zones` must also contain at least one value.
     Indeed, when a machine is created with a compute availability zone and a storage root volume with no specified rootVolume.availabilityZone, [CAPO](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/9d183bd479fe9aed4f6e7ac3d5eee46681c518e7/pkg/cloud/services/compute/instance.go#L439-L442) will use the compute AZ for the volume AZ.
@@ -106,7 +107,8 @@ compute:
       type: ml.large
       rootVolume:
         size: 30
-        type: performance
+        types:
+        - performance
   replicas: 3
 metadata:
   name: test-cluster

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -42,7 +42,7 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 	var checkStorageFlavor bool
 	// Validate Root Volumes
 	if p.RootVolume != nil {
-		allErrs = append(allErrs, validateVolumeTypes(p.RootVolume.Type, ci.VolumeTypes, fldPath.Child("rootVolume").Child("type"))...)
+		allErrs = append(allErrs, validateVolumeTypes(p.RootVolume.Types, ci.VolumeTypes, fldPath.Child("rootVolume").Child("types"))...)
 		if p.RootVolume.Size < minimumStorage {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("rootVolume").Child("size"), p.RootVolume.Size, fmt.Sprintf("Volume size must be greater than %d GB to use root volumes, had %d GB", minimumStorage, p.RootVolume.Size)))
 		} else if p.RootVolume.Size < recommendedStorage {
@@ -89,15 +89,16 @@ func validateZones(input []string, available []string, fldPath *field.Path) fiel
 	return allErrs
 }
 
-func validateVolumeTypes(input string, available []string, fldPath *field.Path) field.ErrorList {
+func validateVolumeTypes(input []string, available []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if input == "" {
-		allErrs = append(allErrs, field.Invalid(fldPath, input, "Volume type must be specified to use root volumes"))
+	if len(input) == 0 {
 		return allErrs
 	}
-	volumeTypes := sets.NewString(available...)
-	if !volumeTypes.Has(input) {
-		allErrs = append(allErrs, field.Invalid(fldPath, input, "Volume Type either does not exist in this cloud, or is not available"))
+	volumeTypes := sets.New[string](available...)
+	for _, volumeType := range input {
+		if !volumeTypes.Has(volumeType) {
+			allErrs = append(allErrs, field.Invalid(fldPath, volumeType, "Volume type either does not exist in this cloud, or is not available"))
+		}
 	}
 
 	return allErrs

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -120,6 +120,14 @@ func TFVars(
 		}
 	}
 
+	// storageVolumeTypes is a slice where each index targets a master.
+	storageVolumeTypes := make([]string, len(masterSpecs))
+	for i := range storageVolumeTypes {
+		if masterSpecs[i].RootVolume != nil {
+			storageVolumeTypes[i] = masterSpecs[i].RootVolume.VolumeType
+		}
+	}
+
 	// Normally baseImage contains a URL that we will use to create a new Glance image, but for testing
 	// purposes we also allow to set a custom Glance image name to skip the uploading. Here we check
 	// whether baseImage is a URL or not. If this is the first case, it means that the image should be
@@ -149,10 +157,8 @@ func TFVars(
 	}
 
 	var rootVolumeSize int
-	var rootVolumeType string
 	if rootVolume := masterSpecs[0].RootVolume; rootVolume != nil {
 		rootVolumeSize = rootVolume.Size
-		rootVolumeType = rootVolume.VolumeType
 	}
 
 	masterServerGroupPolicy := getServerGroupPolicy(mastermpool, defaultmpool, types_openstack.SGPolicySoftAntiAffinity)
@@ -237,7 +243,6 @@ func TFVars(
 		TrunkSupport                      bool                              `json:"openstack_trunk_support,omitempty"`
 		OctaviaSupport                    bool                              `json:"openstack_octavia_support,omitempty"`
 		RootVolumeSize                    int                               `json:"openstack_master_root_volume_size,omitempty"`
-		RootVolumeType                    string                            `json:"openstack_master_root_volume_type,omitempty"`
 		BootstrapShim                     string                            `json:"openstack_bootstrap_shim_ignition,omitempty"`
 		ExternalDNS                       []string                          `json:"openstack_external_dns,omitempty"`
 		MasterServerGroupName             string                            `json:"openstack_master_server_group_name,omitempty"`
@@ -251,6 +256,7 @@ func TFVars(
 		MachinesPorts                     []*terraformPort                  `json:"openstack_machines_ports"`
 		MasterAvailabilityZones           []string                          `json:"openstack_master_availability_zones,omitempty"`
 		MasterRootVolumeAvailabilityZones []string                          `json:"openstack_master_root_volume_availability_zones,omitempty"`
+		MasterRootVolumeTypes             []string                          `json:"openstack_master_root_volume_types,omitempty"`
 		UserManagedLoadBalancer           bool                              `json:"openstack_user_managed_load_balancer"`
 	}{
 		BaseImageName:                     imageName,
@@ -264,7 +270,6 @@ func TFVars(
 		TrunkSupport:                      masterSpecs[0].Trunk,
 		OctaviaSupport:                    octaviaSupport,
 		RootVolumeSize:                    rootVolumeSize,
-		RootVolumeType:                    rootVolumeType,
 		BootstrapShim:                     bootstrapShim,
 		ExternalDNS:                       installConfig.Config.Platform.OpenStack.ExternalDNS,
 		MasterServerGroupName:             masterServerGroupName,
@@ -278,6 +283,7 @@ func TFVars(
 		MachinesPorts:                     machinesPorts,
 		MasterAvailabilityZones:           computeAvailabilityZones,
 		MasterRootVolumeAvailabilityZones: storageAvailabilityZones,
+		MasterRootVolumeTypes:             storageVolumeTypes,
 		UserManagedLoadBalancer:           userManagedLoadBalancer,
 	}, "", "  ")
 }

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -394,6 +394,39 @@ func TestConvertInstallConfig(t *testing.T) {
 			expectedError: "cannot specify computeFlavor and type in defaultMachinePlatform together",
 		},
 		{
+			name: "deprecated OpenStack controlPlane with type in rootVolume",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				ControlPlane: &types.MachinePool{
+					Platform: types.MachinePoolPlatform{
+						OpenStack: &openstack.MachinePool{
+							RootVolume: &openstack.RootVolume{
+								DeprecatedType: "fast",
+							},
+						},
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				ControlPlane: &types.MachinePool{
+					Platform: types.MachinePoolPlatform{
+						OpenStack: &openstack.MachinePool{
+							RootVolume: &openstack.RootVolume{
+								Types: []string{"fast"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "openstack deprecated apiVIP",
 			config: &types.InstallConfig{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -48,7 +48,15 @@ func (o *MachinePool) Set(required *MachinePool) {
 			o.RootVolume = new(RootVolume)
 		}
 		o.RootVolume.Size = required.RootVolume.Size
-		o.RootVolume.Type = required.RootVolume.Type
+		o.RootVolume.DeprecatedType = required.RootVolume.DeprecatedType
+
+		if required.RootVolume.DeprecatedType != "" {
+			o.RootVolume.DeprecatedType = ""
+			o.RootVolume.Types = []string{required.RootVolume.DeprecatedType}
+		} else if len(required.RootVolume.Types) > 0 {
+			o.RootVolume.Types = required.RootVolume.Types
+		}
+
 		if len(required.RootVolume.Zones) > 0 {
 			o.RootVolume.Zones = required.RootVolume.Zones
 		}
@@ -77,8 +85,14 @@ type RootVolume struct {
 	// Required
 	Size int `json:"size"`
 	// Type defines the type of the volume.
-	// Required
-	Type string `json:"type"`
+	// Deprecated: Use Types instead.
+	// +optional
+	DeprecatedType string `json:"type,omitempty"`
+
+	// Types is the list of the volume types of the root volumes.
+	// This is mutually exclusive with Type.
+	// +required
+	Types []string `json:"types"`
 
 	// Zones is the list of availability zones where the root volumes should be deployed.
 	// If no zones are provided, all instances will be deployed on OpenStack Cinder default availability zone

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -25,8 +25,39 @@ func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePo
 		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), machinePool.ServerGroupPolicy, validServerGroupPolicies))
 	}
 
-	if len(machinePool.Zones) > 0 && machinePool.RootVolume != nil && len(machinePool.RootVolume.Zones) == 0 {
-		errs = append(errs, field.Required(fldPath.Child("rootVolume").Child("zones"), "root volume availability zones must be specified when compute availability zones are specified"))
+	if machinePool.RootVolume != nil {
+		if len(machinePool.Zones) > 0 && len(machinePool.RootVolume.Zones) == 0 {
+			errs = append(errs, field.Required(fldPath.Child("rootVolume").Child("zones"), "root volume availability zones must be specified when compute availability zones are specified"))
+		}
+
+		rootVolumeType := machinePool.RootVolume.DeprecatedType
+		rootVolumeTypes := machinePool.RootVolume.Types
+		typePath := fldPath.Child("rootVolume").Child("type")
+		typesPath := fldPath.Child("rootVolume").Child("types")
+
+		if rootVolumeType != "" && len(rootVolumeTypes) > 0 {
+			errs = append(errs, field.Invalid(typePath, rootVolumeType, "Only one of type or types can be specified"))
+			errs = append(errs, field.Invalid(typesPath, rootVolumeTypes, "Only one of type or types can be specified"))
+		}
+
+		if rootVolumeType == "" && len(rootVolumeTypes) == 0 {
+			errs = append(errs, field.Invalid(typePath, rootVolumeType, "Either type or types must be specified"))
+			errs = append(errs, field.Invalid(typesPath, rootVolumeTypes, "Either type or types must be specified"))
+		}
+
+		// When distributing the Root volumes across multiple failure domains, we suggest using multiple Storage types so they use a different backend.
+		// Storage availability zones are purely cosmetic for now and can also be used to define where a volume should be created, however
+		// we don't want to force a user to define a Storage availability zone when using multiple Storage types.
+		// Therefore we decided to require as many Storage types as there are Compute availability zones, if there are multiple Compute availability zones
+		// and more than one Storage type is defined.
+		// Even if we support a single Storage type across multiple failure domains, we still allow doing it.
+		// e.g. it would not make sense to have 3 Compute availability zones and 2 Storage types, because one of the Storage types would be used twice and
+		// therefore the number of failure domains would not be 3 anymore.
+		if machinePool.RootVolume.Types != nil {
+			if computes, volumes := len(machinePool.Zones), len(machinePool.RootVolume.Types); computes > 1 && volumes > 1 && volumes != computes {
+				errs = append(errs, field.Invalid(typesPath, rootVolumeTypes, "Compute and Storage availability zones in a MachinePool should have been validated to have equal length when more than one Storage type is defined"))
+			}
+		}
 	}
 
 	return errs

--- a/scripts/openstack/manifest-tests/root-volume-types/install-config.yaml
+++ b/scripts/openstack/manifest-tests/root-volume-types/install-config.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+baseDomain: shiftstack.example.com
+controlPlane:
+  architecture: amd64
+  name: master
+  platform:
+    openstack:
+      rootVolume:
+        size: 100
+        types: ["type-1", "type-2", "type-3"]
+        zones: ["VolumeAZ1", "VolumeAZ2", "VolumeAZ3"]
+      type: ${COMPUTE_FLAVOR}
+      zones: ["MasterAZ1", "MasterAZ2", "MasterAZ3"]
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      rootVolume:
+        size: 100
+        types: ["type-A", "type-B", "type-C"]
+      type: ${COMPUTE_FLAVOR}
+  replicas: 1000
+metadata:
+  name: manifests1
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.128.0/17
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  openstack:
+    apiFloatingIP: ${API_FIP}
+    cloud: ${OS_CLOUD}
+    externalNetwork: ${EXTERNAL_NETWORK}
+pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/root-volume-types/test_cpms.py
+++ b/scripts/openstack/manifest-tests/root-volume-types/test_cpms.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import xmlrunner
+
+import os
+import sys
+import yaml
+
+ASSETS_DIR = ""
+
+EXPECTED_MASTER_ZONE_NAMES = ["MasterAZ1", "MasterAZ2", "MasterAZ3"]
+EXPECTED_MASTER_ROOT_VOLUME_TYPE_NAMES = ["type-1", "type-2", "type-3"]
+EXPECTED_MASTER_ROOT_VOLUME_ZONE_NAMES = ["VolumeAZ1", "VolumeAZ2", "VolumeAZ3"]
+
+class ControlPlaneMachineSet(unittest.TestCase):
+    def setUp(self):
+        """Parse the CPMS into a Python data structure."""
+        with open(f'{ASSETS_DIR}/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml') as f:
+            self.cpms = yaml.load(f, Loader=yaml.FullLoader)
+
+    def test_providerspec_failuredomain_fields(self):
+        """Assert that the failure-domain-managed fields in the CPMS providerSpec are omitted."""
+        provider_spec = self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["spec"]["providerSpec"]["value"]
+        self.assertNotIn("availabilityZone", provider_spec)
+        self.assertNotIn("availabilityZone", provider_spec["rootVolume"])
+
+    def test_compute_zones(self):
+        """Assert that the CPMS failure domain zones match the expected machine-pool zones."""
+        self.assertIn("failureDomains", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"])
+        failure_domains = self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"]["openstack"]
+
+        compute_zones = []
+        for failure_domain in failure_domains:
+            zone = failure_domain["availabilityZone"]
+            compute_zones.append(zone)
+            self.assertIn(zone, EXPECTED_MASTER_ZONE_NAMES)
+
+        for expected_zone in EXPECTED_MASTER_ZONE_NAMES:
+            self.assertIn(expected_zone, compute_zones)
+
+    def test_storage_types(self):
+        """Assert that the CPMS storage types match the expected machine-pool storage types."""
+        self.assertIn("failureDomains", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"])
+        self.assertIn("openstack", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"])
+        failure_domains = self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"]["openstack"]
+
+        storage_types = []
+        for failure_domain in failure_domains:
+            self.assertIn("rootVolume", failure_domain)
+            self.assertIn("volumeType", failure_domain["rootVolume"])
+            storage_type = failure_domain["rootVolume"]["volumeType"]
+            storage_types.append(storage_type)
+            self.assertIn(storage_type, EXPECTED_MASTER_ROOT_VOLUME_TYPE_NAMES)
+
+        for expected_type in EXPECTED_MASTER_ROOT_VOLUME_TYPE_NAMES:
+            self.assertIn(expected_type, storage_types)
+
+    def test_storage_zones(self):
+        """Assert that the CPMS failure domain root volume zones match the expected machine-pool zones."""
+        self.assertIn("failureDomains", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"])
+        self.assertIn("openstack", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"])
+        failure_domains = self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"]["openstack"]
+
+        storage_zones = []
+        for failure_domain in failure_domains:
+            self.assertIn("rootVolume", failure_domain)
+            self.assertIn("availabilityZone", failure_domain["rootVolume"])
+            rootVolumeZone = failure_domain["rootVolume"]["availabilityZone"]
+            storage_zones.append(rootVolumeZone)
+            self.assertIn(rootVolumeZone, EXPECTED_MASTER_ROOT_VOLUME_ZONE_NAMES)
+
+        for expected_zone in EXPECTED_MASTER_ROOT_VOLUME_ZONE_NAMES:
+            self.assertIn(expected_zone, storage_zones)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:
+        unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), failfast=False, buffer=False, catchbreak=False, verbosity=2)

--- a/scripts/openstack/manifest-tests/root-volume-types/test_machines.py
+++ b/scripts/openstack/manifest-tests/root-volume-types/test_machines.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import xmlrunner
+
+import os
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+
+EXPECTED_MASTER_REPLICAS = 3
+EXPECTED_MASTER_ROOT_VOLUME_TYPE_NAMES = ["type-1", "type-2", "type-3"]
+EXPECTED_MASTER_ROOT_VOLUME_ZONE_NAMES = ["VolumeAZ1", "VolumeAZ2", "VolumeAZ3"]
+EXPECTED_MASTER_ZONE_NAMES = ["MasterAZ1", "MasterAZ2", "MasterAZ3"]
+
+EXPECTED_WORKER_REPLICAS = 1000
+EXPECTED_WORKER_ROOT_VOLUME_TYPES = ["type-A", "type-B", "type-C"]
+
+
+
+class RootVolumeTypeMachines(unittest.TestCase):
+    def setUp(self):
+        """Parse the Machines into a Python data structure."""
+        self.machines = []
+        for machine_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_master-machines-*.yaml'
+        ):
+            with open(machine_path) as f:
+                self.machines.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_zone_names(self):
+        """Assert that all machines have one valid compute az that matches volume az."""
+        for machine in self.machines:
+            master_zone = machine["spec"]["providerSpec"]["value"]["availabilityZone"]
+            volume_zone = machine["spec"]["providerSpec"]["value"]["rootVolume"]["availabilityZone"]
+            self.assertIn(master_zone, EXPECTED_MASTER_ZONE_NAMES)
+            self.assertIn(volume_zone, EXPECTED_MASTER_ROOT_VOLUME_ZONE_NAMES)
+            self.assertEqual(master_zone[-3:], volume_zone[-3:])
+
+    def test_type_names(self):
+        """Assert that all machines have one valid volume type."""
+        for machine in self.machines:
+            volume_type = machine["spec"]["providerSpec"]["value"]["rootVolume"]["volumeType"]
+            self.assertIn(volume_type, EXPECTED_MASTER_ROOT_VOLUME_TYPE_NAMES)
+
+    def test_total_instance_number(self):
+        """Assert that there are as many Machines as required ControlPlane replicas."""
+        self.assertEqual(len(self.machines), EXPECTED_MASTER_REPLICAS)
+
+    def test_replica_distribution(self):
+        """Assert that machines are evenly distributed across failure domains."""
+        volume_zones = {}
+        volume_types = {}
+        for machine in self.machines:
+            volume_zone = machine["spec"]["providerSpec"]["value"]["rootVolume"]["availabilityZone"]
+            volume_zones[volume_zone] = volume_zones.get(volume_zone, 0) + 1
+            volume_type = machine["spec"]["providerSpec"]["value"]["rootVolume"]["volumeType"]
+            volume_types[volume_type] = volume_types.get(volume_zone, 0) + 1
+
+        setpoint = 0
+        for replicas in volume_zones.values():
+            if setpoint == 0:
+                setpoint = replicas
+            else:
+                self.assertTrue(-2 < replicas - setpoint < 2, msg="volume zone mismatch")
+
+        setpoint = 0
+        for replicas in volume_types.values():
+            if setpoint == 0:
+                setpoint = replicas
+            else:
+                self.assertTrue(-2 < replicas - setpoint < 2, msg="volume type mismatch")
+
+
+class RootVolumeTypesMachinesets(unittest.TestCase):
+    def setUp(self):
+        """Parse the MachineSets into a Python data structure."""
+        self.machinesets = []
+        for machineset_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_worker-machineset-*.yaml'
+        ):
+            with open(machineset_path) as f:
+                self.machinesets.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_machineset_zone_name(self):
+        """Assert that there are as many MachineSets as failure domains."""
+        self.assertEqual(len(self.machinesets), len(EXPECTED_WORKER_ROOT_VOLUME_TYPES))
+
+    def test_machineset_volume_type_name(self):
+        """Assert that each MachineSet has a valid volume type."""
+        for machineset in self.machinesets:
+            volume_type = machineset["spec"]["template"]["spec"]["providerSpec"]["value"]["rootVolume"]["volumeType"]
+            self.assertIn(volume_type, EXPECTED_WORKER_ROOT_VOLUME_TYPES)
+
+    def test_total_replica_number(self):
+        """Assert that replicas spread across the MachineSets add up to the expected number."""
+        total_found = 0
+        for machineset in self.machinesets:
+            total_found += machineset["spec"]["replicas"]
+        self.assertEqual(total_found, EXPECTED_WORKER_REPLICAS)
+
+    def test_replica_distribution(self):
+        """Assert that MachineSets are evenly distributed across failure domains."""
+        setpoint = 0
+        for machineset in self.machinesets:
+            replicas = machineset["spec"]["replicas"]
+            if setpoint == 0:
+                setpoint = replicas
+            else:
+                self.assertTrue(-2 < replicas - setpoint < 2)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:
+        unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), failfast=False, buffer=False, catchbreak=False, verbosity=2)


### PR DESCRIPTION
* [x] add the JSON array controlPlane.platform.openstack.rootVolume.types (notice the "s") in install-config (this is an API addition)
* [x] add validation to prevent both rootVolume.type and rootVolume.types to be set
* [x] add validation to ensure that if both Compute availabilityZones and rootVolume.types are set, they have equal length
* [x] change Machine generation to vary rootVolume.volumeType according to the machine-pool rootVolume.types
* [x] instrument the Terraform code to apply variable volume types
* [x] tests in openstack-manifests
* [x] document the new `types` parameter
