### PR TITLE
OCPBUGS-19699: Remove warning about CPUPartitioning

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -387,11 +387,6 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		fieldPath := field.NewPath("BootstrapInPlace", "InstallationDisk")
 		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.BootstrapInPlace.InstallationDisk))
 	}
-
-	if installConfig.CPUPartitioning != "None" {
-		fieldPath := field.NewPath("CPUPartitioning")
-		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.CPUPartitioning))
-	}
 }
 
 // GetReplicaCount gets the configured master and worker replicas.


### PR DESCRIPTION
This warning is both incorrect - since it checks against "None" it generates a warning when not set, and no longer relevant now that https://issues.redhat.com//browse/OCPBUGS-18876 has been fixed.