### PR TITLE
MULTIARCH-3964: Power VS: Control SMT level with machineconfig

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -979,6 +979,10 @@ spec:
                           description: Processors defines the processing units for
                             the instance.
                           x-kubernetes-int-or-string: true
+                        smtLevel:
+                          description: SMTLevel specifies the level of SMT to set
+                            the control plane and worker nodes to.
+                          type: string
                         sysType:
                           description: SysType defines the system type for instance.
                           type: string
@@ -1906,6 +1910,10 @@ spec:
                         description: Processors defines the processing units for the
                           instance.
                         x-kubernetes-int-or-string: true
+                      smtLevel:
+                        description: SMTLevel specifies the level of SMT to set the
+                          control plane and worker nodes to.
+                        type: string
                       sysType:
                         description: SysType defines the system type for instance.
                         type: string
@@ -4152,6 +4160,10 @@ spec:
                         description: Processors defines the processing units for the
                           instance.
                         x-kubernetes-int-or-string: true
+                      smtLevel:
+                        description: SMTLevel specifies the level of SMT to set the
+                          control plane and worker nodes to.
+                        type: string
                       sysType:
                         description: SysType defines the system type for instance.
                         type: string

--- a/pkg/asset/machines/machineconfig/powersmt.go
+++ b/pkg/asset/machines/machineconfig/powersmt.go
@@ -1,0 +1,70 @@
+package machineconfig
+
+import (
+	"fmt"
+
+	ignutil "github.com/coreos/ignition/v2/config/util"
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/asset/ignition"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+// ForPowerSMT sets the SMT level for Power machines.
+func ForPowerSMT(role string, smtLevel string) (*mcfgv1.MachineConfig, error) {
+	powerSMTUnit, err := createPowerSMTUnit(smtLevel)
+	if err != nil {
+		return nil, err
+	}
+
+	ignConfig := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+		Systemd: igntypes.Systemd{
+			Units: []igntypes.Unit{
+				{
+					Contents: &powerSMTUnit,
+					Name:     fmt.Sprintf("99-%s-powersmt.service", role),
+					Enabled:  ignutil.BoolToPtr(true),
+				},
+			},
+		},
+	}
+
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-powersmt", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: rawExt,
+		},
+	}, nil
+}
+
+func createPowerSMTUnit(smtLevel string) (string, error) {
+	unit := `[Unit]
+Description=Set SMT
+After=network-online.target
+Before= crio.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/ppc64_cpu --smt=%s
+[Install]
+WantedBy=multi-user.target`
+	return fmt.Sprintf(unit, smtLevel), nil
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -553,6 +553,15 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "failed to create ignition for Multipath enabled for master machines")
 		}
 		machineConfigs = append(machineConfigs, ignMultipath)
+
+		// set SMT level if specified for powervs.
+		if pool.Platform.PowerVS.SMTLevel != "" {
+			ignPowerSMT, err := machineconfig.ForPowerSMT("master", pool.Platform.PowerVS.SMTLevel)
+			if err != nil {
+				return errors.Wrap(err, "failed to create ignition for Power SMT for master machines")
+			}
+			machineConfigs = append(machineConfigs, ignPowerSMT)
+		}
 	}
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 	// The cluster-network-operator handles the validation of this field.

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -294,6 +294,15 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				return errors.Wrap(err, "failed to create ignition for multipath enabled for worker machines")
 			}
 			machineConfigs = append(machineConfigs, ignMultipath)
+
+			// set SMT level if specified for powervs.
+			if pool.Platform.PowerVS != nil && pool.Platform.PowerVS.SMTLevel != "" {
+				ignPowerSMT, err := machineconfig.ForPowerSMT("worker", pool.Platform.PowerVS.SMTLevel)
+				if err != nil {
+					return errors.Wrap(err, "failed to create ignition for Power SMT for worker machines")
+				}
+				machineConfigs = append(machineConfigs, ignPowerSMT)
+			}
 		}
 		// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 		// The cluster-network-operator handles the validation of this field.

--- a/pkg/types/powervs/machinepools.go
+++ b/pkg/types/powervs/machinepools.go
@@ -30,6 +30,11 @@ type MachinePool struct {
 	// +optional
 	ProcType machinev1.PowerVSProcessorType `json:"procType,omitempty"`
 
+	// SMTLevel specifies the level of SMT to set the control plane and worker nodes to.
+	//
+	// +optional
+	SMTLevel string `json:"smtLevel,omitempty"`
+
 	// SysType defines the system type for instance.
 	//
 	// +optional
@@ -52,6 +57,9 @@ func (a *MachinePool) Set(required *MachinePool) {
 	}
 	if required.ProcType != "" {
 		a.ProcType = required.ProcType
+	}
+	if required.SMTLevel != "" {
+		a.SMTLevel = required.SMTLevel
 	}
 	if required.SysType != "" {
 		a.SysType = required.SysType

--- a/pkg/types/powervs/validation/machinepool.go
+++ b/pkg/types/powervs/validation/machinepool.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/openshift/installer/pkg/types/powervs"
 )
+
+var validSMTLevels = sets.New[string]("1", "2", "3", "4", "5", "6", "7", "8", "on", "off")
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *powervs.MachinePool, fldPath *field.Path) field.ErrorList {
@@ -68,6 +71,11 @@ func ValidateMachinePool(p *powervs.MachinePool, fldPath *field.Path) field.Erro
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("processors"), processors, "minimum number of processors must be from 1 core for Dedicated ProcType"))
 			}
 		}
+	}
+
+	// Validate SMTLevel
+	if p.SMTLevel != "" && !validSMTLevels.Has(p.SMTLevel) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("smtLevel"), p.SMTLevel, fmt.Sprintf("Valid SMT Levels are %s", sets.List(validSMTLevels))))
 	}
 
 	// Validate SysType


### PR DESCRIPTION
Through the installer, you can currently disable SMT. Power hardware allows levels of control that cannot currently be accessed through the installer (1-8). Until we can control SMT via kargs [0], and until igniton kargs support [1] is available in the MCO, we believe this is the best option for SMT control at install time.

[0] https://lore.kernel.org/all/20230705145143.40545-8-ldufour@linux.ibm.com/
[1] https://github.com/openshift/installer/pull/5439