### PR TITLE
gather: Use `journalctl -o with-unit`

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -39,7 +39,7 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done
 
-journalctl --no-pager | gzip > "${ARTIFACTS}/bootstrap/journals/journal.log.gz"
+journalctl -o with-unit --no-pager | gzip > "${ARTIFACTS}/bootstrap/journals/journal.log.gz"
 
 echo "Gathering bootstrap networking ..."
 mkdir -p "${ARTIFACTS}/bootstrap/network"

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -30,7 +30,7 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done
 
-journalctl --no-pager | gzip > "${ARTIFACTS}/journals/journal.log.gz"
+journalctl -o with-unit --no-pager | gzip > "${ARTIFACTS}/journals/journal.log.gz"
 
 echo "Gathering master networking ..."
 mkdir -p "${ARTIFACTS}/network"


### PR DESCRIPTION
Before systemd was created, syslog was the dominant Unix logging system.

Later, systemd introduced the journal whose output intentionally exactly matched that of syslog for compatibility.

In systemd, the "unit" is the technical heart of things; yet the syslog output only includes the "syslog identifier" which might or might not look like the unit.

For many of our units that just run shell script, the syslog identifier is just "bash".

This makes it hard to distinguish what's going on.  With this patch the output will change from e.g.:

```
Jul 26 21:15:00 cvrzlbtm-bbcf1-t58lf-bootstrap release-image-download.sh[1995]: 2c5e0f38687f7acf45adf9de5e841a46bbbda574d121d71d92bfb929826dfa27
```

to

```
Jul 26 21:15:00 cvrzlbtm-bbcf1-t58lf-bootstrap release-image.service[1995]: 2c5e0f38687f7acf45adf9de5e841a46bbbda574d121d71d92bfb929826dfa27
```

And that creates a stronger connection with the code; we can reliably find what `release-image.service` is.