### PR TITLE
OCPBUGS-17218: Warn when firewall rull missing.

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -434,6 +434,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				return err
 			}
 			createFirewallRules = permissions.Has(GCPFirewallPermission)
+
+			if !createFirewallRules {
+				logrus.Warnf("failed to find permission %s, skipping firewall rule creation", GCPFirewallPermission)
+			}
 		}
 
 		masters, err := mastersAsset.Machines()


### PR DESCRIPTION
**GCP Xpn: The compute.firewalls.create rule is not required, but a warning should be provided when it is not found.