### PR TITLE
OCPBUGS-5728: Log "agent wait-for" commands to .openshift_install.log

### DIFF
--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/installer/cmd/openshift-install/command"
 	agentpkg "github.com/openshift/installer/pkg/agent"
 )
 
@@ -52,6 +53,9 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 		Short: "Wait until the cluster bootstrap is complete",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
+			defer cleanup()
+
 			assetDir := cmd.Flags().Lookup("dir").Value.String()
 			logrus.Debugf("asset directory: %s", assetDir)
 			if len(assetDir) == 0 {
@@ -77,6 +81,9 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 		Short: "Wait until the cluster installation is complete",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
+			defer cleanup()
+
 			assetDir := cmd.Flags().Lookup("dir").Value.String()
 			logrus.Debugf("asset directory: %s", assetDir)
 			if len(assetDir) == 0 {

--- a/cmd/openshift-install/analyze.go
+++ b/cmd/openshift-install/analyze.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/installer/cmd/openshift-install/command"
 	"github.com/openshift/installer/pkg/gather/service"
 )
 
@@ -34,7 +35,7 @@ This command helps users to analyze the reasons for an installation that failed 
 				}
 			}
 			if !filepath.IsAbs(gatherBundle) {
-				gatherBundle = filepath.Join(rootOpts.dir, gatherBundle)
+				gatherBundle = filepath.Join(command.RootOpts.Dir, gatherBundle)
 			}
 			if err := service.AnalyzeGatherBundle(gatherBundle); err != nil {
 				logrus.Fatal(err)
@@ -46,7 +47,7 @@ This command helps users to analyze the reasons for an installation that failed 
 }
 
 func getGatherBundleFromAssetsDirectory() (string, error) {
-	matches, err := filepath.Glob(filepath.Join(rootOpts.dir, "log-bundle-*.tar.gz"))
+	matches, err := filepath.Glob(filepath.Join(command.RootOpts.Dir, "log-bundle-*.tar.gz"))
 	if err != nil {
 		return "", errors.Wrap(err, "could not find gather bundles in assets directory")
 	}

--- a/cmd/openshift-install/command/log.go
+++ b/cmd/openshift-install/command/log.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"io"
@@ -10,6 +10,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/version"
+)
+
+var (
+	// RootOpts holds the log directory and log level configuration.
+	RootOpts struct {
+		Dir      string
+		LogLevel string
+	}
 )
 
 type fileHook struct {
@@ -28,7 +36,8 @@ func newFileHook(file io.Writer, level logrus.Level, formatter logrus.Formatter)
 	}
 }
 
-func newFileHookWithNewlineTruncate(file io.Writer, level logrus.Level, formatter logrus.Formatter) *fileHook {
+// NewFileHookWithNewlineTruncate returns a new FileHook with truncated new lines.
+func NewFileHookWithNewlineTruncate(file io.Writer, level logrus.Level, formatter logrus.Formatter) *fileHook {
 	f := newFileHook(file, level, formatter)
 	f.truncateAtNewLine = true
 	return f
@@ -73,7 +82,8 @@ func (h *fileHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-func setupFileHook(baseDir string) func() {
+// SetupFileHook creates the base log directory and configures logrus options.
+func SetupFileHook(baseDir string) func() {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		logrus.Fatal(errors.Wrap(err, "failed to create base directory for logs"))
 	}

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/installer/cmd/openshift-install/command"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	"github.com/openshift/installer/pkg/destroy"
 	"github.com/openshift/installer/pkg/destroy/bootstrap"
@@ -48,10 +49,10 @@ func newDestroyClusterCmd() *cobra.Command {
 		Short: "Destroy an OpenShift cluster",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
-			cleanup := setupFileHook(rootOpts.dir)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			err := runDestroyCmd(rootOpts.dir, os.Getenv("OPENSHIFT_INSTALL_REPORT_QUOTA_FOOTPRINT") == "true")
+			err := runDestroyCmd(command.RootOpts.Dir, os.Getenv("OPENSHIFT_INSTALL_REPORT_QUOTA_FOOTPRINT") == "true")
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -120,11 +121,11 @@ func newDestroyBootstrapCmd() *cobra.Command {
 		Short: "Destroy the bootstrap resources",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			cleanup := setupFileHook(rootOpts.dir)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
 			timer.StartTimer(timer.TotalTimeElapsed)
-			err := bootstrap.Destroy(rootOpts.dir)
+			err := bootstrap.Destroy(command.RootOpts.Dir)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -19,6 +19,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/installer/cmd/openshift-install/command"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	"github.com/openshift/installer/pkg/asset/tls"
@@ -62,9 +63,9 @@ func newGatherBootstrapCmd() *cobra.Command {
 		Short: "Gather debugging data for a failing-to-bootstrap control plane",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
-			cleanup := setupFileHook(rootOpts.dir)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
-			bundlePath, err := runGatherBootstrapCmd(rootOpts.dir)
+			bundlePath, err := runGatherBootstrapCmd(command.RootOpts.Dir)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -12,13 +12,8 @@ import (
 	terminal "golang.org/x/term"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
-)
 
-var (
-	rootOpts struct {
-		dir      string
-		logLevel string
-	}
+	"github.com/openshift/installer/cmd/openshift-install/command"
 )
 
 func main() {
@@ -72,8 +67,8 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors:    true,
 		SilenceUsage:     true,
 	}
-	cmd.PersistentFlags().StringVar(&rootOpts.dir, "dir", ".", "assets directory")
-	cmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
+	cmd.PersistentFlags().StringVar(&command.RootOpts.Dir, "dir", ".", "assets directory")
+	cmd.PersistentFlags().StringVar(&command.RootOpts.LogLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
 	return cmd
 }
 
@@ -81,12 +76,12 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 	logrus.SetOutput(io.Discard)
 	logrus.SetLevel(logrus.TraceLevel)
 
-	level, err := logrus.ParseLevel(rootOpts.logLevel)
+	level, err := logrus.ParseLevel(command.RootOpts.LogLevel)
 	if err != nil {
 		level = logrus.InfoLevel
 	}
 
-	logrus.AddHook(newFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
+	logrus.AddHook(command.NewFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
 		// Setting ForceColors is necessary because logrus.TextFormatter determines
 		// whether or not to enable colors by looking at the output of the logger.
 		// In this case, the output is io.Discard, which is not a terminal.

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/openshift/installer/cmd/openshift-install/command"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
 )
 
@@ -39,10 +40,10 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 			timer.StartTimer(timer.TotalTimeElapsed)
 			ctx := context.Background()
 
-			cleanup := setupFileHook(rootOpts.dir)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(rootOpts.dir, "auth", "kubeconfig"))
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig"))
 			if err != nil {
 				logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 			}
@@ -76,15 +77,15 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 			timer.StartTimer(timer.TotalTimeElapsed)
 			ctx := context.Background()
 
-			cleanup := setupFileHook(rootOpts.dir)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(rootOpts.dir, "auth", "kubeconfig"))
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig"))
 			if err != nil {
 				logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 			}
 
-			err = waitForInstallComplete(ctx, config, rootOpts.dir)
+			err = waitForInstallComplete(ctx, config, command.RootOpts.Dir)
 			if err != nil {
 				if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -126,19 +126,13 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 		return true, false, nil
 	}
 
-	clusterKubeAPILive, clusterKubeAPIErr := czero.API.Kube.IsKubeAPILive()
-	if clusterKubeAPIErr != nil {
-		logrus.Trace(errors.Wrap(clusterKubeAPIErr, "Bootstrap Kube API is not available"))
-	}
+	clusterKubeAPILive := czero.API.Kube.IsKubeAPILive()
 
-	agentRestAPILive, agentRestAPIErr := czero.API.Rest.IsRestAPILive()
-	if agentRestAPIErr != nil {
-		logrus.Trace(errors.Wrap(agentRestAPIErr, "Agent Rest API is not available"))
-	}
+	agentRestAPILive := czero.API.Rest.IsRestAPILive()
 
 	// Both API's are not available
 	if !agentRestAPILive && !clusterKubeAPILive {
-		logrus.Trace("Current API Status: Agent Rest API: down, Bootstrap Kube API: down")
+		// Current API Status: Agent Rest API: down, Bootstrap Kube API: down
 		if !czero.installHistory.RestAPISeen && !czero.installHistory.ClusterKubeAPISeen {
 			logrus.Debug("Agent Rest API never initialized. Bootstrap Kube API never initialized")
 			elapsedSinceInit := time.Since(czero.installHistory.ClusterInitTime)
@@ -207,7 +201,7 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 			czero.clusterInfraEnvID = clusterInfraEnvID
 		}
 
-		logrus.Trace("Getting cluster metadata from Agent Rest API")
+		// Getting cluster metadata from Agent Rest API
 		clusterMetadata, err := czero.GetClusterRestAPIMetadata()
 		if err != nil {
 			return false, false, errors.Wrap(err, "Unable to retrieve cluster metadata from Agent Rest API")
@@ -262,7 +256,7 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 			return false, false, errors.Wrap(err, "Unable to retrieve events about the cluster from the Agent Rest API")
 		}
 		if len(eventList) == 0 {
-			logrus.Trace("No cluster events detected from the Agent Rest API")
+			// No cluster events detected from the Agent Rest API
 		} else {
 			mostRecentEvent := eventList[len(eventList)-1]
 			// Don't print the same status message back to back
@@ -279,7 +273,7 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 
 	}
 
-	logrus.Trace("cluster bootstrap is not complete")
+	// cluster bootstrap is not complete
 	return false, false, nil
 }
 
@@ -438,7 +432,6 @@ func (czero *Cluster) PrintInstallationComplete() error {
 func (czero *Cluster) PrintInstallStatus(cluster *models.Cluster) error {
 
 	friendlyStatus := humanFriendlyClusterInstallStatus(*cluster.Status)
-	logrus.Trace(friendlyStatus)
 	// Don't print the same status message back to back
 	if *cluster.Status != czero.installHistory.RestAPIPreviousClusterStatus {
 		logrus.Info(friendlyStatus)

--- a/pkg/agent/rest.go
+++ b/pkg/agent/rest.go
@@ -99,14 +99,14 @@ func NewNodeZeroRestClient(ctx context.Context, assetDir string) (*NodeZeroRestC
 }
 
 // IsRestAPILive Determine if the Agent Rest API on node zero has initialized
-func (rest *NodeZeroRestClient) IsRestAPILive() (bool, error) {
+func (rest *NodeZeroRestClient) IsRestAPILive() bool {
 	// GET /v2/infraenvs
 	listInfraEnvsParams := installer.NewListInfraEnvsParams()
 	_, err := rest.Client.Installer.ListInfraEnvs(rest.ctx, listInfraEnvsParams)
 	if err != nil {
-		return false, err
+		return false
 	}
-	return true, nil
+	return true
 }
 
 // GetRestAPIServiceBaseURL Return the url of the Agent Rest API on node zero

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -12,8 +12,6 @@ import (
 // WaitForBootstrapComplete Wait for the bootstrap process to complete on
 // cluster installations triggered by the agent installer.
 func WaitForBootstrapComplete(cluster *Cluster) error {
-	start := time.Now()
-	previous := time.Now()
 	timeout := 60 * time.Minute
 	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
 	defer cancel()
@@ -38,15 +36,6 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 				}
 			}
 		}
-
-		current := time.Now()
-		elapsed := current.Sub(previous)
-		elapsedTotal := current.Sub(start)
-		if elapsed >= 1*time.Minute {
-			logrus.Tracef("elapsed: %s, elapsedTotal: %s", elapsed.String(), elapsedTotal.String())
-			previous = current
-		}
-
 	}, 2*time.Second, waitContext.Done())
 
 	waitErr := waitContext.Err()


### PR DESCRIPTION
Updated "agent wait-for" commands to also call
SetupFileHook(RootOpts.Dir) so that it logs to the common .openshift_install.log file.

Moved log.go and rootOpts to a command package so that it can be shared with agent wait-for.