### PR TITLE
OCPBUGS-17246: azurestack: do not use gen2 images

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -111,7 +111,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		image.Version = mpool.OSImage.Version
 	} else {
 		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID)
-		if hyperVGen == "V2" {
+		if hyperVGen == "V2" && platform.CloudName != azure.StackCloud {
 			imageID += "-gen2"
 		}
 		image.ResourceID = imageID


### PR DESCRIPTION
Azurestack does not create `-gen2` images so we should not set them in the machine manifests. Otherwise the following error occurs

```
$ oc describe machine jima411az-xvwvg-worker-mtcazs-4k6hs -n openshift-machine-api
...
Events:
  Type     Reason        Age   From              Message
  ----     ------        ----  ----              -------
  Warning  FailedCreate  3h4m  azure-controller  InvalidConfiguration: failed to reconcile machine "jima411az-xvwvg-worker-mtcazs-4k6hs": failed to create vm jima411az-xvwvg-worker-mtcazs-4k6hs: failure sending request for machine jima411az-xvwvg-worker-mtcazs-4k6hs: cannot create vm: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="NotFound" Message="The Image '/subscriptions/REDACTED/resourceGroups/jima411az-xvwvg-rg/providers/Microsoft.Compute/images/jima411az-xvwvg-gen2' cannot be found in 'mtcazs' region."
  ```