### PR TITLE
AGENT-337: Support both VIP and VIPs in AgentClusterInstall

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_no-credentials.txt
@@ -53,11 +53,15 @@ metadata:
   namespace: cluster0
 spec:
   apiVIP: 192.168.111.5
+  apiVIPs:
+  - 192.168.111.5
   clusterDeploymentRef:
     name: ostest
   imageSetRef:
     name: openshift-was not built correctly
   ingressVIP: 192.168.111.4
+  ingressVIPs:
+  - 192.168.111.4
   networking:
     clusterNetwork:
     - cidr: 10.128.0.0/14

--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
@@ -73,11 +73,15 @@ metadata:
   namespace: cluster0
 spec:
   apiVIP: 192.168.111.5
+  apiVIPs:
+  - 192.168.111.5
   clusterDeploymentRef:
     name: ostest
   imageSetRef:
     name: openshift-was not built correctly
   ingressVIP: 192.168.111.4
+  ingressVIPs:
+  - 192.168.111.4
   networking:
     clusterNetwork:
     - cidr: 10.128.0.0/14

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -201,6 +201,8 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 			}
 			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.BareMetal.APIVIPs[0]
 			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.BareMetal.IngressVIPs[0]
+			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.BareMetal.APIVIPs
+			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.BareMetal.IngressVIPs
 		} else if installConfig.Config.Platform.VSphere != nil {
 			vspherePlatform := vsphere.Platform{}
 			if len(installConfig.Config.Platform.VSphere.APIVIPs) > 1 {
@@ -229,6 +231,8 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 			}
 			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.VSphere.APIVIPs[0]
 			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.VSphere.IngressVIPs[0]
+			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.VSphere.APIVIPs
+			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.VSphere.IngressVIPs
 		} else if installConfig.Config.Platform.External != nil {
 			icOverridden = true
 			icOverrides.Platform = &agentClusterInstallPlatform{

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -46,6 +46,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodACIDualStackVIPs.SetAnnotations(map[string]string{
 		installConfigOverrides: `{"platform":{"baremetal":{"apiVIPs":["192.168.122.10","2001:db8:1111:2222:ffff:ffff:ffff:cafe"],"ingressVIPs":["192.168.122.11","2001:db8:1111:2222:ffff:ffff:ffff:dead"]}}}`,
 	})
+	goodACIDualStackVIPs.Spec.APIVIPs = []string{"192.168.122.10", "2001:db8:1111:2222:ffff:ffff:ffff:cafe"}
+	goodACIDualStackVIPs.Spec.IngressVIPs = []string{"192.168.122.11", "2001:db8:1111:2222:ffff:ffff:ffff:dead"}
 
 	installConfigWithCapabilities := getValidOptionalInstallConfig()
 	installConfigWithCapabilities.Config.Capabilities = &types.Capabilities{
@@ -87,6 +89,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodExternalPlatformACI := getGoodACI()
 	goodExternalPlatformACI.Spec.APIVIP = ""
 	goodExternalPlatformACI.Spec.IngressVIP = ""
+	goodExternalPlatformACI.Spec.APIVIPs = nil
+	goodExternalPlatformACI.Spec.IngressVIPs = nil
 	val := true
 	goodExternalPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType
@@ -108,6 +112,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodExternalOCIPlatformACI := getGoodACI()
 	goodExternalOCIPlatformACI.Spec.APIVIP = ""
 	goodExternalOCIPlatformACI.Spec.IngressVIP = ""
+	goodExternalOCIPlatformACI.Spec.APIVIPs = nil
+	goodExternalOCIPlatformACI.Spec.IngressVIPs = nil
 	val = true
 	goodExternalOCIPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalOCIPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -417,6 +417,8 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 			},
 			APIVIP:       "192.168.122.10",
 			IngressVIP:   "192.168.122.11",
+			APIVIPs:      []string{"192.168.122.10"},
+			IngressVIPs:  []string{"192.168.122.11"},
 			PlatformType: hiveext.BareMetalPlatformType,
 		},
 	}


### PR DESCRIPTION
The assisted-service is deprecating support for the singular APIVIP/IngressVIP in https://github.com/openshift/assisted-service/pull/5501. When that merges it will break the agent-installer since currently APIVIP is set when only one VIP is configured. This change sets both API/Ingress VIP and VIPs and will work before and after the assisted-service change merges. 

Note that as a follow-on, https://github.com/openshift/installer/pull/7574 will remove the multiple settings from install-config override which are not needed after the assisted-service change.