### PR TITLE
CORS-2428: images: add Dockerfile for a terraform-providers image

### DIFF
--- a/images/terraform-providers/Dockerfile
+++ b/images/terraform-providers/Dockerfile
@@ -1,0 +1,26 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macbuilder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 make -C terraform
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macarmbuilder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 make -C terraform
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxbuilder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make -C terraform
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxarmbuilder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 make -C terraform
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15
+WORKDIR /go/src/github.com/openshift/installer
+COPY --from=macbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=macarmbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=linuxbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=linuxarmbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/


### PR DESCRIPTION
This Dockerfile will build the terraform provider binaries for all platforms/arches needed by the Installer images. Reusing this container in CI should stop the terraform provider binaries from being built every time there is a change to the Installer repo, since the providers are changed very sparingly.