### PR TITLE
OCPBUGS-22830: fix google cli verson to 447.0.0

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -28,7 +28,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
       azure-cli-2.49.0-1.el8 \
       gettext \
-      google-cloud-cli \
+      google-cloud-cli-447.0.0-1 \
       gzip \
       jq \
       unzip \


### PR DESCRIPTION
google CLI deprecated` Python 3.5-3.7` from 448.0.0 causing release ci jobs failed with `ERROR: gcloud failed to load. You are running gcloud with Python 3.6, which is no longer supported by gcloud.` . specified version to 447.0.0

Related: https://issues.redhat.com/browse/OCPBUGS-22830
