### PR TITLE
OCPBUGS-18428: Add ip=dhcp,dhcp6 kernel param for vSphere dual-stack

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -557,7 +557,8 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 	// The cluster-network-operator handles the validation of this field.
 	// Reference: https://github.com/openshift/cluster-network-operator/blob/fc3e0e25b4cfa43e14122bdcdd6d7f2585017d75/pkg/network/cluster_config.go#L45-L52
-	if ic.Platform.Name() == openstacktypes.Name && len(installConfig.Config.ServiceNetwork) == 2 {
+	if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 &&
+		(ic.Platform.Name() == openstacktypes.Name || ic.Platform.Name() == vspheretypes.Name) {
 		// Only configure kernel args for dual-stack clusters.
 		ignIPv6, err := machineconfig.ForDualStackAddresses("master")
 		if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -298,7 +298,8 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 		// The cluster-network-operator handles the validation of this field.
 		// Reference: https://github.com/openshift/cluster-network-operator/blob/fc3e0e25b4cfa43e14122bdcdd6d7f2585017d75/pkg/network/cluster_config.go#L45-L52
-		if ic.Platform.Name() == openstacktypes.Name && len(installConfig.Config.ServiceNetwork) == 2 {
+		if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 &&
+			(ic.Platform.Name() == openstacktypes.Name || ic.Platform.Name() == vspheretypes.Name) {
 			// Only configure kernel args for dual-stack clusters.
 			ignIPv6, err := machineconfig.ForDualStackAddresses("worker")
 			if err != nil {


### PR DESCRIPTION
We have observed that when booting up the node, IPv4 and IPv6 stacks can come up at different times causing OpenShift networking services to start when IPv4 is ready but IPv6 is not. This is not desired for dual-stack setups where both stacks should be up before we proceed further.

With this PR we are adding `ip=dhcp,dhcp6` kernel param to master and worker nodes in vSphere scenario when cluster is deployed as dual-stack.

This PR handles only a scenario of initial cluster installation. Conversion from single-stack to dual-stack will be handled separately.

Fixes: OCPBUGS-18428
Contributes-to: [OPNET-230](https://issues.redhat.com//browse/OPNET-230)