### PR TITLE
SPLAT-1218: AWS BYO VPC support for Wavelength Zones

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -103,7 +103,7 @@ func edgeZones(ctx context.Context, session *session.Session, region string) ([]
 		return nil, fmt.Errorf("unable to retrieve Local Zone names: %w", err)
 	}
 
-	wavelengthZones, err := filterZonesByType(ctx, session, region, typesaws.WavelengtyZoneType)
+	wavelengthZones, err := filterZonesByType(ctx, session, region, typesaws.WavelengthZoneType)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Wavelength Zone names: %w", err)
 	}

--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -164,7 +164,8 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		}
 
 		// AWS Local Zones are grouped as Edge subnets
-		if meta.Zone.Type == typesaws.LocalZoneType {
+		if meta.Zone.Type == typesaws.LocalZoneType ||
+			meta.Zone.Type == typesaws.WavelengthZoneType {
 			subnetGroups.Edge[id] = meta
 			continue
 		}
@@ -226,6 +227,9 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 		// or other virtual gateway (starting with vgv)
 		// or vpc peering connections (starting with pcx).
 		if strings.HasPrefix(aws.StringValue(route.GatewayId), "igw") {
+			return true, nil
+		}
+		if strings.HasPrefix(aws.StringValue(route.CarrierGatewayId), "cagw") {
 			return true, nil
 		}
 	}

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -423,7 +423,7 @@ func validateZoneLocal(ctx context.Context, meta *Metadata, fldPath *field.Path,
 	for _, zone := range zones {
 		if aws.StringValue(zone.ZoneName) == zoneName {
 			switch aws.StringValue(zone.ZoneType) {
-			case awstypes.LocalZoneType, awstypes.WavelengtyZoneType:
+			case awstypes.LocalZoneType, awstypes.WavelengthZoneType:
 			default:
 				return field.Invalid(fldPath, zoneName, fmt.Sprintf("only zone type local-zone or wavelength-zone are valid in the edge machine pool: %s", aws.StringValue(zone.ZoneType)))
 			}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -112,7 +112,8 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		if _, ok := sources.AvailabilityZones[zoneName]; !ok {
 			return nil, errors.New(fmt.Sprintf("unable to find the zone when generating terraform vars: %s", zoneName))
 		}
-		if sources.AvailabilityZones[zoneName].Type == typesaws.LocalZoneType || sources.AvailabilityZones[zoneName].Type == typesaws.WavelengtyZoneType {
+		if sources.AvailabilityZones[zoneName].Type == typesaws.LocalZoneType ||
+			sources.AvailabilityZones[zoneName].Type == typesaws.WavelengthZoneType {
 			edgeLocalZoneMap[zoneName] = exists
 			continue
 		}

--- a/pkg/types/aws/availabilityzones.go
+++ b/pkg/types/aws/availabilityzones.go
@@ -3,10 +3,11 @@ package aws
 const (
 	// AvailabilityZoneType is the type of regular zone placed on the region.
 	AvailabilityZoneType = "availability-zone"
-	// LocalZoneType is the type of Local zone placed on the metropolitan areas.
+	// LocalZoneType is the type of AWS Local Zones placed on the metropolitan area.
 	LocalZoneType = "local-zone"
-	// WavelengtyZoneType is the type of Wavelength zone placed in the Carrier infrastructure closer to areas.
-	WavelengtyZoneType = "wavelength-zone"
+	// WavelengthZoneType is the type of AWS Wavelength Zones placed on the telecommunications
+	// providers’ data centers at the edge of the 5G network.
+	WavelengthZoneType = "wavelength-zone"
 	// ZoneOptInStatusOptedIn is the opt-in status of the zone.
 	// For Availability Zones, this parameter always has the value of opt-in-not-required.
 	// For Local Zones and Wavelength Zones, this parameter is the opt-in status.


### PR DESCRIPTION
This change introduces support for BYO VPC when installing a cluster in Wavelength Zones by:

- classifying subnets with zone type `wavelength-zone` as edge zone

This PR is created based on https://github.com/openshift/installer/pull/7369 , the following commits are related to this PR:

- [aws byovpc: classifying wavelength subnets as edge](https://github.com/openshift/installer/commit/cf9c3ac44d5286c781b3c9a1c1e3f77022b043d8)

- [aws/doc: updating edge zones Documentation with Wavelength Zone steps](https://github.com/openshift/installer/pull/7652/commits/77a07ffdd1d44bfaec3405d0df8ab75104488e65)

The following CloudFormation Templates have been introduced in https://github.com/openshift/installer/pull/7722:
- Create Carrier Gateway: provisions carrier gateway and route table for Wavelength Zones
- Create Public and Private subnets: create public and private subnets, associating each one to a provided route table
