### PR TITLE
CORS-2978: enable AWS SDK Installation through feature gates

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -122,7 +122,7 @@ func runGatherBootstrapCmd(directory string) (string, error) {
 			return "", errors.Wrapf(err, "failed to fetch %s", config.Name())
 		}
 
-		provider, err := infra.ProviderForPlatform(config.Config.Platform.Name())
+		provider, err := infra.ProviderForPlatform(config.Config.Platform.Name(), config.Config.EnabledFeatureGates())
 		if err != nil {
 			return "", fmt.Errorf("error getting infrastructure provider: %w", err)
 		}

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -109,7 +109,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		tfvarsFiles = append(tfvarsFiles, file)
 	}
 
-	provider, err := infra.ProviderForPlatform(platform)
+	provider, err := infra.ProviderForPlatform(platform, installConfig.Config.EnabledFeatureGates())
 	if err != nil {
 		return fmt.Errorf("error getting infrastructure provider: %w", err)
 	}

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -9,12 +9,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset/cluster"
 	openstackasset "github.com/openshift/installer/pkg/asset/cluster/openstack"
 	osp "github.com/openshift/installer/pkg/destroy/openstack"
 	infra "github.com/openshift/installer/pkg/infrastructure/platform"
 	ibmcloudtfvars "github.com/openshift/installer/pkg/tfvars/ibmcloud"
 	typesazure "github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/featuregates"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
@@ -68,7 +70,9 @@ func Destroy(dir string) (err error) {
 		logrus.Debugf("generated ibm endpoint overrides file: %s", endpointsFilePath)
 	}
 
-	provider, err := infra.ProviderForPlatform(platform)
+	fg := featuregates.FeatureGateFromFeatureSets(configv1.FeatureSets, metadata.FeatureSet, metadata.CustomFeatureSet)
+
+	provider, err := infra.ProviderForPlatform(platform, fg)
 	if err != nil {
 		return fmt.Errorf("error getting infrastructure provider: %w", err)
 	}

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -25,6 +25,7 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	externaltypes "github.com/openshift/installer/pkg/types/external"
+	"github.com/openshift/installer/pkg/types/featuregates"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
@@ -37,7 +38,7 @@ import (
 )
 
 // ProviderForPlatform returns the stages to run to provision the infrastructure for the specified platform.
-func ProviderForPlatform(platform string) (infrastructure.Provider, error) {
+func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastructure.Provider, error) {
 	switch platform {
 	case alibabacloudtypes.Name:
 		return terraform.InitializeProvider(alibabacloud.PlatformStages), nil

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -6,7 +6,9 @@ package platform
 import (
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/infrastructure"
+	awsinfra "github.com/openshift/installer/pkg/infrastructure/aws"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages/alibabacloud"
 	"github.com/openshift/installer/pkg/terraform/stages/aws"
@@ -43,6 +45,9 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 	case alibabacloudtypes.Name:
 		return terraform.InitializeProvider(alibabacloud.PlatformStages), nil
 	case awstypes.Name:
+		if fg.Enabled(configv1.FeatureGateInstallAlternateInfrastructureAWS) {
+			return awsinfra.InitializeProvider(), nil
+		}
 		return terraform.InitializeProvider(aws.PlatformStages), nil
 	case azuretypes.Name:
 		return terraform.InitializeProvider(azure.PlatformStages), nil

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -10,11 +10,12 @@ import (
 	"github.com/openshift/installer/pkg/infrastructure/aws"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/featuregates"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
 // ProviderForPlatform returns the stages to run to provision the infrastructure for the specified platform.
-func ProviderForPlatform(platform string) (infrastructure.Provider, error) {
+func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastructure.Provider, error) {
 	switch platform {
 	case awstypes.Name:
 		return aws.InitializeProvider(), nil

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -25,6 +26,8 @@ type ClusterMetadata struct {
 	// InfraID is an ID that is used to identify cloud resources created by the installer.
 	InfraID                 string `json:"infraID"`
 	ClusterPlatformMetadata `json:",inline"`
+	FeatureSet              configv1.FeatureSet          `json:"featureSet"`
+	CustomFeatureSet        *configv1.CustomFeatureGates `json:"customFeatureSet"`
 }
 
 // ClusterPlatformMetadata contains metadata for platfrom.


### PR DESCRIPTION
Plumbs feature gates through to the infrastructure provider package to enable exposing alternate infrastructure providers through feature gates. Particularly enables the AWS sdk infrastructure provider.

Also includes a fixup of the machine manifests due to the API bump. 

This PR plumbs the featuregate into the cluster metadata so that it can be used with the bootstrap destroy code. I know this can be problematic for hive (cc @2uasimojo) when we depend on updates to cluster metadata for destroy code, because cluster metadata is not always present. The functionality added here is only being used in bootstrap destroy code, so I don't think this will negatively affect hive. I think it would be a good idea to remove the feature gate field from the metadata once we have finished implementing the alternate infrastructure providers.