### PR TITLE
AGENT-337: Set VIPs directly in api, instead of install-config override

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
@@ -52,14 +52,12 @@ metadata:
   name: ostest
   namespace: cluster0
 spec:
-  apiVIP: 192.168.111.5
   apiVIPs:
   - 192.168.111.5
   clusterDeploymentRef:
     name: ostest
   imageSetRef:
     name: openshift-was not built correctly
-  ingressVIP: 192.168.111.4
   ingressVIPs:
   - 192.168.111.4
   networking:

--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
@@ -72,14 +72,12 @@ metadata:
   name: ostest
   namespace: cluster0
 spec:
-  apiVIP: 192.168.111.5
   apiVIPs:
   - 192.168.111.5
   clusterDeploymentRef:
     name: ostest
   imageSetRef:
     name: openshift-was not built correctly
-  ingressVIP: 192.168.111.4
   ingressVIPs:
   - 192.168.111.4
   networking:

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -45,6 +45,13 @@ type AgentClusterInstall struct {
 	Config *hiveext.AgentClusterInstall
 }
 
+type agentClusterInstallOnPremExternalPlatform struct {
+	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
+	PlatformName string `json:"platformName,omitempty"`
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	CloudControllerManager external.CloudControllerManager `json:"cloudControllerManager,omitempty"`
+}
+
 type agentClusterInstallOnPremPlatform struct {
 	// APIVIPs contains the VIP(s) to use for internal API communication. In
 	// dual stack clusters it contains an IPv4 and IPv6 address, otherwise only
@@ -54,13 +61,6 @@ type agentClusterInstallOnPremPlatform struct {
 	// IngressVIPs contains the VIP(s) to use for ingress traffic. In dual stack
 	// clusters it contains an IPv4 and IPv6 address, otherwise only one VIP
 	IngressVIPs []string `json:"ingressVIPs,omitempty"`
-}
-
-type agentClusterInstallOnPremExternalPlatform struct {
-	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
-	PlatformName string `json:"platformName,omitempty"`
-	// CloudControllerManager when set to external, this property will enable an external cloud provider.
-	CloudControllerManager external.CloudControllerManager `json:"cloudControllerManager,omitempty"`
 }
 
 type agentClusterInstallPlatform struct {
@@ -190,17 +190,6 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 		}
 
 		if installConfig.Config.Platform.BareMetal != nil {
-			if len(installConfig.Config.Platform.BareMetal.APIVIPs) > 1 {
-				icOverridden = true
-				icOverrides.Platform = &agentClusterInstallPlatform{
-					BareMetal: &agentClusterInstallOnPremPlatform{
-						APIVIPs:     installConfig.Config.Platform.BareMetal.APIVIPs,
-						IngressVIPs: installConfig.Config.Platform.BareMetal.IngressVIPs,
-					},
-				}
-			}
-			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.BareMetal.APIVIPs[0]
-			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.BareMetal.IngressVIPs[0]
 			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.BareMetal.APIVIPs
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.BareMetal.IngressVIPs
 		} else if installConfig.Config.Platform.VSphere != nil {
@@ -229,8 +218,6 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 					VSphere: &vspherePlatform,
 				}
 			}
-			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.VSphere.APIVIPs[0]
-			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.VSphere.IngressVIPs[0]
 			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.VSphere.APIVIPs
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.VSphere.IngressVIPs
 		} else if installConfig.Config.Platform.External != nil {

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -45,13 +45,6 @@ type AgentClusterInstall struct {
 	Config *hiveext.AgentClusterInstall
 }
 
-type agentClusterInstallOnPremExternalPlatform struct {
-	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
-	PlatformName string `json:"platformName,omitempty"`
-	// CloudControllerManager when set to external, this property will enable an external cloud provider.
-	CloudControllerManager external.CloudControllerManager `json:"cloudControllerManager,omitempty"`
-}
-
 type agentClusterInstallOnPremPlatform struct {
 	// APIVIPs contains the VIP(s) to use for internal API communication. In
 	// dual stack clusters it contains an IPv4 and IPv6 address, otherwise only
@@ -61,6 +54,13 @@ type agentClusterInstallOnPremPlatform struct {
 	// IngressVIPs contains the VIP(s) to use for ingress traffic. In dual stack
 	// clusters it contains an IPv4 and IPv6 address, otherwise only one VIP
 	IngressVIPs []string `json:"ingressVIPs,omitempty"`
+}
+
+type agentClusterInstallOnPremExternalPlatform struct {
+	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
+	PlatformName string `json:"platformName,omitempty"`
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	CloudControllerManager external.CloudControllerManager `json:"cloudControllerManager,omitempty"`
 }
 
 type agentClusterInstallPlatform struct {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -43,9 +43,6 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig()))
 
 	goodACIDualStackVIPs := getGoodACIDualStack()
-	goodACIDualStackVIPs.SetAnnotations(map[string]string{
-		installConfigOverrides: `{"platform":{"baremetal":{"apiVIPs":["192.168.122.10","2001:db8:1111:2222:ffff:ffff:ffff:cafe"],"ingressVIPs":["192.168.122.11","2001:db8:1111:2222:ffff:ffff:ffff:dead"]}}}`,
-	})
 	goodACIDualStackVIPs.Spec.APIVIPs = []string{"192.168.122.10", "2001:db8:1111:2222:ffff:ffff:ffff:cafe"}
 	goodACIDualStackVIPs.Spec.IngressVIPs = []string{"192.168.122.11", "2001:db8:1111:2222:ffff:ffff:ffff:dead"}
 
@@ -87,8 +84,6 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	}
 
 	goodExternalPlatformACI := getGoodACI()
-	goodExternalPlatformACI.Spec.APIVIP = ""
-	goodExternalPlatformACI.Spec.IngressVIP = ""
 	goodExternalPlatformACI.Spec.APIVIPs = nil
 	goodExternalPlatformACI.Spec.IngressVIPs = nil
 	val := true
@@ -110,11 +105,9 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	}
 
 	goodExternalOCIPlatformACI := getGoodACI()
-	goodExternalOCIPlatformACI.Spec.APIVIP = ""
-	goodExternalOCIPlatformACI.Spec.IngressVIP = ""
+	val = true
 	goodExternalOCIPlatformACI.Spec.APIVIPs = nil
 	goodExternalOCIPlatformACI.Spec.IngressVIPs = nil
-	val = true
 	goodExternalOCIPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalOCIPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType
 	goodExternalOCIPlatformACI.Spec.ExternalPlatformSpec = &hiveext.ExternalPlatformSpec{

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -415,8 +415,6 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 				ControlPlaneAgents: 3,
 				WorkerAgents:       5,
 			},
-			APIVIP:       "192.168.122.10",
-			IngressVIP:   "192.168.122.11",
 			APIVIPs:      []string{"192.168.122.10"},
 			IngressVIPs:  []string{"192.168.122.11"},
 			PlatformType: hiveext.BareMetalPlatformType,


### PR DESCRIPTION
The agent installer has been using install-config override to set multiple VIPs since https://github.com/openshift/installer/pull/6530. The fields for multiple fields are avaiable in AgentClustInstall and should be used now that https://issues.redhat.com/browse/AGENT-692 is fixed.