### PR TITLE
MIXEDARCH-310: Enable the use of the multi payload for agent installer

### DIFF
--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -98,7 +98,7 @@ func (a *AgentArtifacts) fetchAgentTuiFiles(releaseImage string, pullSecret stri
 	files := []string{}
 
 	for _, srcFile := range agentTuiFilenames {
-		extracted, err := release.ExtractFile("agent-installer-utils", srcFile)
+		extracted, err := release.ExtractFile("agent-installer-utils", srcFile, a.CPUArch)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Enable the use of multi payload for the agent installer by adding the --filter-by-os flag when using oc
[Dockerfile.assisted-service.ocp](https://github.com/openshift/assisted-service/blob/c829a60a395054bdb9d77388e56d0d0420ef9670/Dockerfile.assisted-service.ocp#L24) is missing skopeo as a dependency. The PR to fix the problem is [here](https://github.com/openshift/assisted-service/pull/5558)