### PR TITLE
OCPBUGS-17757: check credentials type to handle different gcp authentication methods

### DIFF
--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -70,9 +70,9 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
-		err = gcpconfig.ValidateCredentialMode(client, ic.Config)
-		if err != nil {
-			return errors.Wrap(err, "validating credentials")
+		errorList := gcpconfig.ValidateCredentialMode(client, ic.Config)
+		if errorList != nil {
+			return errors.Wrap(errorList.ToAggregate(), "validating credentials")
 		}
 	case ibmcloud.Name:
 		_, err = ibmcloudconfig.NewClient()

--- a/pkg/types/gcp/doc.go
+++ b/pkg/types/gcp/doc.go
@@ -4,3 +4,20 @@ package gcp
 
 // Name is name for the gcp platform.
 const Name string = "gcp"
+
+// AuthorizationMode is the mode or type of authentication indicated in the google credentials struct.
+type AuthorizationMode string
+
+const (
+	// AuthorizedUserMode indicates that an authorized user without a service account has been used
+	// for authentication with the gcloud.
+	AuthorizedUserMode AuthorizationMode = "authorized_user"
+
+	// ServiceAccountMode indicates that a service account has been used for authentication with
+	// the gcloud.
+	ServiceAccountMode AuthorizationMode = "service_account"
+
+	// ExternalAccountMode indicates that an external user such as AWS, Azure, etc. has been used for
+	// authentication with gcloud.
+	ExternalAccountMode AuthorizationMode = "external_account"
+)


### PR DESCRIPTION
**Altered GCP validation to check the type of credentials that are set (if they are set). The installer cannot

count on GCP credentials being nil or unset when authenticating using the gcloud cli. Now the installer checks for nil credentials and if the credentials exist then check the type.