### PR TITLE
CORS-2870: build: only rebuild terraform providers if needed

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -30,6 +30,46 @@ copy_terraform_to_mirror() {
   cp "${PWD}/terraform/bin/${TARGET_OS_ARCH}/terraform" "${PWD}/pkg/terraform/providers/mirror/terraform/"
 }
 
+# Check if a provider has changed based on the version stored in the binary
+check_module_changes() {
+	binpath="$1"
+	srcpath="$2"
+	build_hash="$(go version -m "${binpath}" | grep 'vcs.revision' | cut -f2 -d'=')"
+	# If it's a locally developed provider
+	if test -n "${build_hash}"; then
+		# Check if a provider has changed based on git changes since the
+		# revision the provider was last built
+		git diff --name-only --exit-code "${build_hash}.." -- "${srcpath}"
+	# If it's an imported module
+	else
+		# Check if a provider has changed based on its go.mod git hash
+		version_info="$(go version -m "${binpath}" | grep -Eo 'main.builtGoModHash=[a-fA-F0-9]+' | cut -f2 -d'=')"
+		test "${version_info}" == "$(git hash-object "${srcpath}/go.mod")"
+	fi
+}
+
+# Build terraform and providers only if needed
+build_terraform_and_providers() {
+	TARGET_OS_ARCH=$(go env GOOS)_$(go env GOARCH)
+	bindir="${PWD}/terraform/bin/${TARGET_OS_ARCH}"
+	find "${PWD}/terraform/providers/" -maxdepth 1 -mindepth 1 -type d | while read -r dir; do
+		provider="$(basename "${dir}")"
+		binpath="${bindir}/terraform-provider-${provider}"
+		if test -s "${binpath}" && test -s "${binpath}.zip" && check_module_changes "${binpath}" "terraform/providers/${provider}"; then
+			echo "${provider} is up-to-date"
+		else
+			echo "Rebuilding ${provider}"
+			make -C terraform "go-build.${provider}"
+		fi
+	done
+	if test -s "${bindir}/terraform" && check_module_changes "${bindir}/terraform" "terraform/terraform"; then
+		echo "terraform is up-to-date"
+	else
+		echo "Rebuilding terraform"
+		make -C terraform go-build-terraform
+	fi
+}
+
 minimum_go_version=1.20
 current_go_version=$(go version | cut -d " " -f 3)
 
@@ -44,8 +84,8 @@ MODE="${MODE:-release}"
 # Build terraform binaries before setting environment variables since it messes up make
 if test "${SKIP_TERRAFORM}" != y && ! (echo "${TAGS}" | grep -q -e 'aro' -e 'altinfra')
 then
-  make -C terraform all
-  copy_terraform_to_mirror # Copy terraform parts to embedded mirror.
+	build_terraform_and_providers
+	copy_terraform_to_mirror # Copy terraform parts to embedded mirror.
 fi
 
 # build cluster-api binaries

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -3,6 +3,8 @@
 
 ARG libvirt_version="8.0.0"
 
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 ARG libvirt_version
 ARG TAGS="libvirt baremetal"
@@ -10,6 +12,7 @@ RUN dnf install -y libvirt-devel-$libvirt_version && \
     dnf clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,28 +1,34 @@
 # This Dockerfile builds an image containing Mac and Linux/AMD64 versions of
 # the installer layered on top of the cluster-native Linux installer image.
 
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_amd64 terraform/bin/darwin_amd64
 RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_arm64 terraform/bin/darwin_arm64
 RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_amd64 terraform/bin/linux_amd64
 RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_arm64 terraform/bin/linux_arm64
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,10 +1,13 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -2,10 +2,13 @@
 # It builds an image containing binaries like jq, terraform, awscli, oc, etc. to allow bringing up UPI infrastructure.
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.15:cli as cli

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -1,12 +1,15 @@
 # This Dockerfile is a used by CI to publish an installer image for creating libvirt clusters
 # It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS="libvirt"
 RUN yum install -y libvirt-devel && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM quay.io/centos/centos:stream

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,9 +1,12 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
+FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.15:cli AS cli


### PR DESCRIPTION
Look at the Golang module information from the binary to determine whether the providers need to be rebuilt. It'll be useful when we use an external container image for the providers.