### PR TITLE
OCPBUGS-13664: Add KMS encryption keys if provided

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -38,6 +38,9 @@ const (
 
 	// PermissionDeleteHostedZone is a set of permissions required when the installer destroys a route53 hosted zone.
 	PermissionDeleteHostedZone PermissionGroup = "delete-hosted-zone"
+
+	// PermissionKMSEncryptionKeys is an additional set of permissions required when the installer uses user provided kms encryption keys.
+	PermissionKMSEncryptionKeys PermissionGroup = "kms-encryption-keys"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -243,6 +246,16 @@ var permissions = map[PermissionGroup][]string{
 	},
 	PermissionDeleteHostedZone: {
 		"route53:DeleteHostedZone",
+	},
+	PermissionKMSEncryptionKeys: {
+		"kms:Decrypt",
+		"kms:Encrypt",
+		"kms:GenerateDataKey",
+		"kms:GenerateDataKeyWithoutPlainText",
+		"kms:DescribeKey",
+		"kms:RevokeGrant",
+		"kms:CreateGrant",
+		"kms:ListGrants",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -47,8 +49,10 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	dependencies.Get(ic)
 
 	if ic.Config.CredentialsMode != "" {
+		logrus.Debug("CredentialsMode is set. Skipping platform permissions checks before attempting installation.")
 		return nil
 	}
+	logrus.Debug("CredentialsMode is not set. Performing platform permissions checks before attempting installation.")
 
 	var err error
 	platform := ic.Config.Platform.Name()
@@ -64,6 +68,23 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 
 		if !usingExistingPrivateZone {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateHostedZone)
+		}
+
+		var ec2RootVolume = aws.EC2RootVolume{}
+		var awsMachinePoolUsingKMS, masterMachinePoolUsingKMS bool
+		if ic.Config.AWS.DefaultMachinePlatform != nil && ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume != ec2RootVolume {
+			awsMachinePoolUsingKMS = len(ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume.KMSKeyARN) != 0
+		}
+		if ic.Config.ControlPlane != nil &&
+			ic.Config.ControlPlane.Name == types.MachinePoolControlPlaneRoleName &&
+			ic.Config.ControlPlane.Platform.AWS != nil &&
+			ic.Config.ControlPlane.Platform.AWS.EC2RootVolume != ec2RootVolume {
+			masterMachinePoolUsingKMS = len(ic.Config.ControlPlane.Platform.AWS.EC2RootVolume.KMSKeyARN) != 0
+		}
+		// Add KMS encryption keys, if provided.
+		if awsMachinePoolUsingKMS || masterMachinePoolUsingKMS {
+			logrus.Debugf("Adding %s to the group of permissions to validate", awsconfig.PermissionKMSEncryptionKeys)
+			permissionGroups = append(permissionGroups, awsconfig.PermissionKMSEncryptionKeys)
 		}
 
 		// Add delete permissions for non-C2S installs.


### PR DESCRIPTION
Add KMS encryption keys if provided either
in master machine pool or in aws machine pool

control plane stanza has to be checked for nil before being accessed.

Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com> + Rafael Fonseca <rdossant@redhat.com>