### PR TITLE
[release-4.13] OCPBUGS-19670: Allow different service account for xpn installs in gcp

### DIFF
--- a/data/data/gcp/cluster/dns/base.tf
+++ b/data/data/gcp/cluster/dns/base.tf
@@ -9,6 +9,7 @@ resource "google_dns_managed_zone" "int" {
   description = local.description
   dns_name    = "${var.cluster_domain}."
   visibility  = "private"
+  project     = var.project_id
 
   private_visibility_config {
     networks {
@@ -27,6 +28,7 @@ resource "google_dns_record_set" "api_external" {
   ttl          = "60"
   managed_zone = var.public_zone_name
   rrdatas      = [var.api_external_lb_ip]
+  project      = var.project_id
 }
 
 resource "google_dns_record_set" "api_internal" {
@@ -35,6 +37,7 @@ resource "google_dns_record_set" "api_internal" {
   ttl          = "60"
   managed_zone = var.private_zone_name != "" ? var.private_zone_name : google_dns_managed_zone.int[0].name
   rrdatas      = [var.api_internal_lb_ip]
+  project      = var.project_id
 }
 
 resource "google_dns_record_set" "api_external_internal_zone" {
@@ -43,4 +46,5 @@ resource "google_dns_record_set" "api_external_internal_zone" {
   ttl          = "60"
   managed_zone = var.private_zone_name != "" ? var.private_zone_name : google_dns_managed_zone.int[0].name
   rrdatas      = [var.api_internal_lb_ip]
+  project      = var.project_id
 }

--- a/data/data/gcp/cluster/dns/variables.tf
+++ b/data/data/gcp/cluster/dns/variables.tf
@@ -38,3 +38,7 @@ variable "public_endpoints" {
   description = "If the cluster should have externally accessible resources."
 }
 
+variable "project_id" {
+  type        = string
+  description = "The target GCP project for the cluster."
+}

--- a/data/data/gcp/cluster/iam/main.tf
+++ b/data/data/gcp/cluster/iam/main.tf
@@ -3,22 +3,19 @@ locals {
 }
 
 resource "google_service_account" "worker-node-sa" {
-  count        = var.service_account == "" ? 1 : 0
   account_id   = "${var.cluster_id}-w"
   display_name = "${var.cluster_id}-worker-node"
   description  = local.description
 }
 
 resource "google_project_iam_member" "worker-compute-viewer" {
-  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/compute.viewer"
-  member  = "serviceAccount:${google_service_account.worker-node-sa[0].email}"
+  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
 }
 
 resource "google_project_iam_member" "worker-storage-admin" {
-  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/storage.admin"
-  member  = "serviceAccount:${google_service_account.worker-node-sa[0].email}"
+  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
 }

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -84,6 +84,7 @@ module "dns" {
   api_external_lb_ip = module.network.cluster_public_ip
   api_internal_lb_ip = module.network.cluster_ip
   public_endpoints   = local.public_endpoints
+  project_id         = var.gcp_project_id
 }
 
 resource "google_compute_image" "cluster" {

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -439,6 +439,13 @@ spec:
                           - Enabled
                           - Disabled
                           type: string
+                        serviceAccount:
+                          description: ServiceAccount is the email of a gcp service
+                            account to be used for shared vpn installations. The provided
+                            service account will be attached to control-plane nodes
+                            in order to provide the permissions required by the cloud
+                            provider in the host project.
+                          type: string
                         tags:
                           description: Tags defines a set of network tags which will
                             be added to instances in the machineset
@@ -1356,6 +1363,13 @@ spec:
                         enum:
                         - Enabled
                         - Disabled
+                        type: string
+                      serviceAccount:
+                        description: ServiceAccount is the email of a gcp service
+                          account to be used for shared vpn installations. The provided
+                          service account will be attached to control-plane nodes
+                          in order to provide the permissions required by the cloud
+                          provider in the host project.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will
@@ -2902,6 +2916,13 @@ spec:
                         enum:
                         - Enabled
                         - Disabled
+                        type: string
+                      serviceAccount:
+                        description: ServiceAccount is the email of a gcp service
+                          account to be used for shared vpn installations. The provided
+                          service account will be attached to control-plane nodes
+                          in order to provide the permissions required by the cloud
+                          provider in the host project.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -233,6 +233,21 @@ func (mr *MockAPIMockRecorder) GetRegions(ctx, project interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegions", reflect.TypeOf((*MockAPI)(nil).GetRegions), ctx, project)
 }
 
+// GetServiceAccount mocks base method.
+func (m *MockAPI) GetServiceAccount(ctx context.Context, project, serviceAccount string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceAccount", ctx, project, serviceAccount)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceAccount indicates an expected call of GetServiceAccount.
+func (mr *MockAPIMockRecorder) GetServiceAccount(ctx, project, serviceAccount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceAccount", reflect.TypeOf((*MockAPI)(nil).GetServiceAccount), ctx, project, serviceAccount)
+}
+
 // GetSubnetworks mocks base method.
 func (m *MockAPI) GetSubnetworks(ctx context.Context, network, project, region string) ([]*compute.Subnetwork, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -157,28 +157,32 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	}
 
 	instanceServiceAccount := fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
-	// In a vanilla install, the installer will create a service account with the naming convention above.
-	// These service accounts require permissions to check for firewalls. In a GCP XPN install, that permission
-	// would be required in the host project, but the installer is not likely to have permissions to create
-	// service accounts with host project privileges. Instead, we can use the existing service account provided
-	// to the installer.
-	if len(platform.NetworkProjectID) > 0 {
-		sess, err := gcpconfig.GetSession(context.TODO())
-		if err != nil {
-			return nil, err
-		}
+	// The installer will create a service account for compute nodes with the above naming convention.
+	// The same service account will be used for control plane nodes during a vanilla installation. During a
+	// xpn installation, the installer will attempt to use an existing service account either through the
+	// credentials or through a user supplied value from the install-config.
+	if role == "master" && len(platform.NetworkProjectID) > 0 {
+		instanceServiceAccount = mpool.ServiceAccount
 
-		var found bool
-		serviceAccount := make(map[string]interface{})
-		err = json.Unmarshal([]byte(sess.Credentials.JSON), &serviceAccount)
-		if err != nil {
-			return nil, err
-		}
-		instanceServiceAccount, found = serviceAccount["client_email"].(string)
-		if !found {
-			return nil, errors.New("could not find google service account")
+		if instanceServiceAccount == "" {
+			sess, err := gcpconfig.GetSession(context.TODO())
+			if err != nil {
+				return nil, err
+			}
+
+			var found bool
+			serviceAccount := make(map[string]interface{})
+			err = json.Unmarshal(sess.Credentials.JSON, &serviceAccount)
+			if err != nil {
+				return nil, err
+			}
+			instanceServiceAccount, found = serviceAccount["client_email"].(string)
+			if !found {
+				return nil, errors.New("could not find google service account")
+			}
 		}
 	}
+
 	shieldedInstanceConfig := machineapi.GCPShieldedInstanceConfig{}
 	if mpool.SecureBoot == string(machineapi.SecureBootPolicyEnabled) {
 		shieldedInstanceConfig.SecureBoot = machineapi.SecureBootPolicyEnabled

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -48,6 +48,13 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
 	ConfidentialCompute string `json:"confidentialCompute,omitempty"`
+
+	// ServiceAccount is the email of a gcp service account to be used for shared
+	// vpn installations. The provided service account will be attached to control-plane nodes
+	// in order to provide the permissions required by the cloud provider in the host project.
+	//
+	// +optional
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // OSDisk defines the disk for machines on GCP.
@@ -129,6 +136,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.ConfidentialCompute != "" {
 		a.ConfidentialCompute = required.ConfidentialCompute
+	}
+
+	if required.ServiceAccount != "" {
+		a.ServiceAccount = required.ServiceAccount
 	}
 }
 

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -50,6 +50,22 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	return allErrs
 }
 
+// ValidateServiceAccount checks that the service account is only supplied for control plane nodes and during
+// a shared vpn installation.
+func ValidateServiceAccount(platform *gcp.Platform, p *types.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if p.Platform.GCP.ServiceAccount != "" {
+		if p.Name != "master" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccount"), p.Platform.GCP.ServiceAccount, fmt.Sprintf("service accounts only valid for master nodes, provided for %s nodes", p.Name)))
+		}
+		if platform.NetworkProjectID == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccount"), p.Platform.GCP.ServiceAccount, "service accounts only valid for xpn installs"))
+		}
+	}
+	return allErrs
+}
+
 // ValidateMasterDiskType checks that the specified disk type is valid for control plane.
 func ValidateMasterDiskType(p *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -141,6 +141,7 @@ func validateGCPMachinePool(platform *types.Platform, p *types.MachinePoolPlatfo
 
 	allErrs = append(allErrs, gcpvalidation.ValidateMachinePool(platform.GCP, p.GCP, f)...)
 	allErrs = append(allErrs, gcpvalidation.ValidateMasterDiskType(pool, f)...)
+	allErrs = append(allErrs, gcpvalidation.ValidateServiceAccount(platform.GCP, pool, f)...)
 
 	return allErrs
 }

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -190,6 +190,48 @@ func TestValidateMachinePool(t *testing.T) {
 			}(),
 			valid: false,
 		},
+		{
+			name:     "valid GCP service account use",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1", NetworkProjectID: "ExampleNetworkProject"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{
+						ServiceAccount: "ExampleServiceAccount@ExampleServiceAccount.com",
+					},
+				}
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name:     "invalid GCP service account on machine pool type",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("worker")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{
+						ServiceAccount: "ExampleServiceAccount@ExampleServiceAccount.com",
+					},
+				}
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name:     "invalid GCP service account non xpn install",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{
+						ServiceAccount: "ExampleServiceAccount@ExampleServiceAccount.com",
+					},
+				}
+				return p
+			}(),
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**Add service account field to the install config for control Planes **Validation to ensure service account field added is only used for xpn installs **Add Validation to ensure that the service account is available in the host project

** Machine manifests will use the provided service account for control planes.

**Pass the service account data used for creating control plane nodes during a shared vpn install.

Manual back port of https://github.com/openshift/installer/pull/7308