### PR TITLE
OCPBUGS-16692: OpenStack: fix crash with empty platform in machinepool

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -169,7 +169,10 @@ func convertOpenStack(config *types.InstallConfig) error {
 	}
 
 	// type has been deprecated in favor of types in the machinePools.
-	if config.ControlPlane != nil && config.ControlPlane.Platform.OpenStack.RootVolume != nil && config.ControlPlane.Platform.OpenStack.RootVolume.DeprecatedType != "" {
+	if config.ControlPlane != nil &&
+		config.ControlPlane.Platform.OpenStack != nil &&
+		config.ControlPlane.Platform.OpenStack.RootVolume != nil &&
+		config.ControlPlane.Platform.OpenStack.RootVolume.DeprecatedType != "" {
 		if len(config.ControlPlane.Platform.OpenStack.RootVolume.Types) > 0 {
 			// Return error if both type and types of rootVolume are specified in the config
 			return field.Forbidden(field.NewPath("controlPlane").Child("platform").Child("openstack").Child("rootVolume").Child("type"), "cannot specify type and types in rootVolume together")
@@ -179,7 +182,7 @@ func convertOpenStack(config *types.InstallConfig) error {
 	}
 	for _, pool := range config.Compute {
 		mpool := pool.Platform.OpenStack
-		if mpool.RootVolume != nil && mpool.RootVolume.DeprecatedType != "" {
+		if mpool != nil && mpool.RootVolume != nil && mpool.RootVolume.DeprecatedType != "" {
 			if mpool.RootVolume.Types != nil && len(mpool.RootVolume.Types) > 0 {
 				// Return error if both type and types of rootVolume are specified in the config
 				return field.Forbidden(field.NewPath("compute").Child("platform").Child("openstack").Child("rootVolume").Child("type"), "cannot specify type and types in rootVolume together")

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -351,6 +351,52 @@ func TestConvertInstallConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "empty OpenStack platform for controlPlane",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				ControlPlane: &types.MachinePool{
+					Platform: types.MachinePoolPlatform{},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				ControlPlane: &types.MachinePool{
+					Platform: types.MachinePoolPlatform{},
+				},
+			},
+		},
+		{
+			name: "empty OpenStack platform for compute",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				Compute: []types.MachinePool{
+					{
+						Platform: types.MachinePoolPlatform{},
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{OpenStack: &openstack.Platform{}},
+				Compute: []types.MachinePool{
+					{
+						Platform: types.MachinePoolPlatform{},
+					},
+				},
+			},
+		},
+		{
 			name: "deprecated OpenStack computeFlavor",
 			config: &types.InstallConfig{
 				TypeMeta: metav1.TypeMeta{

--- a/scripts/openstack/manifest-tests/convert/install-config.yaml
+++ b/scripts/openstack/manifest-tests/convert/install-config.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+baseDomain: shiftstack.example.com
+controlPlane:
+  hyperthreading: Enabled
+  architecture: amd64
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}-worker
+  replicas: 3
+metadata:
+  name: manifests1
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.128.0/17
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  openstack:
+    cloud: ${OS_CLOUD}
+    externalNetwork: ${EXTERNAL_NETWORK}
+    computeFlavor: ${COMPUTE_FLAVOR}  # deprecated in 4.7
+    lbFloatingIP: ${API_FIP}
+pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/convert/test_convert.py
+++ b/scripts/openstack/manifest-tests/convert/test_convert.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import xmlrunner
+
+import os
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+
+class ConvertMachine(unittest.TestCase):
+    def setUp(self):
+        """Parse the Machines into a Python data structure."""
+        self.masters = []
+        for machine_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_master-machines-*.yaml'
+        ):
+            with open(machine_path) as f:
+                self.masters.append(yaml.load(f, Loader=yaml.FullLoader))
+
+        with open(f'{ASSETS_DIR}/manifests/cluster-config.yaml') as f:
+            cluster_config = yaml.load(f, Loader=yaml.FullLoader)
+            self.install_config = yaml.load(cluster_config["data"]["install-config"], Loader=yaml.FullLoader)
+
+    def test_flavor(self):
+        """Assert that all machines take flavor from computeFlavor."""
+        for machine in self.masters:
+            master_flavor = machine["spec"]["providerSpec"]["value"]["flavor"]
+            expected_master_flavor = self.install_config["platform"]["openstack"]["computeFlavor"]
+            self.assertEqual(master_flavor, expected_master_flavor)
+
+class ConvertMachineSet(unittest.TestCase):
+    def setUp(self):
+        """Parse the MachineSets into a Python data structure."""
+        self.machinesets = []
+        for machineset_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_worker-machineset-*.yaml'
+        ):
+            with open(machineset_path) as f:
+                self.machinesets.append(yaml.load(f, Loader=yaml.FullLoader))
+
+        with open(f'{ASSETS_DIR}/manifests/cluster-config.yaml') as f:
+            cluster_config = yaml.load(f, Loader=yaml.FullLoader)
+            self.install_config = yaml.load(cluster_config["data"]["install-config"], Loader=yaml.FullLoader)
+
+    def test_flavor(self):
+        """Assert that worker machinesets take flavor from machinepool."""
+        for machineset in self.machinesets:
+            flavor = machineset["spec"]["template"]["spec"]["providerSpec"]["value"]["flavor"]
+            compute_flavor = self.install_config["platform"]["openstack"]["computeFlavor"]
+            expected_flavor = self.install_config["compute"][0]["platform"]["openstack"]["type"]
+            self.assertEqual(flavor, expected_flavor)
+            self.assertNotEqual(flavor, compute_flavor)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:
+        unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), failfast=False, buffer=False, catchbreak=False, verbosity=2)


### PR DESCRIPTION
Passing an empty platform in machinepools caused the installer to exit with an ugly stack trace. This commit fixes the convertOpenStack() function to account for cases where the platform is not defined in the machine pools.