### PR TITLE
no-jira: go.mod: remove unused terraform-providers-nutanix import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -276,8 +276,6 @@ replace k8s.io/client-go => k8s.io/client-go v0.28.3
 // Needed so that the InstallConfig CRD can be created. Later versions of controller-gen balk at using IPNet as a field.
 replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185
 
-replace github.com/terraform-providers/terraform-provider-nutanix => github.com/nutanix/terraform-provider-nutanix v1.5.0
-
 replace github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 
 replace github.com/openshift/assisted-service/api => github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9810,7 +9810,6 @@ sigs.k8s.io/yaml
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20201009041932-4fe8559913b8
 # k8s.io/client-go => k8s.io/client-go v0.28.3
 # sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185
-# github.com/terraform-providers/terraform-provider-nutanix => github.com/nutanix/terraform-provider-nutanix v1.5.0
 # github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 # github.com/openshift/assisted-service/api => github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8
 # github.com/openshift/assisted-service/client => github.com/openshift/assisted-service/client v0.0.0-20230831114549-1922eda29cf8


### PR DESCRIPTION
When https://github.com/openshift/installer/pull/5635 moved Nutanix under `terraform/providers` it missed removing the import from the root go.mod.

```
$ go mod why github.com/terraform-providers/terraform-provider-nutanix
(main module does not need package
github.com/terraform-providers/terraform-provider-nutanix)
```