### PR TITLE
OCPBUGS-17860: OpenStack: Remove NodePorts range 0.0.0.0/0 rules

### DIFF
--- a/data/data/openstack/masters/sg-master.tf
+++ b/data/data/openstack/masters/sg-master.tf
@@ -233,25 +233,25 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "tcp"
-  port_range_min = 30000
-  port_range_max = 32767
-  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
-  remote_ip_prefix  = "0.0.0.0/0"
+  count             = length(var.machine_v4_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "udp"
-  port_range_min = 30000
-  port_range_max = 32767
-  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
-  remote_ip_prefix  = "0.0.0.0/0"
+  count             = length(var.machine_v4_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }

--- a/data/data/openstack/masters/sg-worker.tf
+++ b/data/data/openstack/masters/sg-worker.tf
@@ -183,25 +183,25 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "tcp"
-  port_range_min = 30000
-  port_range_max = 32767
-  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
-  remote_ip_prefix  = "0.0.0.0/0"
+  count             = length(var.machine_v4_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "udp"
-  port_range_min = 30000
-  port_range_max = 32767
-  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
-  remote_ip_prefix  = "0.0.0.0/0"
+  count             = length(var.machine_v4_cidrs)
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = element(var.machine_v4_cidrs, count.index)
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -162,7 +162,7 @@
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: tcp
-      remote_ip_prefix: "0.0.0.0/0"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -170,7 +170,7 @@
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: udp
-      remote_ip_prefix: "0.0.0.0/0"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -276,7 +276,7 @@
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: tcp
-      remote_ip_prefix: "0.0.0.0/0"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -284,7 +284,7 @@
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: udp
-      remote_ip_prefix: "0.0.0.0/0"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 30000
       port_range_max: 32767
 


### PR DESCRIPTION
With openshift/cluster-cloud-controller-manager-operator#264 we should no longer need the SG rules opening whole NodePorts range by default. cloud-provider-openstack will manage this on its own now.
    
We still need to keep the rules opening the traffic inside the cluster to make sure traffic redirections and regular NodePort services work.
