### PR TITLE
OCPBUGS-18690: ic: azure: validate NVMe-only family types

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -162,9 +162,19 @@ func validateFamily(fieldPath *field.Path, instanceType, family string) field.Er
 	windowsVMFamilies := sets.NewString(
 		"standardNVSv4Family",
 	)
+	diskNVMeVMFamilies := sets.NewString(
+		"standardEIBDSv5Family",
+		"standardEIBSv5Family",
+	)
 	allErrs := field.ErrorList{}
 	if windowsVMFamilies.Has(family) {
 		errMsg := fmt.Sprintf("%s is currently only supported on Windows", family)
+		allErrs = append(allErrs, field.Invalid(fieldPath, instanceType, errMsg))
+	}
+	// FIXME: remove when supported has been added to the provider
+	// https://github.com/hashicorp/terraform-provider-azurerm/issues/22058
+	if diskNVMeVMFamilies.Has(family) {
+		errMsg := fmt.Sprintf("%s is not currently supported but might be in a future release", family)
 		allErrs = append(allErrs, field.Invalid(fieldPath, instanceType, errMsg))
 	}
 


### PR DESCRIPTION
NVMe-only controller type VM families are not yet supported by the azure terraform provider [1]. This commit adds a check during install validation so those VM families cannot be selected, which would cause the install to fail with
```
09-07 17:55:57.613  level=error msg=Error: creating Linux Virtual Machine: (Name "jima-test-wlgrr-bootstrap" / Resource Group "jima-test-wlgrr-rg"): compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The VM size 'Standard_E112ibs_v5' cannot boot with OS image or disk. Please check that disk controller types supported by the OS image or disk is one of the supported disk controller types for the VM size 'Standard_E112ibs_v5'. Please query sku api at https://aka.ms/azure-compute-skus  to determine supported disk controller types for the VM size." Target="vmSize"
```

[1] https://github.com/hashicorp/terraform-provider-azurerm/issues/22058