### PR TITLE
[release-4.13] OCPBUGS-14432: Replica validations

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/validations/compact_too_many_masters.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/compact_too_many_masters.txt
@@ -1,0 +1,114 @@
+! exec openshift-install agent create image --dir $WORK
+
+stderr 'the number of master hosts defined \(4\) exceeds the configured ControlPlane replicas \(3\)'
+
+! exists $WORK/agent.x86_64.iso
+! exists $WORK/auth/kubeconfig
+! exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 3
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+    baremetal:
+      apiVips: 
+        - 192.168.111.5
+      ingressVips: 
+        - 192.168.111.4
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+hosts:
+  - hostname: master-0
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:01
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:01
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.126
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-1
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:02
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:02
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.127
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-2
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:03
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:03
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.128
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-3
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:04
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:04
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.129
+                prefix-length: 23
+            dhcp: false
+

--- a/cmd/openshift-install/testdata/agent/image/validations/compact_too_many_workers.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/compact_too_many_workers.txt
@@ -1,0 +1,114 @@
+! exec openshift-install agent create image --dir $WORK
+
+stderr 'the number of worker hosts defined \(1\) exceeds the configured Compute replicas \(0\)'
+
+! exists $WORK/agent.x86_64.iso
+! exists $WORK/auth/kubeconfig
+! exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 3
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+    baremetal:
+      apiVips: 
+        - 192.168.111.5
+      ingressVips: 
+        - 192.168.111.4
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+hosts:
+  - hostname: master-0
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:01
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:01
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.126
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-1
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:02
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:02
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.127
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-2
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:03
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:03
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.128
+                prefix-length: 23
+            dhcp: false
+  - hostname: worker-0
+    role: worker
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:04
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:04
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.129
+                prefix-length: 23
+            dhcp: false
+


### PR DESCRIPTION
This is a backport of the 2 fixes for replica validations:
https://github.com/openshift/installer/pull/7059
https://github.com/openshift/installer/pull/7268

Also fixes https://issues.redhat.com/browse/OCPBUGS-17759