### PR TITLE
Pd balanced epic

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -215,7 +215,7 @@ func getRegionFromZone(zoneName string) string {
 // projects/project/zones/zone/diskTypes/pd-standard -> "ssd_total_storage"
 func getDiskLimit(typeURL string) string {
 	switch getNameFromURL("diskTypes", typeURL) {
-	case "pd-ssd":
+	case "pd-ssd", "pd-balanced":
 		return "ssd_total_storage"
 	case "pd-standard":
 		return "disks_total_storage"

--- a/pkg/destroy/gcp/gcp_test.go
+++ b/pkg/destroy/gcp/gcp_test.go
@@ -44,6 +44,10 @@ func TestGetDiskLimit(t *testing.T) {
 			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-ssd",
 			expected: "ssd_total_storage",
 		},
+		{
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-balanced",
+			expected: "ssd_total_storage",
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -50,7 +50,7 @@ type OSDisk struct {
 	// DiskType defines the type of disk.
 	// For control plane nodes, the valid value is pd-ssd.
 	// +optional
-	// +kubebuilder:validation:Enum=pd-ssd;pd-standard
+	// +kubebuilder:validation:Enum=pd-ssd;pd-balanced;pd-standard
 	DiskType string `json:"diskType"`
 
 	// DiskSizeGB defines the size of disk in GB.

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -30,7 +30,7 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	}
 
 	if p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-standard", "pd-ssd")
+		diskTypes := sets.NewString("pd-standard", "pd-ssd", "pd-balanced")
 		if !diskTypes.Has(p.OSDisk.DiskType) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
 		}
@@ -66,7 +66,7 @@ func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	if p != nil && p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-ssd")
+		diskTypes := sets.NewString("pd-ssd", "pd-balanced")
 
 		if !diskTypes.Has(p.OSDisk.DiskType) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -48,7 +48,7 @@ func TestValidateMachinePool(t *testing.T) {
 					DiskType: "pd-",
 				},
 			},
-			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-ssd", "pd-standard"$`,
+			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-ssd", "pd-balanced", "pd-standard"$`,
 		},
 		{
 			name: "valid disk size",


### PR DESCRIPTION
pkg/destroy/gcp/gcp_test.go
Commit to repo -- [gcp] Add a pd-balanced test case for the TestGetDiskLimit function

pkg/destroy/gcp/gcp.go
Commit to repo -- [gcp] Add a pd-balanced switch case for the getDiskLimit function

pkg/types/gcp/machinepools.go
Commit to repo --  [gcp] Add comment for pd-balanced disk type in OSDisk struct

pkg/types/gcp/validation/machinepool_test.go
Commit to repo -- [validation] Add support for pd-balanced disk type in TestValidateMachinePool

pkg/types/gcp/validation/machinepool.go
Commit to repo --  [validation] Add support for pd-balanced disk type in ValidateMachinePool