### PR TITLE
OCPBUGS-18986: Tag aws instance profiles.

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -84,6 +84,13 @@ resource "aws_iam_instance_profile" "bootstrap" {
   name = "${var.cluster_id}-bootstrap-profile"
 
   role = var.aws_master_iam_role_name != "" ? var.aws_master_iam_role_name : aws_iam_role.bootstrap[0].name
+
+  tags = merge(
+    {
+      "Name" = "${var.cluster_id}-bootstrap-profile"
+    },
+    local.tags,
+  )
 }
 
 resource "aws_iam_role" "bootstrap" {

--- a/data/data/aws/cluster/iam/main.tf
+++ b/data/data/aws/cluster/iam/main.tf
@@ -8,6 +8,13 @@ resource "aws_iam_instance_profile" "worker" {
   name = "${var.cluster_id}-worker-profile"
 
   role = var.worker_iam_role_name != "" ? var.worker_iam_role_name : aws_iam_role.worker_role[0].name
+
+  tags = merge(
+    {
+      "Name" = "${var.cluster_id}-worker-profile"
+    },
+    var.tags,
+  )
 }
 
 resource "aws_iam_role" "worker_role" {

--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -13,6 +13,13 @@ resource "aws_iam_instance_profile" "master" {
   name = "${var.cluster_id}-master-profile"
 
   role = var.iam_role_name != "" ? var.iam_role_name : aws_iam_role.master_role[0].name
+
+  tags = merge(
+    {
+      "Name" = "${var.cluster_id}-master-profile"
+    },
+    var.tags,
+  )
 }
 
 resource "aws_iam_role" "master_role" {

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -311,13 +311,6 @@ func (o *ClusterUninstaller) findResourcesToDelete(
 	}
 	resources = resources.Union(iamUserResources)
 
-	// Find untaggable resources
-	untaggableResources, err := o.findUntaggableResources(ctx, iamClient, deleted)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	resources = resources.Union(untaggableResources)
-
 	return resources, tagClientsWithResources, utilerrors.NewAggregate(errs)
 }
 
@@ -357,29 +350,6 @@ func (o *ClusterUninstaller) findResourcesByTag(
 			err = errors.Wrap(err, "get tagged resources")
 			o.Logger.Info(err)
 			return resources, err
-		}
-	}
-	return resources, nil
-}
-
-// findUntaggableResources returns the resources for the cluster that cannot be tagged.
-//
-//	deleted - the resources that have already been deleted. Any resources specified in this set will be ignored.
-func (o *ClusterUninstaller) findUntaggableResources(ctx context.Context, iamClient *iam.IAM, deleted sets.String) (sets.String, error) {
-	resources := sets.NewString()
-	o.Logger.Debug("search for IAM instance profiles")
-	for _, profileType := range []string{"master", "worker", "bootstrap"} {
-		profile := fmt.Sprintf("%s-%s-profile", o.ClusterID, profileType)
-		response, err := iamClient.GetInstanceProfileWithContext(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: &profile})
-		if err != nil {
-			if err.(awserr.Error).Code() == iam.ErrCodeNoSuchEntityException {
-				continue
-			}
-			return resources, errors.Wrap(err, "failed to get IAM instance profile")
-		}
-		arnString := *response.InstanceProfile.Arn
-		if !deleted.Has(arnString) {
-			resources.Insert(arnString)
 		}
 	}
 	return resources, nil


### PR DESCRIPTION
** Instance profiles are not always cleaned up correctly. Tags are available for these resources. Tag the resources and let the destroy functions find the resources by tag to be removed.