### PR TITLE
Enforcing the serial execution of the integration tests

### DIFF
--- a/hack/go-integration-test.sh
+++ b/hack/go-integration-test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Example:  ./hack/go-integration-test.sh
 
-go test -parallel 1 -run .Integration ./cmd/... ./data/... ./pkg/... "${@}"
+go test -parallel 1 -p 1 -run .Integration ./cmd/... ./data/... ./pkg/... "${@}"

--- a/hack/go-integration-test.sh
+++ b/hack/go-integration-test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Example:  ./hack/go-integration-test.sh
 
-go test -parallel 1 -p 1 -run .Integration ./cmd/... ./data/... ./pkg/... "${@}"
+go test -parallel 1 -p 1 -timeout 0 -run .Integration ./cmd/... ./data/... ./pkg/... "${@}"


### PR DESCRIPTION
* By default `-p` is equal to `GOMAXPROCS`, forcing it to ensure that the integration tests are executed in parallel
* By default test timeout is 10m, in some cases is not enough, especially when downloading ISO images with a slower network, thus disabling it to avoid intermittent failures (`oc` command may remain hanging)