### PR TITLE
OCPBUGS-18876: Pass CPUPartitioning via install-config overrides if set

### DIFF
--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -81,6 +81,8 @@ type agentClusterInstallInstallConfigOverrides struct {
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 	// Allow override of network type
 	Networking *types.Networking `json:"networking,omitempty"`
+	// Allow override of CPUPartitioning
+	CPUPartitioning types.CPUPartitioningMode `json:"cpuPartitioningMode,omitempty"`
 }
 
 var _ asset.WritableAsset = (*AgentClusterInstall)(nil)
@@ -223,6 +225,12 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 			icOverrides.AdditionalTrustBundle = installConfig.Config.AdditionalTrustBundle
 			icOverridden = true
 		}
+
+		if installConfig.Config.CPUPartitioning != "" {
+			icOverridden = true
+			icOverrides.CPUPartitioning = installConfig.Config.CPUPartitioning
+		}
+
 		if icOverridden {
 			overrides, err := json.Marshal(icOverrides)
 			if err != nil {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -74,6 +74,14 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 		installConfigOverrides: `{"networking":{"networkType":"CustomNetworkType","machineNetwork":[{"cidr":"10.10.11.0/24"}],"clusterNetwork":[{"cidr":"192.168.111.0/24","hostPrefix":23}],"serviceNetwork":["172.30.0.0/16"]}}`,
 	})
 
+	installConfigWithCPUPartitioning := getValidOptionalInstallConfig()
+	installConfigWithCPUPartitioning.Config.CPUPartitioning = types.CPUPartitioningAllNodes
+
+	goodCPUPartitioningACI := getGoodACI()
+	goodCPUPartitioningACI.SetAnnotations(map[string]string{
+		installConfigOverrides: `{"cpuPartitioningMode":"AllNodes"}`,
+	})
+
 	cases := []struct {
 		name           string
 		dependencies   []asset.Asset
@@ -149,6 +157,13 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				installConfigWithNetworkOverride,
 			},
 			expectedConfig: goodNetworkOverrideACI,
+		},
+		{
+			name: "valid configuration with CPU Partitioning",
+			dependencies: []asset.Asset{
+				installConfigWithCPUPartitioning,
+			},
+			expectedConfig: goodCPUPartitioningACI,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
If CPUPartitioning is set to install-config, set it in the install-config overrides in agentclusterinstall.yaml.