### PR TITLE
OCPBUGS-13408: $ openshift-install agent create agent-config-template --dir=./foo gives nothing in the INFO log-level

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -94,6 +94,12 @@ hosts:
 
 	a.Template = agentConfigTemplate
 
+	// Set the File field correctly with the generated agent config YAML content
+	a.File = &asset.File{
+		Filename: agentConfigFilename,
+		Data:     []byte(a.Template),
+	}
+
 	// TODO: template is not validated
 	return nil
 }


### PR DESCRIPTION
Fixed empty log message by adding the correct INFO log during 'agent-config-template' creation.
