### PR TITLE
Bug OCPBUGS-22298: OpenStack: Fix IPv6 address configuration for bootstrap 

### DIFF
--- a/data/data/bootstrap/openstack/files/etc/NetworkManager/conf.d/02-ipv6.conf
+++ b/data/data/bootstrap/openstack/files/etc/NetworkManager/conf.d/02-ipv6.conf
@@ -1,0 +1,2 @@
+[connection]
+ipv6.addr-gen-mode=0

--- a/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
+++ b/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
@@ -1,6 +1,0 @@
-{{ if .UseDualForNodeIP }}
-[connection]
-type=ethernet
-[ipv6]
-method=auto
-{{end}}


### PR DESCRIPTION
When using an additional network in the cluster,
we end up having two conections of ethernet type, the
main one for the control plane and the additional one.
This would result in Network Manager not happy with the current
Network Manager profile. To avoid this issue, the IPv6
configuration for bootstrap is updated to match the
configuration currently applied on masters and workers[1]. This
config named `addr-gen-mode` ensures nodes get the same IPv6 and mac
addresses that were configured in the OpenStack Ports

[1] https://github.com/openshift/machine-config-operator/blob/release-4.15/templates/common/openstack/files/ipv6-config.yaml