### PR TITLE
OCPBUGS-5471: Try to select rendezvousIP among non-worker hosts

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/validations/no-rendezvousip.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/no-rendezvousip.txt
@@ -1,0 +1,115 @@
+# Verify that when the rendezvousIP is not defined in the agent-config.yaml, it is then
+# selected amongst the non-worker nodes (given that interfaces are properly defined)
+
+exec openshift-install agent create image --dir $WORK
+
+stderr 'The rendezvous host IP \(node0 IP\) is 10.19.17.126'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 3
+compute: 
+- name: worker
+  replicas: 1
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+    baremetal:
+      apiVips: 
+        - 192.168.111.5
+      ingressVips: 
+        - 192.168.111.4
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+hosts:
+  - hostname: worker-0
+    role: worker
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:04
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:04
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.129
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-0
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:01
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:01
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.126
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-1
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:02
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:02
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.127
+                prefix-length: 23
+            dhcp: false
+  - hostname: master-2
+    role: master
+    interfaces:
+     - name: enp1s0
+       macAddress: aa:bb:dc:dd:a8:03
+    networkConfig:
+      interfaces:
+        - name: enp1s0
+          type: ethernet
+          state: up
+          mac-address: aa:bb:dc:dd:a8:03
+          ipv4:
+            enabled: true
+            address:
+              - ip: 10.19.17.128
+                prefix-length: 23
+            dhcp: false

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -518,12 +518,12 @@ func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 		rendezvousIP = agentConfig.RendezvousIP
 		logrus.Debug("RendezvousIP from the AgentConfig ", rendezvousIP)
 
-	} else if len(nmStateConfigs) > 0 {
-		rendezvousIP, err = manifests.GetNodeZeroIP(nmStateConfigs)
-		logrus.Debug("RendezvousIP from the NMStateConfig ", rendezvousIP)
 	} else {
-		err = errors.New("missing rendezvousIP in agent-config or at least one NMStateConfig manifest")
-		return "", err
+		rendezvousIP, err = manifests.GetNodeZeroIP(agentConfig, nmStateConfigs)
+		if err != nil {
+			return "", errors.Wrap(err, "missing rendezvousIP in agent-config, at least one host networkConfig in agent-config, or at least one NMStateConfig manifest")
+		}
+		logrus.Debug("RendezvousIP from the NMStateConfig ", rendezvousIP)
 	}
 
 	// Convert IPv6 address to canonical to match host format for comparisons

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -228,7 +228,7 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "missing rendezvousIP in agent-config or at least one NMStateConfig manifest",
+			expectedError: "missing rendezvousIP in agent-config, at least one host networkConfig in agent-config, or at least one NMStateConfig manifest",
 		},
 		{
 			Name: "non-canonical-ipv6-address",


### PR DESCRIPTION
This patch enhances the rendezvousIP selection logic when it's not explicitly defined in the agent-config.yaml. In such case, it tries to look for an eligible IP within the non-worker hosts eventually configured in the agent-config.yaml first. If none is found (there couldn't be any host defined, or defined without nmstate config), it falls back to the previous behavior (by looking at the static configuration potentially loaded from the `nmstateconfig.yaml` file)