### PR TITLE
OCPBUGS-19017: Add Net capabilities to dnsmasq container

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-dnsmasq.container
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-dnsmasq.container
@@ -11,7 +11,7 @@ ContainerName=dnsmasq
 Image=$IRONIC_IMAGE
 Exec=/bin/rundnsmasq
 Network=host
-AddCapability=NET_ADMIN
+AddCapability=NET_ADMIN NET_RAW NET_BIND_SERVICE
 Volume=ironic.volume:/shared:z
 Environment="PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE}"
 Environment="DHCP_RANGE=${DHCP_RANGE}"


### PR DESCRIPTION
the dnsmasq binary has these capabilites set in the ironic image and can't run on scos without them Added to the container.