### PR TITLE
OCPBUGS-17064: always create a MachineSet

### DIFF
--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -31,9 +31,6 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	if poolPlatform := pool.Platform.Name(); poolPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack machine-pool: %q", poolPlatform)
 	}
-	if pool.Replicas == nil || *pool.Replicas < 1 {
-		return nil, nil
-	}
 	platform := config.Platform.OpenStack
 	mpool := pool.Platform.OpenStack
 	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk", clientOpts)


### PR DESCRIPTION
... even if zero workers is requested from install-config (replicas ==
0).

This was a non backward compatible change introduced by https://github.com/openshift/installer/pull/7300
