### PR TITLE
OCPBUGS-22231: ic/platformpermscheck: fix segfault

### DIFF
--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -75,7 +75,10 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 		if ic.Config.AWS.DefaultMachinePlatform != nil && ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume != ec2RootVolume {
 			awsMachinePoolUsingKMS = len(ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume.KMSKeyARN) != 0
 		}
-		if ic.Config.ControlPlane.Name == types.MachinePoolControlPlaneRoleName && ic.Config.ControlPlane.Platform.AWS.EC2RootVolume != ec2RootVolume {
+		if ic.Config.ControlPlane != nil &&
+			ic.Config.ControlPlane.Name == types.MachinePoolControlPlaneRoleName &&
+			ic.Config.ControlPlane.Platform.AWS != nil &&
+			ic.Config.ControlPlane.Platform.AWS.EC2RootVolume != ec2RootVolume {
 			masterMachinePoolUsingKMS = len(ic.Config.ControlPlane.Platform.AWS.EC2RootVolume.KMSKeyARN) != 0
 		}
 		// Add KMS encryption keys, if provided.


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/openshift/installer/pull/7428 where the control plane stanza has to be checked for `nil` before being accessed, otherwise causing

```
INFO Consuming Common Manifests from target directory
INFO Consuming OpenShift Install (Manifests) from target directory
INFO Consuming Openshift Manifests from target directory
INFO Consuming Worker Machines from target directory
INFO Consuming Master Machines from target directory
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3a30487]

goroutine 1 [running]:
github.com/openshift/installer/pkg/asset/installconfig.(*PlatformPermsCheck).Generate(0xc000184000?, 0x5?)
	/go/src/github.com/openshift/installer/pkg/asset/installconfig/platformpermscheck.go:78 +0x367
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc000d43800, {0x228056b0, 0x277614e0}, {0x832739a, 0x2})
	/go/src/github.com/openshift/installer/pkg/asset/store/store.go:226 +0x743
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc000d43800, {0x7f3bf82c3b00, 0x277102b0}, {0x0, 0x0})
	/go/src/github.com/openshift/installer/pkg/asset/store/store.go:220 +0x5ad
github.com/openshift/installer/pkg/asset/store.(*storeImpl).Fetch(0x7ffe4e8f6c4c?, {0x7f3bf82c3b00, 0x277102b0}, {0x275a1480, 0x8, 0x8})
	/go/src/github.com/openshift/installer/pkg/asset/store/store.go:76 +0x48
main.runTargetCmd.func1({0x7ffe4e8f6c4c, 0x7})
	/go/src/github.com/openshift/installer/cmd/openshift-install/create.go:272 +0x126
main.runTargetCmd.func2(0x275a9320?, {0xc000529d00?, 0x4?, 0x4?})
	/go/src/github.com/openshift/installer/cmd/openshift-install/create.go:302 +0xe7
github.com/spf13/cobra.(*Command).execute(0x275a9320, {0xc000529cc0, 0x4, 0x4})
	/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xc000c9c000)
	/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:1040 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:968
main.installerMain()
	/go/src/github.com/openshift/installer/cmd/openshift-install/main.go:56 +0x2b0
main.main()
	/go/src/github.com/openshift/installer/cmd/openshift-install/main.go:33 +0x7ffe4e8f6c4c
```