### PR TITLE
OCPBUGS-20403: OpenStack: add SG rules for compact clusters on UPI

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -33,7 +33,7 @@ of this method of installation.
     - [Modify NetworkType (Required for Kuryr SDN)](#modify-networktype-required-for-kuryr-sdn)
   - [Edit Manifests](#edit-manifests)
     - [Remove Machines and MachineSets](#remove-machines-and-machinesets)
-    - [Make control-plane nodes unschedulable](#make-control-plane-nodes-unschedulable)
+    - [Set control-plane nodes to desired schedulable state](#set-control-plane-nodes-to-desired-schedulable-state)
   - [Ignition Config](#ignition-config)
     - [Infra ID](#infra-id)
     - [Bootstrap Ignition](#bootstrap-ignition)
@@ -489,22 +489,26 @@ Leave the compute MachineSets in if you want to create compute machines via the 
 [mao]: https://github.com/openshift/machine-api-operator
 [ccpmso]: https://github.com/openshift/cluster-control-plane-machine-set-operator
 
-### Make control-plane nodes unschedulable
+### Set control-plane nodes to desired schedulable state
 
-Currently [emptying the compute pools][empty-compute-pools] makes control-plane nodes schedulable. But due to a [Kubernetes limitation][kubebug], router pods running on control-plane nodes will not be reachable by the ingress load balancer. Update the scheduler configuration to keep router pods and other workloads off the control-plane nodes:
+Currently [emptying the compute pools][empty-compute-pools] makes control-plane nodes schedulable. Let's update the scheduler configuration to match the desired configuration defined on the `inventory.yaml`:
 <!--- e2e-openstack-upi: INCLUDE START --->
 ```sh
 $ python -c '
 import yaml
+inventory = yaml.safe_load(open("inventory.yaml"))
+inventory_os_compute_nodes_number = inventory["all"]["hosts"]["localhost"]["os_compute_nodes_number"]
 path = "manifests/cluster-scheduler-02-config.yml"
 data = yaml.safe_load(open(path))
-data["spec"]["mastersSchedulable"] = False
+if not inventory_os_compute_nodes_number:
+   data["spec"]["mastersSchedulable"] = True
+else:
+   data["spec"]["mastersSchedulable"] = False
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 ```
 <!--- e2e-openstack-upi: INCLUDE END --->
 
 [empty-compute-pools]: #empty-compute-pools
-[kubebug]: https://github.com/kubernetes/kubernetes/issues/65618
 
 ## Ignition Config
 

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -25,7 +25,6 @@ all:
       os_cp_nodes_number: 3
 
       # Number of provisioned Compute nodes.
-      # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
 
       # The IP addresses of DNS servers to be used for the DNS resolution of
@@ -70,3 +69,6 @@ all:
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
       os_ingressVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(7) }}"
+
+      # Set control-plane nodes to schedule workloads when number of compute nodes is zero
+      os_master_schedulable: "{{ os_compute_nodes_number | int == 0 }}"

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -180,6 +180,30 @@
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
 
+  - name: 'Create master-sg rule "master ingress HTTP (TCP)"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      port_range_min: 80
+      port_range_max: 80
+    when: os_master_schedulable is defined and os_master_schedulable
+
+  - name: 'Create master-sg rule "master ingress HTTPS (TCP)"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      port_range_min: 443
+      port_range_max: 443
+    when: os_master_schedulable is defined and os_master_schedulable
+
+  - name: 'Create master-sg rule "router"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 1936
+      port_range_max: 1936
+    when: os_master_schedulable is defined and os_master_schedulable
 
   - name: 'Create worker-sg rule "ICMP"'
     openstack.cloud.security_group_rule:


### PR DESCRIPTION
Compact clusters have been supported for a while in IPI. To also allow compact clusters on UPI, the security group rules for UPI should be adapted enabling the same ingress traffic that is enabled for workers.