### PR TITLE
CORS-2933: IBMCloud: Basic service endpoint override

### DIFF
--- a/data/data/ibmcloud/bootstrap/common.tf
+++ b/data/data/ibmcloud/bootstrap/common.tf
@@ -1,6 +1,9 @@
 locals {
-  description      = "Created By OpenShift Installer"
-  public_endpoints = var.ibmcloud_publish_strategy == "External" ? true : false
+  description = "Created By OpenShift Installer"
+  # If any Service Endpoints are being overridden, set visibility to 'private'
+  # for IBM Terraform Provider to use the endpoints JSON file.
+  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],
     var.ibmcloud_extra_tags
@@ -14,4 +17,8 @@ locals {
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.ibmcloud_region
+
+  # Manage endpoints for IBM Cloud services
+  visibility          = local.endpoint_visibility
+  endpoints_file_path = var.ibmcloud_endpoints_json_file
 }

--- a/data/data/ibmcloud/bootstrap/ignition.tf
+++ b/data/data/ibmcloud/bootstrap/ignition.tf
@@ -1,9 +1,18 @@
+locals {
+  # Use the direct COS endpoint if IBM Cloud Service Endpoints are being overridden,
+  # as public and private may not be available. The direct endpoint requires
+  # additional IBM Cloud Account configuration, which must be configured when using
+  # Service Endpoint overrides.
+  cos_endpoint_type = local.endpoint_visibility == "private" ? "direct" : "public"
+}
+
 ############################################
 # COS bucket
 ############################################
 
 resource "ibm_cos_bucket" "bootstrap_ignition" {
   bucket_name          = "${local.prefix}-bootstrap-ignition"
+  endpoint_type        = local.cos_endpoint_type
   resource_instance_id = var.cos_resource_instance_crn
   region_location      = var.ibmcloud_region
   storage_class        = "smart"
@@ -16,9 +25,10 @@ resource "ibm_cos_bucket" "bootstrap_ignition" {
 resource "ibm_cos_bucket_object" "bootstrap_ignition" {
   bucket_crn      = ibm_cos_bucket.bootstrap_ignition.crn
   bucket_location = ibm_cos_bucket.bootstrap_ignition.region_location
-  key             = "bootstrap.ign"
   content_file    = var.ignition_bootstrap_file
+  endpoint_type   = local.cos_endpoint_type
   etag            = filemd5(var.ignition_bootstrap_file)
+  key             = "bootstrap.ign"
 }
 
 ############################################

--- a/data/data/ibmcloud/master/common.tf
+++ b/data/data/ibmcloud/master/common.tf
@@ -1,6 +1,9 @@
 locals {
-  description      = "Created By OpenShift Installer"
-  public_endpoints = var.ibmcloud_publish_strategy == "External" ? true : false
+  description = "Created By OpenShift Installer"
+  # If any Service Endpoints are being overridden, set visibility to 'private'
+  # for IBM Terraform Provider to use the endpoints JSON file.
+  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],
     var.ibmcloud_extra_tags
@@ -14,4 +17,8 @@ locals {
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.ibmcloud_region
+
+  # Manage endpoints for IBM Cloud services
+  visibility          = local.endpoint_visibility
+  endpoints_file_path = var.ibmcloud_endpoints_json_file
 }

--- a/data/data/ibmcloud/network/common.tf
+++ b/data/data/ibmcloud/network/common.tf
@@ -1,6 +1,9 @@
 locals {
-  description      = "Created By OpenShift Installer"
-  public_endpoints = var.ibmcloud_publish_strategy == "External" ? true : false
+  description = "Created By OpenShift Installer"
+  # If any Service Endpoints are being overridden, set visibility to 'private'
+  # for IBM Terraform Provider to use the endpoints JSON file.
+  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],
     var.ibmcloud_extra_tags
@@ -14,4 +17,8 @@ locals {
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.ibmcloud_region
+
+  # Manage endpoints for IBM Cloud services
+  visibility          = local.endpoint_visibility
+  endpoints_file_path = var.ibmcloud_endpoints_json_file
 }

--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -1,9 +1,18 @@
 locals {
-  prefix = var.cluster_id
+  # Use the direct COS endpoint if IBM Cloud Service Endpoints are being overridden,
+  # as public and private may not be available. The direct endpoint requires
+  # additional IBM Cloud Account configuration, which must be configured when using
+  # Service Endpoint overrides.
+  cos_endpoint_type = var.endpoint_visibility == "private" ? "direct" : "public"
+  prefix            = var.cluster_id
 }
 
 resource "ibm_cos_bucket" "images" {
-  bucket_name          = "${local.prefix}-vsi-image"
+  bucket_name = "${local.prefix}-vsi-image"
+  # Use the direct COS endpoint if IBM Cloud Service endpoints are being overridden,
+  # as public and private may not be available. Direct requires additional IBM Cloud
+  # Account configuration
+  endpoint_type        = local.cos_endpoint_type
   resource_instance_id = var.cos_resource_instance_crn
   region_location      = var.region
   storage_class        = "smart"
@@ -13,6 +22,7 @@ resource "ibm_cos_bucket_object" "file" {
   bucket_crn      = ibm_cos_bucket.images.crn
   bucket_location = ibm_cos_bucket.images.region_location
   content_file    = var.image_filepath
+  endpoint_type   = local.cos_endpoint_type
   key             = basename(var.image_filepath)
 }
 

--- a/data/data/ibmcloud/network/image/variables.tf
+++ b/data/data/ibmcloud/network/image/variables.tf
@@ -25,3 +25,7 @@ variable "tags" {
 variable "cos_resource_instance_crn" {
   type = string
 }
+
+variable "endpoint_visibility" {
+  type = string
+}

--- a/data/data/ibmcloud/network/main.tf
+++ b/data/data/ibmcloud/network/main.tf
@@ -48,6 +48,7 @@ module "image" {
   resource_group_id         = local.resource_group_id
   tags                      = local.tags
   cos_resource_instance_crn = ibm_resource_instance.cos.crn
+  endpoint_visibility       = local.endpoint_visibility
 }
 
 ############################################

--- a/data/data/ibmcloud/variables-ibmcloud.tf
+++ b/data/data/ibmcloud/variables-ibmcloud.tf
@@ -55,6 +55,12 @@ variable "ibmcloud_image_filepath" {
 # Top-level module variables (optional)
 #######################################
 
+variable "ibmcloud_endpoints_json_file" {
+  type        = string
+  description = "JSON file containing IBM Cloud service endpoints"
+  default     = ""
+}
+
 variable "ibmcloud_preexisting_vpc" {
   type        = bool
   description = "Specifies whether an existing VPC should be used or a new one created for installation."

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3364,6 +3364,49 @@ spec:
                       resource group where the cluster should be installed. If empty,
                       a new resource group will be created for the cluster.
                     type: string
+                  serviceEndpoints:
+                    description: ServiceEndpoints is a list which contains custom
+                      endpoints to override default service endpoints of IBM Cloud
+                      Services. There must only be one ServiceEndpoint for a service
+                      (no duplicates).
+                    items:
+                      description: IBMCloudServiceEndpoint stores the configuration
+                        of a custom url to override existing defaults of IBM Cloud
+                        Services.
+                      properties:
+                        name:
+                          description: 'name is the name of the IBM Cloud service.
+                            Possible values are: CIS, COS, DNSServices, GlobalSearch,
+                            GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController,
+                            ResourceManager, or VPC. For example, the IBM Cloud Private
+                            IAM service could be configured with the service `name`
+                            of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                            Whereas the IBM Cloud Private VPC service for US South
+                            (Dallas) could be configured with the service `name` of
+                            `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                          enum:
+                          - CIS
+                          - COS
+                          - DNSServices
+                          - GlobalSearch
+                          - GlobalTagging
+                          - HyperProtect
+                          - IAM
+                          - KeyProtect
+                          - ResourceController
+                          - ResourceManager
+                          - VPC
+                          type: string
+                        url:
+                          description: url is fully qualified URI with scheme https,
+                            that overrides the default generated endpoint for a client.
+                            This must be provided and cannot be empty.
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
                   vpcName:
                     description: VPCName is the name of an already existing VPC to
                       be used during cluster creation.

--- a/pkg/asset/cluster/ibmcloud/ibmcloud.go
+++ b/pkg/asset/cluster/ibmcloud/ibmcloud.go
@@ -10,7 +10,8 @@ import (
 )
 
 // Metadata converts an install configuration to IBM Cloud metadata.
-func Metadata(infraID string, config *types.InstallConfig, meta *icibmcloud.Metadata) *ibmcloud.Metadata {
+func Metadata(infraID string, config *types.InstallConfig) *ibmcloud.Metadata {
+	meta := icibmcloud.NewMetadata(config)
 	accountID, _ := meta.AccountID(context.TODO())
 	cisCrn, _ := meta.CISInstanceCRN(context.TODO())
 	dnsInstance, _ := meta.DNSInstance(context.TODO())
@@ -40,6 +41,7 @@ func Metadata(infraID string, config *types.InstallConfig, meta *icibmcloud.Meta
 		DNSInstanceID:     dnsInstanceID,
 		Region:            config.Platform.IBMCloud.Region,
 		ResourceGroupName: config.Platform.IBMCloud.ClusterResourceGroupName(infraID),
+		ServiceEndpoints:  config.Platform.IBMCloud.ServiceEndpoints,
 		Subnets:           subnets,
 		VPC:               config.Platform.IBMCloud.GetVPCName(),
 	}

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -89,7 +89,7 @@ func (m *Metadata) Generate(parents asset.Parents) (err error) {
 	case gcptypes.Name:
 		metadata.ClusterPlatformMetadata.GCP = gcp.Metadata(installConfig.Config)
 	case ibmcloudtypes.Name:
-		metadata.ClusterPlatformMetadata.IBMCloud = ibmcloud.Metadata(clusterID.InfraID, installConfig.Config, installConfig.IBMCloud)
+		metadata.ClusterPlatformMetadata.IBMCloud = ibmcloud.Metadata(clusterID.InfraID, installConfig.Config)
 	case baremetaltypes.Name:
 		metadata.ClusterPlatformMetadata.BareMetal = baremetal.Metadata(installConfig.Config)
 	case ovirttypes.Name:

--- a/pkg/asset/installconfig/ibmcloud/dns.go
+++ b/pkg/asset/installconfig/ibmcloud/dns.go
@@ -23,7 +23,9 @@ type Zone struct {
 
 // GetDNSZone returns a DNS Zone chosen by survey.
 func GetDNSZone() (*Zone, error) {
-	client, err := NewClient()
+	// A pre-existing installConfig with potential serviceEndpoints would be required,
+	// but doesn't exist at this time (generating an installConfig), so we pass nil
+	client, err := NewClient(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/ibmcloud/metadata_test.go
+++ b/pkg/asset/installconfig/ibmcloud/metadata_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/mock"
 	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/responses"
 	"github.com/openshift/installer/pkg/types"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 )
 
 type editMetadata []func(m *Metadata)
@@ -170,7 +171,14 @@ var (
 )
 
 func baseMetadata() *Metadata {
-	return NewMetadata(goodDomain, region, nil, nil)
+	return NewMetadata(&types.InstallConfig{
+		BaseDomain: goodDomain,
+		Platform: types.Platform{
+			IBMCloud: &ibmcloudtypes.Platform{
+				Region: region,
+			},
+		},
+	})
 }
 
 func TestAccountID(t *testing.T) {

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -159,7 +159,7 @@ func (a *InstallConfig) finish(filename string) error {
 		a.Azure = icazure.NewMetadata(a.Config.Azure.CloudName, a.Config.Azure.ARMEndpoint)
 	}
 	if a.Config.IBMCloud != nil {
-		a.IBMCloud = icibmcloud.NewMetadata(a.Config.BaseDomain, a.Config.IBMCloud.Region, a.Config.IBMCloud.ControlPlaneSubnets, a.Config.IBMCloud.ComputeSubnets)
+		a.IBMCloud = icibmcloud.NewMetadata(a.Config)
 	}
 	if a.Config.PowerVS != nil {
 		a.PowerVS = icpowervs.NewMetadata(a.Config.BaseDomain)
@@ -205,7 +205,12 @@ func (a *InstallConfig) platformValidation() error {
 		return icgcp.Validate(client, a.Config)
 	}
 	if a.Config.Platform.IBMCloud != nil {
-		client, err := icibmcloud.NewClient()
+		// Validate the Service Endpoints now, before performing any additional validation of the InstallConfig
+		err := icibmcloud.ValidateServiceEndpoints(a.Config)
+		if err != nil {
+			return err
+		}
+		client, err := icibmcloud.NewClient(a.Config.Platform.IBMCloud.ServiceEndpoints)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -75,7 +75,9 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(errorList.ToAggregate(), "validating credentials")
 		}
 	case ibmcloud.Name:
-		_, err = ibmcloudconfig.NewClient()
+		// A pre-existing installConfig with potential serviceEndpoints would be required,
+		// but doesn't exist at this time (generating an installConfig), so we pass nil
+		_, err = ibmcloudconfig.NewClient(nil)
 		if err != nil {
 			return errors.Wrap(err, "creating IBM Cloud session")
 		}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -123,11 +123,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case ibmcloud.Name:
-		client, err := ibmcloudconfig.NewClient()
+		client, err := ibmcloudconfig.NewClient(ic.Config.Platform.IBMCloud.ServiceEndpoints)
 		if err != nil {
 			return err
 		}
-		err = ibmcloudconfig.ValidatePreExistingPublicDNS(client, ic.Config, ic.IBMCloud)
+		metadata := ibmcloudconfig.NewMetadata(ic.Config)
+		err = ibmcloudconfig.ValidatePreExistingPublicDNS(client, ic.Config, metadata)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/machines/ibmcloud/zones.go
+++ b/pkg/asset/machines/ibmcloud/zones.go
@@ -3,14 +3,15 @@ package ibmcloud
 import (
 	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
 )
 
 // AvailabilityZones returns a list of supported zones for the specified region.
-func AvailabilityZones(region string) ([]string, error) {
+func AvailabilityZones(region string, serviceEndpoints []configv1.IBMCloudServiceEndpoint) ([]string, error) {
 	ctx := context.TODO()
 
-	client, err := ibmcloud.NewClient()
+	client, err := ibmcloud.NewClient(serviceEndpoints)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -301,7 +301,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.IBMCloud.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.IBMCloud)
 		if len(mpool.Zones) == 0 {
-			azs, err := ibmcloud.AvailabilityZones(ic.Platform.IBMCloud.Region)
+			azs, err := ibmcloud.AvailabilityZones(ic.Platform.IBMCloud.Region, ic.Platform.IBMCloud.ServiceEndpoints)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch availability zones")
 			}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -575,7 +575,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.IBMCloud.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.IBMCloud)
 			if len(mpool.Zones) == 0 {
-				azs, err := ibmcloud.AvailabilityZones(ic.Platform.IBMCloud.Region)
+				azs, err := ibmcloud.AvailabilityZones(ic.Platform.IBMCloud.Region, ic.Platform.IBMCloud.ServiceEndpoints)
 				if err != nil {
 					return errors.Wrap(err, "failed to fetch availability zones")
 				}

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -216,7 +216,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		compute.Set(installConfig.Config.WorkerMachinePool().Platform.IBMCloud)
 
 		if len(controlPlane.Zones) == 0 || len(compute.Zones) == 0 {
-			zones, err := ibmcloudmachines.AvailabilityZones(installConfig.Config.IBMCloud.Region)
+			zones, err := ibmcloudmachines.AvailabilityZones(installConfig.Config.IBMCloud.Region, installConfig.Config.Platform.IBMCloud.ServiceEndpoints)
 			if err != nil {
 				return errors.Wrapf(err, "could not get availability zones for %s", installConfig.Config.IBMCloud.Region)
 			}
@@ -237,6 +237,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			subnetNames,
 			controlPlane.Zones,
 			compute.Zones,
+			installConfig.Config.Platform.IBMCloud.ServiceEndpoints,
 		)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -177,7 +177,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 		config.Spec.PrivateZone = &configv1.DNSZone{ID: privateZoneID}
 
 	case ibmcloudtypes.Name:
-		client, err := icibmcloud.NewClient()
+		client, err := icibmcloud.NewClient(installConfig.Config.Platform.IBMCloud.ServiceEndpoints)
 		if err != nil {
 			return errors.Wrap(err, "failed to get IBM Cloud client")
 		}

--- a/pkg/asset/manifests/ibmcloud/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/ibmcloud/cloudproviderconfig_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestCloudProviderConfig(t *testing.T) {
@@ -31,6 +33,7 @@ g2VpcName = ocp4-8pxks-vpc
 g2workerServiceAccountID = 1e1f75646aef447814a6d907cc83fb3c
 g2VpcSubnetNames = ocp4-8pxks-subnet-compute-us-east-1,ocp4-8pxks-subnet-compute-us-east-2,ocp4-8pxks-subnet-compute-us-east-3,ocp4-8pxks-subnet-control-plane-us-east-1,ocp4-8pxks-subnet-control-plane-us-east-2,ocp4-8pxks-subnet-control-plane-us-east-3
 
+
 `
 
 	existingSubnetConfig := `[global]
@@ -48,6 +51,47 @@ g2VpcName = ocp4-hf4vtt-vpc
 g2workerServiceAccountID = 1e1f75646aef447814a6d907cc83fb3c
 g2VpcSubnetNames = existing-subnet-control-plane-eu-gb-1,existing-subnet-control-plane-eu-gb-2,existing-subnet-control-plane-eu-gb-3,existing-subnet-compute-eu-gb-1,existing-subnet-compute-eu-gb-2,existing-subnet-compute-eu-gb-3
 
+
+`
+
+	singleEndpointOverrideConfig := `[global]
+version = 1.1.0
+[kubernetes]
+config-file = ""
+[provider]
+accountID = 1e1f75646aef447814a6d907cc83fb3c
+clusterID = ocp4-ghs4s3
+cluster-default-provider = g2
+region = eu-gb
+g2Credentials = /etc/vpc/ibmcloud_api_key
+g2ResourceGroupName = ocp4-ghs4s3-rg
+g2VpcName = ocp4-ghs4s3-vpc
+g2workerServiceAccountID = 1e1f75646aef447814a6d907cc83fb3c
+g2VpcSubnetNames = existing-subnet-control-plane-eu-gb-1,existing-subnet-control-plane-eu-gb-2,existing-subnet-control-plane-eu-gb-3,existing-subnet-compute-eu-gb-1,existing-subnet-compute-eu-gb-2,existing-subnet-compute-eu-gb-3
+g2EndpointOverride = https://ibmcloud.vpc.override.endpoint.test
+
+
+`
+
+	multiEndpointOverrideConfig := `[global]
+version = 1.1.0
+[kubernetes]
+config-file = ""
+[provider]
+accountID = 1e1f75646aef447814a6d907cc83fb3c
+clusterID = ocp4-ppcj33
+cluster-default-provider = g2
+region = eu-gb
+g2Credentials = /etc/vpc/ibmcloud_api_key
+g2ResourceGroupName = ocp4-ppcj33-rg
+g2VpcName = ocp4-ppcj33-vpc
+g2workerServiceAccountID = 1e1f75646aef447814a6d907cc83fb3c
+g2VpcSubnetNames = existing-subnet-control-plane-eu-gb-1,existing-subnet-control-plane-eu-gb-2,existing-subnet-control-plane-eu-gb-3,existing-subnet-compute-eu-gb-1,existing-subnet-compute-eu-gb-2,existing-subnet-compute-eu-gb-3
+iamEndpointOverride = https://ibmcloud.iam.override.endpoint.test
+g2EndpointOverride = https://ibmcloud.vpc.override.endpoint.test
+rmEndpointOverride = https://ibmcloud.resource-manager.override.endpoint.test
+
+
 `
 
 	eugbZones := []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"}
@@ -63,6 +107,7 @@ g2VpcSubnetNames = existing-subnet-control-plane-eu-gb-1,existing-subnet-control
 		subnets           []string
 		cpZones           []string
 		computeZones      []string
+		serviceEndpoints  []configv1.IBMCloudServiceEndpoint
 		expectedConfig    string
 	}{
 		{
@@ -89,11 +134,59 @@ g2VpcSubnetNames = existing-subnet-control-plane-eu-gb-1,existing-subnet-control
 			computeZones:      eugbZones,
 			expectedConfig:    existingSubnetConfig,
 		},
+		{
+			name:              "single endpoint override config",
+			infraID:           "ocp4-ghs4s3",
+			accountID:         accountID,
+			region:            "eu-gb",
+			resourceGroupName: "ocp4-ghs4s3-rg",
+			vpcName:           "ocp4-ghs4s3-vpc",
+			subnets:           existingSubnets,
+			cpZones:           eugbZones,
+			computeZones:      eugbZones,
+			serviceEndpoints: []configv1.IBMCloudServiceEndpoint{
+				{
+					Name: configv1.IBMCloudServiceVPC,
+					URL:  "https://ibmcloud.vpc.override.endpoint.test",
+				},
+			},
+			expectedConfig: singleEndpointOverrideConfig,
+		},
+		{
+			name:              "multiple endpoint override config",
+			infraID:           "ocp4-ppcj33",
+			accountID:         accountID,
+			region:            "eu-gb",
+			resourceGroupName: "ocp4-ppcj33-rg",
+			vpcName:           "ocp4-ppcj33-vpc",
+			subnets:           existingSubnets,
+			cpZones:           eugbZones,
+			computeZones:      eugbZones,
+			serviceEndpoints: []configv1.IBMCloudServiceEndpoint{
+				{
+					Name: configv1.IBMCloudServiceCOS,
+					URL:  "https://ibmcloud.cos.override.endpoint.test",
+				},
+				{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  "https://ibmcloud.iam.override.endpoint.test",
+				},
+				{
+					Name: configv1.IBMCloudServiceVPC,
+					URL:  "https://ibmcloud.vpc.override.endpoint.test",
+				},
+				{
+					Name: configv1.IBMCloudServiceResourceManager,
+					URL:  "https://ibmcloud.resource-manager.override.endpoint.test",
+				},
+			},
+			expectedConfig: multiEndpointOverrideConfig,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualConfig, err := CloudProviderConfig(tc.infraID, tc.accountID, tc.region, tc.resourceGroupName, tc.vpcName, tc.subnets, tc.cpZones, tc.computeZones)
+			actualConfig, err := CloudProviderConfig(tc.infraID, tc.accountID, tc.region, tc.resourceGroupName, tc.vpcName, tc.subnets, tc.cpZones, tc.computeZones, tc.serviceEndpoints)
 			assert.NoError(t, err, "failed to create cloud provider config")
 			assert.Equal(t, tc.expectedConfig, actualConfig, "unexpected cloud provider config")
 		})

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -215,6 +215,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			CISInstanceCRN:    cisInstanceCRN,
 			DNSInstanceCRN:    dnsInstanceCRN,
 			ProviderType:      configv1.IBMCloudProviderTypeVPC,
+			ServiceEndpoints:  installConfig.Config.Platform.IBMCloud.ServiceEndpoints,
 		}
 	case libvirt.Name:
 		config.Spec.PlatformSpec.Type = configv1.LibvirtPlatformType

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -139,7 +139,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 			},
 		}
 	case ibmcloudtypes.Name:
-		client, err := ibmcloud.NewClient()
+		client, err := ibmcloud.NewClient(installConfig.Config.Platform.IBMCloud.ServiceEndpoints)
 		if err != nil {
 			return err
 		}

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -3,14 +3,19 @@ package bootstrap
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset/cluster"
 	openstackasset "github.com/openshift/installer/pkg/asset/cluster/openstack"
 	osp "github.com/openshift/installer/pkg/destroy/openstack"
 	infra "github.com/openshift/installer/pkg/infrastructure/platform"
+	ibmcloudtfvars "github.com/openshift/installer/pkg/tfvars/ibmcloud"
 	typesazure "github.com/openshift/installer/pkg/types/azure"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -40,6 +45,27 @@ func Destroy(dir string) (err error) {
 	// Azure Stack uses the Azure platform but has its own Terraform configuration.
 	if platform == typesazure.Name && metadata.Azure.CloudName == typesazure.StackCloud {
 		platform = typesazure.StackTerraformName
+	}
+
+	// IBM Cloud allows override of service endpoints, which would be required during bootstrap destroy.
+	// Create a JSON file with overrides, if these endpoints are present
+	if platform == ibmcloudtypes.Name && metadata.IBMCloud != nil && len(metadata.IBMCloud.ServiceEndpoints) > 0 {
+		// Build the JSON containing the endpoint overrides for IBM Cloud Services.
+		jsonData, err := ibmcloudtfvars.CreateEndpointJSON(metadata.IBMCloud.ServiceEndpoints, metadata.IBMCloud.Region)
+		if err != nil {
+			return fmt.Errorf("failed generating endpoint override JSON data for bootstrap destroy: %w", err)
+		}
+		// Since there are ServiceEndpoints, we expect JSON data to be generated.
+		if jsonData == nil {
+			return fmt.Errorf("no endpoint override JSON data generated for set of endpoint overrides")
+		}
+
+		// If JSON data was generated, create the JSON file for IBM Cloud Terraform provider to use during destroy.
+		endpointsFilePath := filepath.Join(dir, ibmcloudtfvars.IBMCloudEndpointJSONFileName)
+		if err := os.WriteFile(endpointsFilePath, jsonData, 0o600); err != nil {
+			return fmt.Errorf("failed to write IBM Cloud service endpoint override JSON file for bootstrap destroy: %w", err)
+		}
+		logrus.Debugf("generated ibm endpoint overrides file: %s", endpointsFilePath)
 	}
 
 	provider, err := infra.ProviderForPlatform(platform)

--- a/pkg/terraform/stages/ibmcloud/stages.go
+++ b/pkg/terraform/stages/ibmcloud/stages.go
@@ -1,9 +1,18 @@
 package ibmcloud
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
 	"github.com/openshift/installer/pkg/terraform/stages"
+	ibmcloudtfvars "github.com/openshift/installer/pkg/tfvars/ibmcloud"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 )
 
 // PlatformStages are the stages to run to provision the infrastructure in IBM Cloud.
@@ -17,11 +26,34 @@ var PlatformStages = []terraform.Stage{
 		"ibmcloud",
 		"bootstrap",
 		[]providers.Provider{providers.IBM},
-		stages.WithNormalBootstrapDestroy(),
+		stages.WithCustomBootstrapDestroy(customBootstrapDestroy),
 	),
 	stages.NewStage(
 		"ibmcloud",
 		"master",
 		[]providers.Provider{providers.IBM},
 	),
+}
+
+func customBootstrapDestroy(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
+	opts := make([]tfexec.DestroyOption, 0, len(varFiles)+1)
+	for _, varFile := range varFiles {
+		opts = append(opts, tfexec.VarFile(varFile))
+	}
+
+	// If these is a endpoint override JSON file in the terraformDir's parent directory (terraformDir isn't available during JSON file creation),
+	// we want to inject that file into the Terraform variables so IBM Cloud Service endpoints are overridden.
+	terraformParentDir := filepath.Dir(terraformDir)
+	endpointOverrideFile := filepath.Join(terraformParentDir, ibmcloudtfvars.IBMCloudEndpointJSONFileName)
+	if _, err := os.Stat(endpointOverrideFile); err == nil {
+		// Set variable to use private endpoints (overrides) from JSON file, via the IBM Cloud Terraform variable: 'ibmcloud_endpoints_json_file'.
+		opts = append(opts, tfexec.Var(fmt.Sprintf("ibmcloud_endpoints_json_file=%s", endpointOverrideFile)))
+		logrus.Debugf("configuring terraform bootstrap destroy with ibm endpoint overrides: %s", endpointOverrideFile)
+	}
+	err := terraform.Destroy(directory, ibmcloudtypes.Name, s, terraformDir, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to destroy bootstrap: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/tfvars/ibmcloud/ibmcloud.go
+++ b/pkg/tfvars/ibmcloud/ibmcloud.go
@@ -2,13 +2,19 @@ package ibmcloud
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	ibmcloudprovider "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1"
 )
+
+// IBMCloudEndpointJSONFileName is the file containing the IBM Cloud Terraform provider's endpoint override JSON.
+const IBMCloudEndpointJSONFileName = "ibmcloud_endpoints_override.json"
 
 // Auth is the collection of credentials that will be used by terrform.
 type Auth struct {
@@ -23,25 +29,26 @@ type DedicatedHost struct {
 
 type config struct {
 	Auth                     `json:",inline"`
-	Region                   string          `json:"ibmcloud_region,omitempty"`
 	BootstrapInstanceType    string          `json:"ibmcloud_bootstrap_instance_type,omitempty"`
 	CISInstanceCRN           string          `json:"ibmcloud_cis_crn,omitempty"`
+	ComputeSubnets           []string        `json:"ibmcloud_compute_subnets,omitempty"`
+	ControlPlaneSubnets      []string        `json:"ibmcloud_control_plane_subnets,omitempty"`
 	DNSInstanceID            string          `json:"ibmcloud_dns_id,omitempty"`
+	EndpointsJSONFile        string          `json:"ibmcloud_endpoints_json_file,omitempty"`
 	ExtraTags                []string        `json:"ibmcloud_extra_tags,omitempty"`
+	ImageFilePath            string          `json:"ibmcloud_image_filepath,omitempty"`
 	MasterAvailabilityZones  []string        `json:"ibmcloud_master_availability_zones"`
-	WorkerAvailabilityZones  []string        `json:"ibmcloud_worker_availability_zones"`
 	MasterInstanceType       string          `json:"ibmcloud_master_instance_type,omitempty"`
 	MasterDedicatedHosts     []DedicatedHost `json:"ibmcloud_master_dedicated_hosts,omitempty"`
-	WorkerDedicatedHosts     []DedicatedHost `json:"ibmcloud_worker_dedicated_hosts,omitempty"`
-	PublishStrategy          string          `json:"ibmcloud_publish_strategy,omitempty"`
 	NetworkResourceGroupName string          `json:"ibmcloud_network_resource_group_name,omitempty"`
-	ResourceGroupName        string          `json:"ibmcloud_resource_group_name,omitempty"`
-	ImageFilePath            string          `json:"ibmcloud_image_filepath,omitempty"`
 	PreexistingVPC           bool            `json:"ibmcloud_preexisting_vpc,omitempty"`
+	PublishStrategy          string          `json:"ibmcloud_publish_strategy,omitempty"`
+	Region                   string          `json:"ibmcloud_region,omitempty"`
+	ResourceGroupName        string          `json:"ibmcloud_resource_group_name,omitempty"`
 	VPC                      string          `json:"ibmcloud_vpc,omitempty"`
 	VPCPermitted             bool            `json:"ibmcloud_vpc_permitted,omitempty"`
-	ControlPlaneSubnets      []string        `json:"ibmcloud_control_plane_subnets,omitempty"`
-	ComputeSubnets           []string        `json:"ibmcloud_compute_subnets,omitempty"`
+	WorkerAvailabilityZones  []string        `json:"ibmcloud_worker_availability_zones"`
+	WorkerDedicatedHosts     []DedicatedHost `json:"ibmcloud_worker_dedicated_hosts,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -49,6 +56,7 @@ type TFVarsSources struct {
 	Auth                     Auth
 	CISInstanceCRN           string
 	DNSInstanceID            string
+	EndpointsJSONFile        string
 	ImageURL                 string
 	MasterConfigs            []*ibmcloudprovider.IBMCloudMachineProviderSpec
 	MasterDedicatedHosts     []DedicatedHost
@@ -96,26 +104,119 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Auth:                     sources.Auth,
 		BootstrapInstanceType:    masterConfig.Profile,
 		CISInstanceCRN:           sources.CISInstanceCRN,
+		ComputeSubnets:           workerSubnets,
+		ControlPlaneSubnets:      masterSubnets,
 		DNSInstanceID:            sources.DNSInstanceID,
+		EndpointsJSONFile:        sources.EndpointsJSONFile,
 		ImageFilePath:            cachedImage,
 		MasterAvailabilityZones:  masterAvailabilityZones,
 		MasterDedicatedHosts:     sources.MasterDedicatedHosts,
 		MasterInstanceType:       masterConfig.Profile,
 		NetworkResourceGroupName: sources.NetworkResourceGroupName,
+		PreexistingVPC:           sources.PreexistingVPC,
 		PublishStrategy:          string(sources.PublishStrategy),
 		Region:                   masterConfig.Region,
 		ResourceGroupName:        sources.ResourceGroupName,
-		WorkerAvailabilityZones:  workerAvailabilityZones,
-		WorkerDedicatedHosts:     sources.WorkerDedicatedHosts,
-		PreexistingVPC:           sources.PreexistingVPC,
 		VPC:                      vpc,
 		VPCPermitted:             sources.VPCPermitted,
-		ControlPlaneSubnets:      masterSubnets,
-		ComputeSubnets:           workerSubnets,
+		WorkerAvailabilityZones:  workerAvailabilityZones,
+		WorkerDedicatedHosts:     sources.WorkerDedicatedHosts,
 
 		// TODO: IBM: Future support
 		// ExtraTags:               masterConfig.Tags,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")
+}
+
+// CreateEndpointJSON creates JSON data containing IBM Cloud service endpoint override mappings.
+func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region string) ([]byte, error) {
+	// If no endpoint overrides, simply return
+	if len(endpoints) == 0 {
+		return nil, nil
+	}
+
+	endpointContents := ibmcloudtypes.EndpointsJSON{}
+	for _, endpoint := range endpoints {
+		switch endpoint.Name {
+		case configv1.IBMCloudServiceCOS:
+			endpointContents.IBMCloudEndpointCOS = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceCIS:
+			endpointContents.IBMCloudEndpointCIS = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceDNSServices:
+			endpointContents.IBMCloudEndpointDNSServices = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceGlobalSearch:
+			endpointContents.IBMCloudEndpointGlobalSearch = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceGlobalTagging:
+			endpointContents.IBMCloudEndpointGlobalTagging = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceHyperProtect:
+			endpointContents.IBMCloudEndpointHyperProtect = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceIAM:
+			endpointContents.IBMCloudEndpointIAM = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceKeyProtect:
+			endpointContents.IBMCloudEndpointKeyProtect = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceResourceController:
+			endpointContents.IBMCloudEndpointResourceController = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceResourceManager:
+			endpointContents.IBMCloudEndpointResourceManager = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		case configv1.IBMCloudServiceVPC:
+			endpointContents.IBMCloudEndpointVPC = &ibmcloudtypes.EndpointsVisibility{
+				Private: map[string]string{
+					region: endpoint.URL,
+				},
+			}
+		default:
+			return nil, fmt.Errorf("unable to build override values for unknown service: %s", endpoint.Name)
+		}
+	}
+	jsonData, err := json.Marshal(endpointContents)
+	if err != nil {
+		return nil, fmt.Errorf("failure building service endpoint override JSON data: %w", err)
+	}
+
+	// If the JSON contains no data, none was populated (jsonData == "{}"), but endpoints is not empty (initial check), that should cause an error (endpoints provided are not supported)
+	if len(jsonData) <= 2 {
+		return nil, fmt.Errorf("unsupported endpoints provided: %s", endpoints)
+	}
+	return jsonData, nil
 }

--- a/pkg/types/ibmcloud/metadata.go
+++ b/pkg/types/ibmcloud/metadata.go
@@ -1,13 +1,16 @@
 package ibmcloud
 
+import configv1 "github.com/openshift/api/config/v1"
+
 // Metadata contains IBM Cloud metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	AccountID         string   `json:"accountID"`
-	BaseDomain        string   `json:"baseDomain"`
-	CISInstanceCRN    string   `json:"cisInstanceCRN,omitempty"`
-	DNSInstanceID     string   `json:"dnsInstanceID,omitempty"`
-	Region            string   `json:"region,omitempty"`
-	ResourceGroupName string   `json:"resourceGroupName,omitempty"`
-	VPC               string   `json:"vpc,omitempty"`
-	Subnets           []string `json:"subnets,omitempty"`
+	AccountID         string                             `json:"accountID"`
+	BaseDomain        string                             `json:"baseDomain"`
+	CISInstanceCRN    string                             `json:"cisInstanceCRN,omitempty"`
+	DNSInstanceID     string                             `json:"dnsInstanceID,omitempty"`
+	Region            string                             `json:"region,omitempty"`
+	ResourceGroupName string                             `json:"resourceGroupName,omitempty"`
+	ServiceEndpoints  []configv1.IBMCloudServiceEndpoint `json:"serviceEndpoints,omitempty"`
+	Subnets           []string                           `json:"subnets,omitempty"`
+	VPC               string                             `json:"vpc,omitempty"`
 }

--- a/pkg/types/ibmcloud/platform.go
+++ b/pkg/types/ibmcloud/platform.go
@@ -1,5 +1,120 @@
 package ibmcloud
 
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	// IBM Cloud Service Endpoint variables are supplied via documentation:
+	// https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints#supported-endpoint-customizations
+
+	// IBMCloudServiceCISVar is the variable name used by the IBM Cloud Terraform Provider to override the CIS endpoint.
+	IBMCloudServiceCISVar string = "IBMCLOUD_CIS_API_ENDPOINT"
+
+	// IBMCloudServiceCOSVar is the variable name used by the IBM Cloud Terraform Provider to override the COS endpoint.
+	IBMCloudServiceCOSVar string = "IBMCLOUD_COS_CONFIG_ENDPOINT"
+
+	// IBMCloudServiceDNSServicesVar is the variable name used by the IBM Cloud Terraform Provider to override the DNS Services endpoint.
+	IBMCloudServiceDNSServicesVar string = "IBMCLOUD_PRIVATE_DNS_API_ENDPOINT"
+
+	// IBMCloudServiceGlobalSearchVar is the variable name used by the IBM Cloud Terraform Provider to override the Global Search endpoint.
+	IBMCloudServiceGlobalSearchVar string = "IBMCLOUD_GS_API_ENDPOINT"
+
+	// IBMCloudServiceGlobalTaggingVar is the variable name used by the IBM Cloud Terraform Provider to override the Global Tagging endpoint.
+	IBMCloudServiceGlobalTaggingVar string = "IBMCLOUD_GT_API_ENDPOINT"
+
+	// IBMCloudServiceHyperProtectVar is the variable name used by the IBM Cloud Terraform Provider to override the Hyper Protect endpoint.
+	IBMCloudServiceHyperProtectVar string = "IBMCLOUD_HPCS_API_ENDPOINT"
+
+	// IBMCloudServiceIAMVar is the variable name used by the IBM Cloud Terraform Provider to override the IAM endpoint.
+	IBMCloudServiceIAMVar string = "IBMCLOUD_IAM_API_ENDPOINT"
+
+	// IBMCloudServiceKeyProtectVar is the variable name used by the IBM Cloud Terraform Provider to override the Key Protect endpoint.
+	IBMCloudServiceKeyProtectVar string = "IBMCLOUD_KP_API_ENDPOINT"
+
+	// IBMCloudServiceResourceControllerVar is the variable name used by the IBM Cloud Terraform Provider to override the Resource Controller endpoint.
+	IBMCloudServiceResourceControllerVar string = "IBMCLOUD_RESOURCE_CONTROLLER_API_ENDPOINT"
+
+	// IBMCloudServiceResourceManagerVar is the variable name used by the IBM Cloud Terraform Provider to override the Resource Manager endpoint.
+	IBMCloudServiceResourceManagerVar string = "IBMCLOUD_RESOURCE_MANAGEMENT_API_ENDPOINT"
+
+	// IBMCloudServiceVPCVar is the variable name used by the IBM Cloud Terraform Provider to override the VPC endpoint.
+	IBMCloudServiceVPCVar string = "IBMCLOUD_IS_NG_API_ENDPOINT"
+)
+
+var (
+	// IBMCloudServiceOverrides is a set of IBM Cloud services allowed to have their endpoints overridden mapped to their override variable.
+	IBMCloudServiceOverrides = map[configv1.IBMCloudServiceName]string{
+		configv1.IBMCloudServiceCIS:                IBMCloudServiceCISVar,
+		configv1.IBMCloudServiceCOS:                IBMCloudServiceCOSVar,
+		configv1.IBMCloudServiceDNSServices:        IBMCloudServiceDNSServicesVar,
+		configv1.IBMCloudServiceGlobalSearch:       IBMCloudServiceGlobalSearchVar,
+		configv1.IBMCloudServiceGlobalTagging:      IBMCloudServiceGlobalTaggingVar,
+		configv1.IBMCloudServiceHyperProtect:       IBMCloudServiceHyperProtectVar,
+		configv1.IBMCloudServiceIAM:                IBMCloudServiceIAMVar,
+		configv1.IBMCloudServiceKeyProtect:         IBMCloudServiceKeyProtectVar,
+		configv1.IBMCloudServiceResourceController: IBMCloudServiceResourceControllerVar,
+		configv1.IBMCloudServiceResourceManager:    IBMCloudServiceResourceManagerVar,
+		configv1.IBMCloudServiceVPC:                IBMCloudServiceVPCVar,
+	}
+)
+
+// EndpointsJSON represents the JSON format to override IBM Cloud Terraform provider utilized service endpoints.
+// https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints#file-structure-for-endpoints-file
+type EndpointsJSON struct {
+	// IBMCloudEndpointCIS contains endpoint mapping for IBM Cloud CIS.
+	IBMCloudEndpointCIS *EndpointsVisibility `json:"IBMCLOUD_CIS_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointCOS contains endpoint mapping for IBM Cloud COS.
+	IBMCloudEndpointCOS *EndpointsVisibility `json:"IBMCLOUD_COS_CONFIG_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointDNSServices contains endpoint mapping for IBM Cloud DNS Services.
+	IBMCloudEndpointDNSServices *EndpointsVisibility `json:"IBMCLOUD_PRIVATE_DNS_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointGlobalSearch contains endpoint mapping for IBM Cloud Global Search.
+	IBMCloudEndpointGlobalSearch *EndpointsVisibility `json:"IBMCLOUD_GS_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointGlobalTagging contains endpoint mapping for IBM Cloud Global Tagging.
+	IBMCloudEndpointGlobalTagging *EndpointsVisibility `json:"IBMCLOUD_GT_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointHyperProtect contains endpoint mapping for IBM Cloud Hyper Protect.
+	IBMCloudEndpointHyperProtect *EndpointsVisibility `json:"IBMCLOUD_HPCS_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointIAM contains endpoint mapping for IBM Cloud IAM.
+	IBMCloudEndpointIAM *EndpointsVisibility `json:"IBMCLOUD_IAM_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointKeyProtect contains endpoint mapping for IBM Cloud Key Protect.
+	IBMCloudEndpointKeyProtect *EndpointsVisibility `json:"IBMCLOUD_KP_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointResourceController contains endpoint mapping for IBM Cloud Resource Controller.
+	IBMCloudEndpointResourceController *EndpointsVisibility `json:"IBMCLOUD_RESOURCE_CONTROLLER_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointResourceManager contains endpoint mapping for IBM Cloud Resource Manager.
+	IBMCloudEndpointResourceManager *EndpointsVisibility `json:"IBMCLOUD_RESOURCE_MANAGEMENT_API_ENDPOINT,omitempty"`
+
+	// IBMCloudEndpointVPC contains endpoint mapping for IBM Cloud VPC.
+	IBMCloudEndpointVPC *EndpointsVisibility `json:"IBMCLOUDIS_NG_API_ENDPOINT,omitempty"`
+}
+
+// EndpointsVisibility contains region mapped endpoint for a service.
+type EndpointsVisibility struct {
+	// Private is a string-string map of a region name to endpoint URL
+	// To prevent maintaining a list of supported regions here, we simply use a map instead of a struct
+	Private map[string]string `json:"private"`
+}
+
+// CheckServiceEndpointOverride checks whether a service has an override endpoint.
+func CheckServiceEndpointOverride(service configv1.IBMCloudServiceName, serviceEndpoints []configv1.IBMCloudServiceEndpoint) string {
+	if len(serviceEndpoints) > 0 {
+		for _, endpoint := range serviceEndpoints {
+			if endpoint.Name == service {
+				return endpoint.URL
+			}
+		}
+	}
+	return ""
+}
+
 // Platform stores all the global configuration that all machinesets use.
 type Platform struct {
 	// Region specifies the IBM Cloud region where the cluster will be
@@ -38,6 +153,12 @@ type Platform struct {
 	// configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// ServiceEndpoints is a list which contains custom endpoints to override default
+	// service endpoints of IBM Cloud Services.
+	// There must only be one ServiceEndpoint for a service (no duplicates).
+	// +optional
+	ServiceEndpoints []configv1.IBMCloudServiceEndpoint `json:"serviceEndpoints,omitempty"`
 }
 
 // ClusterResourceGroupName returns the name of the resource group for the cluster.

--- a/pkg/types/ibmcloud/platform_test.go
+++ b/pkg/types/ibmcloud/platform_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestClusterResourceGroupName(t *testing.T) {
@@ -30,5 +32,43 @@ func TestGetVPCName(t *testing.T) {
 	for _, tc := range testCases {
 		platform.VPCName = tc.vpcName
 		assert.Equal(t, tc.expectedResult, platform.GetVPCName())
+	}
+}
+
+func TestCheckServiceEndpointOverride(t *testing.T) {
+	endpoints := []configv1.IBMCloudServiceEndpoint{
+		{
+			Name: configv1.IBMCloudServiceIAM,
+			URL:  "e2e.unittest.local",
+		},
+		{
+			Name: configv1.IBMCloudServiceCOS,
+			URL:  "e2e.unittest.local",
+		},
+		{
+			Name: configv1.IBMCloudServiceVPC,
+			URL:  "e2e.unittest.local",
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		service        configv1.IBMCloudServiceName
+		expectedResult string
+	}{
+		{
+			name:           "service not found",
+			service:        "new-service",
+			expectedResult: "",
+		},
+		{
+			name:           "service found",
+			service:        configv1.IBMCloudServiceVPC,
+			expectedResult: "e2e.unittest.local",
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedResult, CheckServiceEndpointOverride(tc.service, endpoints))
 	}
 }

--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -1,8 +1,13 @@
 package validation
 
 import (
+	"fmt"
+	"net/url"
+	"regexp"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 )
 
@@ -59,5 +64,68 @@ func ValidatePlatform(p *ibmcloud.Platform, fldPath *field.Path) field.ErrorList
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
+
+	if p.ServiceEndpoints != nil {
+		allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
+	}
 	return allErrs
+}
+
+// validateServiceEndpoints checks that the specified ServiceEndpoints are valid.
+func validateServiceEndpoints(endpoints []configv1.IBMCloudServiceEndpoint, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	tracker := map[configv1.IBMCloudServiceName]int{}
+	for index, endpoint := range endpoints {
+		fldp := fldPath.Index(index)
+		if eindex, ok := tracker[endpoint.Name]; ok {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("name"), endpoint.Name, fmt.Sprintf("duplicate service endpoint not allowed for %s, service endpoint already defined at %s", endpoint.Name, fldPath.Index(eindex))))
+		} else {
+			tracker[endpoint.Name] = index
+		}
+
+		if err := validateServiceURL(endpoint.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("url"), endpoint.URL, err.Error()))
+		}
+	}
+	return allErrs
+}
+
+// schemeRE is used to check whether a string starts with a scheme (URI format).
+var schemeRE = regexp.MustCompile("^([^:]+)://")
+
+// versionPath is the regexp for a trailing API version in URL path ('/v1', '/v22/', etc.)
+var versionPath = regexp.MustCompile(`(/v\d+[/]{0,1})$`)
+
+// validateServiceURL checks that a string meets certain URI expectations.
+func validateServiceURL(uri string) error {
+	endpoint := uri
+	httpsScheme := "https"
+
+	// determine if the endpoint (uri) starts with an URI scheme
+	// add 'https' scheme if not
+	if !schemeRE.MatchString(endpoint) {
+		endpoint = fmt.Sprintf("%s://%s", httpsScheme, endpoint)
+	}
+
+	// verify the endpoint meets the following criteria
+	// 1. contains a hostname
+	// 2. uses 'https' scheme
+	// 3. contains no path or request parameters, except API version paths ('/v1')
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("empty hostname provided, it cannot be empty")
+	}
+	// check the scheme in case one was provided and is not 'https' (we didn't set it above)
+	if s := u.Scheme; s != httpsScheme {
+		return fmt.Errorf("invalid scheme %s, only https is allowed", s)
+	}
+	// check that the path is empty ('/'), or only contains an API version ('/v1'), by using regexp to replace the API version and should result in empty string
+	if r := u.RequestURI(); r != "/" && versionPath.ReplaceAllString(r, "") != "" {
+		return fmt.Errorf("no path or request parameters can be provided, %q was provided", r)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adding basic support to allow overrides of IBM Cloud service endpoints. This is a hard requirement for disconnected cluster support, to allow use of non-default endpoints for IBM Cloud services.