### PR TITLE
OCPBUGS-22489: destroy: gcp: fix destroying regional disks

### DIFF
--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -65,24 +65,32 @@ func (o *ClusterUninstaller) listDisksWithFilter(ctx context.Context, fields str
 		for _, scopedList := range list.Items {
 			for _, item := range scopedList.Disks {
 				if filterFunc == nil || filterFunc != nil && filterFunc(item) {
-					zone := o.getZoneName(item.Zone)
-					o.Logger.Debugf("Found disk: %s in zone %s", item.Name, zone)
-					result = append(result, cloudResource{
-						key:      fmt.Sprintf("%s/%s", zone, item.Name),
-						name:     item.Name,
-						typeName: "disk",
-						zone:     zone,
-						quota: []gcp.QuotaUsage{{
-							Metric: &gcp.Metric{
-								Service: gcp.ServiceComputeEngineAPI,
-								Limit:   getDiskLimit(item.Type),
-								Dimensions: map[string]string{
-									"region": getRegionFromZone(zone),
+					// Regional disks are replicated in multiple zones, so we
+					// need to destroy all the replicas
+					zoneUrls := item.ReplicaZones
+					if len(item.Zone) > 0 {
+						zoneUrls = append(zoneUrls, item.Zone)
+					}
+					for _, url := range zoneUrls {
+						zone := o.getZoneName(url)
+						o.Logger.Debugf("Found disk: %s in zone %s", item.Name, zone)
+						result = append(result, cloudResource{
+							key:      fmt.Sprintf("%s/%s", zone, item.Name),
+							name:     item.Name,
+							typeName: "disk",
+							zone:     zone,
+							quota: []gcp.QuotaUsage{{
+								Metric: &gcp.Metric{
+									Service: gcp.ServiceComputeEngineAPI,
+									Limit:   getDiskLimit(item.Type),
+									Dimensions: map[string]string{
+										"region": getRegionFromZone(zone),
+									},
 								},
-							},
-							Amount: item.SizeGb,
-						}},
-					})
+								Amount: item.SizeGb,
+							}},
+						})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Regional disks are replicated in multiple zones but our logic was not taking them into account, only zonal disks. When trying to run `cluster destroy` in a cluster with regional disks, the following panic was observed:

```
time="2023-07-25T10:02:16Z" level=debug msg="Found disk: pvc-c8cf8f18-cd22-441e-b47a-565bed5573ee in zone europe-west2-a"
time="2023-07-25T10:02:16Z" level=debug msg="Found disk: pvc-3e703665-2271-4c16-8bf8-533b5e7be444 in zone "
E0725 10:02:16.633982       1 runtime.go:79] Observed a panic: runtime.boundsError{x:-1, y:0, signed:true, code:0x1} (runtime error: slice bounds out of range [:-1])
goroutine 1 [running]:
[k8s.io/apimachinery/pkg/util/runtime.logPanic(
{0x7b0e040|http://k8s.io/apimachinery/pkg/util/runtime.logPanic(%7B0x7b0e040]?, 0xc00007dde8}

)
                k8s.io/apimachinery@v0.24.1/pkg/util/runtime/runtime.go:75 +0x99
[k8s.io/apimachinery/pkg/util/runtime.HandleCrash(
{0x0|http://k8s.io/apimachinery/pkg/util/runtime.HandleCrash(%7B0x0], 0x0, 0xc000120260?}
)
                k8s.io/apimachinery@v0.24.1/pkg/util/runtime/runtime.go:49 +0x75
panic({0x7b0e040, 0xc00007dde8})
                runtime/panic.go:884 +0x212
github.com/openshift/installer/pkg/destroy/gcp.getRegionFromZone(...)
                github.com/openshift/installer@v0.9.0-master.0.20220901213408-25aa6a41b7ca/pkg/destroy/gcp/gcp.go:204
github.com/openshift/installer/pkg/destroy/gcp.(*ClusterUninstaller).listDisksWithFilter.func1(0xc00165eec0?)
```

This fix includes logic to deal with finding the replicated zones and deleting the disks in all of them.