### PR TITLE
MULTIARCH-4042: Reuse existing Transit Gateway in target Workspace, or create anew

### DIFF
--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -35,14 +35,13 @@ module "pi_network" {
   }
   source = "./power_network"
 
-  cluster_id              = var.cluster_id
-  cloud_instance_id       = module.iaas.si_guid
-  resource_group          = var.powervs_resource_group
-  machine_cidr            = var.machine_v4_cidrs[0]
-  vpc_crn                 = module.vpc.vpc_crn
-  dns_server              = module.dns.dns_server
-  enable_snat             = var.powervs_enable_snat
-  transit_gateway_enabled = var.powervs_transit_gateway_enabled
+  cluster_id        = var.cluster_id
+  cloud_instance_id = module.iaas.si_guid
+  resource_group    = var.powervs_resource_group
+  machine_cidr      = var.machine_v4_cidrs[0]
+  vpc_crn           = module.vpc.vpc_crn
+  dns_server        = module.dns.dns_server
+  enable_snat       = var.powervs_enable_snat
 }
 
 resource "ibm_pi_key" "cluster_key" {
@@ -148,12 +147,13 @@ module "transit_gateway" {
   }
   source = "./transit_gateway"
 
-  cluster_id              = var.cluster_id
-  resource_group          = var.powervs_resource_group
-  service_instance_crn    = module.iaas.si_crn
-  transit_gateway_enabled = var.powervs_transit_gateway_enabled
-  vpc_crn                 = module.vpc.vpc_crn
-  vpc_region              = var.powervs_vpc_region
+  cluster_id               = var.cluster_id
+  resource_group           = var.powervs_resource_group
+  service_instance_crn     = module.iaas.si_crn
+  attached_transit_gateway = var.powervs_attached_transit_gateway
+  tg_connection_vpc_id     = var.powervs_tg_connection_vpc_id
+  vpc_crn                  = module.vpc.vpc_crn
+  vpc_region               = var.powervs_vpc_region
 }
 
 module "iaas" {

--- a/data/data/powervs/cluster/transit_gateway/transit_gateway.tf
+++ b/data/data/powervs/cluster/transit_gateway/transit_gateway.tf
@@ -1,6 +1,6 @@
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_gateway
 resource "ibm_tg_gateway" "transit_gateway" {
-  count          = var.transit_gateway_enabled ? 1 : 0
+  count          = var.attached_transit_gateway == "" ? 1 : 0
   name           = "tg-${var.cluster_id}"
   location       = var.vpc_region
   global         = true
@@ -14,8 +14,8 @@ data "ibm_resource_group" "rg_pvs_ipi_rg" {
 
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_connection
 resource "ibm_tg_connection" "tg_connection_vpc" {
-  count        = var.transit_gateway_enabled ? 1 : 0
-  gateway      = resource.ibm_tg_gateway.transit_gateway[count.index].id
+  count        = var.tg_connection_vpc_id == "" ? 1 : 0
+  gateway      = var.attached_transit_gateway == "" ? resource.ibm_tg_gateway.transit_gateway[0].id : var.attached_transit_gateway
   network_type = "vpc"
   name         = "tg-${var.cluster_id}-conn-vpc"
   network_id   = var.vpc_crn
@@ -23,7 +23,7 @@ resource "ibm_tg_connection" "tg_connection_vpc" {
 
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_connection
 resource "ibm_tg_connection" "tg_connection_pvs" {
-  count        = var.transit_gateway_enabled ? 1 : 0
+  count        = var.attached_transit_gateway == "" ? 1 : 0
   gateway      = resource.ibm_tg_gateway.transit_gateway[count.index].id
   network_type = "power_virtual_server"
   name         = "tg-${var.cluster_id}-conn-pvs"

--- a/data/data/powervs/cluster/transit_gateway/variables.tf
+++ b/data/data/powervs/cluster/transit_gateway/variables.tf
@@ -8,10 +8,14 @@ variable "resource_group" {
   description = "The name of the Power VS resource group to which the user belongs."
 }
 
-variable "transit_gateway_enabled" {
-  type        = bool
-  description = "Boolean indicating if Transit Gateways should be used."
-  default     = false
+variable "attached_transit_gateway" {
+  type        = string
+  description = "The ID of already attached Transit Gateways, if any."
+}
+
+variable "tg_connection_vpc_id" {
+  type        = string
+  description = "ID of a VPC connection to the transit gateway specified in attached_transit_gateway, if any."
 }
 
 variable "service_instance_crn" {

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -93,6 +93,11 @@ variable "powervs_vpc_gateway_attached" {
   default     = false
 }
 
+variable "powervs_tg_connection_vpc_id" {
+  type        = string
+  description = "ID of a VPC connection to the transit gateway specified in attached_transit_gateway, if any."
+}
+
 variable "powervs_vpc_gateway_name" {
   type        = string
   description = "The name of a pre-created VPC gateway. Must be in $powervs_vpc_region"
@@ -115,6 +120,12 @@ variable "powervs_transit_gateway_enabled" {
   type        = bool
   description = "Boolean indicating if Transit Gateways should be used."
   default     = false
+}
+
+variable "powervs_attached_transit_gateway" {
+  type        = string
+  description = "ID of already attached Transit Gateways."
+  default     = ""
 }
 
 ################################################################

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/bluemix-go/crn"
@@ -14,6 +15,7 @@ import (
 	"github.com/IBM/networking-go-sdk/dnssvcsv1"
 	"github.com/IBM/networking-go-sdk/dnszonesv1"
 	"github.com/IBM/networking-go-sdk/resourcerecordsv1"
+	"github.com/IBM/networking-go-sdk/transitgatewayapisv1"
 	"github.com/IBM/networking-go-sdk/zonesv1"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
@@ -42,16 +44,19 @@ type API interface {
 	ListServiceInstances(ctx context.Context) ([]string, error)
 	ServiceInstanceGUIDToName(ctx context.Context, id string) (string, error)
 	GetDatacenterCapabilities(ctx context.Context, region string) (map[string]bool, error)
+	GetAttachedTransitGateway(ctx context.Context, svcInsID string) (string, error)
+	GetTGConnectionVPC(ctx context.Context, gatewayID string, vpcSubnetID string) (string, error)
 }
 
 // Client makes calls to the PowerVS API.
 type Client struct {
-	APIKey         string
-	BXCli          *BxClient
-	managementAPI  *resourcemanagerv2.ResourceManagerV2
-	controllerAPI  *resourcecontrollerv2.ResourceControllerV2
-	vpcAPI         *vpcv1.VpcV1
-	dnsServicesAPI *dnssvcsv1.DnsSvcsV1
+	APIKey            string
+	BXCli             *BxClient
+	managementAPI     *resourcemanagerv2.ResourceManagerV2
+	controllerAPI     *resourcecontrollerv2.ResourceControllerV2
+	vpcAPI            *vpcv1.VpcV1
+	dnsServicesAPI    *dnssvcsv1.DnsSvcsV1
+	transitGatewayAPI *transitgatewayapisv1.TransitGatewayApisV1
 }
 
 // cisServiceID is the Cloud Internet Services' catalog service ID.
@@ -138,6 +143,7 @@ func (c *Client) loadSDKServices() error {
 		c.loadResourceControllerAPI,
 		c.loadVPCV1API,
 		c.loadDNSServicesAPI,
+		c.loadTransitGatewayAPI,
 	}
 
 	// Call all the load functions.
@@ -504,6 +510,22 @@ func (c *Client) loadDNSServicesAPI() error {
 	return nil
 }
 
+func (c *Client) loadTransitGatewayAPI() error {
+	authenticator := &core.IamAuthenticator{
+		ApiKey: c.APIKey,
+	}
+	versionDate := "2023-07-04"
+	tgSvc, err := transitgatewayapisv1.NewTransitGatewayApisV1(&transitgatewayapisv1.TransitGatewayApisV1Options{
+		Authenticator: authenticator,
+		Version:       &versionDate,
+	})
+	if err != nil {
+		return err
+	}
+	c.transitGatewayAPI = tgSvc
+	return nil
+}
+
 // SetVPCServiceURLForRegion will set the VPC Service URL to a specific IBM Cloud Region, in order to access Region scoped resources
 func (c *Client) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
 	regionOptions := c.vpcAPI.NewGetRegionOptions(region)
@@ -663,12 +685,6 @@ func (c *Client) ListServiceInstances(ctx context.Context) ([]string, error) {
 	return serviceInstances, nil
 }
 
-// TransitGatewayEnabledZone returns if a zone is configured for transit gateways rather than cloud connections.
-func TransitGatewayEnabledZone(zone string) bool {
-	// @TBD - HACK.  Waiting for officially supported detection function
-	return zone == "dal10"
-}
-
 // ServiceInstanceGUIDToName returns the name of the matching service instance GUID which was passed in.
 func (c *Client) ServiceInstanceGUIDToName(ctx context.Context, id string) (string, error) {
 	var (
@@ -764,4 +780,112 @@ func (c *Client) GetDatacenterCapabilities(ctx context.Context, region string) (
 		return nil, fmt.Errorf("failed to get datacenter capabilities: %w", err)
 	}
 	return getOk.Payload.Capabilities, nil
+}
+
+// GetAttachedTransitGateway finds an existing Transit Gateway attached to the provided PowerVS cloud instance.
+func (c *Client) GetAttachedTransitGateway(ctx context.Context, svcInsID string) (string, error) {
+	var (
+		gateways []transitgatewayapisv1.TransitGateway
+		gateway  transitgatewayapisv1.TransitGateway
+		err      error
+		conns    []transitgatewayapisv1.TransitConnection
+		conn     transitgatewayapisv1.TransitConnection
+	)
+	gateways, err = c.getTransitGateways(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, gateway = range gateways {
+		conns, err = c.getTransitConnections(ctx, *gateway.ID)
+		if err != nil {
+			return "", err
+		}
+		for _, conn = range conns {
+			if *conn.NetworkType == "power_virtual_server" && strings.Contains(*conn.NetworkID, svcInsID) {
+				return *conn.TransitGateway.ID, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// GetTGConnectionVPC checks if the VPC subnet is attached to the provided Transit Gateway.
+func (c *Client) GetTGConnectionVPC(ctx context.Context, gatewayID string, vpcSubnetID string) (string, error) {
+	conns, err := c.getTransitConnections(ctx, gatewayID)
+	if err != nil {
+		return "", err
+	}
+	for _, conn := range conns {
+		if *conn.NetworkType == "vpc" && strings.Contains(*conn.NetworkID, vpcSubnetID) {
+			return *conn.ID, nil
+		}
+	}
+	return "", nil
+}
+
+func (c *Client) getTransitGateways(ctx context.Context) ([]transitgatewayapisv1.TransitGateway, error) {
+	var (
+		listTransitGatewaysOptions *transitgatewayapisv1.ListTransitGatewaysOptions
+		gatewayCollection          *transitgatewayapisv1.TransitGatewayCollection
+		response                   *core.DetailedResponse
+		err                        error
+		perPage                    int64 = 32
+		moreData                         = true
+	)
+
+	listTransitGatewaysOptions = c.transitGatewayAPI.NewListTransitGatewaysOptions()
+	listTransitGatewaysOptions.Limit = &perPage
+
+	result := []transitgatewayapisv1.TransitGateway{}
+
+	for moreData {
+		// https://github.com/IBM/networking-go-sdk/blob/master/transitgatewayapisv1/transit_gateway_apis_v1.go#L184
+		gatewayCollection, response, err = c.transitGatewayAPI.ListTransitGatewaysWithContext(ctx, listTransitGatewaysOptions)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list transit gateways: %w and the respose is: %s", err, response)
+		}
+
+		result = append(result, gatewayCollection.TransitGateways...)
+
+		if gatewayCollection.Next != nil {
+			listTransitGatewaysOptions.SetStart(*gatewayCollection.Next.Start)
+		}
+
+		moreData = gatewayCollection.Next != nil
+	}
+
+	return result, nil
+}
+
+func (c *Client) getTransitConnections(ctx context.Context, tgID string) ([]transitgatewayapisv1.TransitConnection, error) {
+	var (
+		listConnectionsOptions *transitgatewayapisv1.ListConnectionsOptions
+		connectionCollection   *transitgatewayapisv1.TransitConnectionCollection
+		response               *core.DetailedResponse
+		err                    error
+		perPage                int64 = 32
+		moreData                     = true
+	)
+
+	listConnectionsOptions = c.transitGatewayAPI.NewListConnectionsOptions()
+	listConnectionsOptions.Limit = &perPage
+
+	result := []transitgatewayapisv1.TransitConnection{}
+
+	for moreData {
+		connectionCollection, response, err = c.transitGatewayAPI.ListConnectionsWithContext(ctx, listConnectionsOptions)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list transit gateways: %w and the respose is: %s", err, response)
+		}
+
+		result = append(result, connectionCollection.Connections...)
+
+		if connectionCollection.Next != nil {
+			listConnectionsOptions.SetStart(*connectionCollection.Next.Start)
+		}
+
+		moreData = connectionCollection.Next != nil
+	}
+
+	return result, nil
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -53,6 +53,21 @@ func (mr *MockAPIMockRecorder) GetAPIKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKey", reflect.TypeOf((*MockAPI)(nil).GetAPIKey))
 }
 
+// GetAttachedTransitGateway mocks base method.
+func (m *MockAPI) GetAttachedTransitGateway(ctx context.Context, svcInsID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAttachedTransitGateway", ctx, svcInsID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAttachedTransitGateway indicates an expected call of GetAttachedTransitGateway.
+func (mr *MockAPIMockRecorder) GetAttachedTransitGateway(ctx, svcInsID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttachedTransitGateway", reflect.TypeOf((*MockAPI)(nil).GetAttachedTransitGateway), ctx, svcInsID)
+}
+
 // GetAuthenticatorAPIKeyDetails mocks base method.
 func (m *MockAPI) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error) {
 	m.ctrl.T.Helper()
@@ -171,6 +186,21 @@ func (m *MockAPI) GetSubnetByName(ctx context.Context, subnetName, region string
 func (mr *MockAPIMockRecorder) GetSubnetByName(ctx, subnetName, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetByName", reflect.TypeOf((*MockAPI)(nil).GetSubnetByName), ctx, subnetName, region)
+}
+
+// GetTGConnectionVPC mocks base method.
+func (m *MockAPI) GetTGConnectionVPC(ctx context.Context, gatewayID, vpcSubnetID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTGConnectionVPC", ctx, gatewayID, vpcSubnetID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTGConnectionVPC indicates an expected call of GetTGConnectionVPC.
+func (mr *MockAPIMockRecorder) GetTGConnectionVPC(ctx, gatewayID, vpcSubnetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTGConnectionVPC", reflect.TypeOf((*MockAPI)(nil).GetTGConnectionVPC), ctx, gatewayID, vpcSubnetID)
 }
 
 // GetVPCByName mocks base method.

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -14,58 +14,60 @@ import (
 )
 
 type config struct {
-	APIKey                string `json:"powervs_api_key"`
-	SSHKey                string `json:"powervs_ssh_key"`
-	PowerVSRegion         string `json:"powervs_region"`
-	PowerVSZone           string `json:"powervs_zone"`
-	VPCRegion             string `json:"powervs_vpc_region"`
-	VPCZone               string `json:"powervs_vpc_zone"`
-	COSRegion             string `json:"powervs_cos_region"`
-	PowerVSResourceGroup  string `json:"powervs_resource_group"`
-	CISInstanceCRN        string `json:"powervs_cis_crn"`
-	DNSInstanceGUID       string `json:"powervs_dns_guid"`
-	ImageBucketName       string `json:"powervs_image_bucket_name"`
-	ImageBucketFileName   string `json:"powervs_image_bucket_file_name"`
-	VPCName               string `json:"powervs_vpc_name"`
-	VPCSubnetName         string `json:"powervs_vpc_subnet_name"`
-	VPCPermitted          bool   `json:"powervs_vpc_permitted"`
-	VPCGatewayName        string `json:"powervs_vpc_gateway_name"`
-	VPCGatewayAttached    bool   `json:"powervs_vpc_gateway_attached"`
-	BootstrapMemory       int32  `json:"powervs_bootstrap_memory"`
-	BootstrapProcessors   string `json:"powervs_bootstrap_processors"`
-	MasterMemory          int32  `json:"powervs_master_memory"`
-	MasterProcessors      string `json:"powervs_master_processors"`
-	ProcType              string `json:"powervs_proc_type"`
-	SysType               string `json:"powervs_sys_type"`
-	PublishStrategy       string `json:"powervs_publish_strategy"`
-	EnableSNAT            bool   `json:"powervs_enable_snat"`
-	TransitGatewayEnabled bool   `json:"powervs_transit_gateway_enabled"`
-	ServiceInstanceName   string `json:"powervs_service_instance_name"`
+	APIKey                 string `json:"powervs_api_key"`
+	SSHKey                 string `json:"powervs_ssh_key"`
+	PowerVSRegion          string `json:"powervs_region"`
+	PowerVSZone            string `json:"powervs_zone"`
+	VPCRegion              string `json:"powervs_vpc_region"`
+	VPCZone                string `json:"powervs_vpc_zone"`
+	COSRegion              string `json:"powervs_cos_region"`
+	PowerVSResourceGroup   string `json:"powervs_resource_group"`
+	CISInstanceCRN         string `json:"powervs_cis_crn"`
+	DNSInstanceGUID        string `json:"powervs_dns_guid"`
+	ImageBucketName        string `json:"powervs_image_bucket_name"`
+	ImageBucketFileName    string `json:"powervs_image_bucket_file_name"`
+	VPCName                string `json:"powervs_vpc_name"`
+	VPCSubnetName          string `json:"powervs_vpc_subnet_name"`
+	VPCPermitted           bool   `json:"powervs_vpc_permitted"`
+	VPCGatewayName         string `json:"powervs_vpc_gateway_name"`
+	VPCGatewayAttached     bool   `json:"powervs_vpc_gateway_attached"`
+	BootstrapMemory        int32  `json:"powervs_bootstrap_memory"`
+	BootstrapProcessors    string `json:"powervs_bootstrap_processors"`
+	MasterMemory           int32  `json:"powervs_master_memory"`
+	MasterProcessors       string `json:"powervs_master_processors"`
+	ProcType               string `json:"powervs_proc_type"`
+	SysType                string `json:"powervs_sys_type"`
+	PublishStrategy        string `json:"powervs_publish_strategy"`
+	EnableSNAT             bool   `json:"powervs_enable_snat"`
+	AttachedTransitGateway string `json:"powervs_attached_transit_gateway"`
+	TGConnectionVPCID      string `json:"powervs_tg_connection_vpc_id"`
+	ServiceInstanceName    string `json:"powervs_service_instance_name"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	MasterConfigs         []*machinev1.PowerVSMachineProviderConfig
-	APIKey                string
-	SSHKey                string
-	Region                string
-	Zone                  string
-	ImageBucketName       string
-	ImageBucketFileName   string
-	PowerVSResourceGroup  string
-	CISInstanceCRN        string
-	DNSInstanceCRN        string
-	VPCRegion             string
-	VPCZone               string
-	VPCName               string
-	VPCSubnetName         string
-	VPCPermitted          bool
-	VPCGatewayName        string
-	VPCGatewayAttached    bool
-	PublishStrategy       types.PublishingStrategy
-	EnableSNAT            bool
-	TransitGatewayEnabled bool
-	ServiceInstanceName   string
+	MasterConfigs          []*machinev1.PowerVSMachineProviderConfig
+	APIKey                 string
+	SSHKey                 string
+	Region                 string
+	Zone                   string
+	ImageBucketName        string
+	ImageBucketFileName    string
+	PowerVSResourceGroup   string
+	CISInstanceCRN         string
+	DNSInstanceCRN         string
+	VPCRegion              string
+	VPCZone                string
+	VPCName                string
+	VPCSubnetName          string
+	VPCPermitted           bool
+	VPCGatewayName         string
+	VPCGatewayAttached     bool
+	PublishStrategy        types.PublishingStrategy
+	EnableSNAT             bool
+	AttachedTransitGateway string
+	TGConnectionVPCID      string
+	ServiceInstanceName    string
 }
 
 // TFVars generates Power VS-specific Terraform variables launching the cluster.
@@ -95,33 +97,34 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	}
 
 	cfg := &config{
-		APIKey:                sources.APIKey,
-		SSHKey:                sources.SSHKey,
-		PowerVSRegion:         sources.Region,
-		PowerVSZone:           sources.Zone,
-		VPCRegion:             sources.VPCRegion,
-		VPCZone:               sources.VPCZone,
-		COSRegion:             cosRegion,
-		PowerVSResourceGroup:  sources.PowerVSResourceGroup,
-		CISInstanceCRN:        sources.CISInstanceCRN,
-		DNSInstanceGUID:       dnsGUID,
-		ImageBucketName:       sources.ImageBucketName,
-		ImageBucketFileName:   sources.ImageBucketFileName,
-		VPCName:               sources.VPCName,
-		VPCSubnetName:         sources.VPCSubnetName,
-		VPCPermitted:          sources.VPCPermitted,
-		VPCGatewayName:        sources.VPCGatewayName,
-		VPCGatewayAttached:    sources.VPCGatewayAttached,
-		BootstrapMemory:       masterConfig.MemoryGiB,
-		BootstrapProcessors:   processor,
-		MasterMemory:          masterConfig.MemoryGiB,
-		MasterProcessors:      processor,
-		ProcType:              strings.ToLower(string(masterConfig.ProcessorType)),
-		SysType:               masterConfig.SystemType,
-		PublishStrategy:       string(sources.PublishStrategy),
-		EnableSNAT:            sources.EnableSNAT,
-		TransitGatewayEnabled: sources.TransitGatewayEnabled,
-		ServiceInstanceName:   sources.ServiceInstanceName,
+		APIKey:                 sources.APIKey,
+		SSHKey:                 sources.SSHKey,
+		PowerVSRegion:          sources.Region,
+		PowerVSZone:            sources.Zone,
+		VPCRegion:              sources.VPCRegion,
+		VPCZone:                sources.VPCZone,
+		COSRegion:              cosRegion,
+		PowerVSResourceGroup:   sources.PowerVSResourceGroup,
+		CISInstanceCRN:         sources.CISInstanceCRN,
+		DNSInstanceGUID:        dnsGUID,
+		ImageBucketName:        sources.ImageBucketName,
+		ImageBucketFileName:    sources.ImageBucketFileName,
+		VPCName:                sources.VPCName,
+		VPCSubnetName:          sources.VPCSubnetName,
+		VPCPermitted:           sources.VPCPermitted,
+		VPCGatewayName:         sources.VPCGatewayName,
+		VPCGatewayAttached:     sources.VPCGatewayAttached,
+		BootstrapMemory:        masterConfig.MemoryGiB,
+		BootstrapProcessors:    processor,
+		MasterMemory:           masterConfig.MemoryGiB,
+		MasterProcessors:       processor,
+		ProcType:               strings.ToLower(string(masterConfig.ProcessorType)),
+		SysType:                masterConfig.SystemType,
+		PublishStrategy:        string(sources.PublishStrategy),
+		EnableSNAT:             sources.EnableSNAT,
+		AttachedTransitGateway: sources.AttachedTransitGateway,
+		TGConnectionVPCID:      sources.TGConnectionVPCID,
+		ServiceInstanceName:    sources.ServiceInstanceName,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
We pivoted from the original approach. Skip the part that's been stricken out.

~Presence of Transit Gateway in the target Workspace in PowerVS suggests there is an existing cluster (or other arbitrary workload), and sharing it with the new cluster that the current installer run would create could be a problem. Therefore, we decided to block install from proceeding if we detect such a condition.~

~So, we first get all the TGs in the account, loop through them checking all associated connections of each TG, until finding a match to the target Workspace, or reaching the end.~

With late discovery of limitation as of how many Transit Gateway you can have in an account (default: 10), we decided to allow reuse of existing TGs if one happens to be attached to the target workspace that the installer is working with.

Existing logic around TG was to create a new one if the zone is enabled for TG. So, this PR is altering it so it'd create a new TG only if no existing TG is attached to the target workspace, or it'll opt for reuse. Additional `create_transit_gateway` TF var controls what TF does, and the var is computed by scanning all TGs in the account and see if any is attached to the target workspace.

Tested with 2 workspaces in `dal10` (the only PER/TG enabled zone at this time), 1 has a TG attached, and the other without, and the TF var indeed reflected the intended logic here. My install attempt ultimately failed to complete bootstrap, but before it failed, it had been able to create a new TG, attach it to the target workspace and the newly created VPC. 
```
  "powervs_transit_gateway_enabled": true,
  "powervs_create_transit_gateway": true,
```