### PR TITLE
OCPBUGS-18830: AWS terraform bootstrap destroy will not refresh state

### DIFF
--- a/pkg/terraform/stages/aws/stages.go
+++ b/pkg/terraform/stages/aws/stages.go
@@ -1,9 +1,14 @@
 package aws
 
 import (
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
 	"github.com/openshift/installer/pkg/terraform/stages"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
 // PlatformStages are the stages to run to provision the infrastructure in AWS.
@@ -17,6 +22,22 @@ var PlatformStages = []terraform.Stage{
 		"aws",
 		"bootstrap",
 		[]providers.Provider{providers.AWS},
-		stages.WithNormalBootstrapDestroy(),
+		stages.WithCustomBootstrapDestroy(customBootstrapDestroy),
 	),
+}
+
+func customBootstrapDestroy(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
+	opts := make([]tfexec.DestroyOption, 0, len(varFiles)+1)
+	for _, varFile := range varFiles {
+		opts = append(opts, tfexec.VarFile(varFile))
+	}
+	// The bootstrap destroy will no longer refresh state. This was added as a change to counteract
+	// the upgrade to the aws terraform provider v5.4.0 where the state changes were causing unsupported
+	// operation errors when removing security group rules in sc2s regions.
+	logrus.Debugf("aws bootstrap destroy stage will not refresh terraform state")
+	opts = append(opts, tfexec.Refresh(false))
+	return errors.Wrap(
+		terraform.Destroy(directory, awstypes.Name, s, terraformDir, opts...),
+		"failed to destroy bootstrap",
+	)
 }


### PR DESCRIPTION
Destroy AWS bootstrap will now use the terraform option -refresh=false.
https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options#skipping-automatic-state-refresh Adding the option so that the terraform state is not refreshed. This should counter the requirement to bump the terraform aws provider for DescribeSecurityGroupRule changes that we have noticed since the bump to 5.4.0.