### PR TITLE
OCPBUGS-4038: bootstrap: Skip gatewayd units only on OKD agent-installer

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -181,7 +181,7 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 	if err := AddSystemdUnits(a.Config, "bootstrap/systemd/common/units", templateData, commonEnabledServices); err != nil {
 		return err
 	}
-	if !templateData.IsOKD {
+	if !(templateData.IsOKD && templateData.Invoker == "agent-installer") {
 		if err := AddSystemdUnits(a.Config, "bootstrap/systemd/rhcos/units", templateData, rhcosEnabledServices); err != nil {
 			return err
 		}


### PR DESCRIPTION
Follow up to https://github.com/openshift/installer/pull/7580
/cc @vrutkovs @andfasano 