### PR TITLE
OCPBUGS-22773: PowerVS: fix removeFromLoadBalancers

### DIFF
--- a/pkg/terraform/stages/powervs/stages.go
+++ b/pkg/terraform/stages/powervs/stages.go
@@ -32,8 +32,12 @@ func removeFromLoadBalancers(s stages.SplitStage, directory string, terraformDir
 		opts = append(opts, tfexec.VarFile(varFile))
 	}
 	opts = append(opts, tfexec.Var("powervs_expose_bootstrap=false"))
+	err := terraform.Apply(directory, powervstypes.Name, s, terraformDir, opts...)
+	if err == nil {
+		return nil
+	}
 	return fmt.Errorf(
 		"failed disabling bootstrap load balancing: %w",
-		terraform.Apply(directory, powervstypes.Name, s, terraformDir, opts...),
+		err,
 	)
 }


### PR DESCRIPTION
When we switched from using the errors package to using fmt.Errorf, we missed the fact that a nil error passed in would return nil.