### PR TITLE
Bug 2108582 [4.6] RHCOS: move to rhcos.mirror.openshift.com

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -68,7 +68,7 @@
         "image": "rhcos-46.82.202109242004-0-azure.x86_64.vhd",
         "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202109242004-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
     "buildid": "46.82.202109242004-0",
     "gcp": {
         "image": "rhcos-46-82-202109242004-0-gcp-x86-64",

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,5 +1,5 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-ppc64le/46.82.202109180809-0/ppc64le/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.6-ppc64le/46.82.202109180809-0/ppc64le/",
     "buildid": "46.82.202109180809-0",
     "images": {
         "live-initramfs": {

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,5 +1,5 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-s390x/46.82.202109180304-0/s390x/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.6-s390x/46.82.202109180304-0/s390x/",
     "buildid": "46.82.202109180304-0",
     "images": {
         "dasd": {

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -68,7 +68,7 @@
         "image": "rhcos-46.82.202109242004-0-azure.x86_64.vhd",
         "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202109242004-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
     "buildid": "46.82.202109242004-0",
     "gcp": {
         "image": "rhcos-46-82-202109242004-0-gcp-x86-64",

--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -6,7 +6,7 @@ import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com'
+RHCOS_RELEASES_APP = 'https://rhcos.mirror.openshift.com'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
rhcos.mirror.openshift.com is the new formal location to download RHCOS boot images. It is backed by CloudFront CDN, which should be more reliable and faster than the rhcos-redirector.