### PR TITLE
OCPBUGS-23539: Keep Machine manifests out of OpenShift Manifests asset

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -747,6 +747,21 @@ func IsMachineManifest(file *asset.File) bool {
 	} else if matched {
 		return true
 	}
+	if matched, err := filepath.Match(secretFileNamePattern, filename); err != nil {
+		panic("bad format for secret file name pattern")
+	} else if matched {
+		return true
+	}
+	if matched, err := filepath.Match(networkConfigSecretFileNamePattern, filename); err != nil {
+		panic("bad format for network config secret file name pattern")
+	} else if matched {
+		return true
+	}
+	if matched, err := filepath.Match(hostFileNamePattern, filename); err != nil {
+		panic("bad format for host file name pattern")
+	} else if matched {
+		return true
+	}
 	if matched, err := filepath.Match(masterMachineFileNamePattern, filename); err != nil {
 		panic("bad format for master machine file name pattern")
 	} else if matched {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -747,31 +747,23 @@ func IsMachineManifest(file *asset.File) bool {
 	} else if matched {
 		return true
 	}
-	if matched, err := filepath.Match(secretFileNamePattern, filename); err != nil {
-		panic("bad format for secret file name pattern")
-	} else if matched {
-		return true
+	for _, pattern := range []struct {
+		Pattern string
+		Type    string
+	}{
+		{Pattern: secretFileNamePattern, Type: "secret"},
+		{Pattern: networkConfigSecretFileNamePattern, Type: "network config secret"},
+		{Pattern: hostFileNamePattern, Type: "host"},
+		{Pattern: masterMachineFileNamePattern, Type: "master machine"},
+		{Pattern: workerMachineSetFileNamePattern, Type: "worker machineset"},
+	} {
+		if matched, err := filepath.Match(pattern.Pattern, filename); err != nil {
+			panic(fmt.Sprintf("bad format for %s file name pattern", pattern.Type))
+		} else if matched {
+			return true
+		}
 	}
-	if matched, err := filepath.Match(networkConfigSecretFileNamePattern, filename); err != nil {
-		panic("bad format for network config secret file name pattern")
-	} else if matched {
-		return true
-	}
-	if matched, err := filepath.Match(hostFileNamePattern, filename); err != nil {
-		panic("bad format for host file name pattern")
-	} else if matched {
-		return true
-	}
-	if matched, err := filepath.Match(masterMachineFileNamePattern, filename); err != nil {
-		panic("bad format for master machine file name pattern")
-	} else if matched {
-		return true
-	}
-	if matched, err := filepath.Match(workerMachineSetFileNamePattern, filename); err != nil {
-		panic("bad format for worker machine file name pattern")
-	} else {
-		return matched
-	}
+	return false
 }
 
 func createSecretAssetFiles(resources []corev1.Secret, fileName string) ([]*asset.File, error) {

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -310,6 +310,7 @@ func TestBaremetalGeneratedAssetFiles(t *testing.T) {
 }
 
 func verifyHost(t *testing.T, a *asset.File, eFilename, eName string) {
+	t.Helper()
 	assert.Equal(t, a.Filename, eFilename)
 	var host v1alpha1.BareMetalHost
 	assert.NoError(t, yaml.Unmarshal(a.Data, &host))
@@ -317,6 +318,7 @@ func verifyHost(t *testing.T, a *asset.File, eFilename, eName string) {
 }
 
 func verifySecret(t *testing.T, a *asset.File, eFilename, eName, eData string) {
+	t.Helper()
 	assert.Equal(t, a.Filename, eFilename)
 	var secret corev1.Secret
 	assert.NoError(t, yaml.Unmarshal(a.Data, &secret))

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -307,6 +307,7 @@ func TestBaremetalGeneratedAssetFiles(t *testing.T) {
 
 	assert.Len(t, master.NetworkConfigSecretFiles, 1)
 	verifySecret(t, master.NetworkConfigSecretFiles[0], "openshift/99_openshift-cluster-api_host-network-config-secrets-0.yaml", "master-0-network-config-secret", "map[nmstate:[105 110 116 101 114 102 97 99 101 115 58 32 110 117 108 108 10]]")
+	verifyManifestOwnership(t, master)
 }
 
 func verifyHost(t *testing.T, a *asset.File, eFilename, eName string) {
@@ -324,6 +325,13 @@ func verifySecret(t *testing.T, a *asset.File, eFilename, eName, eData string) {
 	assert.NoError(t, yaml.Unmarshal(a.Data, &secret))
 	assert.Equal(t, eName, secret.Name)
 	assert.Equal(t, eData, fmt.Sprintf("%v", secret.Data))
+}
+
+func verifyManifestOwnership(t *testing.T, a asset.WritableAsset) {
+	t.Helper()
+	for _, file := range a.Files() {
+		assert.True(t, IsMachineManifest(file), file.Filename)
+	}
 }
 
 func networkConfig(config string) *v1.JSON {


### PR DESCRIPTION
IsMachineManifest() should match all of the manifests generated by either the Master or Worker machines asset. Several new types of files have been added, particularly for baremetal, without updating this function. This resulted in the files being matched by the generic OpenShift Manifests asset as well as the one that actually created them.

As a result, there was a bogus warning every time we generated the manifests for a baremetal cluster:

```
WARNING Discarding the Openshift Manifests that was provided in the target directory because its dependencies are dirty and it needs to be regenerated
```

even when there is no pre-existing `openshift` directory with contents to discard.