### PR TITLE
MULTIARCH-4024: Power VS: Remove all instances of transit gateway enabled flag.

### DIFF
--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -35,14 +35,13 @@ module "pi_network" {
   }
   source = "./power_network"
 
-  cluster_id              = var.cluster_id
-  cloud_instance_id       = module.iaas.si_guid
-  resource_group          = var.powervs_resource_group
-  machine_cidr            = var.machine_v4_cidrs[0]
-  vpc_crn                 = module.vpc.vpc_crn
-  dns_server              = module.dns.dns_server
-  enable_snat             = var.powervs_enable_snat
-  transit_gateway_enabled = var.powervs_transit_gateway_enabled
+  cluster_id        = var.cluster_id
+  cloud_instance_id = module.iaas.si_guid
+  resource_group    = var.powervs_resource_group
+  machine_cidr      = var.machine_v4_cidrs[0]
+  vpc_crn           = module.vpc.vpc_crn
+  dns_server        = module.dns.dns_server
+  enable_snat       = var.powervs_enable_snat
 }
 
 resource "ibm_pi_key" "cluster_key" {
@@ -148,12 +147,11 @@ module "transit_gateway" {
   }
   source = "./transit_gateway"
 
-  cluster_id              = var.cluster_id
-  resource_group          = var.powervs_resource_group
-  service_instance_crn    = module.iaas.si_crn
-  transit_gateway_enabled = var.powervs_transit_gateway_enabled
-  vpc_crn                 = module.vpc.vpc_crn
-  vpc_region              = var.powervs_vpc_region
+  cluster_id           = var.cluster_id
+  resource_group       = var.powervs_resource_group
+  service_instance_crn = module.iaas.si_crn
+  vpc_crn              = module.vpc.vpc_crn
+  vpc_region           = var.powervs_vpc_region
 }
 
 module "iaas" {

--- a/data/data/powervs/cluster/power_network/variables.tf
+++ b/data/data/powervs/cluster/power_network/variables.tf
@@ -35,8 +35,3 @@ variable "enable_snat" {
   default     = true
 }
 
-variable "transit_gateway_enabled" {
-  type        = bool
-  description = "Boolean indicating if Transit Gateways should be used."
-  default     = false
-}

--- a/data/data/powervs/cluster/transit_gateway/transit_gateway.tf
+++ b/data/data/powervs/cluster/transit_gateway/transit_gateway.tf
@@ -1,6 +1,5 @@
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_gateway
 resource "ibm_tg_gateway" "transit_gateway" {
-  count          = var.transit_gateway_enabled ? 1 : 0
   name           = "tg-${var.cluster_id}"
   location       = var.vpc_region
   global         = true
@@ -14,8 +13,7 @@ data "ibm_resource_group" "rg_pvs_ipi_rg" {
 
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_connection
 resource "ibm_tg_connection" "tg_connection_vpc" {
-  count        = var.transit_gateway_enabled ? 1 : 0
-  gateway      = resource.ibm_tg_gateway.transit_gateway[count.index].id
+  gateway      = resource.ibm_tg_gateway.transit_gateway.id
   network_type = "vpc"
   name         = "tg-${var.cluster_id}-conn-vpc"
   network_id   = var.vpc_crn
@@ -23,8 +21,7 @@ resource "ibm_tg_connection" "tg_connection_vpc" {
 
 # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_connection
 resource "ibm_tg_connection" "tg_connection_pvs" {
-  count        = var.transit_gateway_enabled ? 1 : 0
-  gateway      = resource.ibm_tg_gateway.transit_gateway[count.index].id
+  gateway      = resource.ibm_tg_gateway.transit_gateway.id
   network_type = "power_virtual_server"
   name         = "tg-${var.cluster_id}-conn-pvs"
   network_id   = var.service_instance_crn

--- a/data/data/powervs/cluster/transit_gateway/variables.tf
+++ b/data/data/powervs/cluster/transit_gateway/variables.tf
@@ -8,12 +8,6 @@ variable "resource_group" {
   description = "The name of the Power VS resource group to which the user belongs."
 }
 
-variable "transit_gateway_enabled" {
-  type        = bool
-  description = "Boolean indicating if Transit Gateways should be used."
-  default     = false
-}
-
 variable "service_instance_crn" {
   type        = string
   description = "The CRN of the service instance."

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -106,11 +106,6 @@ variable "powervs_enable_snat" {
   default     = true
 }
 
-variable "powervs_transit_gateway_enabled" {
-  type        = bool
-  description = "Boolean indicating if Transit Gateways should be used."
-  default     = false
-}
 
 ################################################################
 # Configure instances

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -877,6 +877,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			vpcZone = fmt.Sprintf("%s-%d", vpcRegion, rand.Intn(2)+1) //nolint:gosec // we don't need a crypto secure number
 		}
 
+		cpStanza := installConfig.Config.ControlPlane
+		if cpStanza == nil || cpStanza.Platform.PowerVS == nil || cpStanza.Platform.PowerVS.SysType == "" {
+			sysTypes, err := powervs.AvailableSysTypes(installConfig.Config.PowerVS.Region)
+			if err != nil {
+				return err
+			}
+			for i := range masters {
+				masterConfigs[i].SystemType = sysTypes[0]
+			}
+		}
+
 		transitGatewayEnabled := powervsconfig.TransitGatewayEnabledZone(installConfig.Config.Platform.PowerVS.Zone)
 
 		osImage := strings.SplitN(string(*rhcosImage), "/", 2)

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -179,6 +179,11 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
+		err = powervsconfig.ValidateSystemTypeForRegion(client, ic.Config)
+		if err != nil {
+			return err
+		}
 	case external.Name, libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:

--- a/pkg/asset/installconfig/powervs/validation.go
+++ b/pkg/asset/installconfig/powervs/validation.go
@@ -253,3 +253,26 @@ func ValidateResourceGroup(client API, ic *types.InstallConfig) error {
 
 	return nil
 }
+
+// ValidateSystemTypeForRegion checks if the specified sysType is available in the target region.
+func ValidateSystemTypeForRegion(client API, ic *types.InstallConfig) error {
+	if ic.ControlPlane == nil || ic.ControlPlane.Platform.PowerVS == nil || ic.ControlPlane.Platform.PowerVS.SysType == "" {
+		return nil
+	}
+	availableOnes, err := powervstypes.AvailableSysTypes(ic.PowerVS.Region)
+	if err != nil {
+		return fmt.Errorf("failed to obtain available SysTypes for: %s", ic.PowerVS.Region)
+	}
+	requested := ic.ControlPlane.Platform.PowerVS.SysType
+	found := false
+	for i := range availableOnes {
+		if requested == availableOnes[i] {
+			found = true
+			break
+		}
+	}
+	if found {
+		return nil
+	}
+	return fmt.Errorf("%s is not available in: %s", requested, ic.PowerVS.Region)
+}

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -14,32 +14,31 @@ import (
 )
 
 type config struct {
-	APIKey                string `json:"powervs_api_key"`
-	SSHKey                string `json:"powervs_ssh_key"`
-	PowerVSRegion         string `json:"powervs_region"`
-	PowerVSZone           string `json:"powervs_zone"`
-	VPCRegion             string `json:"powervs_vpc_region"`
-	VPCZone               string `json:"powervs_vpc_zone"`
-	COSRegion             string `json:"powervs_cos_region"`
-	PowerVSResourceGroup  string `json:"powervs_resource_group"`
-	CISInstanceCRN        string `json:"powervs_cis_crn"`
-	DNSInstanceGUID       string `json:"powervs_dns_guid"`
-	ImageBucketName       string `json:"powervs_image_bucket_name"`
-	ImageBucketFileName   string `json:"powervs_image_bucket_file_name"`
-	VPCName               string `json:"powervs_vpc_name"`
-	VPCSubnetName         string `json:"powervs_vpc_subnet_name"`
-	VPCPermitted          bool   `json:"powervs_vpc_permitted"`
-	VPCGatewayName        string `json:"powervs_vpc_gateway_name"`
-	VPCGatewayAttached    bool   `json:"powervs_vpc_gateway_attached"`
-	BootstrapMemory       int32  `json:"powervs_bootstrap_memory"`
-	BootstrapProcessors   string `json:"powervs_bootstrap_processors"`
-	MasterMemory          int32  `json:"powervs_master_memory"`
-	MasterProcessors      string `json:"powervs_master_processors"`
-	ProcType              string `json:"powervs_proc_type"`
-	SysType               string `json:"powervs_sys_type"`
-	PublishStrategy       string `json:"powervs_publish_strategy"`
-	EnableSNAT            bool   `json:"powervs_enable_snat"`
-	TransitGatewayEnabled bool   `json:"powervs_transit_gateway_enabled"`
+	APIKey               string `json:"powervs_api_key"`
+	SSHKey               string `json:"powervs_ssh_key"`
+	PowerVSRegion        string `json:"powervs_region"`
+	PowerVSZone          string `json:"powervs_zone"`
+	VPCRegion            string `json:"powervs_vpc_region"`
+	VPCZone              string `json:"powervs_vpc_zone"`
+	COSRegion            string `json:"powervs_cos_region"`
+	PowerVSResourceGroup string `json:"powervs_resource_group"`
+	CISInstanceCRN       string `json:"powervs_cis_crn"`
+	DNSInstanceGUID      string `json:"powervs_dns_guid"`
+	ImageBucketName      string `json:"powervs_image_bucket_name"`
+	ImageBucketFileName  string `json:"powervs_image_bucket_file_name"`
+	VPCName              string `json:"powervs_vpc_name"`
+	VPCSubnetName        string `json:"powervs_vpc_subnet_name"`
+	VPCPermitted         bool   `json:"powervs_vpc_permitted"`
+	VPCGatewayName       string `json:"powervs_vpc_gateway_name"`
+	VPCGatewayAttached   bool   `json:"powervs_vpc_gateway_attached"`
+	BootstrapMemory      int32  `json:"powervs_bootstrap_memory"`
+	BootstrapProcessors  string `json:"powervs_bootstrap_processors"`
+	MasterMemory         int32  `json:"powervs_master_memory"`
+	MasterProcessors     string `json:"powervs_master_processors"`
+	ProcType             string `json:"powervs_proc_type"`
+	SysType              string `json:"powervs_sys_type"`
+	PublishStrategy      string `json:"powervs_publish_strategy"`
+	EnableSNAT           bool   `json:"powervs_enable_snat"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -93,32 +92,31 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	}
 
 	cfg := &config{
-		APIKey:                sources.APIKey,
-		SSHKey:                sources.SSHKey,
-		PowerVSRegion:         sources.Region,
-		PowerVSZone:           sources.Zone,
-		VPCRegion:             sources.VPCRegion,
-		VPCZone:               sources.VPCZone,
-		COSRegion:             cosRegion,
-		PowerVSResourceGroup:  sources.PowerVSResourceGroup,
-		CISInstanceCRN:        sources.CISInstanceCRN,
-		DNSInstanceGUID:       dnsGUID,
-		ImageBucketName:       sources.ImageBucketName,
-		ImageBucketFileName:   sources.ImageBucketFileName,
-		VPCName:               sources.VPCName,
-		VPCSubnetName:         sources.VPCSubnetName,
-		VPCPermitted:          sources.VPCPermitted,
-		VPCGatewayName:        sources.VPCGatewayName,
-		VPCGatewayAttached:    sources.VPCGatewayAttached,
-		BootstrapMemory:       masterConfig.MemoryGiB,
-		BootstrapProcessors:   processor,
-		MasterMemory:          masterConfig.MemoryGiB,
-		MasterProcessors:      processor,
-		ProcType:              strings.ToLower(string(masterConfig.ProcessorType)),
-		SysType:               masterConfig.SystemType,
-		PublishStrategy:       string(sources.PublishStrategy),
-		EnableSNAT:            sources.EnableSNAT,
-		TransitGatewayEnabled: sources.TransitGatewayEnabled,
+		APIKey:               sources.APIKey,
+		SSHKey:               sources.SSHKey,
+		PowerVSRegion:        sources.Region,
+		PowerVSZone:          sources.Zone,
+		VPCRegion:            sources.VPCRegion,
+		VPCZone:              sources.VPCZone,
+		COSRegion:            cosRegion,
+		PowerVSResourceGroup: sources.PowerVSResourceGroup,
+		CISInstanceCRN:       sources.CISInstanceCRN,
+		DNSInstanceGUID:      dnsGUID,
+		ImageBucketName:      sources.ImageBucketName,
+		ImageBucketFileName:  sources.ImageBucketFileName,
+		VPCName:              sources.VPCName,
+		VPCSubnetName:        sources.VPCSubnetName,
+		VPCPermitted:         sources.VPCPermitted,
+		VPCGatewayName:       sources.VPCGatewayName,
+		VPCGatewayAttached:   sources.VPCGatewayAttached,
+		BootstrapMemory:      masterConfig.MemoryGiB,
+		BootstrapProcessors:  processor,
+		MasterMemory:         masterConfig.MemoryGiB,
+		MasterProcessors:     processor,
+		ProcType:             strings.ToLower(string(masterConfig.ProcessorType)),
+		SysType:              masterConfig.SystemType,
+		PublishStrategy:      string(sources.PublishStrategy),
+		EnableSNAT:           sources.EnableSNAT,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -2,6 +2,8 @@ package powervs
 
 import (
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Since there is no API to query these, we have to hard-code them here.
@@ -13,6 +15,7 @@ type Region struct {
 	Description string
 	VPCRegion   string
 	Zones       []string
+	SysTypes    []string
 }
 
 // Regions holds the regions for IBM Power VS, and descriptions used during the survey.
@@ -21,6 +24,7 @@ var Regions = map[string]Region{
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		Zones:       []string{"dal10"},
+		SysTypes:    []string{"s922", "e980"},
 	},
 }
 
@@ -89,4 +93,22 @@ func RegionFromZone(zone string) string {
 		}
 	}
 	return ""
+}
+
+// AvailableSysTypes returns the default system type for the zone.
+func AvailableSysTypes(region string) ([]string, error) {
+	knownRegion, ok := Regions[region]
+	if !ok {
+		return nil, fmt.Errorf("unknown region name provided")
+	}
+	return knownRegion.SysTypes, nil
+}
+
+// AllKnownSysTypes returns aggregated known system types from all regions.
+func AllKnownSysTypes() sets.Set[string] {
+	sysTypes := sets.New[string]()
+	for _, region := range Regions {
+		sysTypes.Insert(region.SysTypes...)
+	}
+	return sysTypes
 }

--- a/pkg/types/powervs/validation/machinepool.go
+++ b/pkg/types/powervs/validation/machinepool.go
@@ -72,10 +72,8 @@ func ValidateMachinePool(p *powervs.MachinePool, fldPath *field.Path) field.Erro
 
 	// Validate SysType
 	if p.SysType != "" {
-		const sysTypeRegex = `^(?:e980|s922(-.*|))$`
-		// Allowing for a staging-only pattern of s922-* but not exposing here
-		if !regexp.MustCompile(sysTypeRegex).MatchString(p.SysType) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("sysType"), p.SysType, "system type must be one of {e980,s922}"))
+		if !powervs.AllKnownSysTypes().Has(p.SysType) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("sysType"), p.SysType, "unknown system type specified"))
 		}
 	}
 

--- a/pkg/types/powervs/validation/machinepool_test.go
+++ b/pkg/types/powervs/validation/machinepool_test.go
@@ -142,7 +142,7 @@ func TestValidateMachinePool(t *testing.T) {
 			pool: &powervs.MachinePool{
 				SysType: "p922",
 			},
-			expected: `^test-path\.sysType: Invalid value: "p922": system type must be one of {e980,s922}$`,
+			expected: `^test-path\.sysType: Invalid value: "p922": unknown system type specified$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Removal of references to `transit gateway enabled` flag since transit gateways are now enabled by default.