### PR TITLE
SPLAT-1123: Revert Alibaba deprecation warning

### DIFF
--- a/pkg/asset/installconfig/alibabacloud/alibabacloud.go
+++ b/pkg/asset/installconfig/alibabacloud/alibabacloud.go
@@ -63,11 +63,6 @@ func Platform() (*alibabacloud.Platform, error) {
 		return nil, err
 	}
 
-	err = bypassDeprecation()
-	if err != nil {
-		return nil, err
-	}
-
 	region, err := selectRegion(client)
 	if err != nil {
 		return nil, err
@@ -140,24 +135,4 @@ func selectRegion(client *Client) (string, error) {
 		return "", err
 	}
 	return selectedRegion, nil
-}
-
-func bypassDeprecation() error {
-	confirmationMsg := "DEPRECATED. Alibaba Cloud is deprecated and will be " +
-		"removed in a future OpenShift version. Would you still like to continue?"
-
-	shouldContinue := false
-	prompt := &survey.Confirm{
-		Message: confirmationMsg,
-	}
-	err := survey.AskOne(prompt, &shouldContinue)
-	if err != nil {
-		return err
-	}
-
-	if !shouldContinue {
-		return errors.Errorf("deprecated platform")
-	}
-
-	return nil
 }

--- a/pkg/types/alibabacloud/validation/platform.go
+++ b/pkg/types/alibabacloud/validation/platform.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -14,8 +13,6 @@ import (
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *alibabacloud.Platform, n *types.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	logrus.Warn("Alibaba Cloud is deprecated and will be removed in a future OpenShift version. Please reach out to your Red Hat Support or Technical Account Manager for more information.")
 
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region must be specified"))


### PR DESCRIPTION
The deprecation of support for the Alibaba Cloud platform is being postponed by one release, so we need to revert [SPLAT-1094](https://issues.redhat.com/browse/SPLAT-1094). 

Fixes https://issues.redhat.com/browse/SPLAT-1123