### PR TITLE
openstack: Test zero replicas in worker machine-pool

### DIFF
--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -45,6 +45,9 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	for idx := range machinesets {
 		var replicaNumber int32
 		{
+			// The replica number is set to 3 by default when install-config does not have
+			// any Compute machine-pool, or when the Compute machine-pool does not have the
+			// `replicas` property. As a consequence, pool.Replicas is never nil
 			replicas := *pool.Replicas / numberOfFailureDomains
 			if int64(idx) < *pool.Replicas%numberOfFailureDomains {
 				replicas++

--- a/scripts/openstack/manifest-tests/zero-workers/install-config.yaml
+++ b/scripts/openstack/manifest-tests/zero-workers/install-config.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+baseDomain: shiftstack.example.com
+controlPlane:
+  architecture: amd64
+  name: master
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+  replicas: 0
+metadata:
+  name: zero-workers
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.128.0/17
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  openstack:
+    cloud: ${OS_CLOUD}
+    externalNetwork: ${EXTERNAL_NETWORK}
+    lbFloatingIP: ${API_FIP}
+pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/zero-workers/test_cpms.py
+++ b/scripts/openstack/manifest-tests/zero-workers/test_cpms.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import xmlrunner
+
+import os
+import sys
+import yaml
+
+ASSETS_DIR = ""
+
+class ControlPlaneMachineSet(unittest.TestCase):
+    def setUp(self):
+        """Parse the CPMS into a Python data structure."""
+        with open(f'{ASSETS_DIR}/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml') as f:
+            self.cpms = yaml.load(f, Loader=yaml.FullLoader)
+
+    def test_compute_zones(self):
+        """Assert that the OpenStack CPMS failureDomains value is empty."""
+        self.assertNotIn("openstack", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"])
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:
+        unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), failfast=False, buffer=False, catchbreak=False, verbosity=2)

--- a/scripts/openstack/manifest-tests/zero-workers/test_machines.py
+++ b/scripts/openstack/manifest-tests/zero-workers/test_machines.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import xmlrunner
+
+import os
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+
+EXPECTED_MASTER_REPLICAS = 3
+EXPECTED_WORKER_REPLICAS = 0
+
+
+class Machines(unittest.TestCase):
+    def setUp(self):
+        """Parse the Machines into a Python data structure."""
+        self.machines = []
+        for machine_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_master-machines-*.yaml'
+        ):
+            with open(machine_path) as f:
+                self.machines.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_total_instance_number(self):
+        """Assert that there are as many Machines as required ControlPlane replicas."""
+        self.assertEqual(len(self.machines), EXPECTED_MASTER_REPLICAS)
+
+
+class Machinesets(unittest.TestCase):
+    def setUp(self):
+        """Parse the MachineSets into a Python data structure."""
+        self.machinesets = []
+        for machineset_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_worker-machineset-*.yaml'
+        ):
+            with open(machineset_path) as f:
+                self.machinesets.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_total_replica_number(self):
+        """Assert that there is at least one MachineSet."""
+        self.assertGreater(len(self.machinesets), 0)
+
+    def test_total_replica_number(self):
+        """Assert that replicas spread across the MachineSets add up to the expected number."""
+        total_found = 0
+        for machineset in self.machinesets:
+            total_found += machineset["spec"]["replicas"]
+        self.assertEqual(total_found, EXPECTED_WORKER_REPLICAS)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    with open(os.environ.get('JUNIT_FILE', '/dev/null'), 'wb') as output:
+        unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), failfast=False, buffer=False, catchbreak=False, verbosity=2)


### PR DESCRIPTION
Assert that:
* setting zero workers does not crash the Installer
* there always is at least one MachineSet

A follow-up to #7380