### PR TITLE
OCPBUGS-18365: Fix defaulting of userManagedNetworking value

### DIFF
--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -287,7 +287,7 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 		agentClusterInstall.Spec.PlatformType = hiveext.ExternalPlatformType
 	case none.Name:
 		agentClusterInstall.Spec.PlatformType = hiveext.NonePlatformType
-		if agentClusterInstall.Spec.Networking.UserManagedNetworking != swag.Bool(true) {
+		if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil || !*agentClusterInstall.Spec.Networking.UserManagedNetworking {
 			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", none.Name)
 			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
 		}

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -287,12 +287,18 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 		agentClusterInstall.Spec.PlatformType = hiveext.ExternalPlatformType
 	case none.Name:
 		agentClusterInstall.Spec.PlatformType = hiveext.NonePlatformType
-		if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil || !*agentClusterInstall.Spec.Networking.UserManagedNetworking {
-			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", none.Name)
-			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
-		}
 	case vsphere.Name:
 		agentClusterInstall.Spec.PlatformType = hiveext.VSpherePlatformType
+	}
+
+	// Set the default value for userManagedNetworking, as would be done by the
+	// mutating webhook in ZTP.
+	switch agentClusterInstall.Spec.PlatformType {
+	case hiveext.NonePlatformType:
+		if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil || !*agentClusterInstall.Spec.Networking.UserManagedNetworking {
+			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", agentClusterInstall.Spec.PlatformType)
+			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
+		}
 	}
 
 	a.Config = agentClusterInstall

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -293,9 +293,9 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 
 	// Set the default value for userManagedNetworking, as would be done by the
 	// mutating webhook in ZTP.
-	switch agentClusterInstall.Spec.PlatformType {
-	case hiveext.NonePlatformType, hiveext.ExternalPlatformType:
-		if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil || !*agentClusterInstall.Spec.Networking.UserManagedNetworking {
+	if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil {
+		switch agentClusterInstall.Spec.PlatformType {
+		case hiveext.NonePlatformType, hiveext.ExternalPlatformType:
 			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", agentClusterInstall.Spec.PlatformType)
 			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)
 		}
@@ -409,10 +409,19 @@ func (a *AgentClusterInstall) validateIPAddressAndNetworkType() field.ErrorList 
 func (a *AgentClusterInstall) validateSupportedPlatforms() field.ErrorList {
 	var allErrs field.ErrorList
 
-	fieldPath := field.NewPath("spec", "platformType")
-
 	if a.Config.Spec.PlatformType != "" && !agent.IsSupportedPlatform(a.Config.Spec.PlatformType) {
+		fieldPath := field.NewPath("spec", "platformType")
 		allErrs = append(allErrs, field.NotSupported(fieldPath, a.Config.Spec.PlatformType, agent.SupportedHivePlatforms()))
+	}
+
+	switch a.Config.Spec.PlatformType {
+	case hiveext.NonePlatformType, hiveext.ExternalPlatformType:
+		if a.Config.Spec.Networking.UserManagedNetworking != nil && !*a.Config.Spec.Networking.UserManagedNetworking {
+			fieldPath := field.NewPath("spec", "networking", "userManagedNetworking")
+			allErrs = append(allErrs, field.Forbidden(fieldPath,
+				fmt.Sprintf("%s platform requires user-managed networking",
+					a.Config.Spec.PlatformType)))
+		}
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -294,7 +294,7 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 	// Set the default value for userManagedNetworking, as would be done by the
 	// mutating webhook in ZTP.
 	switch agentClusterInstall.Spec.PlatformType {
-	case hiveext.NonePlatformType:
+	case hiveext.NonePlatformType, hiveext.ExternalPlatformType:
 		if agentClusterInstall.Spec.Networking.UserManagedNetworking == nil || !*agentClusterInstall.Spec.Networking.UserManagedNetworking {
 			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", agentClusterInstall.Spec.PlatformType)
 			agentClusterInstall.Spec.Networking.UserManagedNetworking = swag.Bool(true)


### PR DESCRIPTION
Set default value for `userManagedNetworking` in AgentClusterInstall ZTP manifest regardless of whether the user specified the platform type as `none` or `None`.
Also, return a validation error if the user explicitly specifies `false` when the value must be `true`, instead of overwriting it.