### PR TITLE
OCPBUGS-18304: for vsphere ipi add cluster domain to the uploaded vm configs so that…

### DIFF
--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -72,6 +72,7 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
       "guestinfo.ignition.config.data"          = base64encode(var.ignition_bootstrap)
       "guestinfo.ignition.config.data.encoding" = "base64"
       "guestinfo.hostname"                      = "${var.cluster_id}-bootstrap"
+      "guestinfo.domain"                        = "${var.cluster_domain}"
       "stealclock.enable"                       = "TRUE"
     },
     length(var.vsphere_bootstrap_network_kargs) > 0 ?


### PR DESCRIPTION
… 30-local-dns-prepender can use it

Fixes https://github.com/okd-project/okd/issues/1715

This re-adds domain setting from https://github.com/openshift/installer/pull/5788 removed in https://github.com/openshift/installer/pull/6770