### PR TITLE
OCPBUGS-16640: [release-4.13] Update azure cli version to 2.49.0

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -20,12 +20,12 @@ COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshif
 COPY --from=govc /govc /bin/govc
 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
-    sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo' && \
+    sh -c 'echo -e "[packages-microsoft-com-prod]\nname=packages-microsoft-com-prod\nbaseurl=https://packages.microsoft.com/rhel/8/prod\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/microsoft-prod.repo' && \
     sh -c 'echo -e "[google-cloud-cli]\nname=Google Cloud CLI\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg\n       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-      azure-cli \
+      azure-cli-2.49.0-1.el8 \
       gettext \
       google-cloud-cli \
       gzip \


### PR DESCRIPTION
Due to [security vulnerability](https://github.com/Azure/azure-cli/security/advisories/GHSA-47xc-9rr2-q7p4) affecting Azure CLI versions previous to 2.40.0, it is recommended to update azure cli to higher version to avoid this issue.