### PR TITLE
azure: validation: machinepool: sort slice before comparing

### DIFF
--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -25,6 +26,7 @@ var (
 		for n := range validSecurityEncryptionTypes {
 			v = append(v, string(n))
 		}
+		sort.Strings(v)
 		return v
 	}()
 )

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -415,7 +415,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType: Unsupported value: "invalidSecurityEncryptionType": supported values: "VMGuestStateOnly", "DiskWithVMGuestState"$`,
+			expected: `^test-path.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType: Unsupported value: "invalidSecurityEncryptionType": supported values: "DiskWithVMGuestState", "VMGuestStateOnly"$`,
 		},
 		{
 			name:          "securityType set to ConfidentialVM, securityEncryptionType is set but confidentialVM section is empty",


### PR DESCRIPTION
We cannot rely on any ordering from iterating over a Golang map. If we do, we might fail unit tests because the values we compare with are different:
```
 --- FAIL: TestValidateMachinePool (0.00s)
    --- FAIL: TestValidateMachinePool/securityType_set_to_ConfidentialVM_but_securityEncryptionType_is_invalid (0.00s)
        machinepool_test.go:610:
            	Error Trace:	/go/src/github.com/openshift/installer/pkg/types/azure/validation/machinepool_test.go:610
            	Error:      	Expect "test-path.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType: Unsupported value: "invalidSecurityEncryptionType": supported values: "DiskWithVMGuestState", "VMGuestStateOnly"" to match "^test-path.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType: Unsupported value: "invalidSecurityEncryptionType": supported values: "VMGuestStateOnly", "DiskWithVMGuestState"$"
            	Test:       	TestValidateMachinePool/securityType_set_to_ConfidentialVM_but_securityEncryptionType_is_invalid
FAIL
```
Using a sorted list resolves the problem.