### PR TITLE
MULTIARCH-3701: Enable ppc64le for agent installer

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -96,6 +96,9 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(installConfig.Platform)) {
 		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedInstallerPlatforms()))
 	}
+	if installConfig.Platform.Name() != none.Name && installConfig.ControlPlane.Architecture == types.ArchitecturePPC64LE {
+		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitecturePPC64LE, none.Name)))
+	}
 	fieldPath = field.NewPath("Platform", "External", "PlatformName")
 	if installConfig.Platform.Name() == external.Name && installConfig.Platform.External.PlatformName != "oci" {
 		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.External.PlatformName, []string{"oci"}))
@@ -111,8 +114,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 	switch string(installConfig.ControlPlane.Architecture) {
 	case types.ArchitectureAMD64:
 	case types.ArchitectureARM64:
+	case types.ArchitecturePPC64LE:
 	default:
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64}))
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE}))
 	}
 
 	for i, compute := range installConfig.Compute {
@@ -121,8 +125,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 		switch string(compute.Architecture) {
 		case types.ArchitectureAMD64:
 		case types.ArchitectureARM64:
+		case types.ArchitecturePPC64LE:
 		default:
-			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64}))
+			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE}))
 		}
 	}
 

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -209,7 +209,46 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\"]",
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\"]",
+		},
+		{
+			name: "invalid platform.baremetal for architecture ppc64le",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+compute:
+  - architecture: ppc64le
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: ppc64le
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+platform:
+  baremetal:
+    apiVIP: 192.168.122.10
+    ingressVIP: 192.168.122.11
+    hosts:
+    - name: host1
+      bootMACAddress: 52:54:01:aa:aa:a1
+    - name: host2
+      bootMACAddress: 52:54:01:bb:bb:b1
+    - name: host3
+      bootMACAddress: 52:54:01:cc:cc:c1
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: Platform: Invalid value: \"baremetal\": CPU architecture \"ppc64le\" only supports platform \"none\".",
 		},
 		{
 			name: "unsupported platformName for external platform",

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -142,9 +142,9 @@ func (i *InfraEnv) finish() error {
 		return errors.New("missing configuration or manifest file")
 	}
 
-	// Throw an error if CpuArchitecture isn't x86_64, aarch64, or ""
+	// Throw an error if CpuArchitecture isn't x86_64, aarch64, ppc64le, or ""
 	switch i.Config.Spec.CpuArchitecture {
-	case arch.RpmArch(types.ArchitectureAMD64), arch.RpmArch(types.ArchitectureARM64), "":
+	case arch.RpmArch(types.ArchitectureAMD64), arch.RpmArch(types.ArchitectureARM64), arch.RpmArch(types.ArchitecturePPC64LE), "":
 	default:
 		return errors.Errorf("Config.Spec.CpuArchitecture %s is not supported ", i.Config.Spec.CpuArchitecture)
 	}


### PR DESCRIPTION
Enable openshift-install to be able to create agent based install ISO for Power, and it only supports platform none.