### PR TITLE
OCPBUGS-23141: Specify google cloud CLI to version 447.0.0

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -30,7 +30,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
       azure-cli \
       gettext \
-      google-cloud-sdk \
+      google-cloud-sdk-447.0.0-1 \
       gzip \
       jq \
       unzip \

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -27,7 +27,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
       azure-cli-2.49.0-1.el8 \
       gettext \
-      google-cloud-cli \
+      google-cloud-cli-447.0.0-1 \
       gzip \
       jq \
       unzip \


### PR DESCRIPTION
google CLI deprecated Python 3.5-3.7 from 448.0.0, specified version to 447.0.0