### PR TITLE
AGENT-718: Add vSphere credentials to install-config overrides

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
@@ -1,4 +1,4 @@
-# Verify a default configuration for the compact topology on vsphere
+# Verify a default configuration for the compact topology on vsphere when credentials are not provided
 
 exec openshift-install agent create image --dir $WORK
 
@@ -7,6 +7,7 @@ stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
 exists $WORK/agent.x86_64.iso
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
+isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
 
 -- install-config.yaml --
 apiVersion: v1
@@ -44,3 +45,35 @@ metadata:
   name: ostest
   namespace: cluster0
 rendezvousIP: 192.168.111.20
+
+-- expected/agent-cluster-install.yaml --
+metadata:
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  apiVIP: 192.168.111.5
+  clusterDeploymentRef:
+    name: ostest
+  imageSetRef:
+    name: openshift-was not built correctly
+  ingressVIP: 192.168.111.4
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    machineNetwork:
+    - cidr: 192.168.111.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - 172.30.0.0/16
+  platformType: VSphere
+  provisionRequirements:
+    controlPlaneAgents: 3
+  sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  debugInfo:
+    eventsURL: ""
+    logsURL: ""
+  progress:
+    totalPercentage: 0

--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
@@ -1,0 +1,99 @@
+# Verify a default configuration for the compact topology on vsphere with credentials
+
+exec openshift-install agent create image --dir $WORK
+
+stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+    vsphere:
+      apiVips:
+        - 192.168.111.5
+      ingressVips:
+        - 192.168.111.4
+      vcenters:
+      - datacenters:
+        - testDatacenter
+        password: testPassword
+        server: vcenter.openshift.com
+        user: testUser
+      failuredomains:
+      - name: testfailureDomain
+        server: vcenter.openshift.com
+        region: testRegion
+        topology:
+          datacenter: testDatacenter
+          datastore: /testDatacenter/datastore/testDatastore
+          computeCluster: /testDatacenter/host/testComputecluster
+          folder: /testDatacenter/vm/testFolder
+          networks:
+          - testNetwork
+        zone: testZone
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+
+-- expected/agent-cluster-install.yaml --
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"vsphere":{"vcenters":[{"server":"vcenter.openshift.com","user":"testUser","password":"testPassword","datacenters":["testDatacenter"]}],"failureDomains":[{"name":"testfailureDomain","region":"testRegion","zone":"testZone","server":"vcenter.openshift.com","topology":{"datacenter":"testDatacenter","computeCluster":"/testDatacenter/host/testComputecluster","networks":["testNetwork"],"datastore":"/testDatacenter/datastore/testDatastore","resourcePool":"/testDatacenter/host/testComputecluster//Resources","folder":"/testDatacenter/vm/testFolder"}}]}}}'
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  apiVIP: 192.168.111.5
+  clusterDeploymentRef:
+    name: ostest
+  imageSetRef:
+    name: openshift-was not built correctly
+  ingressVIP: 192.168.111.4
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    machineNetwork:
+    - cidr: 192.168.111.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - 172.30.0.0/16
+  platformType: VSphere
+  provisionRequirements:
+    controlPlaneAgents: 3
+  sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  debugInfo:
+    eventsURL: ""
+    logsURL: ""
+  progress:
+    totalPercentage: 0

--- a/cmd/openshift-install/testdata/agent/image/validations/vsphere_with-partial-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/vsphere_with-partial-credentials.txt
@@ -1,0 +1,62 @@
+! exec openshift-install agent create image --dir $WORK
+
+stderr 'Invalid value: "diff.openshift.com": server does not exist in vcenters'
+stderr 'Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs'
+
+! exists $WORK/agent.x86_64.iso
+! exists $WORK/auth/kubeconfig
+! exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+    vsphere:
+      apiVips:
+        - 192.168.111.5
+      ingressVips:
+        - 192.168.111.4
+      vcenters:
+      - datacenters:
+        - testDatacenter
+        password: testPassword
+        server: vcenter.openshift.com
+        user: testUser
+      failuredomains:
+      - name: testfailureDomain
+        server: diff.openshift.com
+        region: testRegion
+        topology:
+          datacenter: testDatacenter
+          datastore: /testDatacenter/datastore/testDatastore
+          computeCluster: /testDatacenter/host/testComputecluster
+          networks:
+          - testNetwork
+        zone: testZone
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -175,7 +175,7 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 	return allErrs
 }
 
-// VcenterCredentialsAreProvider returns true if server, username, password, and at least one datacenter
+// VCenterCredentialsAreProvided returns true if server, username, password, and at least one datacenter
 // have been provided.
 func VCenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
 	if vcenter.Server != "" || vcenter.Username != "" || vcenter.Password != "" || len(vcenter.Datacenters) > 0 {

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -222,11 +222,6 @@ func (a *OptionalInstallConfig) validateVSpherePlatform(installConfig *types.Ins
 	}
 
 	for _, failureDomain := range vspherePlatform.FailureDomains {
-		// if !vcenterServers[failureDomain.Server] {
-		// 	fieldPath := field.NewPath("Platform", "VSphere", "failureDomains", "Server")
-		// 	allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("failureDomain server %v must have a corresponding vcenter server defined", failureDomain.Server)))
-		// }
-
 		// Although folder is optional in IPI/UPI, it is must be set for agent-based installs.
 		// If it is not set, assisted-service will set a placeholder value for folder:
 		// "/datacenterplaceholder/vm/folderplaceholder"

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -175,7 +175,9 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 	return allErrs
 }
 
-func vcenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
+// VcenterCredentialsAreProvider returns true if server, username, password, and at least one datacenter
+// have been provided.
+func VCenterCredentialsAreProvided(vcenter vsphere.VCenter) bool {
 	if vcenter.Server != "" || vcenter.Username != "" || vcenter.Password != "" || len(vcenter.Datacenters) > 0 {
 		return true
 	}
@@ -191,7 +193,7 @@ func (a *OptionalInstallConfig) validateVSpherePlatform(installConfig *types.Ins
 		vcenterServers[vcenter.Server] = true
 
 		// If any one of the required credential values is entered, then the user is choosing to enter credentials
-		if vcenterCredentialsAreProvided(vcenter) {
+		if VCenterCredentialsAreProvided(vcenter) {
 			// Then check all required credential values are filled
 			userProvidedCredentials = true
 			if !(vcenter.Server != "" && vcenter.Username != "" && vcenter.Password != "" && len(vcenter.Datacenters) > 0) {

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -107,7 +107,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "ingressVIP missing and vcenter vSphere credentials are present",
@@ -120,12 +120,24 @@ platform:
   vsphere:
     apiVips:
       - 192.168.122.10
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
       password: testpassword
-      datacenters: 
+      datacenters:
       - testDatacenter
+    failureDomains:
+    - name: testFailuredomain
+      server: test.vcenter.com
+      zone: testZone
+      region: testRegion
+      topology:
+        computeCluster: "/testDatacenter/host/testcluster"
+        datacenter: testDatacenter
+        datastore: "/testDatacenter/datastore/testDatastore"
+        folder: "/testDatacenter/vm/testFolder"
+        networks:
+        - testNetwork
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
@@ -144,24 +156,39 @@ platform:
       - 192.168.122.10
     ingressVips:
       - 192.168.122.11
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
       password: testpassword
-      datacenters: 
-      - testDatacenter
-    - server: vcenter2.vcenter.com
-      user: testuser
-      password: testpassword
-      datacenters: 
+      datacenters:
       - testDatacenter
     failureDomains:
-    - server: different.vcenter.com
-    - server: vcenter2.vcenter.com
+    - name: testFailuredomain
+      server: diff1.vcenter.com
+      zone: testZone
+      region: testRegion
+      topology:
+        computeCluster: "/testDatacenter/host/testcluster"
+        datacenter: testDatacenter
+        datastore: "/testDatacenter/datastore/testDatastore"
+        folder: "/testDatacenter/vm/testFolder"
+        networks:
+        - testNetwork
+    - name: testFailuredomain2
+      server: diff2.vcenter.com
+      zone: testZone2
+      region: testRegion2
+      topology:
+        computeCluster: "/testDatacenter2/host/testcluster2"
+        datacenter: testDatacenter2
+        datastore: "/testDatacenter2/datastore/testDatastore2"
+        folder: "/testDatacenter2/vm/testFolder"
+        networks:
+        - testNetwork2
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: Platform.VSphere.failureDomains.Server: Required value: failureDomain server different.vcenter.com must have a corresponding vcenter server defined`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.failureDomains.server: Invalid value: "diff1.vcenter.com": server does not exist in vcenters, platform.vsphere.failureDomains.server: Invalid value: "diff2.vcenter.com": server does not exist in vcenters]`,
 		},
 		{
 			name: "All required vSphere fields must be entered if some of them are entered - deprecated fields",
@@ -180,7 +207,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified]`,
+			expectedError: `invalid install-config configuration: [Platform.VSphere.username: Required value: All credential fields are required if any one is specified, Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "All required vSphere fields must be entered if some of them are entered - vcenter fields",
@@ -195,13 +222,13 @@ platform:
       - 192.168.122.10
     ingressVips:
       - 192.168.122.11
-    vcenters: 
+    vcenters:
     - server: test.vcenter.com
       user: testuser
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified]`,
+			expectedError: `invalid install-config configuration: [Platform.VSphere.password: Required value: All credential fields are required if any one is specified, Platform.VSphere.datacenter: Required value: All credential fields are required if any one is specified, Platform.VSphere.failureDomains.topology.folder: Required value: must specify a folder for agent-based installs]`,
 		},
 		{
 			name: "ingressVIP missing for vSphere, credentials not provided and should not flag error",
@@ -728,6 +755,7 @@ platform:
     password: testPassword
     datacenter: testDataCenter
     defaultDataStore: testDefaultDataStore
+    folder: testFolder
     cluster: testCluster
     apiVIP: 192.168.122.10
     ingressVIPs: 
@@ -779,6 +807,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						DeprecatedDatacenter:       "testDataCenter",
 						DeprecatedCluster:          "testCluster",
 						DeprecatedDefaultDatastore: "testDefaultDataStore",
+						DeprecatedFolder:           "testFolder",
 						DeprecatedAPIVIP:           "192.168.122.10",
 						APIVIPs:                    []string{"192.168.122.10"},
 						IngressVIPs:                []string{"192.168.122.11"},
@@ -800,7 +829,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 								Networks:       []string{""},
 								Datastore:      "/testDataCenter/datastore/testDefaultDataStore",
 								ResourcePool:   "/testDataCenter/host/testCluster//Resources",
-								Folder:         "",
+								Folder:         "/testDataCenter/vm/testFolder",
 							},
 						}},
 					},

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -13,9 +13,12 @@ import (
 var localLogger = logrus.New()
 
 const (
-	GeneratedFailureDomainName   string = "generated-failure-domain"
+	// GeneratedFailureDomainName is a placeholder name when one wasn't provided.
+	GeneratedFailureDomainName string = "generated-failure-domain"
+	// GeneratedFailureDomainRegion is a placeholder region when one wasn't provided.
 	GeneratedFailureDomainRegion string = "generated-region"
-	GeneratedFailureDomainZone   string = "generated-zone"
+	// GeneratedFailureDomainZone is a placeholder zone when one wasn't provided.
+	GeneratedFailureDomainZone string = "generated-zone"
 )
 
 // ConvertInstallConfig modifies a given platform spec for the new requirements.

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -12,6 +12,12 @@ import (
 
 var localLogger = logrus.New()
 
+const (
+	GeneratedFailureDomainName   string = "generated-failure-domain"
+	GeneratedFailureDomainRegion string = "generated-region"
+	GeneratedFailureDomainZone   string = "generated-zone"
+)
+
 // ConvertInstallConfig modifies a given platform spec for the new requirements.
 func ConvertInstallConfig(config *types.InstallConfig) error {
 	platform := config.Platform.VSphere
@@ -55,10 +61,10 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 		localLogger.Warn("vsphere topology fields are now depreciated please use failureDomains")
 
 		platform.FailureDomains = make([]vsphere.FailureDomain, 1)
-		platform.FailureDomains[0].Name = "generated-failure-domain"
+		platform.FailureDomains[0].Name = GeneratedFailureDomainName
 		platform.FailureDomains[0].Server = platform.VCenters[0].Server
-		platform.FailureDomains[0].Region = "generated-region"
-		platform.FailureDomains[0].Zone = "generated-zone"
+		platform.FailureDomains[0].Region = GeneratedFailureDomainRegion
+		platform.FailureDomains[0].Zone = GeneratedFailureDomainZone
 
 		platform.FailureDomains[0].Topology.Datacenter = platform.DeprecatedDatacenter
 		platform.FailureDomains[0].Topology.ResourcePool = platform.DeprecatedResourcePool


### PR DESCRIPTION
If vSphere credentials are present in install-config.yaml, they are passed through as a install-config override annotation in AgentClusterInstall.

If vSphere credentials are not present, then nothing is added to the install-config override.

Requires: https://github.com/openshift/installer/pull/7572