### PR TITLE
OCPBUGS-19092: Enable serial console for external OCI platform

### DIFF
--- a/cmd/openshift-install/testdata/agent/pxe/configurations/compact_external.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/compact_external.txt
@@ -1,31 +1,31 @@
-# Verify a default configuration for the SNO topology for ARM architecture
+# Verify a default configuration for the compact topology for external platform. 
+# Verify kernel args 'console=ttyS0' is added for extenal oci platform.
 
 exec openshift-install agent create pxe-files --dir $WORK
 
-stderr 'Created iPXE script agent.aarch64.ipxe'
+stderr 'Created iPXE script agent.x86_64.ipxe'
 
-exists $WORK/boot-artifacts/agent.aarch64-initrd.img
-exists $WORK/boot-artifacts/agent.aarch64-rootfs.img
-exists $WORK/boot-artifacts/agent.aarch64-vmlinuz
-exists $WORK/boot-artifacts/agent.aarch64.ipxe
+exists $WORK/boot-artifacts/agent.x86_64-initrd.img
+exists $WORK/boot-artifacts/agent.x86_64-rootfs.img
+exists $WORK/boot-artifacts/agent.x86_64-vmlinuz
+exists $WORK/boot-artifacts/agent.x86_64.ipxe
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
 
-grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.aarch64-initrd.img' $WORK/boot-artifacts/agent.aarch64.ipxe
-grep 'kernel http://user-specified-pxe-infra.com/agent.aarch64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.aarch64-rootfs.img .*ignition.firstboot ignition.platform.id=metal' $WORK/boot-artifacts/agent.aarch64.ipxe
-! grep 'coreos.liveiso=' $WORK/boot-artifacts/agent.aarch64.ipxe
+grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img' $WORK/boot-artifacts/agent.x86_64.ipxe
+grep 'kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img .*ignition.firstboot ignition.platform.id=metal console=ttyS0' $WORK/boot-artifacts/agent.x86_64.ipxe
+! grep 'coreos.liveiso=' $WORK/boot-artifacts/agent.x86_64.ipxe
+
 
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
 controlPlane: 
   name: master
-  replicas: 1
-  architecture: arm64
+  replicas: 3
 compute: 
 - name: worker
   replicas: 0
-  architecture: arm64
 metadata:
   namespace: cluster0
   name: ostest
@@ -39,7 +39,8 @@ networking:
   serviceNetwork: 
   - 172.30.0.0/16
 platform:
-  none: {}
+  external:
+    platformName: oci
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno.txt
@@ -49,9 +49,3 @@ metadata:
   namespace: cluster0
 rendezvousIP: 192.168.111.20
 bootArtifactsBaseURL: http://user-specified-pxe-infra.com
-
--- expected/agent.x86_64.ipxe --
-#!ipxe
-initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img
-kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img ignition.firstboot ignition.platform.id=metal
-boot

--- a/pkg/asset/agent/image/kargs.go
+++ b/pkg/asset/agent/image/kargs.go
@@ -1,29 +1,45 @@
 package image
 
 import (
+	"github.com/sirupsen/logrus"
+
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent/manifests"
 )
 
-// Kargs is an Asset the generates the additional kernel args.
+// Kargs is an Asset that generates the additional kernel args.
 type Kargs struct {
+	consoleArgs string
 }
 
-// Dependencies returns the assets on which the AgentArtifacts asset depends.
+// Dependencies returns the assets on which the Kargs asset depends.
 func (a *Kargs) Dependencies() []asset.Asset {
-	return []asset.Asset{}
+	return []asset.Asset{
+		&manifests.AgentManifests{},
+	}
 }
 
-// Generate generates the configurations for the agent ISO image and PXE assets.
+// Generate generates the kernel args configurations for the agent ISO image and PXE assets.
 func (a *Kargs) Generate(dependencies asset.Parents) error {
+	agentManifests := &manifests.AgentManifests{}
+	dependencies.Get(agentManifests)
+
+	// Add kernel args for external oci platform
+	if agentManifests.GetExternalPlatformName() == string(models.PlatformTypeOci) {
+		logrus.Debugf("Added kernel args to enable serial console for %s %s platform", hiveext.ExternalPlatformType, string(models.PlatformTypeOci))
+		a.consoleArgs = " console=ttyS0"
+	}
 	return nil
 }
 
 // Name returns the human-friendly name of the asset.
 func (a *Kargs) Name() string {
-	return "Agent ISO Kernel Arguments"
+	return "Agent ISO/PXE files Kernel Arguments"
 }
 
 // KernelCmdLine returns the data to be appended to the kernel arguments.
 func (a *Kargs) KernelCmdLine() []byte {
-	return nil
+	return []byte(a.consoleArgs)
 }

--- a/pkg/asset/agent/manifests/agent.go
+++ b/pkg/asset/agent/manifests/agent.go
@@ -111,6 +111,15 @@ func (m *AgentManifests) GetPullSecretData() string {
 	return m.PullSecret.StringData[".dockerconfigjson"]
 }
 
+// GetExternalPlatformName returns the platform name for the external platform.
+func (m *AgentManifests) GetExternalPlatformName() string {
+	var platformName string
+	if m.AgentClusterInstall.Spec.ExternalPlatformSpec != nil {
+		platformName = m.AgentClusterInstall.Spec.ExternalPlatformSpec.PlatformName
+	}
+	return platformName
+}
+
 func (m *AgentManifests) finish() error {
 	if err := m.validateAgentManifests().ToAggregate(); err != nil {
 		return errors.Wrapf(err, "invalid agent configuration")


### PR DESCRIPTION
When creating an Agent ISO for OCI, add the kernel argument `console=ttyS0` to the ISO/PXE kargs.

CoreOS does not include a console arg by default when using metal as the platform because different hardware has different consoles and specifying one can cause booting to fail on some, but it [does](https://github.com/coreos/fedora-coreos-config/blob/stable/platforms.yaml) on many cloud platforms. Since we know when the user is definitely using OCI  and we know the correct settings for OCI, we should set them up automatically.

Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com>
@pawanpinjarkar
