### PR TITLE
OSASINFRA-3303: OpenStack: remove generation of trunks name

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -28,8 +28,5 @@
       os_cp_server_group_name: "{{ infraID }}-master"
       os_compute_server_name: "{{ infraID }}-worker"
       os_compute_server_group_name: "{{ infraID }}-worker"
-      # Trunk names
-      os_cp_trunk_name: "{{ infraID }}-master-trunk"
-      os_compute_trunk_name: "{{ infraID }}-worker-trunk"
       # Ignition files
       os_bootstrap_ignition: "{{ infraID }}-bootstrap-ignition.json"


### PR DESCRIPTION
Since Kuryr removal we don't need to generate the trunks name anymore. This commit removes it.