### PR TITLE
OCPBUGS-16912: Ensure DHCPv6 client sends Solicit with mac address

### DIFF
--- a/data/data/agent/files/etc/NetworkManager/conf.d/clientid.conf
+++ b/data/data/agent/files/etc/NetworkManager/conf.d/clientid.conf
@@ -1,0 +1,3 @@
+[connection]
+ipv6.dhcp-duid=ll
+ipv6.dhcp-iaid=mac

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -356,6 +356,7 @@ func commonFiles() []string {
 		"/etc/issue",
 		"/etc/multipath.conf",
 		"/etc/containers/containers.conf",
+		"/etc/NetworkManager/conf.d/clientid.conf",
 		"/root/.docker/config.json",
 		"/root/assisted.te",
 		"/usr/local/bin/agent-config-image-wait.sh",

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -36,6 +36,7 @@ func GetConfigImageFiles() []string {
 		"/etc/assisted/hostconfig",      // all files in directory
 		"/etc/assisted/hostnames",       // all files in directory
 		"/etc/assisted/network",         // all files in directory
+		"/etc/NetworkManager/conf.d/clientid.conf",
 		"/etc/issue",
 		"/etc/systemd/system.conf.d/10-default-env.conf",
 		"/root/.docker/config.json",


### PR DESCRIPTION
When using DHCPv6, ensure that the host sends a DHCP Solicitation with the Client ID containing the mac address, i.e. DUID-LL. See https://datatracker.ietf.org/doc/html/rfc3315#section-9.4 for more info.  This allows the DHCPv6 server to assign an IPv6 address that can be used as the rendezvousIP.