### PR TITLE
OCPBUGS-16395: openstack/upi: update doc for CCPMSO

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -461,10 +461,10 @@ $ tree
 ### Remove Machines and MachineSets
 
 Remove the control-plane Machines and compute MachineSets, because we'll be providing those ourselves and don't want to involve the
-[machine-API operator][mao]:
+[machine-API operator][mao] and [cluster-control-plane-machine-set operator][ccpmso]:
 <!--- e2e-openstack-upi: INCLUDE START --->
 ```sh
-$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ```
 <!--- e2e-openstack-upi: INCLUDE END --->
 Leave the compute MachineSets in if you want to create compute machines via the machine API. However, some references must be updated in the machineset spec (`openshift/99_openshift-cluster-api_worker-machineset-0.yaml`) to match your environment:
@@ -472,6 +472,7 @@ Leave the compute MachineSets in if you want to create compute machines via the 
 * The OS image: `spec.template.spec.providerSpec.value.image`
 
 [mao]: https://github.com/openshift/machine-api-operator
+[ccpmso]: https://github.com/openshift/cluster-control-plane-machine-set-operator
 
 ### Make control-plane nodes unschedulable
 


### PR DESCRIPTION
We don't want CCPMSO with UPI, the machines are managed by the user, not
OpenShift.
