### PR TITLE
OpenStack: Set external network for cloud-provider

### DIFF
--- a/pkg/asset/installconfig/openstack/session.go
+++ b/pkg/asset/installconfig/openstack/session.go
@@ -17,6 +17,7 @@ var onceLoggers = map[string]*sync.Once{}
 // Session is an object representing session for OpenStack.
 type Session struct {
 	CloudConfig *clientconfig.Cloud
+	ClientOpts  *clientconfig.ClientOpts
 }
 
 // GetSession returns an OpenStack session for a given cloud name in clouds.yaml.
@@ -30,6 +31,7 @@ func GetSession(cloudName string) (*Session, error) {
 	}
 	return &Session{
 		CloudConfig: cloudConfig,
+		ClientOpts:  opts,
 	}, nil
 }
 

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 func TestCloudProviderConfigSecret(t *testing.T) {
@@ -102,6 +103,9 @@ func TestCloudProviderConfig(t *testing.T) {
 			name: "default install config",
 			installConfig: &types.InstallConfig{
 				Networking: &types.Networking{},
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{},
+				},
 			},
 			expectedConfig: `[Global]
 secret-name = openstack-credentials
@@ -125,8 +129,9 @@ region = my_region
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualConfig, _, _ := generateCloudProviderConfig(&cloud, *tc.installConfig)
-			assert.Equal(t, tc.expectedConfig, string(actualConfig), "unexpected cloud provider config")
+			actualConfig, _, err := generateCloudProviderConfig(nil, &cloud, *tc.installConfig)
+			assert.NoError(t, err, "unexpected error when generating cloud provider config")
+			assert.Equal(t, tc.expectedConfig, actualConfig, "unexpected cloud provider config")
 		})
 	}
 }


### PR DESCRIPTION
We allow users to specify an external network to create the floating IPs from on the install-config.yaml. We use that to create the API and Ingress FIPs and forget about it. We can however also use it to configure the cloud-provider-openstack to make sure it'll choose the correct network when creating FIPs for the `type=LoadBalancer` Services too. This commit implements it.