### PR TITLE
OCPBUGS-19552: Fixed DNS issues in OKD/FCOS due to split dns in systemd-resolved

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
+++ b/data/data/bootstrap/baremetal/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
@@ -25,6 +25,7 @@ EOF
             mkdir -p /etc/systemd/resolved.conf.d
             echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
             echo "DNS=$DNS_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
+            echo "Domains={{.ClusterDomain}}" >> /etc/systemd/resolved.conf.d/60-kni.conf
             if systemctl -q is-active systemd-resolved; then
                 >&2 echo "NM resolv-prepender: restarting systemd-resolved"
                 systemctl restart systemd-resolved

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -86,6 +86,7 @@ type bootstrapTemplateData struct {
 	APIIntServerURL       string
 	FeatureSet            configv1.FeatureSet
 	Invoker               string
+	ClusterDomain         string
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -336,6 +337,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		APIIntServerURL:       apiIntURL,
 		FeatureSet:            installConfig.Config.FeatureSet,
 		Invoker:               openshiftInstallInvoker,
+		ClusterDomain:         installConfig.Config.ClusterDomain(),
 	}
 }
 


### PR DESCRIPTION
OKD/FCOS uses FCOS without OKD/OCP code as bootimages for IPI, SNO and Agent-based Installer. FCOS uses systemd-resolved for handling DNS queries.

During installation, the bootstrap node or rendezvous host executes a bootkube.sh script which queries the cluster api.* and api-int.* endpoints to detect when the in-cluster control plane has come up. The DNS name resolution of these endpoints is supposed to be handled by CoreDNS which listens to 0.0.0.0:53 at the same node and is registered with 127.0.0.1 in /etc/resolv.conf.

Some tools such as curl which are called via [bootkube.sh](https://github.com/openshift/installer/blob/master/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh) do not query /etc/resolv.conf but use [Name Service Switch (NSS)](https://www.mankier.com/5/nsswitch.conf) which delegates queries to systemd-resolved. [systemd-resolved uses split DNS](https://fedoramagazine.org/systemd-resolved-introduction-to-split-dns/) to route DNS queries to specific nameservers depending on the dns domain settings of the network interfaces.

When the bootstrap node or rendezvous host is booted with FCOS, it will retrieve its network configuration via DHCP. The domain record which is received via DHCP (and is part of the OKD cluster domain) is associated with the network interface which handled the DHCP exchange. This causes systemd-resolved to send all DNS queries for the OKD cluster domain through the network DNS server, but never to CoreDNS.

OKD and OCP do not require the network DNS server to be able to resolve the api-int.* endpoint on bare-metal servers for HA deployments with IPI or Agent-based Installer (for SNO it is required). When api-int.* is not resolved by the network DNS servers, then services such as bootkube.sh at the rendezvous host (from Agent-based Installer) cannot query the in-cluster control plane and installation will stall (because systemd-resolved will not use CoreDNS due to Split DNS).

With this change, the cluster domain will be associated with the DNS server at 127.0.0.1 which is CoreDNS. systemd-resolved will then properly query CoreDNS when resolving api-int.* and Agent-based Installer can finish successfully.

cc @vrutkovs @andfasano @LorbusChris