### PR TITLE
OCPBUGS-22840: ic/azure: validate field Plan when for marketplace images

### DIFF
--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -216,6 +216,14 @@ var (
 		Name: to.StringPtr("VMImage"),
 		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
 			HyperVGeneration: azenc.HyperVGenerationTypesV1,
+			Plan:             &azenc.PurchasePlan{},
+		},
+	}
+
+	marketplaceImageAPIResultNoPlan = azenc.VirtualMachineImage{
+		Name: to.StringPtr("VMImage"),
+		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
+			HyperVGeneration: azenc.HyperVGenerationTypesV1,
 		},
 	}
 
@@ -1283,7 +1291,7 @@ func TestAzureMarketplaceImage(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringOSImageSKU).Return(true, nil).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, noPlanOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, noPlanOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResultNoPlan, nil).AnyTimes()
 	// Should not check terms of images with no purchase plan
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, noPlanOSImageSKU).MaxTimes(0)
 


### PR DESCRIPTION
If you try to deploy a cluster with a marketplace image that requires a purchase plan to be accepted but set it to `NoPurchasePlan` in the install-config, the VM provisioning will fail with:
```
ERROR Error: waiting for creation of Linux Virtual Machine: (Name "jima02test-7jf8d-bootstrap" / Resource Group "jima02test-7jf8d-rg"): Code="VMMarketplaceInvalidInput" Message="Creating a virtual machine from Marketplace image or a custom image sourced from a Marketplace image requires Plan information in the request. VM: '/subscriptions/$ID/resourceGroups/jima02test-7jf8d-rg/providers/Microsoft.Compute/virtualMachines/jima02test-7jf8d-bootstrap'."
```
Let's check if the `Plan` field actually matches what's expected based on the image's plan properties.