### PR TITLE
destroy/aws: replaced deprecated sets syntax

### DIFF
--- a/pkg/destroy/aws/ec2helpers.go
+++ b/pkg/destroy/aws/ec2helpers.go
@@ -23,7 +23,7 @@ import (
 // stage and the second list is the list of resources that are not terminated.
 //
 //	deleted - the resources that have already been deleted. Any resources specified in this set will be ignored.
-func findEC2Instances(ctx context.Context, ec2Client *ec2.EC2, deleted sets.String, filters []Filter, logger logrus.FieldLogger) ([]string, []string, error) {
+func findEC2Instances(ctx context.Context, ec2Client *ec2.EC2, deleted sets.Set[string], filters []Filter, logger logrus.FieldLogger) ([]string, []string, error) {
 	if ec2Client.Config.Region == nil {
 		return nil, nil, errors.New("EC2 client does not have region configured")
 	}

--- a/pkg/destroy/aws/iamhelpers.go
+++ b/pkg/destroy/aws/iamhelpers.go
@@ -158,27 +158,27 @@ func (search *iamUserSearch) arns(ctx context.Context) ([]string, error) {
 // findIAMRoles returns the IAM roles for the cluster.
 //
 //	deleted - the resources that have already been deleted. Any resources specified in this set will be ignored.
-func findIAMRoles(ctx context.Context, search *iamRoleSearch, deleted sets.String, logger logrus.FieldLogger) (sets.String, error) {
+func findIAMRoles(ctx context.Context, search *iamRoleSearch, deleted sets.Set[string], logger logrus.FieldLogger) (sets.Set[string], error) {
 	logger.Debug("search for IAM roles")
 	resources, _, err := search.find(ctx)
 	if err != nil {
 		logger.Info(err)
 		return nil, err
 	}
-	return sets.NewString(resources...).Difference(deleted), nil
+	return sets.New[string](resources...).Difference(deleted), nil
 }
 
 // findIAMUsers returns the IAM users for the cluster.
 //
 //	deleted - the resources that have already been deleted. Any resources specified in this set will be ignored.
-func findIAMUsers(ctx context.Context, search *iamUserSearch, deleted sets.String, logger logrus.FieldLogger) (sets.String, error) {
+func findIAMUsers(ctx context.Context, search *iamUserSearch, deleted sets.Set[string], logger logrus.FieldLogger) (sets.Set[string], error) {
 	logger.Debug("search for IAM users")
 	resources, err := search.arns(ctx)
 	if err != nil {
 		logger.Info(err)
 		return nil, err
 	}
-	return sets.NewString(resources...).Difference(deleted), nil
+	return sets.New[string](resources...).Difference(deleted), nil
 }
 
 func deleteIAM(ctx context.Context, session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {


### PR DESCRIPTION
The new syntax uses Golang generics.