### PR TITLE
CORS-2835: use build tags to produce installer with alternate infrastructure providers

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -122,7 +122,10 @@ func runGatherBootstrapCmd(directory string) (string, error) {
 			return "", errors.Wrapf(err, "failed to fetch %s", config.Name())
 		}
 
-		provider := infra.ProviderForPlatform(config.Config.Platform.Name())
+		provider, err := infra.ProviderForPlatform(config.Config.Platform.Name())
+		if err != nil {
+			return "", fmt.Errorf("error getting infrastructure provider: %w", err)
+		}
 		if err = provider.ExtractHostAddresses(directory, config.Config, ha); err != nil {
 			logrus.Warnf("Failed to extract host addresses: %s", err.Error())
 		}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,7 +42,7 @@ export CGO_ENABLED=0
 MODE="${MODE:-release}"
 
 # Build terraform binaries before setting environment variables since it messes up make
-if test "${SKIP_TERRAFORM}" != y
+if test "${SKIP_TERRAFORM}" != y && ! (echo "${TAGS}" | grep -q -e 'aro' -e 'altinfra')
 then
   make -j8 -C terraform all
   copy_terraform_to_mirror # Copy terraform parts to embedded mirror.

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -109,7 +109,10 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		tfvarsFiles = append(tfvarsFiles, file)
 	}
 
-	provider := infra.ProviderForPlatform(platform)
+	provider, err := infra.ProviderForPlatform(platform)
+	if err != nil {
+		return fmt.Errorf("error getting infrastructure provider: %w", err)
+	}
 	files, err := provider.Provision(InstallDir, tfvarsFiles)
 	c.FileList = append(c.FileList, files...) // append state files even in case of failure
 	if err != nil {

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -42,7 +42,11 @@ func Destroy(dir string) (err error) {
 		platform = typesazure.StackTerraformName
 	}
 
-	provider := infra.ProviderForPlatform(platform)
+	provider, err := infra.ProviderForPlatform(platform)
+	if err != nil {
+		return fmt.Errorf("error getting infrastructure provider: %w", err)
+	}
+
 	if err := provider.DestroyBootstrap(dir); err != nil {
 		return fmt.Errorf("error destroying bootstrap resources %w", err)
 	}

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -1,3 +1,6 @@
+//go:build !(altinfra || aro)
+// +build !altinfra,!aro
+
 package platform
 
 import (

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -34,40 +34,40 @@ import (
 )
 
 // ProviderForPlatform returns the stages to run to provision the infrastructure for the specified platform.
-func ProviderForPlatform(platform string) infrastructure.Provider {
+func ProviderForPlatform(platform string) (infrastructure.Provider, error) {
 	switch platform {
 	case alibabacloudtypes.Name:
-		return terraform.InitializeProvider(alibabacloud.PlatformStages)
+		return terraform.InitializeProvider(alibabacloud.PlatformStages), nil
 	case awstypes.Name:
-		return terraform.InitializeProvider(aws.PlatformStages)
+		return terraform.InitializeProvider(aws.PlatformStages), nil
 	case azuretypes.Name:
-		return terraform.InitializeProvider(azure.PlatformStages)
+		return terraform.InitializeProvider(azure.PlatformStages), nil
 	case azuretypes.StackTerraformName:
-		return terraform.InitializeProvider(azure.StackPlatformStages)
+		return terraform.InitializeProvider(azure.StackPlatformStages), nil
 	case baremetaltypes.Name:
-		return terraform.InitializeProvider(baremetal.PlatformStages)
+		return terraform.InitializeProvider(baremetal.PlatformStages), nil
 	case gcptypes.Name:
-		return terraform.InitializeProvider(gcp.PlatformStages)
+		return terraform.InitializeProvider(gcp.PlatformStages), nil
 	case ibmcloudtypes.Name:
-		return terraform.InitializeProvider(ibmcloud.PlatformStages)
+		return terraform.InitializeProvider(ibmcloud.PlatformStages), nil
 	case libvirttypes.Name:
-		return terraform.InitializeProvider(libvirt.PlatformStages)
+		return terraform.InitializeProvider(libvirt.PlatformStages), nil
 	case nutanixtypes.Name:
-		return terraform.InitializeProvider(nutanix.PlatformStages)
+		return terraform.InitializeProvider(nutanix.PlatformStages), nil
 	case powervstypes.Name:
-		return terraform.InitializeProvider(powervs.PlatformStages)
+		return terraform.InitializeProvider(powervs.PlatformStages), nil
 	case openstacktypes.Name:
-		return terraform.InitializeProvider(openstack.PlatformStages)
+		return terraform.InitializeProvider(openstack.PlatformStages), nil
 	case ovirttypes.Name:
-		return terraform.InitializeProvider(ovirt.PlatformStages)
+		return terraform.InitializeProvider(ovirt.PlatformStages), nil
 	case vspheretypes.Name:
-		return terraform.InitializeProvider(vsphere.PlatformStages)
+		return terraform.InitializeProvider(vsphere.PlatformStages), nil
 	case nonetypes.Name:
 		// terraform is not used when the platform is "none"
-		return terraform.InitializeProvider([]terraform.Stage{})
+		return terraform.InitializeProvider([]terraform.Stage{}), nil
 	case externaltypes.Name:
 		// terraform is not used when the platform is "external"
-		return terraform.InitializeProvider([]terraform.Stage{})
+		return terraform.InitializeProvider([]terraform.Stage{}), nil
 	}
-	panic(fmt.Sprintf("unsupported platform %q", platform))
+	return nil, fmt.Errorf("unsupported platform %q", platform)
 }

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -1,0 +1,29 @@
+//go:build altinfra || aro
+// +build altinfra aro
+
+package platform
+
+import (
+	"fmt"
+
+	"github.com/openshift/installer/pkg/infrastructure"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
+)
+
+// ProviderForPlatform returns the stages to run to provision the infrastructure for the specified platform.
+func ProviderForPlatform(platform string) (infrastructure.Provider, error) {
+	switch platform {
+	case awstypes.Name:
+		panic("not implemented")
+		return nil, nil
+	case azuretypes.Name:
+		panic("not implemented")
+		return nil, nil
+	case vspheretypes.Name:
+		panic("not implemented")
+		return nil, nil
+	}
+	return nil, fmt.Errorf("platform %q is not supported in the altinfra Installer build", platform)
+}


### PR DESCRIPTION
Build tags in the `pkg/infrastructure/platform.go` and `pkg/infrastructure/platform_altinfra.go` files selectively determine which file is included in the build. `platform.go` contains the normal Terraform dependencies for building infrastructure, while `platform_altinfra.go` will be where we land [non-Terraform implementors of the provider interface](https://github.com/openshift/installer/pull/7573/commits/266882741f4860da9f5fbbe6f1e0367d9b0bb91c#diff-34cd4c77afbf6c0c9931be6bd63b6540c7a0c392c340822dc6b06ec78fc50481). 

By using the `-v` flag with `go build` we can see that no Terraform dependencies are included when building. 

```shell
$ GOFLAGS='-mod=vendor -v' ./hack/build.sh &> normal-verbose-build.log
$ grep github.com/hashicorp/terraform/ normal-verbose-build.log | wc -l
72

$ go clean -cache

$ TAGS=altinfra GOFLAGS='-mod=vendor -v' ./hack/build.sh &> altinfra-verbose-build.log
$ grep github.com/hashicorp/terraform/ altinfra-verbose-build.log | wc -l
0
```

openshift/release#45169 will promote this build to a separate installer image.