### PR TITLE
SPLAT-1170: enable cloud controller manager type to be defined

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3017,6 +3017,14 @@ spec:
                 description: External is the configuration used when installing on
                   an external cloud provider.
                 properties:
+                  cloudControllerManager:
+                    default: ""
+                    description: CloudControllerManager when set to external, this
+                      property will enable an external cloud provider.
+                    enum:
+                    - ""
+                    - External
+                    type: string
                   platformName:
                     default: Unknown
                     description: PlatformName holds the arbitrary string representing

--- a/pkg/asset/manifests/external/infrastructure.go
+++ b/pkg/asset/manifests/external/infrastructure.go
@@ -3,6 +3,7 @@ package external
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/types/external"
 )
 
 // GetInfraPlatformSpec constructs ExternalPlatformSpec for the infrastructure spec.
@@ -15,10 +16,21 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig) *configv1.ExternalPla
 }
 
 // GetInfraPlatformStatus constructs ExternalPlatformSpec for the infrastructure spec.
-func GetInfraPlatformStatus() *configv1.ExternalPlatformStatus {
+func GetInfraPlatformStatus(ic *installconfig.InstallConfig) *configv1.ExternalPlatformStatus {
+	icPlatformSpec := ic.Config.External
+
+	var ccmState configv1.CloudControllerManagerState
+
+	switch icPlatformSpec.CloudControllerManager {
+	case external.CloudControllerManagerTypeExternal:
+		ccmState = configv1.CloudControllerManagerExternal
+	default:
+		ccmState = configv1.CloudControllerManagerNone
+	}
+
 	return &configv1.ExternalPlatformStatus{
 		CloudControllerManager: configv1.CloudControllerManagerStatus{
-			State: configv1.CloudControllerManagerExternal,
+			State: ccmState,
 		},
 	}
 }

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -207,7 +207,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	case external.Name:
 		config.Spec.PlatformSpec.Type = configv1.ExternalPlatformType
 		config.Spec.PlatformSpec.External = externalinfra.GetInfraPlatformSpec(installConfig)
-		config.Status.PlatformStatus.External = externalinfra.GetInfraPlatformStatus()
+		config.Status.PlatformStatus.External = externalinfra.GetInfraPlatformStatus(installConfig)
 	case none.Name:
 		config.Spec.PlatformSpec.Type = configv1.NonePlatformType
 	case openstack.Name:

--- a/pkg/types/external/defaults/platform.go
+++ b/pkg/types/external/defaults/platform.go
@@ -5,4 +5,5 @@ import "github.com/openshift/installer/pkg/types/external"
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *external.Platform) {
 	p.PlatformName = "Unknown"
+	p.CloudControllerManager = external.CloudControllerManagerTypeNone
 }

--- a/pkg/types/external/platform.go
+++ b/pkg/types/external/platform.go
@@ -1,5 +1,16 @@
 package external
 
+// CloudControllerManager describes the type of cloud controller manager to be enabled.
+type CloudControllerManager string
+
+const (
+	// CloudControllerManagerTypeExternal specifies that an external cloud provider is to be configured.
+	CloudControllerManagerTypeExternal = "External"
+
+	// CloudControllerManagerTypeNone specifies that no cloud provider is to be configured.
+	CloudControllerManagerTypeNone = ""
+)
+
 // Platform stores configuration related to external cloud providers.
 type Platform struct {
 	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
@@ -9,4 +20,11 @@ type Platform struct {
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'Unknown' || self == oldSelf",message="platform name cannot be changed once set"
 	// +optional
 	PlatformName string `json:"platformName,omitempty"`
+
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	// +kubebuilder:default:=""
+	// +default=""
+	// +kubebuilder:validation:Enum="";External
+	// +optional
+	CloudControllerManager CloudControllerManager `json:"cloudControllerManager,omitempty"`
 }


### PR DESCRIPTION
Introduces a new configuration to the platform external platform spec which allows an external cloud provider to be enabled.  By default, external cloud providers will be disabled.