### PR TITLE
no-jira: azure: add metadata info to resource group tags

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -302,3 +302,9 @@ variable "azure_user_assigned_identity_key" {
   description = "Defines the user identity key used for the encryption of storage account."
   default     = ""
 }
+
+variable "azure_resource_group_metadata_tags" {
+  type        = map(string)
+  description = "Metadata Azure tags to be applied to the cluster resource group."
+  default     = {}
+}

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_resource_group" "main" {
 
   name     = "${var.cluster_id}-rg"
   location = var.azure_region
-  tags     = var.azure_extra_tags
+  tags     = merge(var.azure_extra_tags, var.azure_resource_group_metadata_tags)
 }
 
 data "azurerm_resource_group" "main" {

--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -124,6 +124,17 @@ func tagResourceGroup(ctx context.Context, clusterID string, installConfig *inst
 	tagKey, tagValue := ownedTag(clusterID)
 	group.Tags[tagKey] = tagValue
 	logrus.Debugf("Tagging resource group %s with %s: %s", installConfig.Config.Azure.ResourceGroupName, tagKey, *tagValue)
+
+	// Save metadata needed to destroy cluster into tags
+	config := installConfig.Config.Azure
+	group.Tags[azure.TagMetadataRegion] = to.StringPtr(config.Region)
+	if len(config.BaseDomainResourceGroupName) > 0 {
+		group.Tags[azure.TagMetadataBaseDomainRG] = to.StringPtr(config.BaseDomainResourceGroupName)
+	}
+	if len(config.NetworkResourceGroupName) > 0 {
+		group.Tags[azure.TagMetadataNetworkRG] = to.StringPtr(config.NetworkResourceGroupName)
+	}
+
 	_, err = client.Update(ctx, installConfig.Config.Azure.ResourceGroupName, resources.GroupPatchable{
 		Tags: group.Tags,
 	})

--- a/pkg/types/azure/metadata.go
+++ b/pkg/types/azure/metadata.go
@@ -8,3 +8,10 @@ type Metadata struct {
 	ResourceGroupName           string           `json:"resourceGroupName"`
 	BaseDomainResourceGroupName string           `json:"baseDomainResourceGroupName"`
 }
+
+// Keys used to save Metadata information as tags.
+const (
+	TagMetadataRegion       = "openshift_region"
+	TagMetadataBaseDomainRG = "openshift_basedomainRG"
+	TagMetadataNetworkRG    = "openshift_networkRG"
+)


### PR DESCRIPTION
When Hive runs the Installer destroy code, they don't always have all
the cluster metadata information the destroyer needs. Adding new fields
to the metadata is also a very painful process for them.

This PR adds some cluster metadata information to the cluster resource
group as tags, so that it can be discovered during destroy even if
azure-specific information is missing from the `metadata.json` file.

For now we are saving "region", "base domain resource group name", and
"network resource group name" but the mechanism will be useful if we
wish to add more data in the future without impacting Hive.