### PR TITLE
OCPBUGS-21781: Rectify GCP label key validation check

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -67,7 +67,7 @@ var (
 	}()
 
 	// userLabelKeyRegex is for verifying that the label key contains only allowed characters.
-	userLabelKeyRegex = regexp.MustCompile(`^[a-z][0-9a-z_-]{1,62}$`)
+	userLabelKeyRegex = regexp.MustCompile(`^[a-z][0-9a-z_-]{0,62}$`)
 
 	// userLabelValueRegex is for verifying that the label value contains only allowed characters.
 	userLabelValueRegex = regexp.MustCompile(`^[0-9a-z_-]{1,63}$`)


### PR DESCRIPTION
Regex check used for validating GCP label key configured in install-config expects minimum two characters for the key, which is corrected to accept minimum 1 character and maximum of 63 characters.