### PR TITLE
OCPBUGS-17227: gcp: fix validation of custom instance types

### DIFF
--- a/pkg/asset/machines/gcp/zones.go
+++ b/pkg/asset/machines/gcp/zones.go
@@ -64,17 +64,6 @@ func ZonesForInstanceType(project, region, instanceType string) ([]string, error
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	machines, err := gcpconfig.GetMachineTypeList(ctx, svc, project, region, instanceType, "items/*/machineTypes(zone),nextPageToken")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get zones for instance type: %w", err)
-	}
-
-	zones := sets.New[string]()
-	for _, machine := range machines {
-		zones.Insert(machine.Zone)
-	}
-
-	// Not all instance zones might be available in the project
 	pZones, err := gcpconfig.GetZones(ctx, svc, project, fmt.Sprintf("(region eq .*%s) (status eq UP)", region))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zones for project: %w", err)
@@ -84,5 +73,20 @@ func ZonesForInstanceType(project, region, instanceType string) ([]string, error
 		pZoneNames.Insert(z.Name)
 	}
 
+	machines, err := gcpconfig.GetMachineTypeList(ctx, svc, project, region, instanceType, "items/*/machineTypes(zone),nextPageToken")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get zones for instance type: %w", err)
+	}
+	// Custom machine types do not show up in the list. Let's fallback to the project zones
+	if len(machines) == 0 {
+		return sets.List(pZoneNames), nil
+	}
+
+	zones := sets.New[string]()
+	for _, machine := range machines {
+		zones.Insert(machine.Zone)
+	}
+
+	// Not all instance zones might be available in the project
 	return sets.List(zones.Intersection(pZoneNames)), nil
 }


### PR DESCRIPTION
Users can create their own instance types in GCloud. Those types are not returned when listing the machine types for a given project/region. This would cause those installs with custom types to fail with the error:

```
Internal error: failed to fetch instance type, this error usually occurs if the region or the instance type is not found
```

after the validations introduced by
https://github.com/openshift/installer/pull/7317 and https://github.com/openshift/installer/pull/7096.

To fix that, let's fallback to the previous way of fetching the specific machine type whenever the aggregated list returns 0 elements.