### PR TITLE
OCPBUGS-17823: CORS-2445: GCP: Add osImage to the install config

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -414,6 +414,20 @@ spec:
                           required:
                           - DiskSizeGB
                           type: object
+                        osImage:
+                          description: OSImage defines a custom image for instance.
+                          properties:
+                            name:
+                              description: Name defines the name of the image.
+                              type: string
+                            project:
+                              description: Project defines the name of the project
+                                containing the image.
+                              type: string
+                          required:
+                          - name
+                          - project
+                          type: object
                         secureBoot:
                           description: SecureBoot Defines whether the instance should
                             have secure boot enabled. secure boot Verify the digital
@@ -1317,6 +1331,20 @@ spec:
                             type: object
                         required:
                         - DiskSizeGB
+                        type: object
+                      osImage:
+                        description: OSImage defines a custom image for instance.
+                        properties:
+                          name:
+                            description: Name defines the name of the image.
+                            type: string
+                          project:
+                            description: Project defines the name of the project containing
+                              the image.
+                            type: string
+                        required:
+                        - name
+                        - project
                         type: object
                       secureBoot:
                         description: SecureBoot Defines whether the instance should
@@ -2849,6 +2877,20 @@ spec:
                             type: object
                         required:
                         - DiskSizeGB
+                        type: object
+                      osImage:
+                        description: OSImage defines a custom image for instance.
+                        properties:
+                          name:
+                            description: Name defines the name of the image.
+                            type: string
+                          project:
+                            description: Project defines the name of the project containing
+                              the image.
+                            type: string
+                        required:
+                        - name
+                        - project
                         type: object
                       secureBoot:
                         description: SecureBoot Defines whether the instance should

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -40,6 +40,7 @@ type API interface {
 	GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error)
 	GetEnabledServices(ctx context.Context, project string) ([]string, error)
 	GetCredentials() *googleoauth.Credentials
+	GetImage(ctx context.Context, name string, project string) (*compute.Image, error)
 	GetProjectPermissions(ctx context.Context, project string, permissions []string) (sets.Set[string], error)
 	GetProjectByID(ctx context.Context, project string) (*cloudresourcemanager.Project, error)
 	ValidateServiceAccountHasPermissions(ctx context.Context, project string, permissions []string) (bool, error)
@@ -370,6 +371,19 @@ func (c *Client) getServiceUsageService(ctx context.Context) (*serviceusage.Serv
 // GetCredentials returns the credentials used to authenticate the GCP session.
 func (c *Client) GetCredentials() *googleoauth.Credentials {
 	return c.ssn.Credentials
+}
+
+// GetImage returns the marketplace image specified by the user.
+func (c *Client) GetImage(ctx context.Context, name string, project string) (*compute.Image, error) {
+	svc, err := c.getComputeService(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	return svc.Images.Get(project, name).Context(ctx).Do()
 }
 
 func (c *Client) getPermissions(ctx context.Context, project string, permissions []string) ([]string, error) {

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -98,6 +98,21 @@ func (mr *MockAPIMockRecorder) GetEnabledServices(ctx, project interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledServices", reflect.TypeOf((*MockAPI)(nil).GetEnabledServices), ctx, project)
 }
 
+// GetImage mocks base method.
+func (m *MockAPI) GetImage(ctx context.Context, name, project string) (*compute.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImage", ctx, name, project)
+	ret0, _ := ret[0].(*compute.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImage indicates an expected call of GetImage.
+func (mr *MockAPIMockRecorder) GetImage(ctx, name, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockAPI)(nil).GetImage), ctx, name, project)
+}
+
 // GetMachineType mocks base method.
 func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/validate"
 )
 
@@ -56,6 +57,7 @@ func Validate(client API, ic *types.InstallConfig) error {
 	allErrs = append(allErrs, validateNetworks(client, ic, field.NewPath("platform").Child("gcp"))...)
 	allErrs = append(allErrs, validateInstanceTypes(client, ic)...)
 	allErrs = append(allErrs, validateCredentialMode(client, ic)...)
+	allErrs = append(allErrs, validateMarketplaceImages(client, ic)...)
 
 	return allErrs.ToAggregate()
 }
@@ -389,4 +391,77 @@ func validateCredentialMode(client API, ic *types.InstallConfig) field.ErrorList
 	}
 
 	return allErrs
+}
+
+func validateMarketplaceImages(client API, ic *types.InstallConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	const errorMessage string = "could not find the boot image: %v"
+	var err error
+	var defaultImage *compute.Image
+	var defaultOsImage *gcp.OSImage
+
+	if ic.GCP.DefaultMachinePlatform != nil && ic.GCP.DefaultMachinePlatform.OSImage != nil {
+		defaultOsImage = ic.GCP.DefaultMachinePlatform.OSImage
+		defaultImage, err = client.GetImage(context.TODO(), defaultOsImage.Name, defaultOsImage.Project)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("platform", "gcp", "defaultMachinePlatform", "osImage"), *defaultOsImage, fmt.Sprintf(errorMessage, err)))
+		}
+	}
+
+	if ic.ControlPlane != nil {
+		image := defaultImage
+		osImage := defaultOsImage
+		if ic.ControlPlane.Platform.GCP != nil && ic.ControlPlane.Platform.GCP.OSImage != nil {
+			osImage = ic.ControlPlane.Platform.GCP.OSImage
+			image, err = client.GetImage(context.TODO(), osImage.Name, osImage.Project)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("controlPlane", "platform", "gcp", "osImage"), *osImage, fmt.Sprintf(errorMessage, err)))
+			}
+		}
+		if image != nil {
+			if errMsg := checkArchitecture(image.Architecture, ic.ControlPlane.Architecture, "controlPlane"); errMsg != "" {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("controlPlane", "platform", "gcp", "osImage"), *osImage, errMsg))
+			}
+		}
+	}
+
+	for idx, compute := range ic.Compute {
+		image := defaultImage
+		osImage := defaultOsImage
+		fieldPath := field.NewPath("compute").Index(idx)
+		if compute.Platform.GCP != nil && compute.Platform.GCP.OSImage != nil {
+			osImage = compute.Platform.GCP.OSImage
+			image, err = client.GetImage(context.TODO(), osImage.Name, osImage.Project)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("platform", "gcp", "osImage"), *osImage, fmt.Sprintf(errorMessage, err)))
+			}
+		}
+		if image != nil {
+			if errMsg := checkArchitecture(image.Architecture, compute.Architecture, "compute"); errMsg != "" {
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("platform", "gcp", "osImage"), *osImage, errMsg))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func checkArchitecture(imageArch string, icArch types.Architecture, role string) string {
+	const unspecifiedArch string = "ARCHITECTURE_UNSPECIFIED"
+	// The possible architecture names from image.Architecture are of type string hence we cannot directly obtain the possible values
+	// In the docs the possible values are ARM64, X86_64, and ARCHITECTURE_UNSPECIFIED
+	// There is no simple translation between the architecture values from Google and the architecture names used in the install config so a map is used
+
+	translateArchName := map[string]types.Architecture{
+		"ARM64":  types.ArchitectureARM64,
+		"X86_64": types.ArchitectureAMD64,
+	}
+
+	if imageArch == "" || imageArch == unspecifiedArch {
+		logrus.Warn(fmt.Sprintf("Boot image architecture is unspecified and might not be compatible with %s %s nodes", icArch, role))
+	} else if translateArchName[imageArch] != icArch {
+		return fmt.Sprintf("image architecture %s does not match %s node architecture %s", imageArch, role, icArch)
+	}
+	return ""
 }

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	logrusTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	googleoauth "golang.org/x/oauth2/google"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -130,11 +131,13 @@ func validInstallConfig() *types.InstallConfig {
 			},
 		},
 		ControlPlane: &types.MachinePool{
+			Architecture: types.ArchitectureAMD64,
 			Platform: types.MachinePoolPlatform{
 				GCP: &gcp.MachinePool{},
 			},
 		},
 		Compute: []types.MachinePool{{
+			Architecture: types.ArchitectureAMD64,
 			Platform: types.MachinePoolPlatform{
 				GCP: &gcp.MachinePool{},
 			},
@@ -521,7 +524,6 @@ func TestValidateCredentialMode(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-
 			ic := types.InstallConfig{
 				ObjectMeta:      metav1.ObjectMeta{Name: "cluster-name"},
 				BaseDomain:      "base-domain",
@@ -540,6 +542,203 @@ func TestValidateCredentialMode(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.Regexp(t, test.err, err)
+			}
+		})
+	}
+}
+
+func TestValidateMarketplaceImages(t *testing.T) {
+	var (
+		validImage     = "valid-image"
+		projectID      = "project-id"
+		invalidImage   = "invalid-image"
+		mismatchedArch = "mismatched-arch"
+		osImage        = &gcp.OSImage{}
+
+		validDefaultMachineImage = func(ic *types.InstallConfig) {
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage = osImage
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Name = validImage
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Project = projectID
+		}
+		validControlPlaneImage = func(ic *types.InstallConfig) {
+			ic.ControlPlane.Platform.GCP.OSImage = osImage
+			ic.ControlPlane.Platform.GCP.OSImage.Name = validImage
+			ic.ControlPlane.Platform.GCP.OSImage.Project = projectID
+		}
+		validComputeImage = func(ic *types.InstallConfig) {
+			ic.Compute[0].Platform.GCP.OSImage = osImage
+			ic.Compute[0].Platform.GCP.OSImage.Name = validImage
+			ic.Compute[0].Platform.GCP.OSImage.Project = projectID
+		}
+
+		invalidDefaultMachineImage = func(ic *types.InstallConfig) {
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage = osImage
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Name = invalidImage
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Project = projectID
+		}
+		invalidControlPlaneImage = func(ic *types.InstallConfig) {
+			ic.ControlPlane.Platform.GCP.OSImage = osImage
+			ic.ControlPlane.Platform.GCP.OSImage.Name = invalidImage
+			ic.ControlPlane.Platform.GCP.OSImage.Project = projectID
+		}
+		invalidComputeImage = func(ic *types.InstallConfig) {
+			ic.Compute[0].Platform.GCP.OSImage = osImage
+			ic.Compute[0].Platform.GCP.OSImage.Name = invalidImage
+			ic.Compute[0].Platform.GCP.OSImage.Project = projectID
+		}
+
+		mismatchedDefaultMachineImageArchitecture = func(ic *types.InstallConfig) {
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage = osImage
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Name = mismatchedArch
+			ic.Platform.GCP.DefaultMachinePlatform.OSImage.Project = projectID
+			ic.ControlPlane.Architecture = types.ArchitectureARM64
+			ic.Compute[0].Architecture = types.ArchitectureARM64
+		}
+		mismatchedControlPlaneImageArchitecture = func(ic *types.InstallConfig) {
+			ic.ControlPlane.Platform.GCP.OSImage = osImage
+			ic.ControlPlane.Platform.GCP.OSImage.Name = mismatchedArch
+			ic.ControlPlane.Platform.GCP.OSImage.Project = projectID
+			ic.ControlPlane.Architecture = types.ArchitectureARM64
+		}
+		mismatchedComputeImageArchitecture = func(ic *types.InstallConfig) {
+			ic.Compute[0].Platform.GCP.OSImage = osImage
+			ic.Compute[0].Platform.GCP.OSImage.Name = mismatchedArch
+			ic.Compute[0].Platform.GCP.OSImage.Project = projectID
+			ic.Compute[0].Architecture = types.ArchitectureARM64
+		}
+		unspecifiedImageArchitecture = func(ic *types.InstallConfig) {
+			ic.ControlPlane.Platform.GCP.OSImage = osImage
+			ic.ControlPlane.Platform.GCP.OSImage.Name = "unspecified-arch"
+			ic.ControlPlane.Platform.GCP.OSImage.Project = projectID
+		}
+		missingImageArchitecture = func(ic *types.InstallConfig) {
+			ic.ControlPlane.Platform.GCP.OSImage = osImage
+			ic.ControlPlane.Platform.GCP.OSImage.Name = "missing-arch"
+			ic.ControlPlane.Platform.GCP.OSImage.Project = projectID
+		}
+
+		marketplaceImageAPIResult = &compute.Image{
+			Architecture: "X86_64",
+		}
+
+		unspecifiedMarketplaceImageAPIResult = &compute.Image{
+			Architecture: "ARCHITECTURE_UNSPECIFIED",
+		}
+		emptyMarketplaceImageAPIResult = &compute.Image{}
+	)
+
+	cases := []struct {
+		name            string
+		edits           editFunctions
+		expectedError   bool
+		expectedErrMsg  string
+		expectedWarnMsg string // NOTE: this is a REGEXP
+	}{
+		{
+			name:          "Valid default machine image",
+			edits:         editFunctions{validDefaultMachineImage},
+			expectedError: false,
+		},
+		{
+			name:          "Valid control plane image",
+			edits:         editFunctions{validControlPlaneImage},
+			expectedError: false,
+		},
+		{
+			name:          "Valid compute image",
+			edits:         editFunctions{validComputeImage},
+			expectedError: false,
+		},
+		{
+			name:           "Invalid default machine image",
+			edits:          editFunctions{invalidDefaultMachineImage},
+			expectedError:  true,
+			expectedErrMsg: `^\[platform.gcp.defaultMachinePlatform.osImage: Invalid value: gcp.OSImage{Name:"invalid-image", Project:"project-id"}: could not find the boot image: image not found\]$`,
+		},
+		{
+			name:           "Invalid control plane image",
+			edits:          editFunctions{invalidControlPlaneImage},
+			expectedError:  true,
+			expectedErrMsg: `^\[controlPlane.platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"invalid-image", Project:"project-id"}: could not find the boot image: image not found\]$`,
+		},
+		{
+			name:           "Invalid compute image",
+			edits:          editFunctions{invalidComputeImage},
+			expectedError:  true,
+			expectedErrMsg: `^\[compute\[0\].platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"invalid-image", Project:"project-id"}: could not find the boot image: image not found\]$`,
+		},
+		{
+			name:           "Invalid images",
+			edits:          editFunctions{invalidDefaultMachineImage, invalidControlPlaneImage, invalidComputeImage},
+			expectedError:  true,
+			expectedErrMsg: `^\[(.*?\.osImage: Invalid value: gcp\.OSImage\{Name:"invalid-image", Project:"project-id"\}: could not find the boot image: image not found){3}\]$`,
+		},
+		{
+			name:           "Mismatched default machine image architecture",
+			edits:          editFunctions{mismatchedDefaultMachineImageArchitecture},
+			expectedError:  true,
+			expectedErrMsg: `^\[controlPlane.platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"mismatched-arch", Project:"project-id"}: image architecture X86_64 does not match controlPlane node architecture arm64 compute\[0\].platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"mismatched-arch", Project:"project-id"}: image architecture X86_64 does not match compute node architecture arm64]$`,
+		},
+		{
+			name:           "Mismatched control plane image architecture",
+			edits:          editFunctions{mismatchedControlPlaneImageArchitecture},
+			expectedError:  true,
+			expectedErrMsg: `^\[controlPlane.platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"mismatched-arch", Project:"project-id"}: image architecture X86_64 does not match controlPlane node architecture arm64]$`,
+		},
+		{
+			name:           "Mismatched compute image architecture",
+			edits:          editFunctions{mismatchedComputeImageArchitecture},
+			expectedError:  true,
+			expectedErrMsg: `^\[compute\[0\].platform.gcp.osImage: Invalid value: gcp.OSImage{Name:"mismatched-arch", Project:"project-id"}: image architecture X86_64 does not match compute node architecture arm64]$`,
+		},
+		{
+			name:            "Missing image architecture",
+			edits:           editFunctions{missingImageArchitecture},
+			expectedError:   false,
+			expectedWarnMsg: "Boot image architecture is unspecified and might not be compatible with amd64 controlPlane nodes",
+		},
+		{
+			name:            "Unspecified image architecture",
+			edits:           editFunctions{unspecifiedImageArchitecture},
+			expectedError:   false,
+			expectedWarnMsg: "Boot image architecture is unspecified and might not be compatible with amd64 controlPlane nodes",
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	gcpClient := mock.NewMockAPI(mockCtrl)
+
+	// Mocks: valid image with matching architecture
+	gcpClient.EXPECT().GetImage(gomock.Any(), gomock.Eq(validImage), gomock.Any()).Return(marketplaceImageAPIResult, nil).AnyTimes()
+
+	// Mocks: invalid image
+	gcpClient.EXPECT().GetImage(gomock.Any(), gomock.Eq(invalidImage), gomock.Any()).Return(marketplaceImageAPIResult, fmt.Errorf("image not found")).AnyTimes()
+
+	// Mocks: valid image with mismatched architecture
+	gcpClient.EXPECT().GetImage(gomock.Any(), gomock.Eq(mismatchedArch), gomock.Any()).Return(marketplaceImageAPIResult, nil).AnyTimes()
+
+	// Mocks: valid image with no specified architecture
+	gcpClient.EXPECT().GetImage(gomock.Any(), gomock.Eq("unspecified-arch"), gomock.Any()).Return(unspecifiedMarketplaceImageAPIResult, nil).AnyTimes()
+	gcpClient.EXPECT().GetImage(gomock.Any(), gomock.Eq("missing-arch"), gomock.Any()).Return(emptyMarketplaceImageAPIResult, nil).AnyTimes()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+
+			hook := logrusTest.NewGlobal()
+			errs := validateMarketplaceImages(gcpClient, editedInstallConfig)
+			if tc.expectedError {
+				assert.Regexp(t, tc.expectedErrMsg, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+			if len(tc.expectedWarnMsg) > 0 {
+				assert.Regexp(t, tc.expectedWarnMsg, hook.LastEntry().Message)
 			}
 		})
 	}

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -134,6 +134,8 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	az := mpool.Zones[azIdx]
 	if len(platform.Licenses) > 0 {
 		osImage = fmt.Sprintf("%s-rhcos-image", clusterID)
+	} else if mpool.OSImage != nil {
+		osImage = fmt.Sprintf("projects/%s/global/images/%s", mpool.OSImage.Project, mpool.OSImage.Name)
 	}
 	network, subnetwork, err := getNetworks(platform, clusterID, role)
 	if err != nil {

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -18,6 +18,11 @@ type MachinePool struct {
 	// +optional
 	OSDisk `json:"osDisk"`
 
+	// OSImage defines a custom image for instance.
+	//
+	// +optional
+	OSImage *OSImage `json:"osImage,omitempty"`
+
 	// Tags defines a set of network tags which will be added to instances in the machineset
 	//
 	// +optional
@@ -65,6 +70,19 @@ type OSDisk struct {
 	EncryptionKey *EncryptionKeyReference `json:"encryptionKey,omitempty"`
 }
 
+// OSImage defines the image to use for the OS.
+type OSImage struct {
+	// Name defines the name of the image.
+	//
+	// +required
+	Name string `json:"name"`
+
+	// Project defines the name of the project containing the image.
+	//
+	// +required
+	Project string `json:"project"`
+}
+
 // Set sets the values from `required` to `a`.
 func (a *MachinePool) Set(required *MachinePool) {
 	if required == nil || a == nil {
@@ -89,6 +107,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.OSDisk.DiskType != "" {
 		a.OSDisk.DiskType = required.OSDisk.DiskType
+	}
+
+	if required.OSImage != nil {
+		a.OSImage = required.OSImage
 	}
 
 	if required.EncryptionKey != nil {


### PR DESCRIPTION
The initial stage towards enabling users to specify a boot images from Google Cloud Marketplace. This involves the introduction of a new field called oSImage. Within this field, users can indicate the project and name of the desired image.

Manual cherry-pick of https://github.com/openshift/installer/pull/7215