### PR TITLE
CORS-2877: Fix panic when feature gates are not part of a feature set

### DIFF
--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -1,6 +1,9 @@
 package defaults
 
 import (
+	"github.com/sirupsen/logrus"
+
+	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
@@ -90,6 +93,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		} else if c.Platform.PowerVS != nil {
 			c.CredentialsMode = types.ManualCredentialsMode
 		}
+	}
+
+	if len(c.FeatureSet) == 0 && len(c.FeatureGates) > 0 {
+		c.FeatureSet = configv1.CustomNoUpgrade
+		logrus.Warn("Feature gates were provided in the Install Config without a feature set: setting FeatureSet to CustomNoUpgrade")
 	}
 
 	switch {

--- a/pkg/types/featuregates/featuregate.go
+++ b/pkg/types/featuregates/featuregate.go
@@ -3,8 +3,6 @@ package featuregates
 // source: https://github.com/openshift/library-go/blob/c515269de16e5e239bd6e93e1f9821a976bb460b/pkg/operator/configobserver/featuregates/featuregate.go#L23-L28
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -46,12 +44,5 @@ func newFeatureGate(enabled, disabled []configv1.FeatureGateName) FeatureGate {
 // Enabled returns true if the provided feature gate is enabled
 // in the active feature sets.
 func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
-	if f.enabled.Has(key) {
-		return true
-	}
-	if f.disabled.Has(key) {
-		return false
-	}
-
-	panic(fmt.Errorf("feature %q is not registered in FeatureGates", key))
+	return f.enabled.Has(key)
 }


### PR DESCRIPTION
Updates the feature gate Enabled check to return false rather than
panic if a valid feature gate that is not part of a feature set is
not Enabled.

Instead of panicking, the function will return false. User-entered
feature gates are already validated in the install config. This panic
occurs when developers create feature gate checks in code, but the
feature gate is not part of a feature set, such as TechPreview. This
change will allow us to use the feature gates as part of the
CustomNoUpgrade feature set.

Fixes:

```shell
panic: feature "ClusterAPIInstall" is not registered in FeatureGates
```

Also, set the default feature set to CustomNoUpgrade when user supplies feautre gates but no feature set.