### PR TITLE
Skip cluster config

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -47,6 +47,7 @@ MACHINE_CONFIG_ETCD_IMAGE=$(image_for etcd)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
+API_IMAGE=$(image_for cluster-config-api)
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
@@ -84,6 +85,28 @@ elif [ -f $IDMS_MANIFEST_FILE ]; then
 fi
 
 VERSION="$(oc adm release info -o 'jsonpath={.metadata.version}' "${MIRROR_FLAG}" "${RELEASE_IMAGE_DIGEST}")"
+
+if [ ! -f api-bootstrap.done ]
+then
+    record_service_stage_start "api-bootstrap"
+	echo "Rendering api manifests..."
+
+	rm --recursive --force api-bootstrap
+
+	bootkube_podman_run \
+		--name api-render \
+		--volume "$PWD:/assets:z" \
+		"${API_IMAGE}" \
+		/usr/bin/render \
+		--asset-output-dir=/assets/api-bootstrap \
+		--rendered-manifest-dir=/assets/manifests \
+		--payload-version=$VERSION
+
+	cp api-bootstrap/manifests/* manifests/
+
+	touch api-bootstrap.done
+    record_service_stage_success
+fi
 
 if [ ! -f config-bootstrap.done ]
 then

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -125,6 +125,7 @@ then
 		--volume "$PWD:/assets:z" \
 		"${CONFIG_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-config-operator render \
+		--skip-api-rendering \
 		--cluster-infrastructure-input-file=/assets/manifests/cluster-infrastructure-02-config.yml \
 		--cloud-provider-config-output-file=/assets/config-bootstrap/cloud-provider-config-generated.yaml \
 		--config-output-file=/assets/config-bootstrap/config \
@@ -133,8 +134,6 @@ then
 		--rendered-manifest-files=/assets/manifests \
 		--payload-version=$VERSION \
 		"${ADDITIONAL_FLAGS[@]}"
-
-	cp config-bootstrap/manifests/* manifests/
 
 	touch config-bootstrap.done
     record_service_stage_success


### PR DESCRIPTION
Should merged with 

1. https://github.com/openshift/api/pull/1666
2. https://github.com/openshift/cluster-config-operator/pull/379
3. https://github.com/openshift/cluster-config-operator/pull/349

ideally these all land in a single unit.  If they don't, merges to openshift/api will get wedged on machine-configs not matching until they do.