### PR TITLE
OCPBUGS-12707: always write AWS cloud.conf

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -99,10 +99,10 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	case awstypes.Name:
 		// Store the additional trust bundle in the ca-bundle.pem key if the cluster is being installed on a C2S region.
 		trustBundle := installConfig.Config.AdditionalTrustBundle
-		if trustBundle == "" || !awstypes.IsSecretRegion(installConfig.Config.AWS.Region) {
-			return nil
+		if trustBundle != "" && awstypes.IsSecretRegion(installConfig.Config.AWS.Region) {
+			cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
 		}
-		cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
+
 		// Include a non-empty kube config to appease components--such as the kube-apiserver--that
 		// expect there to be a kube config if the cloud-provider-config ConfigMap exists. See
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1926975.


### PR DESCRIPTION
AWS Service endpoints are injected into the cloud.conf cloud-provider config by the cluster-config operator running on bootstrap, as described in:
https://github.com/openshift/enhancements/blob/master/enhancements/installer/aws-custom-region-and-endpoints.md

OCPBUGS-12707 occurs because the installer does not, by the design in the enhancement,
write the service endpoints to the cloud config and there are no other uses of the config, so the installer does not populate the config at all. Accordingly, with no installer-generated config, the infrastructure object does not include a reference to the config.

The bug occurs because the MCO's bootstrap mode rendering of the cloud provider config depends on the infrastructure object containing the name of the cloud.conf, but because that is not populated it produces an empty cloud.conf. Apparently the normal non-bootstrap mode differs and does correctly generate the cloud.conf. This causes an error because the MCO has a check to capture any drift between bootstrap and cluster.

This bug can be resolved by always populating the empty cloud.conf, as it will correctly setup the cluster infrastructure object. It would also be possible to limit populating the cloud.conf only when service endpoints are set, but there is no reason to add extra gating logic.