### PR TITLE
AGENT-717: Modify InstallConfig asset to not ignore vSphere creds

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -187,35 +187,10 @@ func VCenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
 func (a *OptionalInstallConfig) validateVSpherePlatform(installConfig *types.InstallConfig) field.ErrorList {
 	var allErrs field.ErrorList
 	vspherePlatform := installConfig.Platform.VSphere
-	vcenterServers := map[string]bool{}
 	userProvidedCredentials := false
 	for _, vcenter := range vspherePlatform.VCenters {
-		vcenterServers[vcenter.Server] = true
-
-		// If any one of the required credential values is entered, then the user is choosing to enter credentials
 		if VCenterCredentialsAreProvided(vcenter) {
-			// Then check all required credential values are filled
 			userProvidedCredentials = true
-			message := "All credential fields are required if any one is specified"
-			if vcenter.Server == "" {
-				fieldPath := field.NewPath("Platform", "VSphere", "vcenter")
-				allErrs = append(allErrs, field.Required(fieldPath, message))
-			}
-			if vcenter.Username == "" {
-				fieldPath := field.NewPath("Platform", "VSphere", "user")
-				if vspherePlatform.DeprecatedVCenter != "" || vspherePlatform.DeprecatedPassword != "" || vspherePlatform.DeprecatedDatacenter != "" {
-					fieldPath = field.NewPath("Platform", "VSphere", "username")
-				}
-				allErrs = append(allErrs, field.Required(fieldPath, message))
-			}
-			if vcenter.Password == "" {
-				fieldPath := field.NewPath("Platform", "VSphere", "password")
-				allErrs = append(allErrs, field.Required(fieldPath, message))
-			}
-			if len(vcenter.Datacenters) == 0 {
-				fieldPath := field.NewPath("Platform", "VSphere", "datacenter")
-				allErrs = append(allErrs, field.Required(fieldPath, message))
-			}
 		}
 	}
 

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -175,7 +175,7 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 	return allErrs
 }
 
-// VcenterCredentialsAreProvider returns true if server, username, password, and at least one datacenter
+// VCenterCredentialsAreProvided returns true if server, username, password, and at least one datacenter
 // have been provided.
 func VCenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
 	if vcenter.Server != "" || vcenter.Username != "" || vcenter.Password != "" || len(vcenter.Datacenters) > 0 {

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -222,11 +222,6 @@ func (a *OptionalInstallConfig) validateVSpherePlatform(installConfig *types.Ins
 	}
 
 	for _, failureDomain := range vspherePlatform.FailureDomains {
-		// if !vcenterServers[failureDomain.Server] {
-		// 	fieldPath := field.NewPath("Platform", "VSphere", "failureDomains", "Server")
-		// 	allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("failureDomain server %v must have a corresponding vcenter server defined", failureDomain.Server)))
-		// }
-
 		// Although folder is optional in IPI/UPI, it is must be set for agent-based installs.
 		// If it is not set, assisted-service will set a placeholder value for folder:
 		// "/datacenterplaceholder/vm/folderplaceholder"

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -175,7 +175,9 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 	return allErrs
 }
 
-func vcenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
+// VcenterCredentialsAreProvider returns true if server, username, password, and at least one datacenter
+// have been provided.
+func VCenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
 	if vcenter.Server != "" || vcenter.Username != "" || vcenter.Password != "" || len(vcenter.Datacenters) > 0 {
 		return true
 	}
@@ -191,7 +193,7 @@ func (a *OptionalInstallConfig) validateVSpherePlatform(installConfig *types.Ins
 		vcenterServers[vcenter.Server] = true
 
 		// If any one of the required credential values is entered, then the user is choosing to enter credentials
-		if vcenterCredentialsAreProvided(vcenter) {
+		if VCenterCredentialsAreProvided(vcenter) {
 			// Then check all required credential values are filled
 			userProvidedCredentials = true
 			if !(vcenter.Server != "" && vcenter.Username != "" && vcenter.Password != "" && len(vcenter.Datacenters) > 0) {

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -207,7 +207,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.vcenters.username: Required value: must specify the username, platform.vsphere.vcenters.password: Required value: must specify the password, platform.vsphere.vcenters.datacenters: Required value: must specify at least one datacenter, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "All required vSphere fields must be entered if some of them are entered - vcenter fields",
@@ -228,7 +228,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.vcenters.password: Required value: must specify the password, platform.vsphere.vcenters.datacenters: Required value: must specify at least one datacenter, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "ingressVIP missing for vSphere, credentials not provided and should not flag error",

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -107,7 +107,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "ingressVIP missing and vcenter vSphere credentials are present",
@@ -120,12 +120,24 @@ platform:
   vsphere:
     apiVips:
       - 192.168.122.10
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
       password: testpassword
-      datacenters: 
+      datacenters:
       - testDatacenter
+    failureDomains:
+    - name: testFailuredomain
+      server: test.vcenter.com
+      zone: testZone
+      region: testRegion
+      topology:
+        computeCluster: "/testDatacenter/host/testcluster"
+        datacenter: testDatacenter
+        datastore: "/testDatacenter/datastore/testDatastore"
+        folder: "/testDatacenter/vm/testFolder"
+        networks:
+        - testNetwork
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
@@ -144,24 +156,39 @@ platform:
       - 192.168.122.10
     ingressVips:
       - 192.168.122.11
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
       password: testpassword
-      datacenters: 
-      - testDatacenter
-    - server: vcenter2.vcenter.com
-      user: testuser
-      password: testpassword
-      datacenters: 
+      datacenters:
       - testDatacenter
     failureDomains:
-    - server: different.vcenter.com
-    - server: vcenter2.vcenter.com
+    - name: testFailuredomain
+      server: diff1.vcenter.com
+      zone: testZone
+      region: testRegion
+      topology:
+        computeCluster: "/testDatacenter/host/testcluster"
+        datacenter: testDatacenter
+        datastore: "/testDatacenter/datastore/testDatastore"
+        folder: "/testDatacenter/vm/testFolder"
+        networks:
+        - testNetwork
+    - name: testFailuredomain2
+      server: diff2.vcenter.com
+      zone: testZone2
+      region: testRegion2
+      topology:
+        computeCluster: "/testDatacenter2/host/testcluster2"
+        datacenter: testDatacenter2
+        datastore: "/testDatacenter2/datastore/testDatastore2"
+        folder: "/testDatacenter2/vm/testFolder"
+        networks:
+        - testNetwork2
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: Platform.VSphere.failureDomains.Server: Required value: failureDomain server different.vcenter.com must have a corresponding vcenter server defined`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.failureDomains.server: Invalid value: "diff1.vcenter.com": server does not exist in vcenters, platform.vsphere.failureDomains.server: Invalid value: "diff2.vcenter.com": server does not exist in vcenters]`,
 		},
 		{
 			name: "All required vSphere fields must be entered if some of them are entered - deprecated fields",
@@ -180,7 +207,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified]`,
+			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "All required vSphere fields must be entered if some of them are entered - vcenter fields",
@@ -195,13 +222,13 @@ platform:
       - 192.168.122.10
     ingressVips:
       - 192.168.122.11
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified]`,
+			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "ingressVIP missing for vSphere, credentials not provided and should not flag error",
@@ -728,6 +755,7 @@ platform:
     password: testPassword
     datacenter: testDataCenter
     defaultDataStore: testDefaultDataStore
+    folder: testFolder
     cluster: testCluster
     apiVIP: 192.168.122.10
     ingressVIPs: 
@@ -779,6 +807,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						DeprecatedDatacenter:       "testDataCenter",
 						DeprecatedCluster:          "testCluster",
 						DeprecatedDefaultDatastore: "testDefaultDataStore",
+						DeprecatedFolder:           "testFolder",
 						DeprecatedAPIVIP:           "192.168.122.10",
 						APIVIPs:                    []string{"192.168.122.10"},
 						IngressVIPs:                []string{"192.168.122.11"},
@@ -800,7 +829,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 								Networks:       []string{""},
 								Datastore:      "/testDataCenter/datastore/testDefaultDataStore",
 								ResourcePool:   "/testDataCenter/host/testCluster//Resources",
-								Folder:         "",
+								Folder:         "/testDataCenter/vm/testFolder",
 							},
 						}},
 					},

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -13,9 +13,12 @@ import (
 var localLogger = logrus.New()
 
 const (
-	GeneratedFailureDomainName   string = "generated-failure-domain"
+	// GeneratedFailureDomainName is a placeholder name when one wasn't provided.
+	GeneratedFailureDomainName string = "generated-failure-domain"
+	// GeneratedFailureDomainRegion is a placeholder region when one wasn't provided.
 	GeneratedFailureDomainRegion string = "generated-region"
-	GeneratedFailureDomainZone   string = "generated-zone"
+	// GeneratedFailureDomainZone is a placeholder zone when one wasn't provided.
+	GeneratedFailureDomainZone string = "generated-zone"
 )
 
 // ConvertInstallConfig modifies a given platform spec for the new requirements.

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -12,6 +12,12 @@ import (
 
 var localLogger = logrus.New()
 
+const (
+	GeneratedFailureDomainName   string = "generated-failure-domain"
+	GeneratedFailureDomainRegion string = "generated-region"
+	GeneratedFailureDomainZone   string = "generated-zone"
+)
+
 // ConvertInstallConfig modifies a given platform spec for the new requirements.
 func ConvertInstallConfig(config *types.InstallConfig) error {
 	platform := config.Platform.VSphere
@@ -55,10 +61,10 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 		localLogger.Warn("vsphere topology fields are now depreciated please use failureDomains")
 
 		platform.FailureDomains = make([]vsphere.FailureDomain, 1)
-		platform.FailureDomains[0].Name = "generated-failure-domain"
+		platform.FailureDomains[0].Name = GeneratedFailureDomainName
 		platform.FailureDomains[0].Server = platform.VCenters[0].Server
-		platform.FailureDomains[0].Region = "generated-region"
-		platform.FailureDomains[0].Zone = "generated-zone"
+		platform.FailureDomains[0].Region = GeneratedFailureDomainRegion
+		platform.FailureDomains[0].Zone = GeneratedFailureDomainZone
 
 		platform.FailureDomains[0].Topology.Datacenter = platform.DeprecatedDatacenter
 		platform.FailureDomains[0].Topology.ResourcePool = platform.DeprecatedResourcePool

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -51,10 +51,13 @@ func ValidatePlatform(p *vsphere.Platform, agentBasedInstallation bool, fldPath 
 			allErrs = append(allErrs, validateHosts(p, c, fldPath.Child("hosts"))...)
 		}
 	} else {
-		// agent-based installation allows the credentials to be optional
 		if len(p.VCenters) > 0 {
-			if p.VCenters[0].Username != "" && p.VCenters[0].Password != "" &&
-				p.VCenters[0].Server != "" && len(p.VCenters[0].Datacenters) != 0 {
+			if p.VCenters[0].Username == "" && p.VCenters[0].Password == "" &&
+				p.VCenters[0].Server == "" && len(p.VCenters[0].Datacenters) == 0 {
+				// agent-based installation allows the credentials to be optional.
+				// do not validate the vcenters if credentials are not provided
+			} else {
+				// credentials are provided, validate them
 				allErrs = append(allErrs, validateVCenters(p, fldPath.Child("vcenters"))...)
 			}
 		}


### PR DESCRIPTION
Removed the warnings for vSphere credentials.

Added validations to check
* all required credential fields have been filled in if any are provided
* if failureDomains are defined there is a corresponding vcenter with the same server defined

Added new warnings for new fields LoadBalancer and Hosts.