### PR TITLE
OSASINFRA-3199: Configure User-Agent for OpenStack API calls

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -82,27 +82,27 @@ func GetCloudInfo(ic *types.InstallConfig) (*CloudInfo, error) {
 
 	opts := openstackdefaults.DefaultClientOpts(ic.OpenStack.Cloud)
 
-	ci.clients.networkClient, err = clientconfig.NewServiceClient("network", opts)
+	ci.clients.networkClient, err = openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a network client: %w", err)
 	}
 
-	ci.clients.computeClient, err = clientconfig.NewServiceClient("compute", opts)
+	ci.clients.computeClient, err = openstackdefaults.NewServiceClient("compute", opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a compute client: %w", err)
 	}
 
-	ci.clients.imageClient, err = clientconfig.NewServiceClient("image", opts)
+	ci.clients.imageClient, err = openstackdefaults.NewServiceClient("image", opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an image client: %w", err)
 	}
 
-	ci.clients.identityClient, err = clientconfig.NewServiceClient("identity", opts)
+	ci.clients.identityClient, err = openstackdefaults.NewServiceClient("identity", opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an identity client: %w", err)
 	}
 
-	ci.clients.volumeClient, err = clientconfig.NewServiceClient("volume", opts)
+	ci.clients.volumeClient, err = openstackdefaults.NewServiceClient("volume", opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a volume client: %w", err)
 	}

--- a/pkg/asset/installconfig/openstack/validvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/validvaluesfetcher.go
@@ -30,7 +30,7 @@ func getCloudNames() ([]string, error) {
 // getExternalNetworkNames interrogates OpenStack to get the external network
 // names.
 func getExternalNetworkNames(cloud string) ([]string, error) {
-	conn, err := clientconfig.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func getExternalNetworkNames(cloud string) ([]string, error) {
 
 // getFlavorNames gets a list of valid flavor names.
 func getFlavorNames(cloud string) ([]string, error) {
-	conn, err := clientconfig.NewServiceClient("compute", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (fips sortableFloatingIPCollection) Contains(value string) bool {
 }
 
 func getFloatingIPs(cloud string, floatingNetworkName string) (sortableFloatingIPCollection, error) {
-	conn, err := clientconfig.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -364,7 +364,7 @@ func checkNetworkExtensionAvailability(cloud, alias string, opts *clientconfig.C
 	if opts == nil {
 		opts = openstackdefaults.DefaultClientOpts(cloud)
 	}
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/types"
+	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
 )
 
 // Error represents a failure while generating OpenStack provider
@@ -108,7 +109,7 @@ secret-namespace = kube-system
 }
 
 func getNetworkClient(session *openstack.Session) (*gophercloud.ServiceClient, error) {
-	return clientconfig.NewServiceClient("network", session.ClientOpts)
+	return openstackdefaults.NewServiceClient("network", session.ClientOpts)
 }
 
 // GenerateCloudProviderConfig adds the cloud provider config for the OpenStack

--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -108,22 +108,18 @@ secret-namespace = kube-system
 	return cloudProviderConfigData, cloudProviderConfigCABundleData, nil
 }
 
-func getNetworkClient(session *openstack.Session) (*gophercloud.ServiceClient, error) {
-	return openstackdefaults.NewServiceClient("network", session.ClientOpts)
-}
-
 // GenerateCloudProviderConfig adds the cloud provider config for the OpenStack
 // platform in the provided configmap.
 func GenerateCloudProviderConfig(installConfig types.InstallConfig) (cloudProviderConfigData, cloudProviderConfigCABundleData string, err error) {
-	cloud, err := openstack.GetSession(installConfig.Platform.OpenStack.Cloud)
+	session, err := openstack.GetSession(installConfig.Platform.OpenStack.Cloud)
 	if err != nil {
 		return "", "", Error{err, "failed to get cloud config for openstack"}
 	}
 
-	networkClient, err := getNetworkClient(cloud)
+	networkClient, err := openstackdefaults.NewServiceClient("network", session.ClientOpts)
 	if err != nil {
 		return "", "", Error{err, "failed to create a network client"}
 	}
 
-	return generateCloudProviderConfig(networkClient, cloud.CloudConfig, installConfig)
+	return generateCloudProviderConfig(networkClient, session.CloudConfig, installConfig)
 }

--- a/pkg/destroy/openstack/glance.go
+++ b/pkg/destroy/openstack/glance.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -30,7 +29,7 @@ func DeleteGlanceImage(name string, cloud string) error {
 }
 
 func deleteGlanceImage(name string, cloud string) (bool, error) {
-	conn, err := clientconfig.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		logrus.Warningf("There was an error during the image removal: %v", err)
 		return false, nil

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -217,7 +217,7 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 	logger.Debug("Deleting openstack servers")
 	defer logger.Debugf("Exiting deleting openstack servers")
 
-	conn, err := clientconfig.NewServiceClient("compute", opts)
+	conn, err := openstackdefaults.NewServiceClient("compute", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -278,7 +278,7 @@ func deleteServerGroups(opts *clientconfig.ClientOpts, filter Filter, logger log
 		}
 	}
 
-	conn, err := clientconfig.NewServiceClient("compute", opts)
+	conn, err := openstackdefaults.NewServiceClient("compute", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -399,7 +399,7 @@ func deletePorts(opts *clientconfig.ClientOpts, listOpts ports.ListOpts, logger 
 	logger.Debug("Deleting openstack ports")
 	defer logger.Debugf("Exiting deleting openstack ports")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -539,7 +539,7 @@ func deleteSecurityGroups(opts *clientconfig.ClientOpts, filter Filter, logger l
 	logger.Debug("Deleting openstack security-groups")
 	defer logger.Debugf("Exiting deleting openstack security-groups")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -572,7 +572,7 @@ func deleteSecurityGroups(opts *clientconfig.ClientOpts, filter Filter, logger l
 }
 
 func updateFips(allFIPs []floatingips.FloatingIP, opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) error {
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return err
 	}
@@ -595,7 +595,7 @@ func updateFips(allFIPs []floatingips.FloatingIP, opts *clientconfig.ClientOpts,
 
 // deletePortFIPs looks up FIPs associated to the port and attempts to delete them
 func deletePortFIPs(portID string, opts *clientconfig.ClientOpts, logger logrus.FieldLogger) error {
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return err
 	}
@@ -630,7 +630,7 @@ func deletePortFIPs(portID string, opts *clientconfig.ClientOpts, logger logrus.
 }
 
 func getRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) ([]routers.Router, error) {
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 	logger.Debug("Deleting openstack routers")
 	defer logger.Debugf("Exiting deleting openstack routers")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -767,7 +767,7 @@ func getRouterInterfaces(conn *gophercloud.ServiceClient, allNetworks []networks
 func clearRouterInterfaces(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
 	logger.Debugf("Removing interfaces from router")
 	defer logger.Debug("Exiting removal of interfaces from router")
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -922,7 +922,7 @@ func getRouterByPort(client *gophercloud.ServiceClient, allPorts []ports.Port) (
 }
 
 func deleteLeftoverLoadBalancers(opts *clientconfig.ClientOpts, logger logrus.FieldLogger, networkID string) error {
-	conn, err := clientconfig.NewServiceClient("load-balancer", opts)
+	conn, err := openstackdefaults.NewServiceClient("load-balancer", opts)
 	if err != nil {
 		// Ignore the error if Octavia is not available for the cloud
 		var gerr *gophercloud.ErrEndpointNotFound
@@ -1000,7 +1000,7 @@ func deleteSubnets(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 	logger.Debug("Deleting openstack subnets")
 	defer logger.Debugf("Exiting deleting openstack subnets")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1047,7 +1047,7 @@ func deleteNetworks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.
 	logger.Debug("Deleting openstack networks")
 	defer logger.Debugf("Exiting deleting openstack networks")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1108,7 +1108,7 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 	logger.Debug("Deleting openstack containers")
 	defer logger.Debugf("Exiting deleting openstack containers")
 
-	conn, err := clientconfig.NewServiceClient("object-store", opts)
+	conn, err := openstackdefaults.NewServiceClient("object-store", opts)
 	if err != nil {
 		// Ignore the error if Swift is not available for the cloud
 		var gerr *gophercloud.ErrEndpointNotFound
@@ -1244,7 +1244,7 @@ func deleteTrunks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 	logger.Debug("Deleting openstack trunks")
 	defer logger.Debugf("Exiting deleting openstack trunks")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1336,7 +1336,7 @@ func deleteLoadBalancers(opts *clientconfig.ClientOpts, filter Filter, logger lo
 	logger.Debug("Deleting openstack load balancers")
 	defer logger.Debugf("Exiting deleting openstack load balancers")
 
-	conn, err := clientconfig.NewServiceClient("load-balancer", opts)
+	conn, err := openstackdefaults.NewServiceClient("load-balancer", opts)
 	if err != nil {
 		// Ignore the error if Octavia is not available for the cloud
 		var gerr *gophercloud.ErrEndpointNotFound
@@ -1433,7 +1433,7 @@ func deleteSubnetPools(opts *clientconfig.ClientOpts, filter Filter, logger logr
 	logger.Debug("Deleting openstack subnet-pools")
 	defer logger.Debugf("Exiting deleting openstack subnet-pools")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1486,7 +1486,7 @@ func deleteVolumes(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		}
 	}
 
-	conn, err := clientconfig.NewServiceClient("volume", opts)
+	conn, err := openstackdefaults.NewServiceClient("volume", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1557,7 +1557,7 @@ func deleteVolumeSnapshots(opts *clientconfig.ClientOpts, filter Filter, logger 
 		}
 	}
 
-	conn, err := clientconfig.NewServiceClient("volume", opts)
+	conn, err := openstackdefaults.NewServiceClient("volume", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1613,7 +1613,7 @@ func deleteShares(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 		}
 	}
 
-	conn, err := clientconfig.NewServiceClient("sharev2", opts)
+	conn, err := openstackdefaults.NewServiceClient("sharev2", opts)
 	if err != nil {
 		// Ignore the error if Manila is not available in the cloud
 		var gerr *gophercloud.ErrEndpointNotFound
@@ -1715,7 +1715,7 @@ func deleteFloatingIPs(opts *clientconfig.ClientOpts, filter Filter, logger logr
 	logger.Debug("Deleting openstack floating ips")
 	defer logger.Debugf("Exiting deleting openstack floating ips")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1761,7 +1761,7 @@ func deleteImages(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 	logger.Debug("Deleting openstack base image")
 	defer logger.Debugf("Exiting deleting openstack base image")
 
-	conn, err := clientconfig.NewServiceClient("image", opts)
+	conn, err := openstackdefaults.NewServiceClient("image", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil
@@ -1845,7 +1845,7 @@ func untagPrimaryNetwork(opts *clientconfig.ClientOpts, infraID string, logger l
 	logger.Debugf("Removing tag %v from openstack networks", networkTag)
 	defer logger.Debug("Exiting untagging openstack networks")
 
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Debug(err)
 		return false, nil
@@ -1894,7 +1894,7 @@ func validateCloud(opts *clientconfig.ClientOpts, logger logrus.FieldLogger) err
 	//
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=2013877
 	logger.Debug("Validating network extensions")
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return fmt.Errorf("failed to build the network client: %w", err)
 	}
@@ -1930,7 +1930,7 @@ func isClusterSG(providedPortSG string, clusterSGs []sg.SecGroup) bool {
 func cleanVIPsPorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
 	logger.Debug("Cleaning provided Ports for API and Ingress VIPs")
 	defer logger.Debugf("Exiting clean of provided Ports for API and Ingress VIPs")
-	conn, err := clientconfig.NewServiceClient("network", opts)
+	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		logger.Error(err)
 		return false, nil

--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -11,7 +11,6 @@ import (
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/sirupsen/logrus"
 	"github.com/vincent-petithory/dataurl"
 
@@ -26,7 +25,7 @@ import (
 func uploadBootstrapConfig(cloud string, bootstrapIgn string, clusterID string) (string, error) {
 	logrus.Debugln("Creating a Glance image for your bootstrap ignition config...")
 
-	conn, err := clientconfig.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return "", err
 	}
@@ -179,7 +178,7 @@ func generateIgnitionShim(userCA string, clusterID string, bootstrapConfigURL st
 
 // getAuthToken fetches valid OpenStack authentication token ID
 func getAuthToken(cloud string) (string, error) {
-	conn, err := clientconfig.NewServiceClient("identity", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("identity", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
@@ -49,7 +48,7 @@ func uploadBaseImage(cloud string, baseImage, imageName string, infraID string, 
 	}
 	defer f.Close()
 
-	conn, err := clientconfig.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return err
 	}
@@ -145,7 +144,7 @@ func isImageImportSupported(cloud string) (bool, error) {
 	// https://docs.openstack.org/api-ref/image/v2/?expanded=#image-service-info-discovery
 	logrus.Debugln("Checking if the image import mechanism is supported")
 
-	conn, err := clientconfig.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("image", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/types/openstack/defaults/client.go
+++ b/pkg/types/openstack/defaults/client.go
@@ -1,0 +1,42 @@
+package defaults
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	"github.com/openshift/installer/pkg/version"
+)
+
+// getUserAgent generates a Gophercloud UserAgent to help cloud operators
+// disambiguate openshift-installer requests.
+func getUserAgent() (gophercloud.UserAgent, error) {
+	ua := gophercloud.UserAgent{}
+
+	version, err := version.Version()
+	if err != nil {
+		return ua, err
+	}
+
+	ua.Prepend(fmt.Sprintf("openshift-installer/%s", version))
+	return ua, nil
+}
+
+// NewServiceClient is a wrapper around Gophercloud's NewServiceClient that
+// ensures we consistently set a user-agent.
+func NewServiceClient(service string, opts *clientconfig.ClientOpts) (*gophercloud.ServiceClient, error) {
+	ua, err := getUserAgent()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clientconfig.NewServiceClient(service, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	client.UserAgent = ua
+
+	return client, nil
+}


### PR DESCRIPTION
gophercloud provides the ability to configure a User-Agent header for all API calls. This is a very helpful breadcrumb when debugging issues with the various OpenStack components. Configure it for all OpenStack API clients in the installer.
