### PR TITLE
AGENT-710: Use invoker for bootstrap template generation

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
@@ -42,7 +42,7 @@ if [ ! -f /opt/openshift/.pivot-done ]; then
   record_service_stage_start "rebase-to-okd-os-image"
 {{if .IsFCOS -}}
   mnt="$(podman image mount "${MACHINE_OS_IMAGE}")"
-{{- if .BootstrapInPlace }}
+{{- if or (.BootstrapInPlace) (eq .Invoker "agent-installer") }}
   # SNO setup boots into Live ISO which cannot be rebased
   # https://github.com/coreos/rpm-ostree/issues/4547
   mkdir /var/mnt/{upper,worker}

--- a/data/data/bootstrap/systemd/units/release-image-pivot.service.template
+++ b/data/data/bootstrap/systemd/units/release-image-pivot.service.template
@@ -3,7 +3,7 @@
 Description=Pivot bootstrap to the OpenShift Release Image
 Wants=release-image.service
 After=release-image.service
-{{- if .BootstrapInPlace }}
+{{- if or (.BootstrapInPlace) (eq .Invoker "agent-installer") }}
 Before=bootkube.service kubelet.service
 {{ else }}
 Before=bootkube.service

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -85,6 +85,7 @@ type bootstrapTemplateData struct {
 	APIServerURL          string
 	APIIntServerURL       string
 	FeatureSet            configv1.FeatureSet
+	Invoker               string
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -309,6 +310,9 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 
 	apiURL := fmt.Sprintf("api.%s", installConfig.Config.ClusterDomain())
 	apiIntURL := fmt.Sprintf("api-int.%s", installConfig.Config.ClusterDomain())
+
+	openshiftInstallInvoker := os.Getenv("OPENSHIFT_INSTALL_INVOKER")
+
 	return &bootstrapTemplateData{
 		AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
 		FIPS:                  installConfig.Config.FIPS,
@@ -331,6 +335,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		APIServerURL:          apiURL,
 		APIIntServerURL:       apiIntURL,
 		FeatureSet:            installConfig.Config.FeatureSet,
+		Invoker:               openshiftInstallInvoker,
 	}
 }
 


### PR DESCRIPTION
Some of the scripts generated by the `create ignition-configs` command for OKD may require to discriminate the cases where SNO is being managed or agent-based installer is currently used, thus adding the `OPENSHIFT_INSTALL_INVOKER` env var in the template inputs.