### PR TITLE
OCPBUGS-18457: Fix PXE integration tests

### DIFF
--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
@@ -7,10 +7,12 @@ stderr 'Created iPXE script agent.x86_64.ipxe'
 exists $WORK/pxe/agent.x86_64-initrd.img
 exists $WORK/pxe/agent.x86_64-rootfs.img
 exists $WORK/pxe/agent.x86_64-vmlinuz
+exists $WORK/pxe/agent.x86_64.ipxe
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
 
-cmp $WORK/pxe/agent.x86_64.ipxe $WORK/expected/agent.x86_64.ipxe
+grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img' $WORK/pxe/agent.x86_64.ipxe
+grep 'kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img .*ignition.firstboot ignition.platform.id=metal' $WORK/pxe/agent.x86_64.ipxe
 
 -- install-config.yaml --
 apiVersion: v1
@@ -45,9 +47,3 @@ metadata:
   namespace: cluster0
 rendezvousIP: 192.168.111.20
 ipxeBaseURL: http://user-specified-pxe-infra.com
-
--- expected/agent.x86_64.ipxe --
-#!ipxe
-initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img
-kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img ignition.firstboot ignition.platform.id=metal
-boot

--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
@@ -7,10 +7,12 @@ stderr 'Created iPXE script agent.aarch64.ipxe'
 exists $WORK/pxe/agent.aarch64-initrd.img
 exists $WORK/pxe/agent.aarch64-rootfs.img
 exists $WORK/pxe/agent.aarch64-vmlinuz
+exists $WORK/pxe/agent.aarch64.ipxe
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
 
-cmp $WORK/pxe/agent.aarch64.ipxe $WORK/expected/agent.aarch64.ipxe
+grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.aarch64-initrd.img' $WORK/pxe/agent.aarch64.ipxe
+grep 'kernel http://user-specified-pxe-infra.com/agent.aarch64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.aarch64-rootfs.img .*ignition.firstboot ignition.platform.id=metal' $WORK/pxe/agent.aarch64.ipxe
 
 -- install-config.yaml --
 apiVersion: v1
@@ -47,9 +49,3 @@ metadata:
   namespace: cluster0
 rendezvousIP: 192.168.111.20
 ipxeBaseURL: http://user-specified-pxe-infra.com
-
--- expected/agent.aarch64.ipxe --
-#!ipxe
-initrd --name initrd http://user-specified-pxe-infra.com/agent.aarch64-initrd.img
-kernel http://user-specified-pxe-infra.com/agent.aarch64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.aarch64-rootfs.img ignition.firstboot ignition.platform.id=metal
-boot


### PR DESCRIPTION
- Check the contents of the generated iPXE script using a regular expression and `grep` function.
- Rename the sno arm test case to match naming conventions

Signed-off-by: 
Andrea Fasano <afasano@redhat.com> @andfasano 
Pawan Pinjarkar <ppinjark@redhat.com> @pawanpinjarkar

