### PR TITLE
AGENT-670: Add assisted-db data to agent-gather

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -80,6 +80,30 @@ function gather_storage_data() {
 	( >&2 echo " Done")
 }
 
+function gather_container_status() {
+	( >&2 echo  -n "Gathering container status" )
+	mkdir -p "${ARTIFACTS_DIR}/"
+	( >&2 echo -n ".")
+	sudo podman ps -a > "${ARTIFACTS_DIR}/container-status"
+	( >&2 echo " Done")
+}
+
+function gather_database_data() {
+	( >&2 echo  -n "Gathering assisted database data" )
+	db_container=$(sudo podman ps -a | grep assisted-db)
+	if [[ "$db_container" != "" ]]; then
+		mkdir -p "${ARTIFACTS_DIR}/postgresql"
+		( >&2 echo -n ".")
+		sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status, validations_info from hosts' > "${ARTIFACTS_DIR}/postgresql/hosts-status"
+		( >&2 echo -n ".")
+		sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status, validations_info from clusters' > "${ARTIFACTS_DIR}/postgresql/clusters-status"
+		( >&2 echo -n ".")
+	else
+		( >&2 echo ".. Skipping, assisted-db container not running.")
+	fi
+	( >&2 echo " Done")
+}
+
 function Help()
 {
 	echo "Gathers the necessary data for troubleshooting OpenShift's agent based installation"
@@ -120,6 +144,8 @@ gather_agent_data
 gather_config_status
 gather_network_data
 gather_storage_data
+gather_container_status
+gather_database_data
 
 # Set permissions so regular users can delete the extracted content
 find "$ARTIFACTS_DIR" -type d -exec chmod a+rwx "{}" \;


### PR DESCRIPTION
The hosts and clusters tables are queried for their status and validation_info information. This information can aid in triaging cluster installation failures when the validation information from wait-for bootstrap is missing or inadequate.