### PR TITLE
Fix FailureDomains check on manifests test

### DIFF
--- a/scripts/openstack/manifest-tests/base-case/test_cpms.py
+++ b/scripts/openstack/manifest-tests/base-case/test_cpms.py
@@ -18,7 +18,7 @@ class ControlPlaneMachineSet(unittest.TestCase):
 
     def test_compute_zones(self):
         """Assert that the OpenStack CPMS failureDomains value is empty."""
-        self.assertNotIn("openstack", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"])
+        self.assertIsNone(self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"].get("failureDomains"))
 
 
 if __name__ == '__main__':

--- a/scripts/openstack/manifest-tests/zero-workers/test_cpms.py
+++ b/scripts/openstack/manifest-tests/zero-workers/test_cpms.py
@@ -18,7 +18,7 @@ class ControlPlaneMachineSet(unittest.TestCase):
 
     def test_compute_zones(self):
         """Assert that the OpenStack CPMS failureDomains value is empty."""
-        self.assertNotIn("openstack", self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"]["failureDomains"])
+        self.assertIsNone(self.cpms["spec"]["template"]["machines_v1beta1_machine_openshift_io"].get("failureDomains"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `FailureDomains` was updated to become a pointer, consequently the field may be absent in the `OpenShiftMachineV1Beta1MachineTemplate`. This commits updates the manifests test to take that into account.