### PR TITLE
OCPBUGS-21777: baremetal: populate customDeploy in advance

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -141,6 +141,12 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 			// with a machine without triggering provisioning. We only
 			// want to do that for control plane hosts.
 			newHost.Spec.ExternallyProvisioned = true
+			// Setting CustomDeploy early ensures that the
+			// corresponding Ironic node gets correctly configured
+			// from the beginning.
+			newHost.Spec.CustomDeploy = &baremetalhost.CustomDeploy{
+				Method: "install_coreos",
+			}
 			// Pause reconciliation until we can annotate with the initial
 			// status containing the HardwareDetails
 			newHost.ObjectMeta.Annotations = map[string]string{"baremetalhost.metal3.io/paused": ""}

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -61,7 +61,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy()).build(),
 		},
 		{
 			Scenario: "default-norole",
@@ -70,7 +70,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy()).build(),
 		},
 		{
 			Scenario: "network-config",
@@ -88,7 +88,8 @@ routes:
 						consumerRef("machine-0").
 						annotation("baremetalhost.metal3.io/paused", "").
 						preprovisioningNetworkDataName("master-0-network-config-secret").
-						externallyProvisioned()).build(),
+						externallyProvisioned().
+						customDeploy()).build(),
 		},
 		{
 			Scenario: "3-hosts-3-machines-norole-all",
@@ -107,9 +108,9 @@ routes:
 					secret("master-1-bmc-secret").creds("usr1", "pwd1"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines",
@@ -130,9 +131,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("master-3-bmc-secret").creds("usr3", "pwd3")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
 					host("master-3")).build(),
 		},
 		{
@@ -154,9 +155,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
 					host("worker-0")).build(),
 		},
 		{
@@ -180,9 +181,9 @@ routes:
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0"),
 					secret("worker-1-bmc-secret").creds("wrk1", "pwd1")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
 					host("worker-0"),
 					host("worker-1")).build(),
 		},
@@ -207,11 +208,11 @@ routes:
 					secret("master-0-bmc-secret").creds("usr0", "pwd0"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-1").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
 					host("worker-0"),
 					host("worker-1"),
-					host("master-0").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+					host("master-0").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-master",
@@ -233,9 +234,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
 					host("worker-0"),
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-worker",
@@ -256,9 +257,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned().customDeploy(),
 					host("worker-0")).build(),
 		},
 	}
@@ -427,6 +428,13 @@ func (hb *hostBuilder) build() *baremetalhost.BareMetalHost {
 
 func (hb *hostBuilder) externallyProvisioned() *hostBuilder {
 	hb.Spec.ExternallyProvisioned = true
+	return hb
+}
+
+func (hb *hostBuilder) customDeploy() *hostBuilder {
+	hb.Spec.CustomDeploy = &baremetalhost.CustomDeploy{
+		Method: "install_coreos",
+	}
 	return hb
 }
 


### PR DESCRIPTION
Currently, we do not populate any deployment fields when creating
BareMetalHosts, relying on the Machine API to do it instead.
However, not setting customDeploy makes the BMH controller think that
we're doing an image-based deployment and configure its resources
accordingly. If MAPI is slow enough, the hosts become provisioned
before customDeploy is set, and the controller enters a loop trying and
failing to switch away from the image-based deployment.

TL;DR just set customDeploy on creation.
