### PR TITLE
OCPBUGS-19398: IBMCloud: Add eu-es region

### DIFF
--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -16,6 +16,7 @@ var (
 		"us-east":  "US East (Washington DC)",
 		"eu-gb":    "United Kindom (London)",
 		"eu-de":    "EU Germany (Frankfurt)",
+		"eu-es":    "Spain (Madrid)",
 		"jp-tok":   "Japan (Tokyo)",
 		"jp-osa":   "Japan (Osaka)",
 		"au-syd":   "Australia (Sydney)",


### PR DESCRIPTION
Add support to use the Madrid region in IBM Cloud, eu-es.

Related: https://issues.redhat.com/browse/OCPBUGS-19398