### PR TITLE
OCPBUGS-17869: azure: fix setting outboundType

### DIFF
--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -56,6 +56,7 @@ type config struct {
 	ComputeSubnet                           string            `json:"azure_compute_subnet"`
 	PreexistingNetwork                      bool              `json:"azure_preexisting_network"`
 	Private                                 bool              `json:"azure_private"`
+	OutboundType                            string            `json:"azure_outbound_routing_type"`
 	BootstrapIgnitionStub                   string            `json:"azure_bootstrap_ignition_stub"`
 	BootstrapIgnitionURLPlaceholder         string            `json:"azure_bootstrap_ignition_url_placeholder"`
 	HyperVGeneration                        string            `json:"azure_hypervgeneration_version"`
@@ -165,6 +166,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ImageURL:                                sources.ImageURL,
 		ImageRelease:                            sources.ImageRelease,
 		Private:                                 sources.Publish == types.InternalPublishingStrategy,
+		OutboundType:                            string(sources.OutboundType),
 		ResourceGroupName:                       sources.ResourceGroupName,
 		BaseDomainResourceGroupName:             sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:                masterConfig.NetworkResourceGroup,


### PR DESCRIPTION
https://github.com/openshift/installer/pull/7312 inadvertently removed the setting of `OutboundType` in the terraform variables, causing the outbound to always be the default `LoadBalancer` even if `NatGateway` is set in the install-config.