### PR TITLE
OCPBUGS-22933: [release-4.12]: vsphere: fix validation of CPUS and CoresPerSocket

### DIFF
--- a/pkg/types/vsphere/validation/machinepool_test.go
+++ b/pkg/types/vsphere/validation/machinepool_test.go
@@ -84,7 +84,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs$`,
+			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than the number of CPUs \(which is by default \d+\)$`,
 		},
 		{
 			name:     "numCPUs not a multiple of cores per socket",
@@ -97,7 +97,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket$`,
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket \(which is by default \d+\)$`,
 		},
 		{
 			name:     "numCPUs not a multiple of default cores per socket",
@@ -109,7 +109,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket which is by default 4$`,
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket \(which is by default \d+\)$`,
 		},
 		{
 			name: "multi-zone invalid zone name",


### PR DESCRIPTION
I think the original intention behind the validation was to check that, in case `CoresPerSocket` was not set by the user, it would be checked against a default value (currently set to 4). However, that's not what is happening in practice, and both the check against the user-inputed value and the default were being performed.

That means that using CPUS=2 and CoresPerSocket=2 as exemplified in the official docs [1] would result in a validation error:
```
failed to create install config: invalid "install-config.yaml" file: controlPlane.platform.vsphere.cpus:
Invalid value: 2: numCPUs specified should be a multiple of cores per socket which is by default 4]
```
even though it's a valid configuration (albeit a pretty tiny compute node).

I'm changing the code a bit to make it more clear what the defaults values are representing and fixing the checks so they are made only once with the correct values for CPUs and CoresPerSocket.

[1] https://docs.openshift.com/container-platform/4.11/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations