### PR TITLE
MULTIARCH-2678: Patch for Agent Based Installer to support s390x as supported architecture.

### DIFF
--- a/pkg/asset/agent/image/agentpxefiles.go
+++ b/pkg/asset/agent/image/agentpxefiles.go
@@ -92,9 +92,12 @@ func (a *AgentPXEFiles) PersistToFile(directory string) error {
 	if err != nil {
 		return err
 	}
-
-	agentVmlinuzFile := filepath.Join(bootArtifactsFullPath, fmt.Sprintf("agent.%s-vmlinuz", a.cpuArch))
-	kernelReader, err := os.Open(filepath.Join(a.tmpPath, "images", "pxeboot", "vmlinuz"))
+	kernelFileType := "vmlinuz"
+	if a.cpuArch == arch.RpmArch(types.ArchitectureS390X) {
+		kernelFileType = "kernel.img"
+	}
+	agentVmlinuzFile := filepath.Join(bootArtifactsFullPath, fmt.Sprintf("agent.%s-%s", a.cpuArch, kernelFileType))
+	kernelReader, err := os.Open(filepath.Join(a.tmpPath, "images", "pxeboot", kernelFileType))
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -130,8 +130,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 	case types.ArchitectureAMD64:
 	case types.ArchitectureARM64:
 	case types.ArchitecturePPC64LE:
+	case types.ArchitectureS390X:
 	default:
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE}))
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE, types.ArchitectureS390X}))
 	}
 
 	for i, compute := range installConfig.Compute {
@@ -141,8 +142,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 		case types.ArchitectureAMD64:
 		case types.ArchitectureARM64:
 		case types.ArchitecturePPC64LE:
+		case types.ArchitectureS390X:
 		default:
-			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE}))
+			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64, types.ArchitecturePPC64LE, types.ArchitectureS390X}))
 		}
 	}
 

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -102,6 +102,9 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 	if installConfig.Platform.Name() != none.Name && installConfig.ControlPlane.Architecture == types.ArchitecturePPC64LE {
 		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitecturePPC64LE, none.Name)))
 	}
+	if installConfig.Platform.Name() != none.Name && installConfig.ControlPlane.Architecture == types.ArchitectureS390X {
+		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitectureS390X, none.Name)))
+	}
 	if installConfig.Platform.Name() == external.Name {
 		if installConfig.Platform.External.PlatformName != string(models.PlatformTypeOci) {
 			fieldPath = field.NewPath("Platform", "External", "PlatformName")

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -351,7 +351,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\"]",
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\"]",
 		},
 		{
 			name: "invalid platform.baremetal for architecture ppc64le",
@@ -391,6 +391,45 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
 			expectedError: "invalid install-config configuration: Platform: Invalid value: \"baremetal\": CPU architecture \"ppc64le\" only supports platform \"none\".",
+		},
+		{
+			name: "invalid platform.baremetal for architecture s390x",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+compute:
+  - architecture: s390x
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: s390x
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+platform:
+  baremetal:
+    apiVIP: 192.168.122.10
+    ingressVIP: 192.168.122.11
+    hosts:
+    - name: host1
+      bootMACAddress: 52:54:01:aa:aa:a1
+    - name: host2
+      bootMACAddress: 52:54:01:bb:bb:b1
+    - name: host3
+      bootMACAddress: 52:54:01:cc:cc:c1
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: Platform: CPU architecture \"s390x\" only supports platform \"baremetal\".",
 		},
 		{
 			name: "unsupported platformName for external platform",

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -326,34 +326,6 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: [Platform: Unsupported value: \"aws\": supported values: \"baremetal\", \"vsphere\", \"none\", \"external\", Platform: Invalid value: \"aws\": Only platform none and external supports 1 ControlPlane and 0 Compute nodes]",
 		},
 		{
-			name: "invalid architecture for SNO cluster",
-			data: `
-apiVersion: v1
-metadata:
-  name: test-cluster
-baseDomain: test-domain
-networking:
-  networkType: OVNKubernetes
-compute:
-  - architecture: s390x
-    hyperthreading: Enabled
-    name: worker
-    platform: {}
-    replicas: 0
-controlPlane:
-  architecture: s390x
-  hyperthreading: Enabled
-  name: master
-  platform: {}
-  replicas: 1
-platform:
-  none : {}
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
-`,
-			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\", Compute[0].Architecture: Unsupported value: \"unsupportedArch\": supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\"]",
-		},
-		{
 			name: "invalid platform.baremetal for architecture ppc64le",
 			data: `
 apiVersion: v1

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -351,7 +351,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", \"ppc64le\"]",
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\", Compute[0].Architecture: Unsupported value: \"unsupportedArch\": supported values: \"amd64\", \"arm64\", \"ppc64le\", \"s390x\"]",
 		},
 		{
 			name: "invalid platform.baremetal for architecture ppc64le",
@@ -429,7 +429,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: Platform: CPU architecture \"s390x\" only supports platform \"baremetal\".",
+			expectedError: "invalid install-config configuration: Platform: Invalid value: \"baremetal\": CPU architecture \"s390x\" only supports platform \"none\".",
 		},
 		{
 			name: "unsupported platformName for external platform",

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -145,9 +145,9 @@ func (i *InfraEnv) finish() error {
 		return errors.New("missing configuration or manifest file")
 	}
 
-	// Throw an error if CpuArchitecture isn't x86_64, aarch64, ppc64le, or ""
+	// Throw an error if CpuArchitecture isn't x86_64, aarch64, ppc64le, s390x, or ""
 	switch i.Config.Spec.CpuArchitecture {
-	case arch.RpmArch(types.ArchitectureAMD64), arch.RpmArch(types.ArchitectureARM64), arch.RpmArch(types.ArchitecturePPC64LE), "":
+	case arch.RpmArch(types.ArchitectureAMD64), arch.RpmArch(types.ArchitectureARM64), arch.RpmArch(types.ArchitecturePPC64LE), arch.RpmArch(types.ArchitectureS390X), "":
 	default:
 		return errors.Errorf("Config.Spec.CpuArchitecture %s is not supported ", i.Config.Spec.CpuArchitecture)
 	}


### PR DESCRIPTION
Added s390x as a supported architecture.
Update PXE files generation to generate kernel.img for s390x as there is no vmlinuz present for it.
