### PR TITLE
Agent: clear service status once all services started

### DIFF
--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -17,10 +17,7 @@ check_services() {
     local not_started
     not_started="$(inactive_services)"
     if [ -z "${not_started}" ]; then
-        if [ -f "${services_issue}" ]; then
-            rm "${services_issue}"
-            agetty --reload
-        fi
+        clear_issue "${services_issue}"
     else
         read -ra show_services <<<"${not_started}"
         {


### PR DESCRIPTION
The commit 4daff6117fce1d73774b02caf605d9e1b836dd7c changed the value of $services_issue so that it will never find the correct file to remove. We should use the clear_issue function to correctly remove the issue file.