### PR TITLE
OCPBUGS-15997: openstack: add root volume AZ validation

### DIFF
--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -49,6 +49,9 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
   * `type` (required string): The volume pool to create the volume from.
   * `zones` (optional list of strings): The names of the availability zones you want to install your root volumes on. If unset, the installer will use your default volume zone.
+    If compute `zones` contains at least one value, `rootVolume.zones` must also contain at least one value.
+    Indeed, when a machine is created with a compute availability zone and a storage root volume with no specified rootVolume.availabilityZone, [CAPO](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/9d183bd479fe9aed4f6e7ac3d5eee46681c518e7/pkg/cloud/services/compute/instance.go#L439-L442) will use the compute AZ for the volume AZ.
+    This can be problematic if the AZ doesn't exist in Cinder, therefore we enforce that `rootVolume.zones` to be set if `zones` is set.
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
 > **Note**

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -25,5 +25,9 @@ func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePo
 		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), machinePool.ServerGroupPolicy, validServerGroupPolicies))
 	}
 
+	if len(machinePool.Zones) > 0 && machinePool.RootVolume != nil && len(machinePool.RootVolume.Zones) == 0 {
+		errs = append(errs, field.Required(fldPath.Child("rootVolume").Child("zones"), "root volume availability zones must be specified when compute availability zones are specified"))
+	}
+
 	return errs
 }


### PR DESCRIPTION
## Problem

When a machine is created with a compute availability zone (defined via `mpool.zones`) and a storage root volume (defined as `mpool.rootVolume`) and that `rootVolume` has no specified `zones`, CAPO will use the compute AZ for the volume AZ.
This can be problematic if the AZ doesn't exist in Cinder.

Source:
https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/9d183bd479fe9aed4f6e7ac3d5eee46681c518e7/pkg/cloud/services/compute/instance.go#L439-L442

```golang
func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec *InstanceSpec, imageID string) (*volumes.Volume, error) {

(...)

        availabilityZone := instanceSpec.FailureDomain
        if rootVolume.AvailabilityZone != "" {
                availabilityZone = rootVolume.AvailabilityZone
        }

(...)
```

## Proposed solution

If a compute AZ is provided alongside with a root volume, we now require
the root volume to have an AZ, so we force the user to make a choice on
which AZ the root volume is deployed on.

We are also enforcing it via CEL validation in https://github.com/openshift/api/pull/1521

## Alternatives

* Do nothing - at the risk of hitting this situation: a failure domain with a Compute AZ and a root volume with no AZ, CAPO using the compute AZ to create the volume but that AZ doesn't exist in Cinder, leading into Machine creation errors.
* Only do a validation in the CPMS - which will require CPMS manual
  edits from the user.
* Change logic in CAPO wrt how root volume AZ is picked - unlikely to happen
