### PR TITLE
OCPBUGS-16292: GCP XPN: clarify service account support

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -436,10 +436,11 @@ spec:
                           type: string
                         serviceAccount:
                           description: ServiceAccount is the email of a gcp service
-                            account to be used for shared vpn installations. The provided
+                            account to be used for shared vpc installations. The provided
                             service account will be attached to control-plane nodes
                             in order to provide the permissions required by the cloud
-                            provider in the host project.
+                            provider in the host project. This field is only supported
+                            in the control-plane machinepool.
                           type: string
                         tags:
                           description: Tags defines a set of network tags which will
@@ -1191,10 +1192,11 @@ spec:
                         type: string
                       serviceAccount:
                         description: ServiceAccount is the email of a gcp service
-                          account to be used for shared vpn installations. The provided
+                          account to be used for shared vpc installations. The provided
                           service account will be attached to control-plane nodes
                           in order to provide the permissions required by the cloud
-                          provider in the host project.
+                          provider in the host project. This field is only supported
+                          in the control-plane machinepool.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will
@@ -2612,10 +2614,11 @@ spec:
                         type: string
                       serviceAccount:
                         description: ServiceAccount is the email of a gcp service
-                          account to be used for shared vpn installations. The provided
+                          account to be used for shared vpc installations. The provided
                           service account will be attached to control-plane nodes
                           in order to provide the permissions required by the cloud
-                          provider in the host project.
+                          provider in the host project. This field is only supported
+                          in the control-plane machinepool.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -45,8 +45,9 @@ type MachinePool struct {
 	ConfidentialCompute string `json:"confidentialCompute,omitempty"`
 
 	// ServiceAccount is the email of a gcp service account to be used for shared
-	// vpn installations. The provided service account will be attached to control-plane nodes
+	// vpc installations. The provided service account will be attached to control-plane nodes
 	// in order to provide the permissions required by the cloud provider in the host project.
+	// This field is only supported in the control-plane machinepool.
 	//
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty"`


### PR DESCRIPTION
Clarify the wording in the service account field in the gcp machine pool to indicate the field is only supported in the control plane machine set.

Because compute and control plane machine pools are the same type, openshift-install explain will display the service account field in the compute machine pool. Hopefully this will make it slightly less confusing.