### PR TITLE
CORS-2845: azure: Enable storage account encryption

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -56,9 +56,8 @@ data "azurerm_storage_account_sas" "ignition" {
 }
 
 resource "azurerm_storage_container" "ignition" {
-  name                  = "ignition"
-  storage_account_name  = var.storage_account_name
-  container_access_type = "private"
+  name                 = "ignition"
+  storage_account_name = var.storage_account_name
 }
 
 resource "azurerm_storage_blob" "ignition" {
@@ -66,7 +65,7 @@ resource "azurerm_storage_blob" "ignition" {
   source                 = var.ignition_bootstrap_file
   storage_account_name   = var.storage_account_name
   storage_container_name = azurerm_storage_container.ignition.name
-  type                   = "Block"
+  type                   = var.azure_keyvault_key_name != "" ? "Page" : "Block"
 }
 
 data "ignition_config" "redirect" {

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -278,3 +278,27 @@ variable "azure_master_virtualized_trusted_platform_module" {
   description = "Defines whether the instance should have vTPM enabled."
   default     = ""
 }
+
+variable "azure_keyvault_resource_group" {
+  type        = string
+  description = "Defines the resource group of the key vault used for storage account encryption."
+  default     = ""
+}
+
+variable "azure_keyvault_name" {
+  type        = string
+  description = "Defines the name of the key vault used for storage account encryption."
+  default     = ""
+}
+
+variable "azure_keyvault_key_name" {
+  type        = string
+  description = "Defines the key in the key vault used for storage account encryption."
+  default     = ""
+}
+
+variable "azure_user_assigned_identity_key" {
+  type        = string
+  description = "Defines the user identity key used for the encryption of storage account."
+  default     = ""
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2457,6 +2457,34 @@ spec:
                     description: ControlPlaneSubnet specifies an existing subnet for
                       use by the control plane nodes
                     type: string
+                  customerManagedKey:
+                    description: CustomerManagedKey has the keys needed to encrypt
+                      the storage account.
+                    properties:
+                      keyVault:
+                        description: KeyVault is the keyvault used for the customer
+                          created key required for encryption.
+                        properties:
+                          keyName:
+                            description: KeyName is the name of the key vault key.
+                            type: string
+                          name:
+                            description: Name is the name of the key vault.
+                            type: string
+                          resourceGroup:
+                            description: ResourceGroup defines the Azure resource
+                              group used by the key vault.
+                            type: string
+                        required:
+                        - keyName
+                        - name
+                        - resourceGroup
+                        type: object
+                      userAssignedIdentityKey:
+                        description: UserAssignedIdentityKey is the name of the user
+                          identity that has access to the managed key.
+                        type: string
+                    type: object
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on Azure for machine pools which do not

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -181,6 +181,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 	}
 
+	lengthBootstrapFile := int64(len(bootstrapIgn))
+	if installConfig.Config.Platform.Azure != nil && installConfig.Config.Platform.Azure.CustomerManagedKey != nil &&
+		installConfig.Config.Platform.Azure.CustomerManagedKey.UserAssignedIdentityKey != "" {
+		if lengthBootstrapFile%512 != 0 {
+			lengthBootstrapFile = (((lengthBootstrapFile / 512) + 1) * 512)
+		}
+	}
+
 	data, err := tfvars.TFVars(
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
@@ -190,6 +198,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		useIPv4,
 		useIPv6,
 		bootstrapIgn,
+		lengthBootstrapFile,
 		masterIgn,
 		masterCount,
 		mastersSchedulable,
@@ -382,6 +391,16 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			bootstrapIgnStub = string(shim)
 		}
 
+		managedKeys := azure.CustomerManagedKey{}
+		if installConfig.Config.Azure.CustomerManagedKey != nil {
+			managedKeys.KeyVault = azure.KeyVault{
+				ResourceGroup: installConfig.Config.Azure.CustomerManagedKey.KeyVault.ResourceGroup,
+				Name:          installConfig.Config.Azure.CustomerManagedKey.KeyVault.Name,
+				KeyName:       installConfig.Config.Azure.CustomerManagedKey.KeyVault.KeyName,
+			}
+			managedKeys.UserAssignedIdentityKey = installConfig.Config.Azure.CustomerManagedKey.UserAssignedIdentityKey
+		}
+
 		data, err := azuretfvars.TFVars(
 			azuretfvars.TFVarsSources{
 				Auth:                            auth,
@@ -401,6 +420,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				HyperVGeneration:                hyperVGeneration,
 				VMArchitecture:                  installConfig.Config.ControlPlane.Architecture,
 				InfrastructureName:              clusterID.InfraID,
+				KeyVault:                        managedKeys.KeyVault,
+				UserAssignedIdentityKey:         managedKeys.UserAssignedIdentityKey,
 			},
 		)
 		if err != nil {

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -213,6 +213,9 @@ func Test_PrintFields(t *testing.T) {
     controlPlaneSubnet <string>
       ControlPlaneSubnet specifies an existing subnet for use by the control plane nodes
 
+    customerManagedKey <object>
+      CustomerManagedKey has the keys needed to encrypt the storage account.
+
     defaultMachinePlatform <object>
       DefaultMachinePlatform is the default configuration used when installing on Azure for machine pools which do not define their own platform configuration.
 

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -69,6 +69,10 @@ type config struct {
 	SecureVirtualMachineDiskEncryptionSetID string `json:"azure_master_secure_vm_disk_encryption_set_id,omitempty"`
 	SecureBoot                              string `json:"azure_master_secure_boot,omitempty"`
 	VirtualizedTrustedPlatformModule        string `json:"azure_master_virtualized_trusted_platform_module,omitempty"`
+	KeyVaultResourceGroup                   string `json:"azure_keyvault_resource_group,omitempty"`
+	KeyVaultName                            string `json:"azure_keyvault_name,omitempty"`
+	KeyVaultKeyName                         string `json:"azure_keyvault_key_name,omitempty"`
+	UserAssignedIdentity                    string `json:"azure_user_assigned_identity_key,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -90,6 +94,8 @@ type TFVarsSources struct {
 	HyperVGeneration                string
 	VMArchitecture                  types.Architecture
 	InfrastructureName              string
+	KeyVault                        azure.KeyVault
+	UserAssignedIdentityKey         string
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -187,6 +193,10 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		SecureVirtualMachineDiskEncryptionSetID: masterConfig.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet.ID,
 		SecureBoot:                              secureBoot,
 		VirtualizedTrustedPlatformModule:        virtualizedTrustedPlatformModule,
+		KeyVaultResourceGroup:                   sources.KeyVault.ResourceGroup,
+		KeyVaultName:                            sources.KeyVault.Name,
+		KeyVaultKeyName:                         sources.KeyVault.KeyName,
+		UserAssignedIdentity:                    sources.UserAssignedIdentityKey,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -27,12 +27,20 @@ type config struct {
 }
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
-func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int, mastersSchedulable bool) ([]byte, error) {
+func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, bootstrapIgnSize int64, masterIgn string, masterCount int, mastersSchedulable bool) ([]byte, error) {
 	f, err := os.CreateTemp("", "openshift-install-bootstrap-*.ign")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create tmp file for bootstrap ignition")
 	}
 	defer f.Close()
+
+	// In azure, if the storage account is encrypted, page blob is used instead of block blob due to lack of support.
+	// Page blobs file size must be a multiple of 512, hence a little padding is needed to push the file.
+	// Finding the nearest size divisible by 512 and adding that padding to the file.
+	// Since the file is json type, padding at the end results in json parsing error at bootstrap ignition.
+	// Adding the paddding to just before the last } in the json file to bypass the parsing error.
+	padding := bootstrapIgnSize - int64(len(bootstrapIgn))
+	bootstrapIgn = bootstrapIgn[0:len(bootstrapIgn)-1] + strings.Repeat(" ", int(padding)) + string(bootstrapIgn[len(bootstrapIgn)-1])
 
 	if _, err := f.WriteString(bootstrapIgn); err != nil {
 		return nil, errors.Wrap(err, "failed to write bootstrap ignition")

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -97,6 +97,28 @@ type Platform struct {
 	// Resources created by the cluster itself may not include these tags.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
+
+	// CustomerManagedKey has the keys needed to encrypt the storage account.
+	CustomerManagedKey *CustomerManagedKey `json:"customerManagedKey,omitempty"`
+}
+
+// KeyVault defines an Azure Key Vault.
+type KeyVault struct {
+	// ResourceGroup defines the Azure resource group used by the key
+	// vault.
+	ResourceGroup string `json:"resourceGroup"`
+	// Name is the name of the key vault.
+	Name string `json:"name"`
+	// KeyName is the name of the key vault key.
+	KeyName string `json:"keyName"`
+}
+
+// CustomerManagedKey defines the customer managed key settings for encryption of the Azure storage account.
+type CustomerManagedKey struct {
+	// KeyVault is the keyvault used for the customer created key required for encryption.
+	KeyVault KeyVault `json:"keyVault,omitempty"`
+	// UserAssignedIdentityKey is the name of the user identity that has access to the managed key.
+	UserAssignedIdentityKey string `json:"userAssignedIdentityKey,omitempty"`
 }
 
 // CloudEnvironment is the name of the Azure cloud environment

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -40,6 +40,15 @@ var (
 
 	// tagKeyPrefixRegex is for verifying that the tag value does not contain restricted prefixes.
 	tagKeyPrefixRegex = regexp.MustCompile(`^(?i)(name$|kubernetes\.io|openshift\.io|microsoft|azure|windows)`)
+
+	// keyVaultNameRegex is for verifying the name of the key vault used for storage account encryption.
+	keyVaultNameRegex = regexp.MustCompile(`^[A-Za-z][0-9A-Za-z-]{1,22}[A-Za-z0-9]$`)
+
+	// keyVaultKeyNameRegex is for verifying the key name of the key vault used for storage account encryption.
+	keyVaultKeyNameRegex = regexp.MustCompile(`^[0-9A-Za-z-]{1,127}$`)
+
+	// keyVaultUserAssignedIdentityRegex is for verifying the user assigned identity key used for storage account encryption.
+	keyVaultUserAssignedIdentityRegex = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z-_]{2,127}$`)
 )
 
 // maxUserTagLimit is the maximum userTags that can be configured as defined in openshift/api.
@@ -99,6 +108,10 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 		}
 	}
 
+	if p.CustomerManagedKey != nil {
+		allErrs = append(allErrs, validateCustomerManagedKeys(p.CloudName, *p.CustomerManagedKey, fldPath.Child("customerManagedKey"))...)
+	}
+
 	// support for Azure user-defined tags made available through
 	// RFE-2017 is for AzurePublicCloud only.
 	if p.CloudName != azure.PublicCloud && len(p.UserTags) > 0 {
@@ -117,6 +130,41 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 		if p.ClusterOSImage != "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("clusterOSImage"), fmt.Sprintf("clusterOSImage must not be set when the cloud name is %s", cloud)))
 		}
+	}
+
+	return allErrs
+}
+
+// validateCustomerManagedKeys validates the key vault id.
+func validateCustomerManagedKeys(cloudName azure.CloudEnvironment, s azure.CustomerManagedKey, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if cloudName == azure.StackCloud {
+		return append(allErrs, field.Invalid(fldPath, s.KeyVault.Name, "storage account encryption is not supported on this platform"))
+	}
+
+	if s.KeyVault.KeyName == "" {
+		allErrs = append(allErrs, field.Required(fldPath, "key vault key name is required for storage account encryption"))
+	} else if !keyVaultKeyNameRegex.MatchString(s.KeyVault.KeyName) {
+		allErrs = append(allErrs, field.Invalid(fldPath, s.KeyVault.KeyName, "invalid key name for encryption"))
+	}
+
+	if s.KeyVault.Name == "" {
+		allErrs = append(allErrs, field.Required(fldPath, "name of the key vault is required for storage account encryption"))
+	} else if !keyVaultNameRegex.MatchString(s.KeyVault.Name) || strings.Contains(s.KeyVault.Name, "--") {
+		allErrs = append(allErrs, field.Invalid(fldPath, s.KeyVault.Name, "invalid name for key vault for encryption"))
+	}
+
+	if s.KeyVault.ResourceGroup == "" {
+		allErrs = append(allErrs, field.Required(fldPath, "resource group of the key vault is required for storage account encryption"))
+	} else if !RxResourceGroup.MatchString(s.KeyVault.ResourceGroup) {
+		allErrs = append(allErrs, field.Invalid(fldPath, s.KeyVault.ResourceGroup, "invalid resource group for encryption"))
+	}
+
+	if s.UserAssignedIdentityKey == "" {
+		allErrs = append(allErrs, field.Required(fldPath, "user assigned identity key is required for storage account encryption"))
+	} else if !keyVaultUserAssignedIdentityRegex.MatchString(s.UserAssignedIdentityKey) {
+		allErrs = append(allErrs, field.Invalid(fldPath, s.UserAssignedIdentityKey, "invalid user assigned identity key for encryption"))
 	}
 
 	return allErrs

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -28,6 +28,18 @@ func validNetworkPlatform() *azure.Platform {
 	return p
 }
 
+func validCustomerManagedKeys() *azure.Platform {
+	p := validPlatform()
+	p.CustomerManagedKey = &azure.CustomerManagedKey{
+		KeyVault: azure.KeyVault{
+			KeyName:       "test",
+			Name:          "test",
+			ResourceGroup: "test123",
+		},
+		UserAssignedIdentityKey: "12345678-1234-1234-1234-123456789123"}
+	return p
+}
+
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -159,6 +171,78 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			expected: `^test-path\.outboundType: Invalid value: "NatGateway": not supported in this feature set$`,
+		},
+		{
+			name: "missing key vault name",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.Name = ""
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Required value: name of the key vault is required for storage account encryption$`,
+		},
+		{
+			name: "invalid key vault name",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.Name = "1invalid"
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Invalid value: "1invalid": invalid name for key vault for encryption$`,
+		},
+		{
+			name: "missing key vault key name",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.KeyName = ""
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Required value: key vault key name is required for storage account encryption$`,
+		},
+		{
+			name: "invalid key vault key name",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.KeyName = "."
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Invalid value: ".": invalid key name for encryption$`,
+		},
+		{
+			name: "missing resource group",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.ResourceGroup = ""
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Required value: resource group of the key vault is required for storage account encryption$`,
+		},
+		{
+			name: "invalid resource group",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.KeyVault.ResourceGroup = "invalid."
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Invalid value: "invalid.": invalid resource group for encryption$`,
+		},
+		{
+			name: "missing user assigned identity",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.UserAssignedIdentityKey = ""
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Required value: user assigned identity key is required for storage account encryption$`,
+		},
+		{
+			name: "invalid user assigned identity",
+			platform: func() *azure.Platform {
+				p := validCustomerManagedKeys()
+				p.CustomerManagedKey.UserAssignedIdentityKey = "-"
+				return p
+			}(),
+			expected: `^test-path\.customerManagedKey: Invalid value: "-": invalid user assigned identity key for encryption$`,
 		},
 	}
 	ic := types.InstallConfig{}


### PR DESCRIPTION
Added a field to accept the customer managed key vault id and
user assigned identity required for the encryption of storage
account.