### PR TITLE
Revert "OCPBUGS-4038: bootstrap: Skip gatewayd units only on OKD agent-installer"

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -181,7 +181,7 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 	if err := AddSystemdUnits(a.Config, "bootstrap/systemd/common/units", templateData, commonEnabledServices); err != nil {
 		return err
 	}
-	if !(templateData.IsOKD && templateData.Invoker == "agent-installer") {
+	if !templateData.IsOKD {
 		if err := AddSystemdUnits(a.Config, "bootstrap/systemd/rhcos/units", templateData, rhcosEnabledServices); err != nil {
 			return err
 		}


### PR DESCRIPTION
This reverts commit ff2ed87a63c3cfe724a1107d2530b51abf2a8b49.

Not needed after all.