### PR TITLE
OCPBUGS-19093,OCPBUGS-19688: Allow agent-tui to use serial console

### DIFF
--- a/data/data/agent/systemd/units/agent-interactive-console-serial@.service
+++ b/data/data/agent/systemd/units/agent-interactive-console-serial@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Get interactive user configuration at boot on %I
+After=dev-fb0.device dev-%i.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+Before=serial-getty@%i.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
+ConditionPathExists=/usr/local/bin/agent-tui
+ConditionPathExists=!/dev/fb0
+ConditionPathExists=!/etc/assisted/node0
+
+[Service]
+Type=oneshot
+TTYPath=/dev/%I
+EnvironmentFile=/etc/assisted/agent-installer.env
+Environment=LD_LIBRARY_PATH=/usr/local/bin/
+Environment=AGENT_TUI_LOG_PATH=/var/log/agent/agent-tui.log
+ExecStartPre=/usr/bin/kill -s SIGRTMIN+21 1
+ExecStartPre=mkdir -p /var/log/agent
+ExecStart=/usr/local/bin/agent-tui
+ExecStopPost=/usr/bin/kill -s SIGRTMIN+20 1
+TimeoutStartSec=0
+StandardInput=tty
+
+[Install]
+WantedBy=serial-getty@.service

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Get interactive user configuration at boot
-After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+After=dev-fb0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=getty@tty1.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
 ConditionPathExists=/usr/local/bin/agent-tui
+ConditionPathExists=/dev/fb0
 ConditionPathExists=!/etc/assisted/node0
 
 [Service]

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -248,6 +248,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 func getDefaultEnabledServices() []string {
 	return []string{
 		"agent-interactive-console.service",
+		"agent-interactive-console-serial@.service",
 		"agent.service",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",


### PR DESCRIPTION
Run agent-tui on the serial console when there is no graphical console available.