### PR TITLE
AGENT-739: Support for install-config baremetal host BMC fields

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/baremetal_host_bmc_config.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/baremetal_host_bmc_config.txt
@@ -1,0 +1,163 @@
+# Verify a default configuration for the compact topology on baremetal using install-config hosts with BMC configuration 
+
+exec openshift-install agent create image --dir $WORK
+
+stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.80'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  baremetal:
+    apiVips:
+      - 192.168.111.5
+    ingressVips:
+      - 192.168.111.4
+    provisioningNetworkInterface: enp1s0
+    provisioningNetworkCIDR: 172.22.0.0/24 
+    provisioningNetwork: Managed 
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
+    hosts:
+    - name: master-0 
+      bootMACAddress: 00:00:00:aa:bb:01
+      bmc:
+        address: http://172.22.0.10:8000/redfish/v1/Systems/d3fe1eb9-f04c-465d-b5d6-d267f0a0059b
+        username: foo
+        password: pwd1
+        disableCertificateVerification: false
+      networkConfig:
+        interfaces:
+        - ipv4:
+            address:
+            - ip: 192.168.111.80
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          mac-address: 00:00:00:aa:bb:01
+          name: eth0
+          state: up
+          type: ethernet
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.168.111.1
+            next-hop-interface: eth0
+            table-id: 254
+    - name: master-1
+      bootMACAddress: 00:00:00:aa:bb:02
+      bmc:
+        address: http://172.22.0.11:8000/redfish/v1/Systems/65bf6806-b634-4494-bccf-032ebdecc65d
+        username: foo
+        password: pwd2
+        disableCertificateVerification: false
+      networkConfig:
+        interfaces:
+        - ipv4:
+            address:
+            - ip: 192.168.111.81
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          mac-address: 00:00:00:aa:bb:02
+          name: eth0
+          state: up
+          type: ethernet
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.168.111.1
+            next-hop-interface: eth0
+            table-id: 254
+    - name: master-2
+      bootMACAddress: 00:00:00:aa:bb:03
+      bmc:
+        address: http://172.22.0.12:8000/redfish/v1/Systems/ff67e706-28c4-42f6-b9a2-ce714195300a
+        username: foo
+        password: pwd3
+        disableCertificateVerification: false
+      networkConfig:
+        interfaces:
+        - ipv4:
+            address:
+            - ip: 192.168.111.82
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          mac-address: 00:00:00:aa:bb:03
+          name: eth0
+          state: up
+          type: ethernet
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.168.111.1
+            next-hop-interface: eth0
+            table-id: 254
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.80
+
+-- expected/agent-cluster-install.yaml --
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"baremetal":{"hosts":[{"name":"master-0","bmc":{"username":"foo","password":"pwd1","address":"http://172.22.0.10:8000/redfish/v1/Systems/d3fe1eb9-f04c-465d-b5d6-d267f0a0059b","disableCertificateVerification":false},"role":"","bootMACAddress":"00:00:00:aa:bb:01","hardwareProfile":""},{"name":"master-1","bmc":{"username":"foo","password":"pwd2","address":"http://172.22.0.11:8000/redfish/v1/Systems/65bf6806-b634-4494-bccf-032ebdecc65d","disableCertificateVerification":false},"role":"","bootMACAddress":"00:00:00:aa:bb:02","hardwareProfile":""},{"name":"master-2","bmc":{"username":"foo","password":"pwd3","address":"http://172.22.0.12:8000/redfish/v1/Systems/ff67e706-28c4-42f6-b9a2-ce714195300a","disableCertificateVerification":false},"role":"","bootMACAddress":"00:00:00:aa:bb:03","hardwareProfile":""}],"clusterProvisioningIP":"172.22.0.3","provisioningNetwork":"Managed","provisioningNetworkInterface":"enp1s0","provisioningNetworkCIDR":"172.22.0.0/24","provisioningDHCPRange":"172.22.0.10,172.22.0.254"}}}'
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  apiVIPs:
+  - 192.168.111.5
+  clusterDeploymentRef:
+    name: ostest
+  imageSetRef:
+    name: openshift-was not built correctly
+  ingressVIPs:
+  - 192.168.111.4
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    machineNetwork:
+    - cidr: 192.168.111.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - 172.30.0.0/16
+  platformType: BareMetal
+  provisionRequirements:
+    controlPlaneAgents: 3
+  sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  debugInfo:
+    eventsURL: ""
+    logsURL: ""
+  progress:
+    totalPercentage: 0

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	baremetaldefaults "github.com/openshift/installer/pkg/types/baremetal/defaults"
+	baremetalvalidation "github.com/openshift/installer/pkg/types/baremetal/validation"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/validation"
@@ -119,6 +120,10 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 
 	if installConfig.Platform.Name() == vsphere.Name {
 		allErrs = append(allErrs, a.validateVSpherePlatform(installConfig)...)
+	}
+
+	if installConfig.Platform.Name() == baremetal.Name {
+		allErrs = append(allErrs, a.validateBMCConfig(installConfig)...)
 	}
 
 	return allErrs
@@ -260,6 +265,25 @@ func (a *OptionalInstallConfig) GetBaremetalHosts() []*baremetal.Host {
 	return nil
 }
 
+func (a *OptionalInstallConfig) validateBMCConfig(installConfig *types.InstallConfig) field.ErrorList {
+	var allErrs field.ErrorList
+
+	bmcConfigured := false
+	for _, host := range installConfig.Platform.BareMetal.Hosts {
+		if host.BMC.Address == "" {
+			continue
+		}
+		bmcConfigured = true
+	}
+
+	if bmcConfigured {
+		fieldPath := field.NewPath("Platform", "BareMetal")
+		allErrs = append(allErrs, baremetalvalidation.ValidateProvisioningNetworking(installConfig.Platform.BareMetal, installConfig.Networking, fieldPath)...)
+	}
+
+	return allErrs
+}
+
 func warnUnusedConfig(installConfig *types.InstallConfig) {
 	// "Proxyonly" is the default set from generic install config code
 	if installConfig.AdditionalTrustBundlePolicy != "Proxyonly" {
@@ -302,14 +326,6 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			fieldPath := field.NewPath("Platform", "Baremetal", "LibvirtURI")
 			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.LibvirtURI))
 		}
-		if baremetal.ClusterProvisioningIP != defaultBM.ClusterProvisioningIP {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ClusterProvisioningIP")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ClusterProvisioningIP))
-		}
-		if baremetal.DeprecatedProvisioningHostIP != defaultBM.DeprecatedProvisioningHostIP {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningHostIP")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.DeprecatedProvisioningHostIP))
-		}
 		if baremetal.BootstrapProvisioningIP != defaultBM.BootstrapProvisioningIP {
 			fieldPath := field.NewPath("Platform", "Baremetal", "BootstrapProvisioningIP")
 			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.BootstrapProvisioningIP))
@@ -318,48 +334,12 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			fieldPath := field.NewPath("Platform", "Baremetal", "ExternalBridge")
 			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ExternalBridge))
 		}
-		if baremetal.ProvisioningNetwork != defaultBM.ProvisioningNetwork {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetwork")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetwork))
-		}
 		if baremetal.ProvisioningBridge != defaultBM.ProvisioningBridge {
 			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningBridge")
 			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningBridge))
 		}
-		if baremetal.ProvisioningNetworkInterface != defaultBM.ProvisioningNetworkInterface {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetworkInterface")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetworkInterface))
-		}
-		if baremetal.ProvisioningNetworkCIDR.String() != defaultBM.ProvisioningNetworkCIDR.String() {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetworkCIDR")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetworkCIDR))
-		}
-		if baremetal.DeprecatedProvisioningDHCPExternal != defaultBM.DeprecatedProvisioningDHCPExternal {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningDHCPExternal")
-			logrus.Warnf(fmt.Sprintf("%s: true is ignored", fieldPath))
-		}
-		if baremetal.ProvisioningDHCPRange != defaultBM.ProvisioningDHCPRange {
-			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningDHCPRange")
-			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningDHCPRange))
-		}
 
 		for i, host := range baremetal.Hosts {
-			if host.BMC.Username != "" {
-				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Username")
-				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Username))
-			}
-			if host.BMC.Password != "" {
-				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Password")
-				logrus.Warnf(fmt.Sprintf("%s is ignored", fieldPath))
-			}
-			if host.BMC.Address != "" {
-				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Address")
-				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Address))
-			}
-			if host.BMC.DisableCertificateVerification {
-				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "DisableCertificateVerification")
-				logrus.Warnf(fmt.Sprintf("%s: true is ignored", fieldPath))
-			}
 			// The default is UEFI. +kubebuilder:validation:Enum="";UEFI;UEFISecureBoot;legacy. Set from generic install config code
 			if host.BootMode != "UEFI" {
 				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BootMode")

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -617,8 +617,6 @@ platform:
     hosts:
       - name: host1
         bootMACAddress: 52:54:01:aa:aa:a1
-        bmc:
-          address: addr
       - name: host2
         bootMACAddress: 52:54:01:bb:bb:b1
       - name: host3
@@ -691,7 +689,6 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 								BootMACAddress:  "52:54:01:aa:aa:a1",
 								BootMode:        "UEFI",
 								HardwareProfile: "default",
-								BMC:             baremetal.BMC{Address: "addr"},
 							},
 							{
 								Name:            "host2",
@@ -848,6 +845,102 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},
+		},
+		{
+			name: "provisioningNetwork invalid for baremetal cluster",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+  serviceNetwork:
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64
+    name: worker
+    replicas: 0
+controlPlane:
+  architecture: amd64
+  name: master
+  replicas: 3
+platform:
+  baremetal:
+    provisioningNetwork: "UNMANAGED"
+    ingressVIPs:
+      - 192.168.122.11
+    apiVIPs:
+      - 192.168.122.10
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: platform.baremetal.provisioningNetwork: Unsupported value: \"UNMANAGED\": supported values: \"Disabled\", \"Managed\", \"Unmanaged\"",
+		},
+		{
+			name: "Provisioning validation failures for baremetal cluster",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+  serviceNetwork:
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64
+    name: worker
+    replicas: 0
+controlPlane:
+  architecture: amd64
+  name: master
+  replicas: 3
+platform:
+  baremetal:
+    ingressVIPs:
+      - 192.168.122.11
+    apiVIPs:
+      - 192.168.122.10
+    clusterProvisioningIP: "172.22.0.11"
+    provisioningNetwork: "Managed"
+    provisioningMACAddress: "52:54:00:6e:3b:02"
+    provisioningNetworkInterface: "eth11"
+    provisioningDHCPExternal: true
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
+    hosts:
+      - name: host1
+        bootMACAddress: 52:54:01:aa:aa:a1
+        bmc:
+          username: "admin"
+          password: "password"
+          address: "redfish+http://10.10.10.1:8000/redfish/v1/Systems/1234"
+      - name: host2
+        bootMACAddress: 52:54:01:bb:bb:b1
+        bmc:
+          username: "admin"
+          password: "password"
+          address: "redfish+http://10.10.10.2:8000/redfish/v1/Systems/1234"
+      - name: host3
+        bootMACAddress: 52:54:01:cc:cc:c1
+        bmc:
+          username: "admin"
+          password: "password"
+          address: "redfish+http://10.10.10.2:8000/redfish/v1/Systems/1234"
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: `invalid install-config configuration: [Platform.BareMetal.clusterProvisioningIP: Invalid value: "172.22.0.11": "172.22.0.11" overlaps with the allocated DHCP range, Platform.BareMetal.hosts[2].BMC.Address: Duplicate value: "redfish+http://10.10.10.2:8000/redfish/v1/Systems/1234"]`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -217,6 +217,19 @@ func getAdditionalTrustBundleValidOptionalInstallConfig() *agent.OptionalInstall
 	return validIC
 }
 
+// getValidOptionalInstallConfigWithProvisioning returns a valid optional install config with baremetal provisioning network settings.
+func getValidOptionalInstallConfigWithProvisioning() *agent.OptionalInstallConfig {
+	installConfig := getValidOptionalInstallConfig()
+	installConfig.Config.Platform.BareMetal.ClusterProvisioningIP = "172.22.0.3"
+	installConfig.Config.Platform.BareMetal.ProvisioningNetwork = "Managed"
+	installConfig.Config.Platform.BareMetal.ProvisioningBridge = "ostestpr"
+	installConfig.Config.Platform.BareMetal.ProvisioningMACAddress = "52:54:00:a6:e6:87"
+	installConfig.Config.Platform.BareMetal.ProvisioningNetworkInterface = "eth0"
+	installConfig.Config.Platform.BareMetal.ProvisioningNetworkCIDR = ipnet.MustParseCIDR("172.22.0.0/24")
+	installConfig.Config.Platform.BareMetal.ProvisioningDHCPRange = "172.22.0.10,172.22.0.254"
+	return installConfig
+}
+
 func getValidAgentConfig() *agentconfig.AgentConfig {
 	return &agentconfig.AgentConfig{
 		Config: &agenttypes.Config{
@@ -380,6 +393,61 @@ func getAgentHostsWithSomeHostsWithoutNetworkConfig() *agentconfig.AgentHosts {
 
 func getAgentHostsNoHosts() *agentconfig.AgentHosts {
 	return &agentconfig.AgentHosts{}
+}
+
+func getAgentHostsWithBMCConfig() *agentconfig.AgentHosts {
+	return &agentconfig.AgentHosts{
+		Hosts: []agenttypes.Host{
+			{
+				Hostname: "control-0.example.org",
+				Role:     "master",
+				Interfaces: []*v1beta1.Interface{
+					{
+						Name:       "enp2s0",
+						MacAddress: "98:af:65:a5:8d:01",
+					},
+				},
+				BMC: baremetal.BMC{
+					Username:                       "bmc-user",
+					Password:                       "password",
+					Address:                        "172.22.0.10",
+					DisableCertificateVerification: true,
+				},
+			},
+			{
+				Hostname: "control-1.example.org",
+				Role:     "master",
+				Interfaces: []*v1beta1.Interface{
+					{
+						Name:       "enp2s0",
+						MacAddress: "98:af:65:a5:8d:02",
+					},
+				},
+				BMC: baremetal.BMC{
+					Username:                       "user2",
+					Password:                       "foo",
+					Address:                        "172.22.0.11",
+					DisableCertificateVerification: false,
+				},
+			},
+			{
+				Hostname: "control-2.example.org",
+				Role:     "master",
+				Interfaces: []*v1beta1.Interface{
+					{
+						Name:       "enp2s0",
+						MacAddress: "98:af:65:a5:8d:03",
+					},
+				},
+				BMC: baremetal.BMC{
+					Username:                       "admin",
+					Password:                       "bar",
+					Address:                        "172.22.0.12",
+					DisableCertificateVerification: true,
+				},
+			},
+		},
+	}
 }
 
 func getGoodACI() *hiveext.AgentClusterInstall {

--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -37,4 +37,5 @@ type Host struct {
 	// list of interfaces and mac addresses
 	Interfaces    []*aiv1beta1.Interface `json:"interfaces,omitempty"`
 	NetworkConfig aiv1beta1.NetConfig    `json:"networkConfig,omitempty"`
+	BMC           baremetal.BMC
 }


### PR DESCRIPTION
Add the baremetal host BMC fields to the AgentHosts asset. Detect changes to these fields when generating agent-cluster-install and include the BMC fields and the provisioning network configuration in the install-config override.

Note that changes are needed to assisted-service to add these fields to the installconfig override. Changes are also needed to dev-scripts for testing.
These are the additional patches needed for testing:
assisted-service - https://github.com/openshift/assisted-service/pull/5675 (merged)
dev-scripts - https://github.com/openshift-metal3/dev-scripts/pull/1601