### PR TITLE
OCPBUGS-22113: Do not generate azure-cloud-provider in manual mode for aro builds

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -270,7 +270,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		assetData["99_baremetal-provisioning-config.yaml"] = applyTemplateData(baremetalConfig.Files()[0].Data, bmTemplateData)
 	}
 
-	if platform == azuretypes.Name && installConfig.Config.Azure.IsARO() {
+	if platform == azuretypes.Name && installConfig.Config.Azure.IsARO() && installConfig.Config.CredentialsMode != types.ManualCredentialsMode {
 		// config is used to created compatible secret to trigger azure cloud
 		// controller config merge behaviour
 		// https://github.com/openshift/origin/blob/90c050f5afb4c52ace82b15e126efe98fa798d88/vendor/k8s.io/legacy-cloud-providers/azure/azure_config.go#L83


### PR DESCRIPTION
[OCPBUGS-22113](https://issues.redhat.com/browse/OCPBUGS-22113):

Builds created with tags=aro result in azure-cloud-provider being generated with the service principal clientID used by the installer.
This results in kube-controller-manager crashlooping, unable to authenticate without the service principal's certificate.
azure-cloud-provider should not be generated in Manual mode.