### PR TITLE
OCPBUGS-16219: Fix timing issue between network services

### DIFF
--- a/data/data/agent/systemd/units/pre-network-manager-config.service
+++ b/data/data/agent/systemd/units/pre-network-manager-config.service
@@ -1,13 +1,11 @@
 [Unit]
 Description=Prepare network manager config content
-Before=dracut-initqueue.service
-After=dracut-cmdline.service
+Before=NetworkManager.service
 DefaultDependencies=no
 
 [Service]
 User=root
 ExecStart=/usr/local/bin/pre-network-manager-config.sh
-
 TimeoutSec=60
 KillMode=none
 Type=oneshot


### PR DESCRIPTION
This fixes a timing issue between pre-network-manager-config.service and NetworkManager.service when defining static IPs in nmstateconfig. The problem is not apparent when using a few network interfaces, but when many interfaces (e.g. more than 8) are defined then the pre-network-manager-config.sh does not complete copying the files to /etc/NetworkManager/system-connections/ BEFORE NetworkManager.service starts running. The result is that the static IPs are not configured.

The fix is to add a dependency on NetworkManager.service to ensure that the pre-network-manager-config.service completes before NetworkManager.service is run.