### PR TITLE
[release-4.11] OCPBUGS-23478: Specify google cloud CLI to version 256.0.0

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -30,7 +30,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
       azure-cli \
       gettext \
-      google-cloud-sdk \
+      google-cloud-sdk-256.0.0 \
       gzip \
       jq \
       unzip \


### PR DESCRIPTION
Per https://github.com/openshift/release/pull/45591, the 4.11 upi-installer need to install 256.0.0, but not 447.0.0, so we did not backport the [change](https://github.com/openshift/installer/pull/7731) here.