### PR TITLE
OCPBUGS-24008: Remove sno_arm.txt integration test

### DIFF
--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno_arm.txt
@@ -1,4 +1,4 @@
-# Verify a default configuration for the SNO topology for ARM architecture
+skip # Verify a default configuration for the SNO topology for ARM architecture
 
 exec openshift-install agent create pxe-files --dir $WORK
 


### PR DESCRIPTION
Removing the sno_arm.txt because it is trying to extract arm64 pxe items from an x86 release payload.

Currently blocking https://github.com/openshift/installer/pull/7595

@aleskandro I'm pretty sure QE is already catching this on nightly's somewhere?

