### PR TITLE
OCPBUGS-14900: Use correct SELinux label. Make rename atomic.

### DIFF
--- a/data/data/agent/files/usr/local/bin/issue_status.sh
+++ b/data/data/agent/files/usr/local/bin/issue_status.sh
@@ -8,7 +8,7 @@ set_issue() {
     local outfile
     outfile="$(issue_file "$1")"
     local tmp
-    tmp="$(mktemp)"
+    tmp="$(mktemp -p /etc/issue.d/)"
     {
         printf '\n'
         cat -


### PR DESCRIPTION
Signed-off-by: Zane Bitter <zbitter@redhat.com > and Pawan Pinjarkar <ppinjark@redhat.com>
