### PR TITLE
CORS-2836: Refactor Stages, encapsulate terraform

### DIFF
--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"fmt"
 
+	"github.com/openshift/installer/pkg/infrastructure"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages/alibabacloud"
 	"github.com/openshift/installer/pkg/terraform/stages/aws"
@@ -32,42 +33,41 @@ import (
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
-// StagesForPlatform returns the terraform stages to run to provision the infrastructure for the specified platform.
-func StagesForPlatform(platform string) []terraform.Stage {
+// ProviderForPlatform returns the stages to run to provision the infrastructure for the specified platform.
+func ProviderForPlatform(platform string) infrastructure.Provider {
 	switch platform {
 	case alibabacloudtypes.Name:
-		return alibabacloud.PlatformStages
+		return terraform.InitializeProvider(alibabacloud.PlatformStages)
 	case awstypes.Name:
-		return aws.PlatformStages
+		return terraform.InitializeProvider(aws.PlatformStages)
 	case azuretypes.Name:
-		return azure.PlatformStages
+		return terraform.InitializeProvider(azure.PlatformStages)
 	case azuretypes.StackTerraformName:
-		return azure.StackPlatformStages
+		return terraform.InitializeProvider(azure.StackPlatformStages)
 	case baremetaltypes.Name:
-		return baremetal.PlatformStages
+		return terraform.InitializeProvider(baremetal.PlatformStages)
 	case gcptypes.Name:
-		return gcp.PlatformStages
+		return terraform.InitializeProvider(gcp.PlatformStages)
 	case ibmcloudtypes.Name:
-		return ibmcloud.PlatformStages
+		return terraform.InitializeProvider(ibmcloud.PlatformStages)
 	case libvirttypes.Name:
-		return libvirt.PlatformStages
+		return terraform.InitializeProvider(libvirt.PlatformStages)
 	case nutanixtypes.Name:
-		return nutanix.PlatformStages
+		return terraform.InitializeProvider(nutanix.PlatformStages)
 	case powervstypes.Name:
-		return powervs.PlatformStages
+		return terraform.InitializeProvider(powervs.PlatformStages)
 	case openstacktypes.Name:
-		return openstack.PlatformStages
+		return terraform.InitializeProvider(openstack.PlatformStages)
 	case ovirttypes.Name:
-		return ovirt.PlatformStages
+		return terraform.InitializeProvider(ovirt.PlatformStages)
 	case vspheretypes.Name:
-		return vsphere.PlatformStages
+		return terraform.InitializeProvider(vsphere.PlatformStages)
 	case nonetypes.Name:
 		// terraform is not used when the platform is "none"
-		return []terraform.Stage{}
+		return terraform.InitializeProvider([]terraform.Stage{})
 	case externaltypes.Name:
 		// terraform is not used when the platform is "external"
-		return []terraform.Stage{}
-	default:
-		panic(fmt.Sprintf("unsupported platform %q", platform))
+		return terraform.InitializeProvider([]terraform.Stage{})
 	}
+	panic(fmt.Sprintf("unsupported platform %q", platform))
 }

--- a/pkg/infrastructure/provider.go
+++ b/pkg/infrastructure/provider.go
@@ -1,0 +1,30 @@
+package infrastructure
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Provider defines the interface to be used for provisioning
+// and working with cloud infrastructure.
+type Provider interface {
+	// Provision creates the infrastructure resources for the stage.
+	// dir: the path of the install dir
+	// vars: cluster configuration input variables, such as terraform variables files
+	// returns a slice of File assets, which will be appended to the cluster asset file list.
+	Provision(dir string, vars []*asset.File) ([]*asset.File, error)
+
+	// DestroyBootstrap destroys the temporary bootstrap resources.
+	DestroyBootstrap(dir string, varFiles []string) error
+
+	// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
+	ExtractHostAddresses(dir string, config *types.InstallConfig, ha *HostAddresses) error
+}
+
+// HostAddresses contains the node addresses & ports to be
+// used for gather bootsrap debug logs.
+type HostAddresses struct {
+	Bootstrap string
+	Masters   []string
+	Port      int
+}

--- a/pkg/infrastructure/provider.go
+++ b/pkg/infrastructure/provider.go
@@ -15,7 +15,7 @@ type Provider interface {
 	Provision(dir string, vars []*asset.File) ([]*asset.File, error)
 
 	// DestroyBootstrap destroys the temporary bootstrap resources.
-	DestroyBootstrap(dir string, varFiles []string) error
+	DestroyBootstrap(dir string) error
 
 	// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
 	ExtractHostAddresses(dir string, config *types.InstallConfig, ha *HostAddresses) error

--- a/pkg/terraform/stage.go
+++ b/pkg/terraform/stage.go
@@ -10,6 +10,9 @@ type Stage interface {
 	// Name is the name of the stage.
 	Name() string
 
+	// Platform is the name of the platform.
+	Platform() string
+
 	// StateFilename is the name of the terraform state file.
 	StateFilename() string
 

--- a/pkg/terraform/stages/split.go
+++ b/pkg/terraform/stages/split.go
@@ -103,6 +103,11 @@ func (s SplitStage) Destroy(directory string, terraformDir string, varFiles []st
 	return s.destroy(s, directory, terraformDir, varFiles)
 }
 
+// Platform implements pkg/terraform/Stage.Platform.
+func (s SplitStage) Platform() string {
+	return s.platform
+}
+
 // ExtractHostAddresses implements pkg/terraform/Stage.ExtractHostAddresses
 func (s SplitStage) ExtractHostAddresses(directory string, ic *types.InstallConfig) (string, int, []string, error) {
 	if s.extractHostAddresses != nil {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -10,8 +11,153 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/infrastructure"
 	"github.com/openshift/installer/pkg/lineprinter"
+	"github.com/openshift/installer/pkg/metrics/timer"
+	"github.com/openshift/installer/pkg/types"
 )
+
+const (
+	tfVarsFileName         = "terraform.tfvars.json"
+	tfPlatformVarsFileName = "terraform.platform.auto.tfvars.json"
+)
+
+// Provider implements the infrastructure.Provider interface.
+type Provider struct {
+	stages []Stage
+}
+
+// InitializeProvider creates a concrete infrastructure.Provider for the given platform.
+func InitializeProvider(stages []Stage) infrastructure.Provider {
+	return &Provider{stages}
+}
+
+// Provision implements pkg/infrastructure/provider.Provision. Provision iterates
+// through each of the stages and applies the Terraform config for the stage.
+func (p *Provider) Provision(dir string, vars []*asset.File) ([]*asset.File, error) {
+	fileList := []*asset.File{}
+	terraformDir := filepath.Join(dir, "terraform")
+	if err := os.Mkdir(terraformDir, 0777); err != nil {
+		return nil, fmt.Errorf("could not create the terraform directory: %w", err)
+	}
+
+	terraformDirPath, err := filepath.Abs(terraformDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get absolute path of terraform directory: %w", err)
+	}
+
+	defer os.RemoveAll(terraformDir)
+	if err = UnpackTerraform(terraformDirPath, p.stages); err != nil {
+		return nil, fmt.Errorf("error unpacking terraform: %w", err)
+	}
+
+	for _, stage := range p.stages {
+		outputs, stateFile, err := applyStage(stage.Platform(), stage, terraformDirPath, vars)
+		if err != nil {
+			// Write the state file to the install directory even if the apply failed.
+			fileList = append(fileList, stateFile)
+			return fileList, fmt.Errorf("failure applying terraform for %q stage: %w", stage.Name(), err)
+		}
+		vars = append(vars, outputs)
+		fileList = append(fileList, outputs)
+		fileList = append(fileList, stateFile)
+	}
+	return fileList, nil
+}
+
+// DestroyBootstrap implements pkg/infrastructure/provider.DestroyBootstrap.
+// DestroyBootstrap iterates through each stage, and will run the destroy
+// command when defined on a stage.
+func (p *Provider) DestroyBootstrap(dir string) error {
+	varFiles := []string{tfVarsFileName, tfPlatformVarsFileName}
+	for _, stage := range p.stages {
+		varFiles = append(varFiles, stage.OutputsFilename())
+	}
+
+	terraformDir := filepath.Join(dir, "terraform")
+	if err := os.Mkdir(terraformDir, 0777); err != nil {
+		return fmt.Errorf("could not create the terraform directory: %w", err)
+	}
+
+	terraformDirPath, err := filepath.Abs(terraformDir)
+	if err != nil {
+		return fmt.Errorf("could not get absolute path of terraform directory: %w", err)
+	}
+
+	defer os.RemoveAll(terraformDirPath)
+	if err = UnpackTerraform(terraformDirPath, p.stages); err != nil {
+		return fmt.Errorf("error unpacking terraform: %w", err)
+	}
+
+	for i := len(p.stages) - 1; i >= 0; i-- {
+		stage := p.stages[i]
+
+		if !stage.DestroyWithBootstrap() {
+			continue
+		}
+
+		tempDir, err := os.MkdirTemp("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to create temporary directory for Terraform execution: %w", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		stateFilePathInInstallDir := filepath.Join(dir, stage.StateFilename())
+		stateFilePathInTempDir := filepath.Join(tempDir, StateFilename)
+		if err := copyFile(stateFilePathInInstallDir, stateFilePathInTempDir); err != nil {
+			return fmt.Errorf("failed to copy state file to the temporary directory: %w", err)
+		}
+
+		targetVarFiles := make([]string, 0, len(varFiles))
+		for _, filename := range varFiles {
+			sourcePath := filepath.Join(dir, filename)
+			targetPath := filepath.Join(tempDir, filename)
+			if err := copyFile(sourcePath, targetPath); err != nil {
+				// platform may not need platform-specific Terraform variables
+				if filename == tfPlatformVarsFileName {
+					var pErr *os.PathError
+					if errors.As(err, &pErr) && pErr.Path == sourcePath {
+						continue
+					}
+				}
+				return fmt.Errorf("failed to copy %s to the temporary directory: %w", filename, err)
+			}
+			targetVarFiles = append(targetVarFiles, targetPath)
+		}
+
+		if err := stage.Destroy(tempDir, terraformDirPath, targetVarFiles); err != nil {
+			return err
+		}
+
+		if err := copyFile(stateFilePathInTempDir, stateFilePathInInstallDir); err != nil {
+			return fmt.Errorf("failed to copy state file from the temporary directory: %w", err)
+		}
+	}
+	return nil
+}
+
+// ExtractHostAddresses implements pkg/infrastructure/provider.ExtractHostAddresses. Extracts the addresses to be used
+// for gathering debug logs by inspecting the Terraform output files.
+func (p *Provider) ExtractHostAddresses(dir string, config *types.InstallConfig, ha *infrastructure.HostAddresses) error {
+	for _, stage := range p.stages {
+		stageBootstrap, stagePort, stageMasters, err := stage.ExtractHostAddresses(dir, config)
+		if err != nil {
+			logrus.Warnf("Failed to extract host addresses: %s", err.Error())
+		} else {
+			if stageBootstrap != "" {
+				ha.Bootstrap = stageBootstrap
+			}
+			if stagePort != 0 {
+				ha.Port = stagePort
+			}
+			if len(stageMasters) > 0 {
+				ha.Masters = stageMasters
+			}
+		}
+	}
+	return nil
+}
 
 // newTFExec creates a tfexec.Terraform for executing Terraform CLI commands.
 // The `datadir` is the location to which the terraform plan (tf files, etc) has been unpacked.
@@ -96,4 +242,64 @@ func Destroy(dir string, platform string, stage Stage, terraformDir string, extr
 		tf.Destroy(context.Background(), extraOpts...),
 		"failed doing terraform destroy",
 	)
+}
+
+func applyStage(platform string, stage Stage, terraformDir string, tfvarsFiles []*asset.File) (*asset.File, *asset.File, error) {
+	// Copy the terraform.tfvars to a temp directory which will contain the terraform plan.
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create temp dir for terraform execution")
+	}
+	defer os.RemoveAll(tmpDir)
+
+	extraOpts := []tfexec.ApplyOption{}
+	for _, file := range tfvarsFiles {
+		if err := os.WriteFile(filepath.Join(tmpDir, file.Filename), file.Data, 0o600); err != nil {
+			return nil, nil, err
+		}
+		extraOpts = append(extraOpts, tfexec.VarFile(filepath.Join(tmpDir, file.Filename)))
+	}
+
+	return applyTerraform(tmpDir, platform, stage, terraformDir, extraOpts...)
+}
+
+func applyTerraform(tmpDir string, platform string, stage Stage, terraformDir string, opts ...tfexec.ApplyOption) (outputsFile, stateFile *asset.File, err error) {
+	timer.StartTimer(stage.Name())
+	defer timer.StopTimer(stage.Name())
+
+	applyErr := Apply(tmpDir, platform, stage, terraformDir, opts...)
+
+	if data, err := os.ReadFile(filepath.Join(tmpDir, StateFilename)); err == nil {
+		stateFile = &asset.File{
+			Filename: stage.StateFilename(),
+			Data:     data,
+		}
+	} else if !os.IsNotExist(err) {
+		logrus.Errorf("Failed to read tfstate: %v", err)
+		return nil, nil, errors.Wrap(err, "failed to read tfstate")
+	}
+
+	if applyErr != nil {
+		return nil, nil, fmt.Errorf("error applying Terraform configs: %w", applyErr)
+	}
+
+	outputs, err := Outputs(tmpDir, terraformDir)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "could not get outputs from stage %q", stage.Name())
+	}
+
+	outputsFile = &asset.File{
+		Filename: stage.OutputsFilename(),
+		Data:     outputs,
+	}
+	return outputsFile, stateFile, nil
+}
+
+func copyFile(from string, to string) error {
+	data, err := os.ReadFile(from)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(to, data, 0o666) //nolint:gosec // state file doesn't need to be 0600
 }


### PR DESCRIPTION
Due to Hashicorp's moving Terraform from an MPL to BSL license, the installer's usage of Terraform presents a risk that we would like to contain. This PR aims to:

1. **Contain Terraform**: moves all terraform dependencies to `pkg/terraform`
2. **Provide an alternative path**:  introduces a generic `infrastructure.Stages` interface (based on `terraform.Stages`) 

The existing code couples the Cluster Asset to terraform dependencies:
```mermaid
flowchart LR
   a[Cluster Asset] --- b[Terraform] & c[Stages]
   b --- c
```

This PR creates an interface to decouple the cluster asset from Terraform dependencies; and, potentially, allow other infrastructure providers.
```mermaid
flowchart LR
   a[Cluster Asset] --- b[Stages Infrastructure Interface] --- c[Terraform] & d[Cloud SDKs] & e[CAPI]
```

https://github.com/openshift/installer/pull/7534/commits/fc87c7503a0380e1e79b9fd40678ff39d968ed7f demonstrates how we can use this approach to use build tags to select infrastructure providers when building the binary, allowing us to produce a terraform-free binary with alternate infrastructure providers.

~~The interface design (laid out in the first commit) is still evocative of terraform because:~~
~~* it uses **stages**, which is a way we grouped resource configuration to allow destruction of bootstrap resources with terraform destroy~~
~~* it expects **tfVars** as inputs to the infrastructure provider~~

~~Both of these opinionated implementations seem easy enough to work with on behalf of other infrastructure providers, but we can explore collapsing these ideas further into the interface.~~