### PR TITLE
bootkube.sh: drop final mention of `machine-os-content`

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -43,7 +43,6 @@ wait_for_etcd_cluster() {
 }
 
 MACHINE_CONFIG_OPERATOR_IMAGE=$(image_for machine-config-operator)
-MACHINE_CONFIG_OSCONTENT=$(image_for machine-os-content)
 MACHINE_CONFIG_ETCD_IMAGE=$(image_for etcd)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 


### PR DESCRIPTION
That variable isn't used anywhere. The last reference was removed as part of 33a74c7d19 ("bootkube: Drop cruft in MCO bootstrap") a while ago.

Part of trying to get rid of `machine-os-content`:

https://issues.redhat.com/browse/MCO-392