### PR TITLE
OCPBUGS-16515: gcp: use zones available for both instance and project

### DIFF
--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -113,6 +113,22 @@ func (mr *MockAPIMockRecorder) GetMachineType(ctx, project, zone, machineType in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineType", reflect.TypeOf((*MockAPI)(nil).GetMachineType), ctx, project, zone, machineType)
 }
 
+// GetMachineTypeWithZones mocks base method.
+func (m *MockAPI) GetMachineTypeWithZones(ctx context.Context, project, region, machineType string) (*compute.MachineType, sets.Set[string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineTypeWithZones", ctx, project, region, machineType)
+	ret0, _ := ret[0].(*compute.MachineType)
+	ret1, _ := ret[1].(sets.Set[string])
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetMachineTypeWithZones indicates an expected call of GetMachineTypeWithZones.
+func (mr *MockAPIMockRecorder) GetMachineTypeWithZones(ctx, project, region, machineType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineTypeWithZones", reflect.TypeOf((*MockAPI)(nil).GetMachineTypeWithZones), ctx, project, region, machineType)
+}
+
 // GetNetwork mocks base method.
 func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*compute.Network, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -53,6 +53,7 @@ func Validate(client API, ic *types.InstallConfig) error {
 	allErrs = append(allErrs, validateProject(client, ic, field.NewPath("platform").Child("gcp"))...)
 	allErrs = append(allErrs, validateNetworkProject(client, ic, field.NewPath("platform").Child("gcp"))...)
 	allErrs = append(allErrs, validateRegion(client, ic, field.NewPath("platform").Child("gcp"))...)
+	allErrs = append(allErrs, validateZones(client, ic)...)
 	allErrs = append(allErrs, validateNetworks(client, ic, field.NewPath("platform").Child("gcp"))...)
 	allErrs = append(allErrs, validateInstanceTypes(client, ic)...)
 	allErrs = append(allErrs, validateCredentialMode(client, ic)...)
@@ -422,6 +423,50 @@ func validateCredentialMode(client API, ic *types.InstallConfig) field.ErrorList
 			if ic.CredentialsMode != "" && ic.CredentialsMode != types.ManualCredentialsMode {
 				errMsg := "environmental authentication is only supported with Manual credentials mode"
 				return append(allErrs, field.Forbidden(field.NewPath("credentialsMode"), errMsg))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func validateZones(client API, ic *types.InstallConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	zones, err := client.GetZones(context.TODO(), ic.GCP.ProjectID, fmt.Sprintf("region eq .*%s", ic.GCP.Region))
+	if err != nil {
+		return append(allErrs, field.InternalError(nil, err))
+	} else if len(zones) == 0 {
+		return append(allErrs, field.InternalError(nil, fmt.Errorf("failed to fetch zones, this error usually occurs if the region is not found")))
+	}
+
+	projZones := sets.New[string]()
+	for _, zone := range zones {
+		projZones.Insert(zone.Name)
+	}
+
+	const errMsg = "zone(s) not found in region"
+
+	if ic.Platform.GCP.DefaultMachinePlatform != nil {
+		diff := sets.New(ic.Platform.GCP.DefaultMachinePlatform.Zones...).Difference(projZones)
+		if len(diff) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("platform", "gcp", "defaultMachinePlatform", "zones"), sets.List(diff), errMsg))
+		}
+	}
+
+	if ic.ControlPlane != nil && ic.ControlPlane.Platform.GCP != nil {
+		diff := sets.New(ic.ControlPlane.Platform.GCP.Zones...).Difference(projZones)
+		if len(diff) > 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("controlPlane", "platform", "gcp", "zones"), sets.List(diff), errMsg))
+		}
+	}
+
+	for idx, compute := range ic.Compute {
+		fldPath := field.NewPath("compute").Index(idx)
+		if compute.Platform.GCP != nil {
+			diff := sets.New(compute.Platform.GCP.Zones...).Difference(projZones)
+			if len(diff) > 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("platform", "gcp", "zones"), sets.List(diff), errMsg))
 			}
 		}
 	}

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -111,6 +111,14 @@ func validateServiceAccountPresent(client API, ic *types.InstallConfig) field.Er
 	return allErrs
 }
 
+// DefaultInstanceTypeForArch returns the appropriate instance type based on the target architecture.
+func DefaultInstanceTypeForArch(arch types.Architecture) string {
+	if arch == types.ArchitectureARM64 {
+		return "t2a-standard-4"
+	}
+	return "n2-standard-4"
+}
+
 // validateInstanceTypes checks that the user-provided instance types are valid.
 func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -100,6 +100,9 @@ var (
 		"n1-standard-1": {GuestCpus: 1, MemoryMb: 3840},
 		"n1-standard-2": {GuestCpus: 2, MemoryMb: 7680},
 		"n1-standard-4": {GuestCpus: 4, MemoryMb: 15360},
+		"n2-standard-1": {GuestCpus: 1, MemoryMb: 8192},
+		"n2-standard-2": {GuestCpus: 2, MemoryMb: 16384},
+		"n2-standard-4": {GuestCpus: 4, MemoryMb: 32768},
 	}
 
 	subnetAPIResult = []*compute.Subnetwork{
@@ -213,7 +216,7 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 			name:           "Invalid default machine type",
 			edits:          editFunctions{invalidateDefaultMachineTypes},
 			expectedError:  true,
-			expectedErrMsg: `\[platform.gcp.defaultMachinePlatform.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 4 vCPUs, platform.gcp.defaultMachinePlatform.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 15360 MB Memory\]`,
+			expectedErrMsg: `\[platform.gcp.defaultMachinePlatform.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 4 vCPUs, platform.gcp.defaultMachinePlatform.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 15360 MB Memory, controlPlane.platform.gcp.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 4 vCPUs, controlPlane.platform.gcp.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 15360 MB Memory, compute\[0\].platform.gcp.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 2 vCPUs, compute\[0\].platform.gcp.type: Invalid value: "n1-standard-1": instance type does not meet minimum resource requirements of 7680 MB Memory\]`,
 		},
 		{
 			name:           "Invalid control plane machine types",

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -628,3 +628,98 @@ func TestValidateServiceAccountPresent(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateZones(t *testing.T) {
+	validZonesDefaultMachine := func(ic *types.InstallConfig) {
+		ic.Platform.GCP.DefaultMachinePlatform.Zones = []string{"us-central1-a", "us-central1-c"}
+	}
+	validZonesControlPlane := func(ic *types.InstallConfig) {
+		ic.ControlPlane.Platform.GCP.Zones = []string{"us-central1-a", "us-central1-b"}
+	}
+	validZonesCompute := func(ic *types.InstallConfig) {
+		ic.Compute[0].Platform.GCP.Zones = []string{"us-central1-b", "us-central1-c", "us-central1-d"}
+	}
+	invalidZonesDefaultMachine := func(ic *types.InstallConfig) {
+		ic.Platform.GCP.DefaultMachinePlatform.Zones = []string{"us-central1-a", "us-central1-x", "us-central1-y"}
+	}
+	invalidZonesControlPlane := func(ic *types.InstallConfig) {
+		ic.ControlPlane.Platform.GCP.Zones = []string{"us-central1-d", "us-central1-x", "us-central1-y"}
+	}
+	invalidZonesCompute := func(ic *types.InstallConfig) {
+		ic.Compute[0].Platform.GCP.Zones = []string{"us-central1-y", "us-central1-z", "us-central1-w"}
+	}
+
+	cases := []struct {
+		name           string
+		edits          editFunctions
+		expectedError  bool
+		expectedErrMsg string
+	}{
+		{
+			name:           "Valid zones for defaultMachine",
+			edits:          editFunctions{validZonesDefaultMachine},
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Invalid zones for defaultMachine",
+			edits:          editFunctions{invalidZonesDefaultMachine},
+			expectedError:  true,
+			expectedErrMsg: `^\[platform.gcp.defaultMachinePlatform.zones: Invalid value: \[\]string\{"us\-central1\-x", "us\-central1\-y"\}: zone\(s\) not found in region\]$`,
+		},
+		{
+			name:           "Valid zones for controlPlane",
+			edits:          editFunctions{validZonesControlPlane},
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Invalid zones for controlPlane",
+			edits:          editFunctions{invalidZonesControlPlane},
+			expectedError:  true,
+			expectedErrMsg: `^\[controlPlane.platform.gcp.zones: Invalid value: \[\]string\{"us\-central1\-x", "us\-central1\-y"\}: zone\(s\) not found in region\]$`,
+		},
+		{
+			name:           "Valid zones for compute",
+			edits:          editFunctions{validZonesCompute},
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Invalid zones for compute",
+			edits:          editFunctions{invalidZonesCompute},
+			expectedError:  true,
+			expectedErrMsg: `^\[compute\[0\].platform.gcp.zones: Invalid value: \[\]string\{"us\-central1\-w", "us\-central1\-y", "us\-central1\-z"\}: zone\(s\) not found in region\]$`,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	gcpClient := mock.NewMockAPI(mockCtrl)
+
+	validZones := []*compute.Zone{
+		{Name: "us-central1-a"},
+		{Name: "us-central1-b"},
+		{Name: "us-central1-c"},
+		{Name: "us-central1-d"},
+	}
+
+	// Should get the list of zones.
+	gcpClient.EXPECT().GetZones(gomock.Any(), gomock.Any(), gomock.Any()).Return(validZones, nil).AnyTimes()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+
+			errs := validateZones(gcpClient, editedInstallConfig)
+			if tc.expectedError {
+				assert.Regexp(t, tc.expectedErrMsg, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -315,10 +315,10 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 
 	// Should return the machine type as specified.
 	for key, value := range machineTypeAPIResult {
-		gcpClient.EXPECT().GetMachineType(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(value, nil).AnyTimes()
+		gcpClient.EXPECT().GetMachineTypeWithZones(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(value, sets.New(validZone), nil).AnyTimes()
 	}
 	// When passed incorrect machine type, the API returns nil.
-	gcpClient.EXPECT().GetMachineType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("404")).AnyTimes()
+	gcpClient.EXPECT().GetMachineTypeWithZones(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("404")).AnyTimes()
 
 	// When passed the correct network & project, return an empty network, which should be enough to validate ok.
 	gcpClient.EXPECT().GetNetwork(gomock.Any(), validNetworkName, validProjectName).Return(&compute.Network{}, nil).AnyTimes()

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/api/googleapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/gcp/mock"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -717,6 +718,101 @@ func TestValidateZones(t *testing.T) {
 			errs := validateZones(gcpClient, editedInstallConfig)
 			if tc.expectedError {
 				assert.Regexp(t, tc.expectedErrMsg, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestValidateInstanceType(t *testing.T) {
+	cases := []struct {
+		name           string
+		zones          []string
+		instanceType   string
+		expectedError  bool
+		expectedErrMsg string
+	}{
+		{
+			name:           "Valid instance type with min requirements and no zones specified",
+			zones:          []string{},
+			instanceType:   "n1-standard-4",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Valid instance type with min requirements and valid zones specified",
+			zones:          []string{"a", "b"},
+			instanceType:   "n1-standard-4",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Valid instance type with min requirements and invalid zones specified",
+			zones:          []string{"a", "b", "d", "x", "y"},
+			instanceType:   "n1-standard-4",
+			expectedError:  true,
+			expectedErrMsg: `\[instance.type: Invalid value: "n1\-standard\-4": instance type not available in zones: \[x y\]\]$`,
+		},
+		{
+			name:           "Valid instance fails min requirements and no zones specified",
+			zones:          []string{},
+			instanceType:   "n1-standard-2",
+			expectedError:  true,
+			expectedErrMsg: `^\[instance.type: Invalid value: "n1\-standard\-2": instance type does not meet minimum resource requirements of 4 vCPUs instance.type: Invalid value: "n1\-standard\-2": instance type does not meet minimum resource requirements of 15360 MB Memory\]$`,
+		},
+		{
+			name:           "Valid instance fails min requirements and valid zones specified",
+			zones:          []string{"a", "b"},
+			instanceType:   "n1-standard-1",
+			expectedError:  true,
+			expectedErrMsg: ``,
+		},
+		{
+			name:           "Valid instance fails min requirements and invalid zones specified",
+			zones:          []string{"a", "x", "y"},
+			expectedError:  true,
+			expectedErrMsg: ``,
+		},
+		{
+			name:           "Invalid instance and no zones specified",
+			zones:          []string{},
+			instanceType:   "invalid-instance-1",
+			expectedError:  true,
+			expectedErrMsg: `^\[<nil>: Internal error: 404\]$`,
+		},
+		{
+			name:           "Invalid instance and valid zones specified",
+			zones:          []string{"a", "b"},
+			instanceType:   "invalid-instance-1",
+			expectedError:  true,
+			expectedErrMsg: `^\[<nil>: Internal error: 404\]$`,
+		},
+		{
+			name:           "Invalid instance and invalid zones specified",
+			zones:          []string{"a", "x", "y", "z"},
+			instanceType:   "invalid-instance-1",
+			expectedError:  true,
+			expectedErrMsg: `^\[<nil>: Internal error: 404\]$`,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	gcpClient := mock.NewMockAPI(mockCtrl)
+
+	// Should return the machine type as specified
+	for key, value := range machineTypeAPIResult {
+		gcpClient.EXPECT().GetMachineTypeWithZones(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(value, sets.New("a", "b", "c", "d"), nil).AnyTimes()
+	}
+	// When passed incorrect machine type, the API returns nil.
+	gcpClient.EXPECT().GetMachineTypeWithZones(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("404")).AnyTimes()
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			errs := ValidateInstanceType(gcpClient, field.NewPath("instance"), "project-id", "region", test.zones, test.instanceType, controlPlaneReq)
+			if test.expectedError {
+				assert.Regexp(t, test.expectedErrMsg, errs)
 			} else {
 				assert.Empty(t, errs)
 			}

--- a/pkg/asset/machines/gcp/zones.go
+++ b/pkg/asset/machines/gcp/zones.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 )
@@ -43,4 +44,45 @@ func AvailabilityZones(project, region string) ([]string, error) {
 
 	sort.Strings(zoneNames)
 	return zoneNames, nil
+}
+
+// ZonesForInstanceType retrieves a filtered list of availability zones where
+// the particular instance type is available. This is mainly necessary for
+// arm64, since the instance t2a-standard-* is not available in all
+// availability zones.
+func ZonesForInstanceType(project, region, instanceType string) ([]string, error) {
+	ssn, err := gcpconfig.GetSession(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session: %w", err)
+	}
+
+	svc, err := compute.NewService(context.Background(), option.WithCredentials(ssn.Credentials))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compute service: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	machines, err := gcpconfig.GetMachineTypeList(ctx, svc, project, region, instanceType, "items/*/machineTypes(zone),nextPageToken")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get zones for instance type: %w", err)
+	}
+
+	zones := sets.New[string]()
+	for _, machine := range machines {
+		zones.Insert(machine.Zone)
+	}
+
+	// Not all instance zones might be available in the project
+	pZones, err := gcpconfig.GetZones(ctx, svc, project, fmt.Sprintf("(region eq .*%s) (status eq UP)", region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get zones for project: %w", err)
+	}
+	pZoneNames := sets.New[string]()
+	for _, z := range pZones {
+		pZoneNames.Insert(z.Name)
+	}
+
+	return sets.List(zones.Intersection(pZoneNames)), nil
 }

--- a/pkg/asset/machines/gcp/zones.go
+++ b/pkg/asset/machines/gcp/zones.go
@@ -30,21 +30,17 @@ func AvailabilityZones(project, region string) ([]string, error) {
 
 	regionURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s",
 		project, region)
-	req := svc.Zones.List(project).Filter(fmt.Sprintf("(region eq %s) (status eq UP)", regionURL))
-
-	var zones []string
-	if err := req.Pages(ctx, func(page *compute.ZoneList) error {
-		for _, z := range page.Items {
-			zones = append(zones, z.Name)
-		}
-		return nil
-	}); err != nil {
-		return nil, errors.Wrap(err, "failed to list zones")
-	}
-	if len(zones) == 0 {
+	filter := fmt.Sprintf("(region eq %s) (status eq UP)", regionURL)
+	zones, err := gcpconfig.GetZones(ctx, svc, project, filter)
+	if err != nil {
 		return nil, errors.New("no zone was found")
 	}
 
-	sort.Strings(zones)
-	return zones, nil
+	zoneNames := make([]string, 0, len(zones))
+	for _, z := range zones {
+		zoneNames = append(zoneNames, z.Name)
+	}
+
+	sort.Strings(zoneNames)
+	return zoneNames, nil
 }

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -271,7 +271,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
 		if len(mpool.Zones) == 0 {
-			azs, err := gcp.AvailabilityZones(ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region)
+			azs, err := gcp.ZonesForInstanceType(ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region, mpool.InstanceType)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch availability zones")
 			}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
+	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/alibabacloud"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
@@ -126,23 +127,12 @@ func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 }
 
 func defaultGCPMachinePoolPlatform(arch types.Architecture) gcptypes.MachinePool {
-	switch arch {
-	case types.ArchitectureARM64:
-		return gcptypes.MachinePool{
-			InstanceType: "t2a-standard-4",
-			OSDisk: gcptypes.OSDisk{
-				DiskSizeGB: powerOfTwoRootVolumeSize,
-				DiskType:   "pd-ssd",
-			},
-		}
-	default:
-		return gcptypes.MachinePool{
-			InstanceType: "n2-standard-4",
-			OSDisk: gcptypes.OSDisk{
-				DiskSizeGB: powerOfTwoRootVolumeSize,
-				DiskType:   "pd-ssd",
-			},
-		}
+	return gcptypes.MachinePool{
+		InstanceType: icgcp.DefaultInstanceTypeForArch(arch),
+		OSDisk: gcptypes.OSDisk{
+			DiskSizeGB: powerOfTwoRootVolumeSize,
+			DiskType:   "pd-ssd",
+		},
 	}
 }
 

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -523,7 +523,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.GCP)
 			if len(mpool.Zones) == 0 {
-				azs, err := gcp.AvailabilityZones(ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region)
+				azs, err := gcp.ZonesForInstanceType(ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region, mpool.InstanceType)
 				if err != nil {
 					return errors.Wrap(err, "failed to fetch availability zones")
 				}


### PR DESCRIPTION
In https://github.com/openshift/installer/pull/7096 we fixed the validation but the same logic needs to be done for the machine asset generation.