### PR TITLE
[release-4.14] OCPBUGS-19922: Do not start agent-tui if no graphical console available

### DIFF
--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Get interactive user configuration at boot
-After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+After=dev-fb0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=getty@tty1.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
 ConditionPathExists=/usr/local/bin/agent-tui
+ConditionPathExists=/dev/fb0
 ConditionPathExists=!/etc/assisted/node0
 
 [Service]


### PR DESCRIPTION
If there is only a serial console, do not start agent-tui since it will not be visible.

We assume that there will be a graphical console if there is a framebuffer device (/dev/fb0). On x86 an alternative would be to check for the existence of /sys/class/vtconsole/vtcon1. However, in the absence of a range of hardware to test, the former seems more likely to work on other platforms as well.

Backported from #7526