### PR TITLE
OCPBUGS-15941: ABI - Validate release image arch, add cpu_architectures to RELEASE_IMAGES

### DIFF
--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -65,7 +65,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	haveMirrorConfig := true
 	publicContainerRegistries := "quay.io,registry.ci.openshift.org"
 
-	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, "x86_64")
+	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, "x86_64", []string{"86_64"})
 	assert.NoError(t, err)
 
 	arch := "x86_64"

--- a/pkg/asset/agent/image/releaseimage.go
+++ b/pkg/asset/agent/image/releaseimage.go
@@ -10,18 +10,18 @@ import (
 )
 
 type releaseImage struct {
-	ReleaseVersion string `json:"openshift_version"`
-	Arch           string `json:"cpu_architecture"`
-	PullSpec       string `json:"url"`
-	Tag            string `json:"version"`
+	ReleaseVersion string   `json:"openshift_version"`
+	Arch           string   `json:"cpu_architecture"`
+	Archs          []string `json:"cpu_architectures"`
+	PullSpec       string   `json:"url"`
+	Tag            string   `json:"version"`
 }
 
 func isDigest(pullspec string) bool {
 	return regexp.MustCompile(`.*sha256:[a-fA-F0-9]{64}$`).MatchString(pullspec)
 }
 
-func releaseImageFromPullSpec(pullSpec, arch string) (releaseImage, error) {
-
+func releaseImageFromPullSpec(pullSpec, arch string, archs []string) (releaseImage, error) {
 	// When the pullspec it's a digest let's use the current version
 	// stored in the installer
 	if isDigest(pullSpec) {
@@ -33,6 +33,7 @@ func releaseImageFromPullSpec(pullSpec, arch string) (releaseImage, error) {
 		return releaseImage{
 			ReleaseVersion: versionString,
 			Arch:           arch,
+			Archs:          archs,
 			PullSpec:       pullSpec,
 			Tag:            versionString,
 		}, nil
@@ -54,14 +55,14 @@ func releaseImageFromPullSpec(pullSpec, arch string) (releaseImage, error) {
 	return releaseImage{
 		ReleaseVersion: relVersion,
 		Arch:           arch,
+		Archs:          archs,
 		PullSpec:       pullSpec,
 		Tag:            tag,
 	}, nil
 }
 
-func releaseImageList(pullSpec, arch string) (string, error) {
-
-	relImage, err := releaseImageFromPullSpec(pullSpec, arch)
+func releaseImageList(pullSpec, arch string, archs []string) (string, error) {
+	relImage, err := releaseImageFromPullSpec(pullSpec, arch, archs)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/asset/agent/image/releaseimage_test.go
+++ b/pkg/asset/agent/image/releaseimage_test.go
@@ -17,37 +17,37 @@ func TestReleaseImageList(t *testing.T) {
 			name:     "4.10rc",
 			pullSpec: "quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64",
 			arch:     "x86_64",
-			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"x86_64\",\"url\":\"quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64\",\"version\":\"4.10.0-rc.1\"}]",
+			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"x86_64\",\"cpu_architectures\":[\"x86_64\"],\"url\":\"quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64\",\"version\":\"4.10.0-rc.1\"}]",
 		},
 		{
 			name:     "pull-spec-includes-port-number",
 			pullSpec: "quay.io:433/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64",
 			arch:     "x86_64",
-			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"x86_64\",\"url\":\"quay.io:433/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64\",\"version\":\"4.10.0-rc.1\"}]",
+			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"x86_64\",\"cpu_architectures\":[\"x86_64\"],\"url\":\"quay.io:433/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64\",\"version\":\"4.10.0-rc.1\"}]",
 		},
 		{
 			name:     "arm",
 			pullSpec: "quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-aarch64",
 			arch:     "aarch64",
-			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"aarch64\",\"url\":\"quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-aarch64\",\"version\":\"4.10.0-rc.1\"}]",
+			result:   "[{\"openshift_version\":\"4.10\",\"cpu_architecture\":\"aarch64\",\"cpu_architectures\":[\"aarch64\"],\"url\":\"quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-aarch64\",\"version\":\"4.10.0-rc.1\"}]",
 		},
 		{
 			name:     "4.11ci",
 			pullSpec: "registry.ci.openshift.org/ocp/release:4.11.0-0.ci-2022-05-16-202609",
 			arch:     "x86_64",
-			result:   "[{\"openshift_version\":\"4.11\",\"cpu_architecture\":\"x86_64\",\"url\":\"registry.ci.openshift.org/ocp/release:4.11.0-0.ci-2022-05-16-202609\",\"version\":\"4.11.0-0.ci-2022-05-16-202609\"}]",
+			result:   "[{\"openshift_version\":\"4.11\",\"cpu_architecture\":\"x86_64\",\"cpu_architectures\":[\"x86_64\"],\"url\":\"registry.ci.openshift.org/ocp/release:4.11.0-0.ci-2022-05-16-202609\",\"version\":\"4.11.0-0.ci-2022-05-16-202609\"}]",
 		},
 		{
 			name:     "CI-ephemeral",
 			pullSpec: "registry.build04.ci.openshift.org/ci-op-m7rfgytz/release@sha256:ebb203f24ee060d61bdb466696a9c20b3841f9929badf9b81fc99cbedc2a679e",
 			arch:     "x86_64",
-			result:   "[{\"openshift_version\":\"was not built correctly\",\"cpu_architecture\":\"x86_64\",\"url\":\"registry.build04.ci.openshift.org/ci-op-m7rfgytz/release@sha256:ebb203f24ee060d61bdb466696a9c20b3841f9929badf9b81fc99cbedc2a679e\",\"version\":\"was not built correctly\"}]",
+			result:   "[{\"openshift_version\":\"was not built correctly\",\"cpu_architecture\":\"x86_64\",\"cpu_architectures\":[\"x86_64\"],\"url\":\"registry.build04.ci.openshift.org/ci-op-m7rfgytz/release@sha256:ebb203f24ee060d61bdb466696a9c20b3841f9929badf9b81fc99cbedc2a679e\",\"version\":\"was not built correctly\"}]",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := releaseImageList(tc.pullSpec, tc.arch)
+			output, err := releaseImageList(tc.pullSpec, tc.arch, []string{tc.arch})
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, tc.result, output)
@@ -65,7 +65,7 @@ func TestReleaseImageListErrors(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc, func(t *testing.T) {
-			_, err := releaseImageList(tc, "x86_64")
+			_, err := releaseImageList(tc, "x86_64", []string{"x86_64"})
 			assert.Error(t, err)
 		})
 	}

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -112,8 +112,7 @@ func (a *UnconfiguredIgnition) Generate(dependencies asset.Parents) error {
 	if infraEnv.Spec.CpuArchitecture != "" {
 		archName = infraEnv.Spec.CpuArchitecture
 	}
-
-	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, archName)
+	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, archName, []string{archName})
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -38,7 +38,7 @@ baseDomain: test-domain
 platform:
   aws:
     region: us-east-1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: Platform: Unsupported value: "aws": supported values: "baremetal", "vsphere", "none", "external"`,
@@ -84,7 +84,7 @@ platform:
         bootMACAddress: 52:54:01:bb:bb:b1
       - name: host3
         bootMACAddress: 52:54:01:cc:cc:c1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: [platform.baremetal.apiVIPs: Required value: must specify at least one VIP for the API, platform.baremetal.apiVIPs: Required value: must specify VIP for API, when VIP for ingress is set]",
@@ -105,7 +105,7 @@ platform:
     password: testpassword
     datacenter: testDatacenter
     defaultDatastore: testDatastore
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: [platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
@@ -139,7 +139,7 @@ platform:
         folder: "/testDatacenter/vm/testFolder"
         networks:
         - testNetwork
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
@@ -186,7 +186,7 @@ platform:
         folder: "/testDatacenter2/vm/testFolder"
         networks:
         - testNetwork2
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: [platform.vsphere.failureDomains.server: Invalid value: "diff1.vcenter.com": server does not exist in vcenters, platform.vsphere.failureDomains.server: Invalid value: "diff2.vcenter.com": server does not exist in vcenters]`,
@@ -205,7 +205,7 @@ platform:
     ingressVips:
       - 192.168.122.11
     vCenter: test.vcenter.com
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
@@ -226,7 +226,7 @@ platform:
     vcenters:
     - server: test.vcenter.com
       user: testuser
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
@@ -242,7 +242,7 @@ platform:
   vsphere:
     apiVips:
       - 192.168.122.10
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
@@ -264,7 +264,7 @@ controlPlane:
   replicas: 1
 platform:
   none : {}
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Total number of Compute.Replicas must be 0 when ControlPlane.Replicas is 1 for platform none or external. Found 3",
@@ -293,7 +293,7 @@ controlPlane:
 platform:
   aws:
     region: us-east-1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: [Platform: Unsupported value: \"aws\": supported values: \"baremetal\", \"vsphere\", \"none\", \"external\", Platform: Invalid value: \"aws\": Only platform none and external supports 1 ControlPlane and 0 Compute nodes]",
@@ -332,7 +332,7 @@ platform:
       bootMACAddress: 52:54:01:bb:bb:b1
     - name: host3
       bootMACAddress: 52:54:01:cc:cc:c1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: Platform: Invalid value: \"baremetal\": CPU architecture \"ppc64le\" only supports platform \"none\".",
@@ -371,7 +371,7 @@ platform:
       bootMACAddress: 52:54:01:bb:bb:b1
     - name: host3
       bootMACAddress: 52:54:01:cc:cc:c1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: Platform: Invalid value: \"baremetal\": CPU architecture \"s390x\" only supports platform \"none\".",
@@ -400,7 +400,7 @@ controlPlane:
 platform:
   external:
    platformName: some-cloud-provider
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -445,7 +445,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						CloudControllerManager: "",
 					},
 				},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				PullSecret: `{"auths":{"example.com":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
@@ -459,7 +459,7 @@ baseDomain: test-domain
 platform:
   external:
     platformName: oci
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: Platform.External.CloudControllerManager: Invalid value: "": When using external oci platform, Platform.External.CloudControllerManager must be set to External`,
@@ -487,7 +487,7 @@ controlPlane:
   replicas: 1
 platform:
   none : {}
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -527,7 +527,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 					},
 				},
 				Platform:   types.Platform{None: &none.Platform{}},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				PullSecret: `{"auths":{"example.com":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
@@ -554,7 +554,7 @@ controlPlane:
   replicas: 3
 platform:
   none : {}
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -594,7 +594,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 					},
 				},
 				Platform:   types.Platform{None: &none.Platform{}},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				PullSecret: `{"auths":{"example.com":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
@@ -656,7 +656,7 @@ platform:
         bootMACAddress: 52:54:01:dd:dd:d1
       - name: host5
         bootMACAddress: 52:54:01:ee:ee:e1
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -755,7 +755,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						BootstrapExternalStaticGateway: "gateway",
 					},
 				},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				PullSecret: `{"auths":{"example.com":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
@@ -799,7 +799,7 @@ platform:
     apiVIP: 192.168.122.10
     ingressVIPs: 
       - 192.168.122.11
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -873,7 +873,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						}},
 					},
 				},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				PullSecret: `{"auths":{"example.com":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
@@ -908,7 +908,7 @@ platform:
       - 192.168.122.11
     apiVIPs:
       - 192.168.122.10
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: platform.baremetal.provisioningNetwork: Unsupported value: \"UNMANAGED\": supported values: \"Disabled\", \"Managed\", \"Unmanaged\"",
@@ -968,7 +968,7 @@ platform:
           username: "admin"
           password: "password"
           address: "redfish+http://10.10.10.2:8000/redfish/v1/Systems/1234"
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
 			expectedError: `invalid install-config configuration: [Platform.BareMetal.clusterProvisioningIP: Invalid value: "172.22.0.11": "172.22.0.11" overlaps with the allocated DHCP range, Platform.BareMetal.hosts[2].BMC.Address: Duplicate value: "redfish+http://10.10.10.2:8000/redfish/v1/Systems/1234"]`,

--- a/pkg/asset/agent/oc.go
+++ b/pkg/asset/agent/oc.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ExecuteOC will execute an oc command.
+func ExecuteOC(pullSecret string, command []string) (string, error) {
+	// create registry config
+	ps, err := os.CreateTemp("", "registry-config")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		ps.Close()
+		os.Remove(ps.Name())
+	}()
+	_, err = ps.Write([]byte(pullSecret))
+	if err != nil {
+		return "", err
+	}
+	// flush the buffer to ensure the file can be read
+	ps.Close()
+	registryConfig := "--registry-config=" + ps.Name()
+	command = append(command, registryConfig)
+	var stdoutBytes, stderrBytes bytes.Buffer
+	cmd := exec.Command(command[0], command[1:]...) // #nosec G204
+	cmd.Stdout = &stdoutBytes
+	cmd.Stderr = &stderrBytes
+
+	err = cmd.Run()
+	if err == nil {
+		return strings.TrimSpace(stdoutBytes.String()), nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		err = fmt.Errorf("command '%s' exited with non-zero exit code %d: %s\n%s", command, exitErr.ExitCode(), stdoutBytes.String(), stderrBytes.String())
+	} else {
+		err = fmt.Errorf("command '%s' failed: %w", command, err)
+	}
+	return "", err
+}


### PR DESCRIPTION
Adding additional validation to check that the release payload architecture matches the cluster's architecture.
Also fixes OCPBUGS-27787 - single arch  ABI installs w/multi payload, adding `cpu_architectures` to RELEASE_IMAGES

RELEASE_IMAGES: 
Single arch -
```  
'[{"openshift_version":"4.15","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift-release-dev/ocp-release:4.15.0-rc.4-x86_64","support_level":"beta","version":"4.15.0-rc.4"}]
```
Multi -
```
[{"openshift_version":"4.15-multi","cpu_architecture":"multi","cpu_architectures":["x86_64","arm64","ppc64le","s390x"],"url":"quay.io/openshift-release-dev/ocp-release:4.15.0-rc.4-multi","support_level":"beta","version":"4.15.0-rc.4-multi"}]'
```

