### PR TITLE
Disable pxe sno arm integration test

### DIFF
--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
@@ -1,3 +1,5 @@
+skip 'Cannot download the live iso image from rhcos.mirror.openshift.com'
+
 # Verify a default configuration for the SNO topology for ARM architecture
 
 exec openshift-install agent create pxe-files --dir $WORK


### PR DESCRIPTION
Currently the integration tests are failing because `https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202309142014-0/aarch64/rhcos-415.92.202309142014-0-live.aarch64.iso` cannot be download. It's not still clear if it's a network issue or something else, in any case this patch temporarily disable the affected 
test to avoid impacting (unrelated) PRs