### PR TITLE
[release-4.14] OCPBUGS-20396: Unable to disable external CCM for platform external

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/external_compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/external_compact.txt
@@ -33,6 +33,7 @@ networking:
 platform:
   external:
     platformName: oci
+    cloudControllerManager: External
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 
@@ -45,6 +46,8 @@ rendezvousIP: 192.168.111.20
 
 -- expected/agent-cluster-install.yaml --
 metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"external":{"platformName":"oci","cloudControllerManager":"External"}}}'
   creationTimestamp: null
   name: ostest
   namespace: cluster0

--- a/cmd/openshift-install/testdata/agent/image/configurations/external_with_bootArtifactsBaseURL_minimal_iso.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/external_with_bootArtifactsBaseURL_minimal_iso.txt
@@ -34,6 +34,7 @@ networking:
 platform:
     external:
       platformName: oci
+      cloudControllerManager: External
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/cmd/openshift-install/testdata/agent/image/configurations/external_without_bootArtifactsBaseURL_minimal_iso.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/external_without_bootArtifactsBaseURL_minimal_iso.txt
@@ -33,6 +33,7 @@ networking:
 platform:
     external:
       platformName: oci
+      cloudControllerManager: External
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/cmd/openshift-install/testdata/agent/image/configurations/sno_external_platform.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/sno_external_platform.txt
@@ -30,6 +30,7 @@ networking:
 platform:
   external:
     platformName: oci
+    cloudControllerManager: External
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/cmd/openshift-install/testdata/agent/pxe/configurations/compact_external.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/compact_external.txt
@@ -41,6 +41,7 @@ networking:
 platform:
   external:
     platformName: oci
+    cloudControllerManager: External
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
@@ -96,9 +97,16 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(installConfig.Platform)) {
 		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedInstallerPlatforms()))
 	}
-	fieldPath = field.NewPath("Platform", "External", "PlatformName")
-	if installConfig.Platform.Name() == external.Name && installConfig.Platform.External.PlatformName != "oci" {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.External.PlatformName, []string{"oci"}))
+	if installConfig.Platform.Name() == external.Name {
+		if installConfig.Platform.External.PlatformName != string(models.PlatformTypeOci) {
+			fieldPath = field.NewPath("Platform", "External", "PlatformName")
+			allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.External.PlatformName, []string{string(models.PlatformTypeOci)}))
+		}
+		if installConfig.Platform.External.PlatformName == string(models.PlatformTypeOci) &&
+			installConfig.Platform.External.CloudControllerManager != external.CloudControllerManagerTypeExternal {
+			fieldPath = field.NewPath("Platform", "External", "CloudControllerManager")
+			allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.External.CloudControllerManager, fmt.Sprintf("When using external %s platform, %s must be set to %s", string(models.PlatformTypeOci), fieldPath, external.CloudControllerManagerTypeExternal)))
+		}
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -227,6 +227,21 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: `invalid install-config configuration: Platform.External.PlatformName: Unsupported value: "some-cloud-provider": supported values: "oci"`,
 		},
 		{
+			name: "unsupported CloudControllerManager for external platform",
+			data: `
+apiVersion: v1
+metadata:
+    name: test-cluster
+baseDomain: test-domain
+platform:
+  external:
+    platformName: oci
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: `invalid install-config configuration: Platform.External.CloudControllerManager: Invalid value: "": When using external oci platform, Platform.External.CloudControllerManager must be set to External`,
+		},
+		{
 			name: "valid configuration for none platform for sno",
 			data: `
 apiVersion: v1


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/installer/pull/7533
___
Adds a validation that cloudControllerManager field must be set to External when using oci as the external platform.
The default value for cloudControllerManager is an empty string. Pass cloudControllerManager field value through to the install-config overrides so that assisted-service uses it in the install-config which ultimately generates the Infrastructure manifest