### PR TITLE
OCPBUGS-17940: Add COS endpoint to proxy server (Power VS)

### DIFF
--- a/data/data/powervs/cluster/dns/templates/cloud-init.yaml.tpl
+++ b/data/data/powervs/cluster/dns/templates/cloud-init.yaml.tpl
@@ -30,7 +30,7 @@ runcmd:
   - systemctl enable named.service
   - systemctl start named.service
 %{ if is_proxy ~}
-  - echo 'acl ibm_endpoints dstdomain .cloud.ibm.com' > /tmp/squid.conf
+  - echo 'acl ibm_endpoints dstdomain .cloud.ibm.com s3.${vpc_region}.cloud-object-storage.appdomain.cloud' > /tmp/squid.conf
   - echo 'http_access deny !ibm_endpoints' >> /tmp/squid.conf
   - cat /etc/squid/squid.conf >> /tmp/squid.conf
   - mv -f /tmp/squid.conf /etc/squid/squid.conf


### PR DESCRIPTION
We were denying COS traffic, preventing the image-registry from properly deploying. This adds the endpoint to the allow list of the proxy server.