### PR TITLE
OCPBUGS-22772: return Terraform statefile on error

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -280,12 +280,12 @@ func applyTerraform(tmpDir string, platform string, stage Stage, terraformDir st
 	}
 
 	if applyErr != nil {
-		return nil, nil, fmt.Errorf("error applying Terraform configs: %w", applyErr)
+		return nil, stateFile, fmt.Errorf("error applying Terraform configs: %w", applyErr)
 	}
 
 	outputs, err := Outputs(tmpDir, terraformDir)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "could not get outputs from stage %q", stage.Name())
+		return nil, stateFile, errors.Wrapf(err, "could not get outputs from stage %q", stage.Name())
 	}
 
 	outputsFile = &asset.File{


### PR DESCRIPTION
Fixes a nil pointer dereference which occurs when there is an error during Terraform apply. A file needs to be written for the cluster asset, but there was a bug where no statefile was being returned upon an error in Terraform apply.

I tested this locally by manually breaking the Terraform configs in the Installer. The result is that the Terraform error is prettily returned:

```
ERROR Error: creating EC2 VPC Endpoint (com.amazonaws.us-east-2.s3): InvalidVpcId.Malformed: Invalid Id: 'my-crazy-vpc' (expecting 'vpc-...; the Id may only contain lowercase alphanumeric characters and a single dash') 
ERROR 	status code: 400, request id: 9178e750-a3a8-423b-be7f-70eb2b31f837 
ERROR                                              
ERROR   with module.vpc.aws_vpc_endpoint.s3[0],    
ERROR   on vpc/vpc.tf line 16, in resource "aws_vpc_endpoint" "s3": 
ERROR   16: resource "aws_vpc_endpoint" "s3" {     
ERROR                                              
ERROR 
```

