### PR TITLE
OSASINFRA-3295: OpenStack: fix client used to list flavors

### DIFF
--- a/pkg/asset/installconfig/openstack/validvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/validvaluesfetcher.go
@@ -61,7 +61,7 @@ func getExternalNetworkNames(cloud string) ([]string, error) {
 
 // getFlavorNames gets a list of valid flavor names.
 func getFlavorNames(cloud string) ([]string, error) {
-	conn, err := openstackdefaults.NewServiceClient("network", openstackdefaults.DefaultClientOpts(cloud))
+	conn, err := openstackdefaults.NewServiceClient("compute", openstackdefaults.DefaultClientOpts(cloud))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The network client is currently used to retrieve the flavors available in the cloud, but the compute client should be used instead.