### PR TITLE
OCPBUGS-4038: bootstrap: don't enable gatewayd socket on OKD

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -50,14 +50,16 @@ var (
 	commonEnabledServices = []string{
 		"progress.service",
 		"kubelet.service",
-		"chown-gatewayd-key.service",
-		"systemd-journal-gatewayd.socket",
 		"approve-csr.service",
 		// baremetal & openstack platform services
 		"keepalived.service",
 		"coredns.service",
 		"ironic.service",
 		"master-bmh-update.service",
+	}
+	ocpEnabledServices = []string{
+		"chown-gatewayd-key.service",
+		"systemd-journal-gatewayd.socket",
 	}
 )
 
@@ -175,6 +177,11 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 	}
 	if err := AddSystemdUnits(a.Config, "bootstrap/systemd/units", templateData, commonEnabledServices); err != nil {
 		return err
+	}
+	if !templateData.IsOKD {
+		if err := AddSystemdUnits(a.Config, "bootstrap/systemd/units", templateData, ocpEnabledServices); err != nil {
+			return err
+		}
 	}
 
 	// Check for optional platform specific files/units


### PR DESCRIPTION
FCOS doesn't come with this service, and now assisted installer fails attempting to enable this socket.

Retry of https://github.com/openshift/installer/pull/6619