### PR TITLE
OCPBUGS-18450: AWS permission missing for security group viewing.

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -72,6 +72,7 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DescribeRegions",
 		"ec2:DescribeRouteTables",
 		"ec2:DescribeSecurityGroups",
+		"ec2:DescribeSecurityGroupRules",
 		"ec2:DescribeSubnets",
 		"ec2:DescribeTags",
 		"ec2:DescribeVolumes",


### PR DESCRIPTION
**Add the permission as a base check. This will error out when the user does not have the DescribeSecurityGroupRules permission.