### PR TITLE
OCPBUGS-16204: aws: attach additional security groups to controlPlane

### DIFF
--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -42,7 +42,7 @@ module "masters" {
   availability_zones               = var.aws_master_availability_zones
   az_to_subnet_id                  = module.vpc.az_to_private_subnet_id
   instance_count                   = var.master_count
-  master_sg_ids                    = [module.vpc.master_sg_id]
+  master_sg_ids                    = concat([module.vpc.master_sg_id], var.aws_master_security_groups)
   root_volume_iops                 = var.aws_master_root_volume_iops
   root_volume_size                 = var.aws_master_root_volume_size
   root_volume_type                 = var.aws_master_root_volume_type

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -205,3 +205,9 @@ variable "aws_preserve_bootstrap_ignition" {
   type        = bool
   description = "The variable that needs to be set to avoid destuction of S3 objects during bootstrap destroy."
 }
+
+variable "aws_master_security_groups" {
+  type        = list(string)
+  description = "(optional) List of additional security group IDs to attach to the master nodes"
+  default     = []
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -294,6 +294,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
 
+		var securityGroups []string
+		if mp := installConfig.Config.ControlPlane; mp != nil {
+			if mp.Platform.AWS != nil {
+				securityGroups = append(securityGroups, mp.Platform.AWS.AdditionalSecurityGroupIDs...)
+			}
+		}
+
 		data, err := awstfvars.TFVars(awstfvars.TFVarsSources{
 			VPC:                       vpc,
 			PrivateSubnets:            privateSubnets,
@@ -315,6 +322,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Architecture:              installConfig.Config.ControlPlane.Architecture,
 			Proxy:                     installConfig.Config.Proxy,
 			PreserveBootstrapIgnition: installConfig.Config.AWS.PreserveBootstrapIgnition,
+			MasterSecurityGroups:      securityGroups,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -46,6 +46,7 @@ type config struct {
 	MasterMetadataAuthentication    string            `json:"aws_master_instance_metadata_authentication,omitempty"`
 	BootstrapMetadataAuthentication string            `json:"aws_bootstrap_instance_metadata_authentication,omitempty"`
 	PreserveBootstrapIgnition       bool              `json:"aws_preserve_bootstrap_ignition"`
+	MasterSecurityGroups            []string          `json:"aws_master_security_groups,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -75,6 +76,8 @@ type TFVarsSources struct {
 	Proxy *types.Proxy
 
 	PreserveBootstrapIgnition bool
+
+	MasterSecurityGroups []string
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
@@ -197,6 +200,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		MasterIAMRoleName:         sources.MasterIAMRoleName,
 		WorkerIAMRoleName:         sources.WorkerIAMRoleName,
 		PreserveBootstrapIgnition: sources.PreserveBootstrapIgnition,
+		MasterSecurityGroups:      sources.MasterSecurityGroups,
 	}
 
 	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle, sources.Proxy)


### PR DESCRIPTION
The security groups are being properly added to the controlPlane resource definition manifest but they are not being piped through to terraform to be attached to the instances.

This fixes the issue that, after installation, checking the Security Groups attached to master and worker, master doesn’t have the specified custom security groups attached while workers have.

For one of the masters:
```
[root@preserve-gpei-worker ~]# aws ec2 describe-instances --instance-ids i-0cd007cca57c86ee9 --region us-west-2 --query 'Reservations[*].Instances[*].SecurityGroups[*]' --output json
[
    [
        [
            {
                "GroupName": "terraform-20230713031140984600000002",
                "GroupId": "sg-05495718555950f77"
            }
        ]
    ]
]
```