### PR TITLE
CORS-3425: Add option to keep input files

### DIFF
--- a/cmd/openshift-install/command/log.go
+++ b/cmd/openshift-install/command/log.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	// RootOpts holds the log directory and log level configuration.
+	// RootOpts holds the directory and log level configuration.
 	RootOpts struct {
-		Dir      string
-		LogLevel string
+		Dir          string
+		LogLevel     string
+		ConsumeFiles bool
 	}
 )
 

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -316,8 +316,12 @@ func newCreateCmd(ctx context.Context) *cobra.Command {
 }
 
 func runTargetCmd(ctx context.Context, targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
-	runner := func(directory string) error {
-		fetcher := assetstore.NewAssetsFetcher(directory)
+	runner := func(directory string, consumeFiles bool) error {
+		if !(forcePreserveInputs || forceConsumeInputs) {
+			logrus.Info("Pass --preserve to leave input files in place")
+		}
+
+		fetcher := assetstore.NewAssetsFetcher(directory, consumeFiles)
 		return fetcher.FetchAndPersist(ctx, targets)
 	}
 
@@ -332,7 +336,7 @@ func runTargetCmd(ctx context.Context, targets ...asset.WritableAsset) func(cmd 
 
 		cluster.InstallDir = command.RootOpts.Dir
 
-		err := runner(command.RootOpts.Dir)
+		err := runner(command.RootOpts.Dir, command.RootOpts.ConsumeFiles)
 		if err != nil {
 			if strings.Contains(err.Error(), asset.InstallConfigError) {
 				logrus.Error(err)

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -131,9 +131,14 @@ func runGatherBootstrapCmd(ctx context.Context, directory string) (string, error
 	}
 
 	if ha.Bootstrap == "" && len(ha.Masters) == 0 {
-		config := &installconfig.InstallConfig{}
-		if err := assetStore.Fetch(ctx, config); err != nil {
-			return "", fmt.Errorf("failed to fetch %s: %w", config.Name(), err)
+		configAsset, err := assetStore.Load(&installconfig.InstallConfig{})
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch %s: %w",
+				(&installconfig.InstallConfig{}).Name(), err)
+		}
+		config, ok := configAsset.(*installconfig.InstallConfig)
+		if !ok {
+			panic("failed to convert InstallConfig asset")
 		}
 
 		provider, err := infra.ProviderForPlatform(config.Config.Platform.Name(), config.Config.EnabledFeatureGates())

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -69,6 +69,10 @@ func installerMain() {
 	}
 }
 
+var (
+	forceConsumeInputs = false
+)
+
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              filepath.Base(os.Args[0]),
@@ -78,8 +82,10 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors:    true,
 		SilenceUsage:     true,
 	}
+	cmd.PersistentFlags().SortFlags = false
 	cmd.PersistentFlags().StringVar(&command.RootOpts.Dir, "dir", ".", "assets directory")
 	cmd.PersistentFlags().StringVar(&command.RootOpts.LogLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
+	cmd.PersistentFlags().BoolVar(&forceConsumeInputs, "consume", false, "remove input files after they are read (default)")
 	return cmd
 }
 

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -70,7 +70,8 @@ func installerMain() {
 }
 
 var (
-	forceConsumeInputs = false
+	forcePreserveInputs = false
+	forceConsumeInputs  = false
 )
 
 func newRootCmd() *cobra.Command {
@@ -86,6 +87,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&command.RootOpts.Dir, "dir", ".", "assets directory")
 	cmd.PersistentFlags().StringVar(&command.RootOpts.LogLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
 	cmd.PersistentFlags().BoolVar(&forceConsumeInputs, "consume", false, "remove input files after they are read (default)")
+	cmd.PersistentFlags().BoolVar(&forcePreserveInputs, "preserve", false, "leave input files after they are read")
 	return cmd
 }
 
@@ -113,6 +115,11 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.Fatal(errors.Wrap(err, "invalid log-level"))
 	}
+
+	if forcePreserveInputs && forceConsumeInputs {
+		logrus.Fatal(errors.New("cannot set both --preserve and --consume"))
+	}
+	command.RootOpts.ConsumeFiles = !forcePreserveInputs
 }
 
 // handleInterrupt executes a graceful shutdown then exits in

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -22,4 +22,7 @@ type Store interface {
 	// Load retrieves the state of the given asset but does not generate it if it
 	// does not exist and instead will return nil if not found.
 	Load(Asset) (Asset, error)
+
+	// PersistToFile writes the asset's files to disk for the user to edit
+	PersistToFile(wa WritableAsset) error
 }

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -105,7 +105,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 					t.Fatalf("failed to fetch %q: %v", a.Name(), err)
 				}
 
-				if err := asset.PersistToFile(a, tempDir); err != nil {
+				if err := assetStore.PersistToFile(a); err != nil {
 					t.Fatalf("failed to write asset %q to disk: %v", a.Name(), err)
 				}
 			}

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -95,7 +95,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 				}
 			}
 
-			assetStore, err := newStore(tempDir)
+			assetStore, err := newStore(tempDir, true)
 			if err != nil {
 				t.Fatalf("failed to create asset store: %v", err)
 			}
@@ -110,7 +110,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 				}
 			}
 
-			newAssetStore, err := newStore(tempDir)
+			newAssetStore, err := newStore(tempDir, true)
 			if err != nil {
 				t.Fatalf("failed to create new asset store: %v", err)
 			}

--- a/pkg/asset/store/assetsfetcher.go
+++ b/pkg/asset/store/assetsfetcher.go
@@ -27,15 +27,6 @@ func NewAssetsFetcher(storeDir string) AssetsFetcher {
 	}
 }
 
-func asFileWriter(a asset.WritableAsset) asset.FileWriter {
-	switch v := a.(type) {
-	case asset.FileWriter:
-		return v
-	default:
-		return asset.NewDefaultFileWriter(a)
-	}
-}
-
 // Fetchs all the writable assets from the configured assets store.
 func (f *fetcher) FetchAndPersist(ctx context.Context, assets []asset.WritableAsset) error {
 	assetStore, err := NewStore(f.storeDir)
@@ -49,7 +40,7 @@ func (f *fetcher) FetchAndPersist(ctx context.Context, assets []asset.WritableAs
 			err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 		}
 
-		err2 := asFileWriter(a).PersistToFile(f.storeDir)
+		err2 := assetStore.PersistToFile(a)
 		if err2 != nil {
 			err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
 			if err != nil {

--- a/pkg/asset/store/assetsfetcher.go
+++ b/pkg/asset/store/assetsfetcher.go
@@ -17,19 +17,21 @@ type AssetsFetcher interface {
 }
 
 type fetcher struct {
-	storeDir string
+	storeDir     string
+	consumeFiles bool
 }
 
 // NewAssetsFetcher creates a new AssetsFetcher instance for the specified assets store folder.
-func NewAssetsFetcher(storeDir string) AssetsFetcher {
+func NewAssetsFetcher(storeDir string, consumeFiles bool) AssetsFetcher {
 	return &fetcher{
-		storeDir: storeDir,
+		storeDir:     storeDir,
+		consumeFiles: consumeFiles,
 	}
 }
 
 // Fetchs all the writable assets from the configured assets store.
 func (f *fetcher) FetchAndPersist(ctx context.Context, assets []asset.WritableAsset) error {
-	assetStore, err := NewStore(f.storeDir)
+	assetStore, err := NewStoreWithConsumption(f.storeDir, f.consumeFiles)
 	if err != nil {
 		return fmt.Errorf("failed to create asset store: %w", err)
 	}

--- a/pkg/asset/store/filefetcher_test.go
+++ b/pkg/asset/store/filefetcher_test.go
@@ -54,7 +54,10 @@ func TestFetchByName(t *testing.T) {
 				}
 			}
 
-			f := &fileFetcher{directory: tempDir}
+			f := &fileFetcher{
+				directory: tempDir,
+				modCheck:  newModificationTracker(),
+			}
 			file, err := f.FetchByName(tt.input)
 			if err != nil {
 				if os.IsNotExist(err) && tt.expectFile == nil {
@@ -155,7 +158,10 @@ func TestFetchByPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			f := &fileFetcher{directory: tempDir}
+			f := &fileFetcher{
+				directory: tempDir,
+				modCheck:  newModificationTracker(),
+			}
 			files, err := f.FetchByPattern(tt.input)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/asset/store/modification.go
+++ b/pkg/asset/store/modification.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"time"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+type modificationChecker interface {
+	CheckModified(string, *asset.File) error
+}
+
+type fileTime struct {
+	time.Time
+}
+
+type timestamps map[string]fileTime
+
+type storedData struct {
+	ModTime timestamps
+}
+
+type empty struct{}
+
+type modificationTracker struct {
+	previous  storedData
+	current   storedData
+	preserved map[string]empty
+}
+
+const modTrackerKey = "modificationTracker"
+
+func newModificationTracker() *modificationTracker {
+	return &modificationTracker{
+		previous:  storedData{timestamps{}},
+		current:   storedData{timestamps{}},
+		preserved: map[string]empty{},
+	}
+}
+
+func (m *modificationTracker) CheckModified(path string, file *asset.File) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return m.checkTimestamp(file.Filename, info.ModTime())
+}
+
+func (m *modificationTracker) checkTimestamp(name string, modTime time.Time) error {
+	if !modTime.After(m.previous.ModTime[name].Time) {
+		m.preserved[name] = empty{}
+		// The file is unmodified, so tell the Asset that it does not exist
+		// on disk. Many assets use os.IsNotExist(err) to check this, so we
+		// cannot even wrap it in our own error as we could if we could rely on
+		// errors.Is(err, fs.ErrNotExist) being used consistently.
+		return fs.ErrNotExist
+	}
+	m.current.ModTime[name] = fileTime{modTime}
+	return nil
+}
+
+func (m *modificationTracker) Purge(wa asset.WritableAsset) {
+	for _, f := range wa.Files() {
+		delete(m.current.ModTime, f.Filename)
+	}
+}
+
+func (m *modificationTracker) HasPreservedFiles(a asset.Asset) bool {
+	if wa, ok := a.(asset.WritableAsset); ok {
+		for _, f := range wa.Files() {
+			if _, present := m.preserved[f.Filename]; present {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *modificationTracker) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(m.current, "", "    ")
+}
+
+func (m *modificationTracker) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &m.previous); err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &m.current)
+}
+
+func (ft fileTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ft.UnixNano())
+}
+
+func (ft *fileTime) UnmarshalJSON(data []byte) error {
+	var nsec int64
+	err := json.Unmarshal(data, &nsec)
+	ft.Time = time.Unix(0, nsec)
+	return err
+}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -372,3 +372,16 @@ func (s *storeImpl) Load(a asset.Asset) (asset.Asset, error) {
 
 	return s.assets[reflect.TypeOf(a)].asset, nil
 }
+
+func asFileWriter(a asset.WritableAsset) asset.FileWriter {
+	switch v := a.(type) {
+	case asset.FileWriter:
+		return v
+	default:
+		return asset.NewDefaultFileWriter(a)
+	}
+}
+
+func (s *storeImpl) PersistToFile(wa asset.WritableAsset) error {
+	return asFileWriter(wa).PersistToFile(s.directory)
+}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -50,18 +50,26 @@ type storeImpl struct {
 	assets          map[reflect.Type]*assetState
 	stateFileAssets map[string]json.RawMessage
 	fileFetcher     asset.FileFetcher
+	modifications   *modificationTracker
+	consumeFiles    bool
 }
 
 // NewStore returns an asset store that implements the asset.Store interface.
 func NewStore(dir string) (asset.Store, error) {
-	return newStore(dir)
+	return newStore(dir, true)
 }
 
-func newStore(dir string) (*storeImpl, error) {
+func newStore(dir string, consumeFiles bool) (*storeImpl, error) {
+	modTracker := newModificationTracker()
 	store := &storeImpl{
-		directory:   dir,
-		fileFetcher: &fileFetcher{directory: dir},
-		assets:      map[reflect.Type]*assetState{},
+		directory: dir,
+		assets:    map[reflect.Type]*assetState{},
+		fileFetcher: &fileFetcher{
+			directory: dir,
+			modCheck:  modTracker,
+		},
+		modifications: modTracker,
+		consumeFiles:  consumeFiles,
 	}
 
 	if err := store.loadStateFile(); err != nil {
@@ -104,6 +112,7 @@ func (s *storeImpl) Destroy(a asset.Asset) error {
 		if err := asset.DeleteAssetFromDisk(wa, s.directory); err != nil {
 			return err
 		}
+		s.modifications.Purge(wa)
 	}
 
 	delete(s.assets, reflect.TypeOf(a))
@@ -142,6 +151,12 @@ func (s *storeImpl) loadStateFile() error {
 		return errors.Wrapf(err, "failed to unmarshal state file %q", path)
 	}
 	s.stateFileAssets = assets
+
+	if mods, ok := assets[modTrackerKey]; ok {
+		if err := json.Unmarshal(mods, s.modifications); err != nil {
+			return errors.Wrapf(err, "failed to unmarshal state file %q", path)
+		}
+	}
 	return nil
 }
 
@@ -175,6 +190,11 @@ func (s *storeImpl) saveStateFile() error {
 		}
 		s.stateFileAssets[k.String()] = json.RawMessage(data)
 	}
+	mods, err := json.Marshal(s.modifications)
+	if err != nil {
+		return err
+	}
+	s.stateFileAssets[modTrackerKey] = json.RawMessage(mods)
 	data, err := json.MarshalIndent(s.stateFileAssets, "", "    ")
 	if err != nil {
 		return err
@@ -272,6 +292,7 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 		stateFileAsset         asset.Asset
 		foundInStateFile       bool
 		onDiskMatchesStateFile bool
+		preservedOnDisk        bool
 	)
 	// Do not need to bother with loading from state file if any of the parents
 	// are dirty because the asset must be re-generated in this case.
@@ -294,6 +315,8 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 				logrus.Debugf("%sOn-disk %s matches asset in state file", indent, a.Name())
 			}
 		}
+
+		preservedOnDisk = s.modifications.HasPreservedFiles(stateFileAsset)
 	}
 
 	var (
@@ -327,7 +350,7 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 		asset:           assetToStore,
 		source:          source,
 		anyParentsDirty: anyParentsDirty,
-		presentOnDisk:   foundOnDisk,
+		presentOnDisk:   foundOnDisk || preservedOnDisk,
 	}
 	s.assets[reflect.TypeOf(a)] = state
 	return state, nil
@@ -345,11 +368,19 @@ func (s *storeImpl) purge(excluded []asset.WritableAsset) error {
 		if !assetState.presentOnDisk || excl[reflect.TypeOf(assetState.asset)] {
 			continue
 		}
-		logrus.Infof("Consuming %s from target directory", assetState.asset.Name())
-		if err := asset.DeleteAssetFromDisk(assetState.asset.(asset.WritableAsset), s.directory); err != nil {
-			return err
+		if s.consumeFiles {
+			logrus.Infof("Consuming %s from target directory", assetState.asset.Name())
+			if wa, ok := assetState.asset.(asset.WritableAsset); ok {
+				if err := asset.DeleteAssetFromDisk(wa, s.directory); err != nil {
+					return err
+				}
+				s.modifications.Purge(wa)
+			}
 		}
 		assetState.presentOnDisk = false
+	}
+	if s.consumeFiles {
+		return s.saveStateFile()
 	}
 	return nil
 }
@@ -383,5 +414,11 @@ func asFileWriter(a asset.WritableAsset) asset.FileWriter {
 }
 
 func (s *storeImpl) PersistToFile(wa asset.WritableAsset) error {
+	if s.consumeFiles {
+		s.modifications.Purge(wa)
+		if err := s.saveStateFile(); err != nil {
+			return err
+		}
+	}
 	return asFileWriter(wa).PersistToFile(s.directory)
 }

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -59,6 +59,12 @@ func NewStore(dir string) (asset.Store, error) {
 	return newStore(dir, true)
 }
 
+// NewStoreWithConsumption returns an asset store that implements the asset.Store
+// interface, configured to either consume input files or allow them to persist.
+func NewStoreWithConsumption(dir string, consumeFiles bool) (asset.Store, error) {
+	return newStore(dir, consumeFiles)
+}
+
 func newStore(dir string, consumeFiles bool) (*storeImpl, error) {
 	modTracker := newModificationTracker()
 	store := &storeImpl{

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -260,7 +260,7 @@ func TestStoreFetch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearAssetBehaviors()
-			store, err := newStore(t.TempDir())
+			store, err := newStore(t.TempDir(), true)
 			assert.NoError(t, err, "error creating store")
 			assets := make(map[string]asset.Asset, len(tc.assets))
 			for name := range tc.assets {
@@ -388,7 +388,7 @@ func TestStoreFetchIdempotency(t *testing.T) {
 	tempDir := t.TempDir()
 
 	for i := 0; i < 2; i++ {
-		store, err := newStore(tempDir)
+		store, err := newStore(tempDir, true)
 		if !assert.NoError(t, err, "(loop %d) unexpected error creating store", i) {
 			t.Fatal()
 		}

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -260,10 +260,8 @@ func TestStoreFetch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearAssetBehaviors()
-			store := &storeImpl{
-				directory: t.TempDir(),
-				assets:    map[reflect.Type]*assetState{},
-			}
+			store, err := newStore(t.TempDir())
+			assert.NoError(t, err, "error creating store")
 			assets := make(map[string]asset.Asset, len(tc.assets))
 			for name := range tc.assets {
 				assets[name] = newTestStoreAsset(name)
@@ -282,7 +280,7 @@ func TestStoreFetch(t *testing.T) {
 					source: generatedSource,
 				}
 			}
-			err := store.Fetch(context.Background(), assets[tc.target])
+			err = store.Fetch(context.Background(), assets[tc.target])
 			assert.NoError(t, err, "error fetching asset")
 			assert.EqualValues(t, tc.expectedGenerationLog, generationLog)
 		})

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -400,7 +400,7 @@ func TestStoreFetchIdempotency(t *testing.T) {
 			if !assert.NoError(t, err, "(loop %d) unexpected error fetching asset %q", a.Name()) {
 				t.Fatal()
 			}
-			err = asset.PersistToFile(a, tempDir)
+			err = store.PersistToFile(a)
 			if !assert.NoError(t, err, "(loop %d) unexpected error persisting asset %q", a.Name()) {
 				t.Fatal()
 			}

--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -45,7 +45,7 @@ func NewAddNodesCommand(directory string, kubeConfig string, generatePXE bool, g
 
 	ctx := workflowreport.Context(string(workflow.AgentWorkflowTypeAddNodes), directory)
 
-	fetcher := store.NewAssetsFetcher(directory)
+	fetcher := store.NewAssetsFetcher(directory, true)
 	err = fetcher.FetchAndPersist(ctx, assets)
 
 	if reportErr := workflowreport.GetReport(ctx).Complete(err); reportErr != nil {


### PR DESCRIPTION
Every user complains about the installer deleting their input file (especially the install-config) so that it's effectively impossible to ever edit one without manually backing it up beforehand.

This PR adds a `--preserve` command line argument to allow input files to be kept, without them causing downstream assets to be regenerated on every subsequent command.

There is also a `--consume` command line argument added to make the default behaviour explicit. This will allow us to change the default in future while allowing users who depend on the current behaviour to opt out.