### PR TITLE
OCPBUGS-18046: update govc version to v0.30.7

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -10,7 +10,7 @@ COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.10:cli as cli
-FROM quay.io/ocp-splat/govc:v0.29.0 as govc
+FROM quay.io/ocp-splat/govc:v0.30.7 as govc
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=cli /usr/bin/oc /bin/oc


### PR DESCRIPTION
update govc version to v0.30.7 to support find.Network by cluster path