### PR TITLE
DNM: Test release-4.14 branch

### DIFF
--- a/pkg/asset/agent/image/kargs.go
+++ b/pkg/asset/agent/image/kargs.go
@@ -37,5 +37,5 @@ func (a *Kargs) KernelCmdLine() []byte {
 	if a.fips {
 		return []byte(" fips=1")
 	}
-	return nil
+	return []byte(" console=ttyS0")
 }


### PR DESCRIPTION
There have been no e2e-agent-compact-ipv4 tests [run on this branch](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-installer-release-4.14-e2e-agent-compact-ipv4) for over a week, but rehearsals in the origin repo suggest it might be broken.

/hold