### PR TITLE
aws: drop hostedZoneRole Feature Gate

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1054,12 +1054,6 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
 		errMsg := "the TechPreviewNoUpgrade feature set must be enabled to use this field"
 
-		if c.AWS != nil {
-			if len(c.AWS.HostedZoneRole) > 0 {
-				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "aws", "hostedZoneRole"), errMsg))
-			}
-		}
-
 		if c.OpenStack != nil {
 			for _, f := range openstackvalidation.FilledInTechPreviewFields(c) {
 				allErrs = append(allErrs, field.Forbidden(f, errMsg))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2087,18 +2087,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "platform.vsphere.apiVIPs: Required value: must specify VIP for API, when VIP for ingress is set",
 		},
 		{
-			name: "platform.aws.hostedZoneRole should return error without TechPreviewNoUpgrade",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					AWS: validAWSPlatform(),
-				}
-				c.Platform.AWS.HostedZoneRole = "test-zone"
-				return c
-			}(),
-			expectedError: `platform.aws.hostedZoneRole: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field`,
-		},
-		{
 			name: "valid custom features",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
AWS hostedZoneRole feature has been promoted in the API. Remove the installer validation for a tech preview feature gate.

API Promotion is in https://github.com/openshift/api/pull/1522
