### PR TITLE
PowerVS: MULTIARCH-3791 Remove cloud connection reuse functionality

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4121,10 +4121,6 @@ spec:
                 description: PowerVS is the configuration used when installing on
                   Power VS.
                 properties:
-                  cloudConnectionName:
-                    description: CloudConnctionName is the name of an existing Power
-                      VS Cloud connection. If empty, one is created by the installer.
-                    type: string
                   clusterOSImage:
                     description: ClusterOSImage is a pre-created Power VS boot image
                       that overrides the default image for cluster nodes.

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -40,7 +40,6 @@ module "pi_network" {
   resource_group          = var.powervs_resource_group
   pvs_network_name        = var.powervs_network_name
   machine_cidr            = var.machine_v4_cidrs[0]
-  cloud_conn_name         = var.powervs_ccon_name
   vpc_crn                 = module.vpc.vpc_crn
   dns_server              = module.dns.dns_server
   enable_snat             = var.powervs_enable_snat

--- a/data/data/powervs/cluster/power_network/pi_network.tf
+++ b/data/data/powervs/cluster/power_network/pi_network.tf
@@ -20,7 +20,7 @@ resource "ibm_pi_dhcp" "new_dhcp_service" {
 }
 
 resource "ibm_pi_cloud_connection" "new_cloud_connection" {
-  count                              = (var.transit_gateway_enabled || var.cloud_conn_name != "") ? 0 : 1
+  count                              = var.transit_gateway_enabled ? 0 : 1
   pi_cloud_instance_id               = var.cloud_instance_id
   pi_cloud_connection_name           = "cloud-con-${var.cluster_id}"
   pi_cloud_connection_speed          = 50
@@ -31,7 +31,7 @@ resource "ibm_pi_cloud_connection" "new_cloud_connection" {
 
 data "ibm_pi_cloud_connection" "cloud_connection" {
   count                    = var.transit_gateway_enabled ? 0 : 1
-  pi_cloud_connection_name = var.cloud_conn_name == "" ? ibm_pi_cloud_connection.new_cloud_connection[0].pi_cloud_connection_name : var.cloud_conn_name
+  pi_cloud_connection_name = ibm_pi_cloud_connection.new_cloud_connection[0].pi_cloud_connection_name
   pi_cloud_instance_id     = var.cloud_instance_id
 }
 

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -75,12 +75,6 @@ variable "powervs_wait_for_vpc" {
   default     = "60s"
 }
 
-variable "powervs_ccon_name" {
-  type        = string
-  description = "The name of a pre-created Power VS Cloud connection"
-  default     = ""
-}
-
 variable "powervs_network_name" {
   type        = string
   description = "The name of a pre-created Power VS DHCP network"

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -906,7 +906,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				VPCPermitted:          vpcPermitted,
 				VPCGatewayName:        vpcGatewayName,
 				VPCGatewayAttached:    vpcGatewayAttached,
-				CloudConnectionName:   installConfig.Config.PowerVS.CloudConnectionName,
 				CISInstanceCRN:        cisCRN,
 				DNSInstanceCRN:        dnsCRN,
 				PublishStrategy:       installConfig.Config.Publish,

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -161,12 +161,9 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		transitGatewayEnabled := configpowervs.TransitGatewayEnabledZone(ic.Config.Platform.PowerVS.Zone)
 
 		if !transitGatewayEnabled {
-			// Only check that there isn't an existing Cloud connection if we're not re-using one
-			if ic.Config.Platform.PowerVS.CloudConnectionName == "" {
-				err = bxCli.ValidateCloudConnectionInPowerVSRegion(context.TODO(), ic.Config.Platform.PowerVS.ServiceInstanceID)
-				if err != nil {
-					return fmt.Errorf("failed to meet the prerequisite for Cloud Connections: %w", err)
-				}
+			err = bxCli.ValidateCloudConnectionInPowerVSRegion(context.TODO(), ic.Config.Platform.PowerVS.ServiceInstanceID)
+			if err != nil {
+				return fmt.Errorf("failed to meet the prerequisite for Cloud Connections: %w", err)
 			}
 		}
 

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -33,7 +33,6 @@ type config struct {
 	VPCPermitted          bool   `json:"powervs_vpc_permitted"`
 	VPCGatewayName        string `json:"powervs_vpc_gateway_name"`
 	VPCGatewayAttached    bool   `json:"powervs_vpc_gateway_attached"`
-	CloudConnectionName   string `json:"powervs_ccon_name"`
 	BootstrapMemory       int32  `json:"powervs_bootstrap_memory"`
 	BootstrapProcessors   string `json:"powervs_bootstrap_processors"`
 	MasterMemory          int32  `json:"powervs_master_memory"`
@@ -57,7 +56,6 @@ type TFVarsSources struct {
 	ImageBucketFileName   string
 	NetworkName           string
 	PowerVSResourceGroup  string
-	CloudConnectionName   string
 	CISInstanceCRN        string
 	DNSInstanceCRN        string
 	VPCRegion             string
@@ -123,7 +121,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VPCPermitted:          sources.VPCPermitted,
 		VPCGatewayName:        sources.VPCGatewayName,
 		VPCGatewayAttached:    sources.VPCGatewayAttached,
-		CloudConnectionName:   sources.CloudConnectionName,
 		BootstrapMemory:       masterConfig.MemoryGiB,
 		BootstrapProcessors:   processor,
 		MasterMemory:          masterConfig.MemoryGiB,

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -54,9 +54,4 @@ type Platform struct {
 	// platform configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
-
-	// CloudConnctionName is the name of an existing Power VS Cloud connection.
-	// If empty, one is created by the installer.
-	// +optional
-	CloudConnectionName string `json:"cloudConnectionName,omitempty"`
 }


### PR DESCRIPTION
One thing we can remove that will make removing cloud connections entirely later on easier is the ability to reuse a cloud connection.

This will require removing any vars in the installer that are specific to cloud connections and then removing the terraform specific to reusing a cloud connection.

This will leave us with an installer that can still be used in CI but is less entangled with cloud connections.

https://issues.redhat.com/browse/MULTIARCH-3791