### PR TITLE
OSASINFRA-3193: Update openstack/Dockerfile.ci for ansible-core

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -26,10 +26,19 @@ RUN yum install --setopt=tsflags=nodocs -y gettext make git gzip util-linux glib
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq nmap && \
+    ansible-core unzip jq nmap && \
+    yum erase -y python36 && \
     yum clean all && rm -rf /var/cache/yum/*
 
-RUN python -m pip install yq
+# ansible 2.9 is EOL in September 2023, so we need to install ansible-core and get the collections from source
+# until we have a package available.
+RUN ansible-galaxy collection install openstack.cloud ansible.netcommon ansible.utils community.general && \
+    mkdir -p /usr/share/ansible/collections/ansible_collections && \
+    cp -r /root/.ansible/collections/ansible_collections/* /usr/share/ansible/collections/ansible_collections/
+
+RUN python3 -m pip install --upgrade pip
+# ansible-core comes with python3.8 but openstacksdk comes with python3.6 so let's install them from pip.
+RUN python3 -m pip install yq openstackclient openstacksdk netaddr
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -64,9 +64,9 @@ all:
       # An IP address that will be assigned to the API VIP.
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
-      os_apiVIP: "{{ os_subnet_range | next_nth_usable(5) }}"
+      os_apiVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(5) }}"
 
       # An IP address that will be assigned to the ingress VIP.
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
-      os_ingressVIP: "{{ os_subnet_range | next_nth_usable(7) }}"
+      os_ingressVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(7) }}"

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -24,8 +24,8 @@
       name: "{{ os_subnet }}"
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
-      allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+      allocation_pool_start: "{{ os_subnet_range | ansible.utils.next_nth_usable(10) }}"
+      allocation_pool_end: "{{ os_subnet_range | ansible.utils.ipaddr('last_usable') }}"
       dns_nameservers: "{{ os_external_dns }}"
 
   - name: 'Set tags on  primary cluster subnet'
@@ -45,9 +45,9 @@
   - name: 'Computing facts for service subnet'
     set_fact:
       first_ip_svc_subnet_range: "{{ svc_subnet_range | ipv4('network') }}"
-      last_ip_svc_subnet_range: "{{ svc_subnet_range | ipaddr('last_usable') |ipmath(1) }}"
+      last_ip_svc_subnet_range: "{{ svc_subnet_range | ansible.utils.ipaddr('last_usable') |ipmath(1) }}"
       first_ip_os_svc_network_range: "{{ os_svc_network_range | ipv4('network') }}"
-      last_ip_os_svc_network_range: "{{ os_svc_network_range | ipaddr('last_usable') |ipmath(1) }}"
+      last_ip_os_svc_network_range: "{{ os_svc_network_range | ansible.utils.ipaddr('last_usable') |ipmath(1) }}"
       allocation_pool: ""
     when: os_networking_type == "Kuryr"
 


### PR DESCRIPTION
Ansible 2.9 is going EOL later this year, we need to use ansible-core
and until we get RPMs for openstack collections, we'll install them from
source.

TODO:

* [ ] Update the doc in docs/user/openstack/install_upi.md