### PR TITLE
OCPBUGS-15994: Update core password after loading config-image

### DIFF
--- a/data/data/agent/files/usr/local/bin/load-config-iso.sh
+++ b/data/data/agent/files/usr/local/bin/load-config-iso.sh
@@ -67,7 +67,7 @@ copy_archive_contents() {
     echo "Successfully copied contents of ${AGENT_CONFIG_ARCHIVE_FILE} on ${devname}"
 
     # Update core password with one from config-image if not overridden by appliance
-    if ! cpio --list < "${unzipped_file}" | grep -q -e "${OVERRIDE_PASSWORD_SET}"; then
+    if [[ ! -f "${OVERRIDE_PASSWORD_SET}" ]]; then
        echo "Setting core password"
        usermod --password "$(cat ${PASSWORD_HASH})" core
     else

--- a/data/data/agent/files/usr/local/bin/load-config-iso.sh
+++ b/data/data/agent/files/usr/local/bin/load-config-iso.sh
@@ -12,6 +12,7 @@ CLUSTER_IMAGE_SET="/etc/assisted/manifests/cluster-image-set.yaml"
 EXTRA_MANIFESTS="/etc/assisted/extra-manifests"
 ASSISTED_NETWORK_DIR="/etc/assisted/network"
 NM_CONNECTION_DIR="/etc/NetworkManager/system-connections"
+PASSWORD_HASH="/opt/agent/tls/kubeadmin-password.hash"
 
 copy_archive_contents() {
     tmpdir=$(mktemp --tmpdir -d "config-image--XXXXXXXXXX")
@@ -63,6 +64,11 @@ copy_archive_contents() {
     fi
 
     echo "Successfully copied contents of ${AGENT_CONFIG_ARCHIVE_FILE} on ${devname}"
+
+    # Update core password with one from config-image if not overridden by appliance
+    if [[ -z "${SKIP_CORE_PASSWORD_SET}" ]] || [[ "${SKIP_CORE_PASSWORD_SET}" == "false" ]]; then
+       usermod --password "$(cat ${PASSWORD_HASH})" core
+    fi
 
     # Enable any services which are not enabled by default
     declare -a servicelist=("start-cluster-installation.service")

--- a/pkg/asset/agent/configimage/configiso.go
+++ b/pkg/asset/agent/configimage/configiso.go
@@ -65,14 +65,6 @@ func (a *ConfigImage) Generate(dependencies asset.Parents) error {
 		}
 	}
 
-	// Add additional file to allow for override of setting the core password
-	if _, ok := os.LookupEnv("OPENSHIFT_APPLIANCE_OVERRIDE_PASSWORD_SET"); ok {
-		err := ca.StoreBytes("/etc/assisted/appliance-override-password-set", []byte("true"), 0o644)
-		if err != nil {
-			return errors.Wrapf(err, "failure storing appliance override password file")
-		}
-	}
-
 	// Save the cpi archive to a temp file
 	tmpPath, err := os.MkdirTemp("", "agent")
 	if err != nil {

--- a/pkg/asset/agent/configimage/configiso.go
+++ b/pkg/asset/agent/configimage/configiso.go
@@ -65,6 +65,14 @@ func (a *ConfigImage) Generate(dependencies asset.Parents) error {
 		}
 	}
 
+	// Add additional file to allow for override of setting the core password
+	if _, ok := os.LookupEnv("OPENSHIFT_APPLIANCE_OVERRIDE_PASSWORD_SET"); ok {
+		err := ca.StoreBytes("/etc/assisted/appliance-override-password-set", []byte("true"), 0o644)
+		if err != nil {
+			return errors.Wrapf(err, "failure storing appliance override password file")
+		}
+	}
+
 	// Save the cpi archive to a temp file
 	tmpPath, err := os.MkdirTemp("", "agent")
 	if err != nil {


### PR DESCRIPTION
The core user password should be set to the one stored in kubeadmin-password.hash after loading the config-image.