### PR TITLE
OCPBUGS-17770: azure: use marketplace image plan's publisher

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -369,6 +369,18 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			}
 		}
 
+		if mpool.OSImage.Publisher != "" {
+			img, ierr := client.GetMarketplaceImage(context.TODO(), ic.Platform.Azure.Region, mpool.OSImage.Publisher, mpool.OSImage.Offer, mpool.OSImage.SKU, mpool.OSImage.Version)
+			if ierr != nil {
+				return fmt.Errorf("failed to fetch marketplace image: %w", ierr)
+			}
+			// Publisher is case-sensitive and matched against exactly. Also the
+			// Plan's publisher might not be exactly the same as the Image's
+			// publisher
+			if img.Plan != nil && img.Plan.Publisher != nil {
+				mpool.OSImage.Publisher = *img.Plan.Publisher
+			}
+		}
 		pool.Platform.Azure = &mpool
 
 		capabilities, err := client.GetVMCapabilities(context.TODO(), mpool.InstanceType, installConfig.Config.Platform.Azure.Region)

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -488,6 +488,18 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				}
 			}
 
+			if mpool.OSImage.Publisher != "" {
+				img, ierr := client.GetMarketplaceImage(context.TODO(), ic.Platform.Azure.Region, mpool.OSImage.Publisher, mpool.OSImage.Offer, mpool.OSImage.SKU, mpool.OSImage.Version)
+				if ierr != nil {
+					return fmt.Errorf("failed to fetch marketplace image: %w", ierr)
+				}
+				// Publisher is case-sensitive and matched against exactly. Also
+				// the Plan's publisher might not be exactly the same as the
+				// Image's publisher
+				if img.Plan != nil && img.Plan.Publisher != nil {
+					mpool.OSImage.Publisher = *img.Plan.Publisher
+				}
+			}
 			pool.Platform.Azure = &mpool
 
 			capabilities, err := client.GetVMCapabilities(context.TODO(), mpool.InstanceType, installConfig.Config.Platform.Azure.Region)


### PR DESCRIPTION
It seems the marketplace image publisher and the image plan's publisher can differ, even in character case. For example:
```
$ az vm image list --offer rh-ocp-worker --all -otable
Architecture    Offer          Publisher       Sku                 Urn                                                             Version
--------------  -------------  --------------  ------------------  --------------------------------------------------------------  --------------
x64             rh-ocp-worker  RedHat          rh-ocp-worker       RedHat:rh-ocp-worker:rh-ocp-worker:4.8.2021122100               4.8.2021122100

$ az vm image show --urn RedHat:rh-ocp-worker:rh-ocp-worker:4.8.2021122100 --query plan
{
  "name": "rh-ocp-worker",
  "product": "rh-ocp-worker",
  "publisher": "redhat"
}
```
When checking for the image plan, Azure will match the properties values exactly and they are case-sensitive. So setting `Publisher: RedHat` in the `install-config.yaml` for the image above will result in:
```
Unable to deploy from the Marketplace image or a custom image sourced from Marketplace image. The part number in the purchase information for VM '/subscriptions/<REDACTED>/resourceGroups/jima15image1-flg24-rg/providers/Microsoft.Compute/virtualMachines/jima15image1-flg24-bootstrap' is not as expected. Beware that the Plan object's properties are case-sensitive. Learn more about common virtual machine error codes.
```
where as using `redhat` works as expected.

To avoid such issues and simplify the user experience, let's query the image's plan properties and use the publisher value returned instead of the one set by the user in the install-config.