### PR TITLE
OCPBUGS-23376: vSphere - when using RP network path is incorrect

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -947,6 +947,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, c := range controlPlanes {
 			var clusterMo mo.ClusterComputeResource
 			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1beta1.VSphereMachineProviderSpec)
+
 			rpObj, err := finder.ResourcePool(ctx, controlPlaneConfigs[i].Workspace.ResourcePool)
 			if err != nil {
 				return err
@@ -957,16 +958,23 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				return err
 			}
 
-			clusterObj := object.NewClusterComputeResource(vim25Client, clusterRef.Reference())
+			// When using finder.ObjectReference the InventoryPath is defined
+			// NewClusterComputeResource I don't believe assigns that value.
+			clusterObjRef, err := finder.ObjectReference(ctx, clusterRef.Reference())
+			if err != nil {
+				return err
+			}
+
+			clusterObj, ok := clusterObjRef.(*object.ClusterComputeResource)
+			if !ok {
+				return errors.New("unable to convert cluster object reference to object cluster compute resource")
+			}
 			err = clusterObj.Properties(ctx, clusterRef.Reference(), []string{"name", "summary"}, &clusterMo)
 			if err != nil {
 				return err
 			}
 
-			clusterPath := strings.SplitAfter(controlPlaneConfigs[i].Workspace.ResourcePool, clusterMo.Name)
-
-			networkPath := path.Join(clusterPath[0], controlPlaneConfigs[i].Network.Devices[0].NetworkName)
-
+			networkPath := path.Join(clusterObj.InventoryPath, controlPlaneConfigs[i].Network.Devices[0].NetworkName)
 			netObj, err := finder.Network(ctx, networkPath)
 			if err != nil {
 				return err

--- a/pkg/asset/installconfig/vsphere/client.go
+++ b/pkg/asset/installconfig/vsphere/client.go
@@ -33,6 +33,7 @@ type Finder interface {
 	VirtualMachine(ctx context.Context, path string) (*object.VirtualMachine, error)
 	VirtualMachineList(ctx context.Context, path string) ([]*object.VirtualMachine, error)
 	HostSystemList(ctx context.Context, path string) ([]*object.HostSystem, error)
+	ObjectReference(ctx context.Context, ref types.ManagedObjectReference) (object.Reference, error)
 }
 
 // NewFinder creates a new client that conforms with the Finder interface and returns a


### PR DESCRIPTION
Instead of using a SplitAfter with the Resource Pool path
and the vCenter Cluster name this PR replaces it
with the Cluster's ManagedObjectReference
and finder.ObjectReference which will set the
InventoryPath.