### PR TITLE
OCPBUGS-18320: CORS-2445: GCP: Add osImage to the install config

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -391,6 +391,20 @@ spec:
                           required:
                           - DiskSizeGB
                           type: object
+                        osImage:
+                          description: OSImage defines a custom image for instance.
+                          properties:
+                            name:
+                              description: Name defines the name of the image.
+                              type: string
+                            project:
+                              description: Project defines the name of the project
+                                containing the image.
+                              type: string
+                          required:
+                          - name
+                          - project
+                          type: object
                         tags:
                           description: Tags defines a set of network tags which will
                             be added to instances in the machineset
@@ -1037,6 +1051,20 @@ spec:
                             type: object
                         required:
                         - DiskSizeGB
+                        type: object
+                      osImage:
+                        description: OSImage defines a custom image for instance.
+                        properties:
+                          name:
+                            description: Name defines the name of the image.
+                            type: string
+                          project:
+                            description: Project defines the name of the project containing
+                              the image.
+                            type: string
+                        required:
+                        - name
+                        - project
                         type: object
                       tags:
                         description: Tags defines a set of network tags which will
@@ -2270,6 +2298,20 @@ spec:
                             type: object
                         required:
                         - DiskSizeGB
+                        type: object
+                      osImage:
+                        description: OSImage defines a custom image for instance.
+                        properties:
+                          name:
+                            description: Name defines the name of the image.
+                            type: string
+                          project:
+                            description: Project defines the name of the project containing
+                              the image.
+                            type: string
+                        required:
+                        - name
+                        - project
                         type: object
                       tags:
                         description: Tags defines a set of network tags which will

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -31,6 +31,7 @@ type API interface {
 	GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error)
 	GetEnabledServices(ctx context.Context, project string) ([]string, error)
 	GetCredentials() *googleoauth.Credentials
+	GetImage(ctx context.Context, name string, project string) (*compute.Image, error)
 }
 
 // Client makes calls to the GCP API.
@@ -342,4 +343,17 @@ func (c *Client) getServiceUsageService(ctx context.Context) (*serviceusage.Serv
 // GetCredentials returns the credentials used to authenticate the GCP session.
 func (c *Client) GetCredentials() *googleoauth.Credentials {
 	return c.ssn.Credentials
+}
+
+// GetImage returns the marketplace image specified by the user.
+func (c *Client) GetImage(ctx context.Context, name string, project string) (*compute.Image, error) {
+	svc, err := c.getComputeService(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	return svc.Images.Get(project, name).Context(ctx).Do()
 }

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -81,6 +81,21 @@ func (mr *MockAPIMockRecorder) GetEnabledServices(ctx, project interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledServices", reflect.TypeOf((*MockAPI)(nil).GetEnabledServices), ctx, project)
 }
 
+// GetImage mocks base method.
+func (m *MockAPI) GetImage(ctx context.Context, name, project string) (*compute.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImage", ctx, name, project)
+	ret0, _ := ret[0].(*compute.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImage indicates an expected call of GetImage.
+func (mr *MockAPIMockRecorder) GetImage(ctx, name, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockAPI)(nil).GetImage), ctx, name, project)
+}
+
 // GetMachineType mocks base method.
 func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -76,6 +76,8 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	az := mpool.Zones[azIdx]
 	if len(platform.Licenses) > 0 {
 		osImage = fmt.Sprintf("%s-rhcos-image", clusterID)
+	} else if mpool.OSImage != nil {
+		osImage = fmt.Sprintf("projects/%s/global/images/%s", mpool.OSImage.Project, mpool.OSImage.Name)
 	}
 	network, subnetwork, err := getNetworks(platform, clusterID, role)
 	if err != nil {

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -18,6 +18,11 @@ type MachinePool struct {
 	// +optional
 	OSDisk `json:"osDisk"`
 
+	// OSImage defines a custom image for instance.
+	//
+	// +optional
+	OSImage *OSImage `json:"osImage,omitempty"`
+
 	// Tags defines a set of network tags which will be added to instances in the machineset
 	//
 	// +optional
@@ -44,6 +49,19 @@ type OSDisk struct {
 	EncryptionKey *EncryptionKeyReference `json:"encryptionKey,omitempty"`
 }
 
+// OSImage defines the image to use for the OS.
+type OSImage struct {
+	// Name defines the name of the image.
+	//
+	// +required
+	Name string `json:"name"`
+
+	// Project defines the name of the project containing the image.
+	//
+	// +required
+	Project string `json:"project"`
+}
+
 // Set sets the values from `required` to `a`.
 func (a *MachinePool) Set(required *MachinePool) {
 	if required == nil || a == nil {
@@ -68,6 +86,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.OSDisk.DiskType != "" {
 		a.OSDisk.DiskType = required.OSDisk.DiskType
+	}
+
+	if required.OSImage != nil {
+		a.OSImage = required.OSImage
 	}
 
 	if required.EncryptionKey != nil {


### PR DESCRIPTION
The initial stage towards enabling users to specify a boot images from Google Cloud Marketplace. This involves the introduction of a new field called oSImage. Within this field, users can indicate the project and name of the desired image.

Manual cherry-pick of https://github.com/openshift/installer/pull/7215