### PR TITLE
pkg/asset/installconfig/powervs: fix dropped error

### DIFF
--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -231,6 +231,9 @@ func (m *Metadata) IsVPCPermittedNetwork(ctx context.Context, vpcName string, ba
 	}
 
 	vpc, err := m.client.GetVPCByName(ctx, vpcName)
+	if err != nil {
+		return false, err
+	}
 	for _, network := range networks {
 		if network == *vpc.CRN {
 			return true, nil


### PR DESCRIPTION
This fixes a dropped `err` variable in `pkg/asset/installconfig/powervs`.