### PR TITLE
Revert #7428 "OCPBUGS-13664: Add KMS encryption keys if provided"

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -38,9 +38,6 @@ const (
 
 	// PermissionDeleteHostedZone is a set of permissions required when the installer destroys a route53 hosted zone.
 	PermissionDeleteHostedZone PermissionGroup = "delete-hosted-zone"
-
-	// PermissionKMSEncryptionKeys is an additional set of permissions required when the installer uses user provided kms encryption keys.
-	PermissionKMSEncryptionKeys PermissionGroup = "kms-encryption-keys"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -246,16 +243,6 @@ var permissions = map[PermissionGroup][]string{
 	},
 	PermissionDeleteHostedZone: {
 		"route53:DeleteHostedZone",
-	},
-	PermissionKMSEncryptionKeys: {
-		"kms:Decrypt",
-		"kms:Encrypt",
-		"kms:GenerateDataKey",
-		"kms:GenerateDataKeyWithoutPlainText",
-		"kms:DescribeKey",
-		"kms:RevokeGrant",
-		"kms:CreateGrant",
-		"kms:ListGrants",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
-	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -49,10 +47,8 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	dependencies.Get(ic)
 
 	if ic.Config.CredentialsMode != "" {
-		logrus.Debug("CredentialsMode is set. Skipping platform permissions checks before attempting installation.")
 		return nil
 	}
-	logrus.Debug("CredentialsMode is not set. Performing platform permissions checks before attempting installation.")
 
 	var err error
 	platform := ic.Config.Platform.Name()
@@ -68,20 +64,6 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 
 		if !usingExistingPrivateZone {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateHostedZone)
-		}
-
-		var ec2RootVolume = aws.EC2RootVolume{}
-		var awsMachinePoolUsingKMS, masterMachinePoolUsingKMS bool
-		if ic.Config.AWS.DefaultMachinePlatform != nil && ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume != ec2RootVolume {
-			awsMachinePoolUsingKMS = len(ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume.KMSKeyARN) != 0
-		}
-		if ic.Config.ControlPlane.Name == types.MachinePoolControlPlaneRoleName && ic.Config.ControlPlane.Platform.AWS.EC2RootVolume != ec2RootVolume {
-			masterMachinePoolUsingKMS = len(ic.Config.ControlPlane.Platform.AWS.EC2RootVolume.KMSKeyARN) != 0
-		}
-		// Add KMS encryption keys, if provided.
-		if awsMachinePoolUsingKMS || masterMachinePoolUsingKMS {
-			logrus.Debugf("Adding %s to the group of permissions to validate", awsconfig.PermissionKMSEncryptionKeys)
-			permissionGroups = append(permissionGroups, awsconfig.PermissionKMSEncryptionKeys)
 		}
 
 		// Add delete permissions for non-C2S installs.


### PR DESCRIPTION
Reverts #7428 ; tracked by OCPBUGS-22231

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR broke default install options for AWS.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please ensure there's a test added which fails if the default install options cause a crash as requested by @soltysh .

CC: @pawanpinjarkar

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
