### PR TITLE
Fix the deployment on OpenStack for worker pools with no replicas.

### DIFF
--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -391,6 +391,7 @@ variable "openstack_master_root_volume_types" {
 
 variable "openstack_worker_server_group_names" {
   type        = set(string)
+  default     = [""]
   description = "Names of the server groups for the worker nodes."
 }
 

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -47,7 +47,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
-  * `type` (optional string): The volume pool to create the volume from. It was replaced by `types`.
+  * `type` (deprectated string): The volume pool to create the volume from. It was replaced by `types`.
   * `types` (required list of strings): The volume pool to create the volume from. If compute `zones` are defined with more than one type, the number of zones must match the number of types.
   * `zones` (optional list of strings): The names of the availability zones you want to install your root volumes on. If unset, the installer will use your default volume zone.
     If compute `zones` contains at least one value, `rootVolume.zones` must also contain at least one value.


### PR DESCRIPTION
Commit https://github.com/openshift/installer/commit/a1ea1c870e71509ccd9df968c63cfc61380778e7 changed how the
machinesets get generated. We no longer generate machineset when the
number of replicas is 0, meaning we need to provide a default value for
`openstack_worker_server_group_names` so that terraform does not blow
up.

Also document the `rootVolume.type` config as deprecated. We now need to use `rootVolume.types`.