### PR TITLE
OpenStack: Fix default for openstack_worker_server_group_names

### DIFF
--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -391,7 +391,7 @@ variable "openstack_master_root_volume_types" {
 
 variable "openstack_worker_server_group_names" {
   type        = set(string)
-  default     = [""]
+  default     = []
   description = "Names of the server groups for the worker nodes."
 }
 


### PR DESCRIPTION
A follow-up to https://github.com/openshift/installer/pull/7356.