### PR TITLE
OWNERS: Remove obsolete agent reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -150,18 +150,12 @@ aliases:
   agent-reviewers:
     - andfasano
     - bfournie
-    - celebdor
-    - dhellmann
-    - lranjbar
     - pawanpinjarkar
     - rwsu
     - zaneb
   agent-approvers:
     - andfasano
     - bfournie
-    - celebdor
-    - dhellmann
-    - lranjbar
     - pawanpinjarkar
     - rwsu
     - zaneb


### PR DESCRIPTION
Spare people not working directly on the agent installer from all the email notifications.