### PR TITLE
OCPBUGS-20364: azure: validation: validate defaultMachinePlatform

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -376,14 +376,18 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	// The assumption here is that since cp and compute arches cannot differ today, it's ok to not check the
 	// default instance as long as it is used in any one place.
 	if !useDefaultInstanceType && defaultInstanceType != "" {
+		architecture := types.Architecture(types.ArchitectureAMD64)
 		if ic.ControlPlane != nil {
-			fieldPath := field.NewPath("platform", "azure", "defaultMachinePlatform")
-			capabilities, err := client.GetVMCapabilities(context.TODO(), defaultInstanceType, ic.Azure.Region)
-			if err != nil {
-				return append(allErrs, field.Invalid(fieldPath.Child("type"), defaultInstanceType, err.Error()))
-			}
-			allErrs = append(allErrs, validateVMArchitecture(fieldPath.Child("type"), defaultInstanceType, ic.ControlPlane.Architecture, capabilities)...)
+			architecture = ic.ControlPlane.Architecture
 		}
+		minReq := computeReq
+		if ic.ControlPlane == nil || ic.ControlPlane.Platform.Azure == nil {
+			minReq = controlPlaneReq
+		}
+		fieldPath := field.NewPath("platform", "azure", "defaultMachinePlatform")
+		ultraSSDEnabled := strings.EqualFold(defaultUltraSSDCapability, "Enabled")
+		allErrs = append(allErrs, ValidateInstanceType(client, fieldPath,
+			ic.Azure.Region, defaultInstanceType, defaultDiskType, minReq, ultraSSDEnabled, defaultVMNetworkingType, defaultZones, architecture)...)
 	}
 	return allErrs
 }


### PR DESCRIPTION
If only `defaultMachinePlatform` is specified, no instance type validation was being done, resulting on installs with invalid instance types when no `controlPlane` and `compute` sections are defined.

Let's make sure it's validated in case it hasn't been used by neither controlPlane nor compute machines.

The only caveat is that `architecture` can only be specified in the `controlPlane` or `compute` stanzas, so we're forced to assume `amd64` when those stanzas are not present.