### PR TITLE
PowerVS: MULTIARCH-3790 Remove zones that only have CCs with exceptions

### DIFF
--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -25,7 +25,7 @@ import (
 type editFunctions []func(ic *types.InstallConfig)
 
 var (
-	validRegion                  = "lon"
+	validRegion                  = "dal"
 	validCIDR                    = "192.168.0.0/24"
 	validCISInstanceCRN          = "crn:v1:bluemix:public:internet-svcs:global:a/valid-account-id:valid-instance-id::"
 	validClusterName             = "valid-cluster-name"
@@ -44,7 +44,7 @@ var (
 		validPrivateSubnetUSSouth2ID,
 	}
 	validUserID = "valid-user@example.com"
-	validZone   = "lon04"
+	validZone   = "dal10"
 
 	existingDNSRecordsResponse = []powervs.DNSRecordResponse{
 		{
@@ -62,7 +62,7 @@ var (
 	invalidMachinePoolCIDR = func(ic *types.InstallConfig) { ic.Networking.MachineNetwork[0].CIDR = *cidrInvalid }
 	cidrValid, _           = ipnet.ParseCIDR("192.168.0.0/24")
 	validMachinePoolCIDR   = func(ic *types.InstallConfig) { ic.Networking.MachineNetwork[0].CIDR = *cidrValid }
-	validVPCRegion         = "eu-gb"
+	validVPCRegion         = "us-south"
 	invalidVPCRegion       = "foo-bah"
 	setValidVPCRegion      = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPCRegion = validVPCRegion }
 	validRG                = "valid-resource-group"

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -20,26 +20,7 @@ var Regions = map[string]Region{
 	"dal": {
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
-		Zones: []string{
-			"dal10",
-			"dal12",
-		},
-	},
-	"eu-de": {
-		Description: "Frankfurt, Germany",
-		VPCRegion:   "eu-de",
-		Zones: []string{
-			"eu-de-1",
-			"eu-de-2",
-		},
-	},
-	"lon": {
-		Description: "London, UK.",
-		VPCRegion:   "eu-gb",
-		Zones: []string{
-			"lon04",
-			"lon06",
-		},
+		Zones:       []string{"dal10"},
 	},
 	"mon": {
 		Description: "Montreal, Canada",
@@ -50,34 +31,6 @@ var Regions = map[string]Region{
 		Description: "Osaka, Japan",
 		VPCRegion:   "jp-osa",
 		Zones:       []string{"osa21"},
-	},
-	"syd": {
-		Description: "Sydney, Australia",
-		VPCRegion:   "au-syd",
-		Zones: []string{
-			"syd04",
-			"syd05",
-		},
-	},
-	"sao": {
-		Description: "São Paulo, Brazil",
-		VPCRegion:   "br-sao",
-		Zones:       []string{"sao01"},
-	},
-	"tor": {
-		Description: "Toronto, Canada",
-		VPCRegion:   "ca-tor",
-		Zones:       []string{"tor01"},
-	},
-	"tok": {
-		Description: "Tokyo, Japan",
-		VPCRegion:   "jp-tok",
-		Zones:       []string{"tok04"},
-	},
-	"us-east": {
-		Description: "Washington DC, USA",
-		VPCRegion:   "us-east",
-		Zones:       []string{"us-east"},
 	},
 }
 

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -94,7 +94,7 @@ func validIBMCloudPlatform() *ibmcloud.Platform {
 
 func validPowerVSPlatform() *powervs.Platform {
 	return &powervs.Platform{
-		Zone: "dal12",
+		Zone: "dal10",
 	}
 }
 


### PR DESCRIPTION
Currently the only zone that supports PER is dal10. Other than that, we'll keep mon01 and osa21 to keep CI running. Remove all zones except for dal10, mon01, and osa21.

https://issues.redhat.com/browse/MULTIARCH-3790