### PR TITLE
pkg/asset/target: add capi manifests

### DIFF
--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
+	"github.com/openshift/installer/pkg/asset/manifests/clusterapi"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/templates/content/bootkube"
 	"github.com/openshift/installer/pkg/asset/templates/content/openshift"
@@ -27,6 +28,7 @@ var (
 		&machines.Worker{},
 		&manifests.Manifests{},
 		&manifests.Openshift{},
+		&clusterapi.Cluster{},
 	}
 
 	// ManifestTemplates are the manifest-templates targeted assets.


### PR DESCRIPTION
Includes CAPI manifests when executing create manifests.

The generation is currently feature gated:

```shell
[padillon@fedora bin]$ yq .featureGates m0/install-config.yaml 
- ClusterAPIInstall=true
[padillon@fedora bin]$ ./openshift-install create manifests --dir m0
INFO Credentials loaded from the "default" profile in file "/home/padillon/.aws/credentials" 
INFO Consuming Install Config from target directory 
INFO Manifests created in: m0/cluster-api, m0/manifests and m0/openshift 
[padillon@fedora bin]$ yq .featureGates m1/install-config.yaml 
null
[padillon@fedora bin]$ ./openshift-install create manifests --dir m1
INFO Credentials loaded from the "default" profile in file "/home/padillon/.aws/credentials" 
INFO Consuming Install Config from target directory 
INFO Manifests created in: m1/manifests and m1/openshift 
```