### PR TITLE
OSASINFRA-3280: OpenStack: clarify root volume size requirements

### DIFF
--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -46,7 +46,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * An additional OpenStack host is needed when migrating instances with a strict "anti-affinity" policy
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
-  * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
+  * `size` (required integer): Size of the root volume in GB. Must be set to at least 25. For production clusters, this must be at least 100.
   * `type` (deprectated string): The volume pool to create the volume from. It was replaced by `types`.
   * `types` (required list of strings): The volume pool to create the volume from. If compute `zones` are defined with more than one type, the number of zones must match the number of types.
   * `zones` (optional list of strings): The names of the availability zones you want to install your root volumes on. If unset, the installer will use your default volume zone.


### PR DESCRIPTION
The recommended minimal value for production cluster is 100 GB.