### PR TITLE
Improve API and Ingress VIPs validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -632,7 +632,7 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 			allErrs = append(allErrs, field.Required(fldPath.Child(fieldNames.IngressVIPs), "must specify VIP for ingress, when VIP for API is set"))
 		}
 
-		if len(vips.API) == 1 {
+		if len(vips.API) >= 1 {
 			hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
 
 			apiVIPIPFamily := corev1.IPv4Protocol
@@ -640,12 +640,20 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 				apiVIPIPFamily = corev1.IPv6Protocol
 			}
 
-			if hasIPv4 && hasIPv6 && apiVIPIPFamily != presence["machineNetwork"].Primary {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API[0], "VIP for the API must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
+			if hasIPv4 && hasIPv6 {
+				for k, v := range presence {
+					if v.Primary != apiVIPIPFamily {
+						allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API[0], fmt.Sprintf("%s primary IP Family and primary IP family for the API VIP should match", k)))
+					}
+				}
 			}
-		} else if len(vips.API) == 2 {
-			if isDualStack, _ := utilsnet.IsDualStackIPStrings(vips.API); !isDualStack {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API, "If two API VIPs are given, one must be an IPv4 address, the other an IPv6"))
+			if len(vips.API) == 2 {
+				if isDualStack, err := utilsnet.IsDualStackIPStrings(vips.API); !isDualStack {
+					if err != nil {
+						allErrs = append(allErrs, field.Invalid(fldPath, vips, err.Error()))
+					}
+					allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API, "If two API VIPs are given, one must be an IPv4 address, the other an IPv6"))
+				}
 			}
 		}
 	} else {
@@ -675,7 +683,7 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 			allErrs = append(allErrs, field.Required(fldPath.Child(fieldNames.APIVIPs), "must specify VIP for API, when VIP for ingress is set"))
 		}
 
-		if len(vips.Ingress) == 1 {
+		if len(vips.Ingress) >= 1 {
 			hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
 
 			ingressVIPIPFamily := corev1.IPv4Protocol
@@ -683,12 +691,20 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 				ingressVIPIPFamily = corev1.IPv6Protocol
 			}
 
-			if hasIPv4 && hasIPv6 && ingressVIPIPFamily != presence["machineNetwork"].Primary {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress[0], "VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
+			if hasIPv4 && hasIPv6 {
+				for k, v := range presence {
+					if v.Primary != ingressVIPIPFamily {
+						allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress[0], fmt.Sprintf("%s primary IP Family and primary IP family for the Ingress VIP should match", k)))
+					}
+				}
 			}
-		} else if len(vips.Ingress) == 2 {
-			if isDualStack, _ := utilsnet.IsDualStackIPStrings(vips.Ingress); !isDualStack {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress, "If two Ingress VIPs are given, one must be an IPv4 address, the other an IPv6"))
+			if len(vips.Ingress) == 2 {
+				if isDualStack, err := utilsnet.IsDualStackIPStrings(vips.Ingress); !isDualStack {
+					if err != nil {
+						allErrs = append(allErrs, field.Invalid(fldPath, vips, err.Error()))
+					}
+					allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress, "If two Ingress VIPs are given, one must be an IPv4 address, the other an IPv6"))
+				}
 			}
 		}
 	} else {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -286,6 +286,34 @@ func validDualStackNetworkingConfig() *types.Networking {
 	}
 }
 
+func InvalidPrimaryV6DualStackNetworkingConfig() *types.Networking {
+	return &types.Networking{
+		NetworkType: "OVNKubernetes",
+		MachineNetwork: []types.MachineNetworkEntry{
+			{
+				CIDR: *ipnet.MustParseCIDR("ffd0::/48"),
+			},
+			{
+				CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+			},
+		},
+		ServiceNetwork: []ipnet.IPNet{
+			*ipnet.MustParseCIDR("172.30.0.0/16"),
+			*ipnet.MustParseCIDR("ffd1::/112"),
+		},
+		ClusterNetwork: []types.ClusterNetworkEntry{
+			{
+				CIDR:       *ipnet.MustParseCIDR("ffd2::/48"),
+				HostPrefix: 64,
+			},
+			{
+				CIDR:       *ipnet.MustParseCIDR("192.168.1.0/24"),
+				HostPrefix: 28,
+			},
+		},
+	}
+}
+
 func TestValidateInstallConfig(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -1930,27 +1958,27 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "baremetal API VIP set to an incorrect IP Family",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Networking = validDualStackNetworkingConfig()
+				c.Networking = InvalidPrimaryV6DualStackNetworkingConfig()
 				c.Platform = types.Platform{
 					BareMetal: validBareMetalPlatform(),
 				}
 				c.Platform.BareMetal.APIVIPs = []string{"ffd0::"}
 				return c
 			}(),
-			expectedError: `platform.baremetal.apiVIPs: Invalid value: "ffd0::": VIP for the API must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6`,
+			expectedError: `[platform.baremetal.apiVIPs: Invalid value: "ffd0::": serviceNetwork primary IP Family and primary IP family for the API VIP should match]`,
 		},
 		{
 			name: "baremetal Ingress VIP set to an incorrect IP Family",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Networking = validDualStackNetworkingConfig()
+				c.Networking = InvalidPrimaryV6DualStackNetworkingConfig()
 				c.Platform = types.Platform{
 					BareMetal: validBareMetalPlatform(),
 				}
 				c.Platform.BareMetal.IngressVIPs = []string{"ffd0::"}
 				return c
 			}(),
-			expectedError: `platform.baremetal.ingressVIPs: Invalid value: "ffd0::": VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6`,
+			expectedError: `[platform.baremetal.ingressVIPs: Invalid value: "ffd0::": serviceNetwork primary IP Family and primary IP family for the Ingress VIP should match]`,
 		},
 		{
 			name: "should validate vips on baremetal (required)",


### PR DESCRIPTION
This commit enhance VIPs validation to ensure the primary IP family of the VIPs matches the primary IP family of all the network fields.