### PR TITLE
OCPBUGS-19376: GCP default value for service account

### DIFF
--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -12,7 +12,7 @@ variable "gcp_network_project_id" {
 variable "gcp_service_account" {
   type        = string
   description = "The service account for authenticating with GCP APIs."
-  default     = ""
+  default     = null
 }
 
 variable "gcp_region" {


### PR DESCRIPTION
** When authenticating with VM credentials the empty string was used in terraform, but null should be used.