### PR TITLE
CORS-2835: pkg/infrastructure: remove ARO build tag

### DIFF
--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -1,5 +1,5 @@
-//go:build !(altinfra || aro)
-// +build !altinfra,!aro
+//go:build !altinfra
+// +build !altinfra
 
 package platform
 

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -1,5 +1,5 @@
-//go:build altinfra || aro
-// +build altinfra aro
+//go:build altinfra
+// +build altinfra
 
 package platform
 


### PR DESCRIPTION
The build tag was added to assist ARO when rebasing their fork. Including the tag was premature and this is now causing issues for QE.

See comments in: https://issues.redhat.com/browse/OCPBUGS-22113