### PR TITLE
CORS-2876: images/installer-altinfra: initial Dockerfile

### DIFF
--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -1,0 +1,28 @@
+# This Dockerfile is used by CI to publish the installer-altinfra image,
+# which, through the use of the altinfra build tag, only uses alternate
+# infrastructure providers to the original Terraform implementations. 
+#
+# This image is intended to be temporary: to provide a Terraform-free image
+# it only supports the subset of providers that have implemented non-Terraform
+# solutions. Once all providers have alternate implementations, this image will
+# not be needed. 
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+ARG TAGS="altinfra"
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
+RUN go run -mod=vendor hack/build-coreos-manifest.go
+
+
+FROM registry.ci.openshift.org/ocp/4.15:base
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output
+# We're not really an operator, we're just getting some data into the release image.
+LABEL io.openshift.release.operator=true
+ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
Creates the initial Dockerfile to create an image using the altinfra build tag. The Dockerfie is necessary to have the Terraform-free image built by ART.

The altinfra image is a temporary image to provide a Terraform-free image for all providers that have implemented alternate infrastructure providers. Once all providers have implemented non-Terraform solutions it will not be necessary.