### PR TITLE
CORS-1770: Support pd-balanced disk types for GCP deployments

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -378,6 +378,7 @@ spec:
                               description: DiskType defines the type of disk. For
                                 control plane nodes, the valid value is pd-ssd.
                               enum:
+                              - pd-balanced
                               - pd-ssd
                               - pd-standard
                               type: string
@@ -1141,6 +1142,7 @@ spec:
                             description: DiskType defines the type of disk. For control
                               plane nodes, the valid value is pd-ssd.
                             enum:
+                            - pd-balanced
                             - pd-ssd
                             - pd-standard
                             type: string
@@ -2569,6 +2571,7 @@ spec:
                             description: DiskType defines the type of disk. For control
                               plane nodes, the valid value is pd-ssd.
                             enum:
+                            - pd-balanced
                             - pd-ssd
                             - pd-standard
                             type: string

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -27,11 +27,11 @@ const (
 func GetConfigImageFiles() []string {
 	return []string{
 		"/etc/assisted/manifests/pull-secret.yaml", //nolint:gosec // not hardcoded credentials
-		"/etc/assisted/manifests/nmstateconfig.yaml",
 		"/etc/assisted/manifests/cluster-deployment.yaml",
 		"/etc/assisted/manifests/cluster-image-set.yaml",
 		"/etc/assisted/manifests/agent-cluster-install.yaml",
 		"/etc/assisted/manifests/infraenv.yaml",
+		"/etc/assisted/manifests",       // optional nmstateconfig.yaml
 		"/etc/assisted/extra-manifests", // all files in directory
 		"/etc/assisted/hostconfig",      // all files in directory
 		"/etc/assisted/hostnames",       // all files in directory

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -215,7 +215,7 @@ func getRegionFromZone(zoneName string) string {
 // projects/project/zones/zone/diskTypes/pd-standard -> "ssd_total_storage"
 func getDiskLimit(typeURL string) string {
 	switch getNameFromURL("diskTypes", typeURL) {
-	case "pd-ssd":
+	case "pd-balanced", "pd-ssd":
 		return "ssd_total_storage"
 	case "pd-standard":
 		return "disks_total_storage"

--- a/pkg/destroy/gcp/gcp_test.go
+++ b/pkg/destroy/gcp/gcp_test.go
@@ -44,6 +44,10 @@ func TestGetDiskLimit(t *testing.T) {
 			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-ssd",
 			expected: "ssd_total_storage",
 		},
+		{
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-balanced",
+			expected: "ssd_total_storage",
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -57,7 +57,7 @@ type OSDisk struct {
 	// DiskType defines the type of disk.
 	// For control plane nodes, the valid value is pd-ssd.
 	// +optional
-	// +kubebuilder:validation:Enum=pd-ssd;pd-standard
+	// +kubebuilder:validation:Enum=pd-balanced;pd-ssd;pd-standard
 	DiskType string `json:"diskType"`
 
 	// DiskSizeGB defines the size of disk in GB.

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -30,7 +30,7 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	}
 
 	if p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-standard", "pd-ssd")
+		diskTypes := sets.NewString("pd-balanced", "pd-ssd", "pd-standard")
 		if !diskTypes.Has(p.OSDisk.DiskType) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
 		}
@@ -69,11 +69,12 @@ func ValidateServiceAccount(platform *gcp.Platform, p *types.MachinePool, fldPat
 // ValidateMasterDiskType checks that the specified disk type is valid for control plane.
 func ValidateMasterDiskType(p *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if p.Name == "master" && p.Platform.GCP.OSDisk.DiskType == "pd-standard" {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, fmt.Sprintf("%s not compatible with control planes.", p.Platform.GCP.OSDisk.DiskType)))
+	if p.Name == "master" && p.Platform.GCP.OSDisk.DiskType != "" {
+		diskTypes := sets.NewString("pd-ssd")
+		if !diskTypes.Has(p.Platform.GCP.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, diskTypes.List()))
+		}
 	}
-
 	return allErrs
 }
 

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -48,7 +48,7 @@ func TestValidateMachinePool(t *testing.T) {
 					DiskType: "pd-",
 				},
 			},
-			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-ssd", "pd-standard"$`,
+			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-balanced", "pd-ssd", "pd-standard"$`,
 		},
 		{
 			name: "valid disk size",


### PR DESCRIPTION
Adding support for `pd-balanced` disk types for the compute nodes by allowing users to provide it in the disk type field under compute in the install config.