### PR TITLE
CORS-3033: Bring your own DNS for Azure

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -46,7 +46,7 @@ import (
 	"github.com/openshift/installer/pkg/gather/service"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/openshift/installer/pkg/types/baremetal"
-	"github.com/openshift/installer/pkg/types/gcp"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/vsphere"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/route/routeapihelpers"
@@ -829,12 +829,9 @@ func handleUnreachableAPIServer(config *rest.Config) error {
 	if err := assetStore.Fetch(installConfig); err != nil {
 		return fmt.Errorf("failed to fetch %s: %w", installConfig.Name(), err)
 	}
-	switch installConfig.Config.Platform.Name() { //nolint:gocritic
-	case gcp.Name:
-		if installConfig.Config.GCP.UserProvisionedDNS != gcp.UserProvisionedDNSEnabled {
-			return nil
-		}
-	default:
+
+	userProvisionedDNS := installConfig.Config.Platform.UserProvisionedDNS()
+	if userProvisionedDNS != dnstypes.UserProvisionedDNSEnabled {
 		return nil
 	}
 

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -58,6 +58,8 @@ module "master" {
 }
 
 module "dns" {
+  count = var.azure_user_provisioned_dns ? 0 : 1
+
   source                          = "./dns"
   cluster_domain                  = var.cluster_domain
   cluster_id                      = var.cluster_id

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -302,3 +302,12 @@ variable "azure_user_assigned_identity_key" {
   description = "Defines the user identity key used for the encryption of storage account."
   default     = ""
 }
+
+variable "azure_user_provisioned_dns" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+When true the user has selected to configure their own dns solution, and no dns records will be created.
+EOF
+}

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -22,6 +22,14 @@ output "public_lb_pip_v6_fqdn" {
   value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn : null
 }
 
+output "public_lb_pip_v4_ip_address" {
+  value = local.need_public_ipv4 ? data.azurerm_public_ip.cluster_public_ip_v4[0].ip_address : null
+}
+
+output "public_lb_pip_v6_ip_address" {
+  value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].ip_address : null
+}
+
 output "internal_lb_ip_v4_address" {
   value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
 }
@@ -68,4 +76,16 @@ output "storage_account_name" {
 
 output "outbound_type" {
   value = var.azure_outbound_routing_type
+}
+
+output "cluster_public_ip" {
+  value = local.need_public_ipv4 ? data.azurerm_public_ip.cluster_public_ip_v4[0].ip_address : null
+}
+
+output "cluster_internal_ip" {
+  value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
+}
+
+output "user_provisioned_dns" {
+  value = var.azure_user_provisioned_dns
 }

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -22,7 +22,7 @@ output "public_lb_pip_v6_fqdn" {
   value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn : null
 }
 
-output "public_lb_pip_v4_ip_address" {
+output "cluster_public_ip" {
   value = local.need_public_ipv4 ? data.azurerm_public_ip.cluster_public_ip_v4[0].ip_address : null
 }
 
@@ -30,7 +30,7 @@ output "public_lb_pip_v6_ip_address" {
   value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].ip_address : null
 }
 
-output "internal_lb_ip_v4_address" {
+output "cluster_internal_ip" {
   value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
 }
 

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -22,16 +22,8 @@ output "public_lb_pip_v6_fqdn" {
   value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn : null
 }
 
-output "cluster_public_ip" {
-  value = local.need_public_ipv4 ? data.azurerm_public_ip.cluster_public_ip_v4[0].ip_address : null
-}
-
 output "public_lb_pip_v6_ip_address" {
   value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].ip_address : null
-}
-
-output "cluster_internal_ip" {
-  value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
 }
 
 output "internal_lb_ip_v6_address" {

--- a/data/data/gcp/cluster/outputs.tf
+++ b/data/data/gcp/cluster/outputs.tf
@@ -1,4 +1,4 @@
-output "cluster_ip" {
+output "cluster_internal_ip" {
   value = module.network.cluster_ip
 }
 

--- a/data/data/gcp/post-bootstrap/main.tf
+++ b/data/data/gcp/post-bootstrap/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_forwarding_rule" "api_internal" {
   name        = "${var.cluster_id}-api-internal"
   description = local.description
 
-  ip_address      = var.cluster_ip
+  ip_address      = var.cluster_internal_ip
   backend_service = google_compute_region_backend_service.api_internal.self_link
   ports           = ["6443", "22623"]
   subnetwork      = var.master_subnet

--- a/data/data/gcp/post-bootstrap/variables.tf
+++ b/data/data/gcp/post-bootstrap/variables.tf
@@ -26,7 +26,7 @@ variable "master_subnet" {
   type = string
 }
 
-variable "cluster_ip" {
+variable "cluster_internal_ip" {
   type = string
 }
 

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2821,6 +2821,15 @@ spec:
                       cluster. If empty, a new resource group will created for the
                       cluster.
                     type: string
+                  userProvisionedDNS:
+                    default: Disabled
+                    description: UserProvisionedDNS indicates if the customer is providing
+                      their own DNS solution in place of the default provisioned by
+                      the Installer.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   userTags:
                     additionalProperties:
                       type: string

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -61,6 +61,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
@@ -429,6 +430,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				KeyVault:                        managedKeys.KeyVault,
 				UserAssignedIdentityKey:         managedKeys.UserAssignedIdentityKey,
 				LBPrivate:                       lbPrivate,
+				UserProvisionedDNS:              installConfig.Config.Azure.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled,
 			},
 		)
 		if err != nil {
@@ -536,7 +538,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				PrivateZoneName:     privateZoneName,
 				PublishStrategy:     installConfig.Config.Publish,
 				InfrastructureName:  clusterID.InfraID,
-				UserProvisionedDNS:  installConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
+				UserProvisionedDNS:  installConfig.Config.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/validate"
 )
@@ -294,7 +295,7 @@ func checkRecordSets(client API, ic *types.InstallConfig, zone *dns.ManagedZone,
 
 // ValidateForProvisioning validates that the install config is valid for provisioning the cluster.
 func ValidateForProvisioning(ic *types.InstallConfig) error {
-	if ic.Platform.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled {
+	if ic.Platform.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 		return nil
 	}
 

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
@@ -91,13 +92,15 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		client := awsconfig.NewClient(session)
 		return awsconfig.ValidateForProvisioning(client, ic.Config, ic.AWS)
 	case azure.Name:
-		dnsConfig, err := ic.Azure.DNSConfig()
-		if err != nil {
-			return err
-		}
-		err = azconfig.ValidatePublicDNS(ic.Config, dnsConfig)
-		if err != nil {
-			return err
+		if ic.Config.Platform.Azure.UserProvisionedDNS != dnstypes.UserProvisionedDNSEnabled {
+			dnsConfig, err := ic.Azure.DNSConfig()
+			if err != nil {
+				return err
+			}
+			err = azconfig.ValidatePublicDNS(ic.Config, dnsConfig)
+			if err != nil {
+				return err
+			}
 		}
 		client, err := ic.Azure.Client()
 		if err != nil {

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -22,6 +22,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
@@ -150,7 +151,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 	case gcptypes.Name:
 		// We donot want to configure cloud DNS when `UserProvisionedDNS` is enabled.
 		// So, do not set PrivateZone and PublicZone fields in the DNS manifest.
-		if installConfig.Config.GCP.UserProvisionedDNS == gcptypes.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 			config.Spec.PublicZone = &configv1.DNSZone{ID: ""}
 			config.Spec.PrivateZone = &configv1.DNSZone{ID: ""}
 			break

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
@@ -199,7 +200,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		// DNS post-install.
 		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{}
 		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.PlatformDefaultDNSType
-		if installConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 			config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
 		}
 	case ibmcloud.Name:

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -1,6 +1,14 @@
 package azure
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/lbconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
 	"github.com/openshift/installer/pkg/terraform/stages"
@@ -13,6 +21,7 @@ var PlatformStages = []terraform.Stage{
 		typesazure.Name,
 		"vnet",
 		[]providers.Provider{providers.AzureRM},
+		stages.WithCustomExtractLBConfig(extractAzureLBConfig),
 	),
 	stages.NewStage(
 		typesazure.Name,
@@ -45,4 +54,83 @@ var StackPlatformStages = []terraform.Stage{
 		"cluster",
 		[]providers.Provider{providers.AzureStack},
 	),
+}
+
+// extractAzureLBConfig extracts the load balancer information from the terraform outputs, generates the
+// Load Balancer Config file, regenerates the bootstrap ignition, and updates the terraform variables file.
+func extractAzureLBConfig(s stages.SplitStage, directory string, terraformDir string, file *asset.File, tfvarsFile *asset.File) (string, error) {
+	// Convert the terraform outputs file into json to extract LB data
+	outputs := map[string]interface{}{}
+	err := json.Unmarshal(file.Data, &outputs)
+	if err != nil {
+		return "", err
+	}
+
+	userConfiguredDNSRaw, ok := outputs["user_provisioned_dns"]
+	if !ok {
+		return "", fmt.Errorf("failed to read cluster hosted dns from terraform inputs")
+	}
+	if !userConfiguredDNSRaw.(bool) {
+		return "", nil
+	}
+
+	// Extract the Load Balancer ip addresses from the terraform output.
+	apiLBIpRaw, ok := outputs["public_lb_pip_v4_ip_address"]
+	if !ok {
+		return "", fmt.Errorf("failed to read External API LB DNS Name from terraform outputs")
+	}
+	apiIntLBIpRaw, ok := outputs["internal_lb_ip_v4_address"]
+	if !ok {
+		return "", fmt.Errorf("failed to read Internal API LB DNS Name from terraform outputs")
+	}
+
+	// Parse the terraform input values. Determine if the install is using a user configured dns solution.
+	tfvarData := map[string]interface{}{}
+	err = json.Unmarshal(tfvarsFile.Data, &tfvarData)
+	if err != nil {
+		return "", err
+	}
+
+	ignitionBootstrap, ok := tfvarData["ignition_bootstrap"]
+	if !ok {
+		return "", fmt.Errorf("failed to read ignition bootstrap from tfvars")
+	}
+
+	ignData := igntypes.Config{}
+	err = json.Unmarshal([]byte(ignitionBootstrap.(string)), &ignData)
+	if err != nil {
+		return "", err
+	}
+
+	lbConfig, err := lbconfig.GenerateLBConfigOverride(apiIntLBIpRaw.(string), apiLBIpRaw.(string))
+	if err != nil {
+		return "", err
+	}
+	if err := asset.NewDefaultFileWriter(lbConfig).PersistToFile(directory); err != nil {
+		return "", fmt.Errorf("failed to save %s to state file: %w", lbConfig.Name(), err)
+	}
+	path := fmt.Sprintf("/opt/openshift/manifests/%s", lbconfig.ConfigName)
+	ignData.Storage.Files = append(ignData.Storage.Files, ignition.FileFromString(path, "root", 0644, string(lbConfig.File.Data)))
+
+	ignitionOutput, err := json.Marshal(ignData)
+	if err != nil {
+		return "", err
+	}
+
+	// Update the ignition bootstrap variable to include the lbconfig.
+	tfvarData["ignition_bootstrap"] = string(ignitionOutput)
+
+	// Convert the bootstrap data and write the data back to a file. This will overwrite the original tfvars file.
+	jsonBootstrap, err := json.Marshal(tfvarData)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert bootstrap ignition to bytes: %w", err)
+	}
+	tfvarsFile.Data = jsonBootstrap
+
+	// update the value on disk to match
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", directory, tfvarsFile.Filename), jsonBootstrap, 0o600); err != nil {
+		return "", fmt.Errorf("failed to rewrite %s: %w", tfvarsFile.Filename, err)
+	}
+
+	return "", nil
 }

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -1,14 +1,6 @@
 package azure
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-
-	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/ignition"
-	"github.com/openshift/installer/pkg/asset/lbconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
 	"github.com/openshift/installer/pkg/terraform/stages"
@@ -21,7 +13,7 @@ var PlatformStages = []terraform.Stage{
 		typesazure.Name,
 		"vnet",
 		[]providers.Provider{providers.AzureRM},
-		stages.WithCustomExtractLBConfig(extractAzureLBConfig),
+		stages.WithCustomExtractLBConfig(stages.ExtractLBConfig),
 	),
 	stages.NewStage(
 		typesazure.Name,
@@ -54,83 +46,4 @@ var StackPlatformStages = []terraform.Stage{
 		"cluster",
 		[]providers.Provider{providers.AzureStack},
 	),
-}
-
-// extractAzureLBConfig extracts the load balancer information from the terraform outputs, generates the
-// Load Balancer Config file, regenerates the bootstrap ignition, and updates the terraform variables file.
-func extractAzureLBConfig(s stages.SplitStage, directory string, terraformDir string, file *asset.File, tfvarsFile *asset.File) (string, error) {
-	// Convert the terraform outputs file into json to extract LB data
-	outputs := map[string]interface{}{}
-	err := json.Unmarshal(file.Data, &outputs)
-	if err != nil {
-		return "", err
-	}
-
-	userConfiguredDNSRaw, ok := outputs["user_provisioned_dns"]
-	if !ok {
-		return "", fmt.Errorf("failed to read cluster hosted dns from terraform inputs")
-	}
-	if !userConfiguredDNSRaw.(bool) {
-		return "", nil
-	}
-
-	// Extract the Load Balancer ip addresses from the terraform output.
-	apiLBIpRaw, ok := outputs["public_lb_pip_v4_ip_address"]
-	if !ok {
-		return "", fmt.Errorf("failed to read External API LB DNS Name from terraform outputs")
-	}
-	apiIntLBIpRaw, ok := outputs["internal_lb_ip_v4_address"]
-	if !ok {
-		return "", fmt.Errorf("failed to read Internal API LB DNS Name from terraform outputs")
-	}
-
-	// Parse the terraform input values. Determine if the install is using a user configured dns solution.
-	tfvarData := map[string]interface{}{}
-	err = json.Unmarshal(tfvarsFile.Data, &tfvarData)
-	if err != nil {
-		return "", err
-	}
-
-	ignitionBootstrap, ok := tfvarData["ignition_bootstrap"]
-	if !ok {
-		return "", fmt.Errorf("failed to read ignition bootstrap from tfvars")
-	}
-
-	ignData := igntypes.Config{}
-	err = json.Unmarshal([]byte(ignitionBootstrap.(string)), &ignData)
-	if err != nil {
-		return "", err
-	}
-
-	lbConfig, err := lbconfig.GenerateLBConfigOverride(apiIntLBIpRaw.(string), apiLBIpRaw.(string))
-	if err != nil {
-		return "", err
-	}
-	if err := asset.NewDefaultFileWriter(lbConfig).PersistToFile(directory); err != nil {
-		return "", fmt.Errorf("failed to save %s to state file: %w", lbConfig.Name(), err)
-	}
-	path := fmt.Sprintf("/opt/openshift/manifests/%s", lbconfig.ConfigName)
-	ignData.Storage.Files = append(ignData.Storage.Files, ignition.FileFromString(path, "root", 0644, string(lbConfig.File.Data)))
-
-	ignitionOutput, err := json.Marshal(ignData)
-	if err != nil {
-		return "", err
-	}
-
-	// Update the ignition bootstrap variable to include the lbconfig.
-	tfvarData["ignition_bootstrap"] = string(ignitionOutput)
-
-	// Convert the bootstrap data and write the data back to a file. This will overwrite the original tfvars file.
-	jsonBootstrap, err := json.Marshal(tfvarData)
-	if err != nil {
-		return "", fmt.Errorf("failed to convert bootstrap ignition to bytes: %w", err)
-	}
-	tfvarsFile.Data = jsonBootstrap
-
-	// update the value on disk to match
-	if err := os.WriteFile(fmt.Sprintf("%s/%s", directory, tfvarsFile.Filename), jsonBootstrap, 0o600); err != nil {
-		return "", fmt.Errorf("failed to rewrite %s: %w", tfvarsFile.Filename, err)
-	}
-
-	return "", nil
 }

--- a/pkg/terraform/stages/gcp/stages.go
+++ b/pkg/terraform/stages/gcp/stages.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/pkg/errors"
 
@@ -24,7 +23,7 @@ var PlatformStages = []terraform.Stage{
 		"gcp",
 		"cluster",
 		[]providers.Provider{providers.Google},
-		stages.WithCustomExtractLBConfig(extractGCPLBConfig),
+		stages.WithCustomExtractLBConfig(stages.ExtractLBConfig),
 	),
 	stages.NewStage(
 		"gcp",

--- a/pkg/terraform/stages/gcp/stages.go
+++ b/pkg/terraform/stages/gcp/stages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/pkg/errors"
 

--- a/pkg/terraform/stages/split.go
+++ b/pkg/terraform/stages/split.go
@@ -6,10 +6,13 @@ import (
 	"os"
 	"path/filepath"
 
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/lbconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
 	"github.com/openshift/installer/pkg/types"
@@ -199,5 +202,84 @@ func normalDestroy(s SplitStage, directory string, terraformDir string, varFiles
 }
 
 func normalExtractLBConfig(s SplitStage, directory string, terraformDir string, file *asset.File, tfvarsFile *asset.File) (string, error) {
+	return "", nil
+}
+
+// ExtractLBConfig is a common function to get the cluster private and public
+// IP from terraform output. This should work for most providers.
+func ExtractLBConfig(s SplitStage, directory string, terraformDir string, file *asset.File, tfvarsFile *asset.File) (string, error) {
+	// Convert the terraform outputs file into json to extract LB data
+	outputs := map[string]interface{}{}
+	err := json.Unmarshal(file.Data, &outputs)
+	if err != nil {
+		return "", err
+	}
+
+	userConfiguredDNSRaw, ok := outputs["user_provisioned_dns"]
+	if !ok {
+		return "", fmt.Errorf("failed to read cluster hosted dns from terraform inputs")
+	}
+	if !userConfiguredDNSRaw.(bool) {
+		return "", nil
+	}
+
+	// Extract the Load Balancer ip addresses from the terraform output.
+	apiLBIpRaw, ok := outputs["cluster_public_ip"]
+	if !ok {
+		return "", fmt.Errorf("failed to read External API LB DNS Name from terraform outputs")
+	}
+	apiIntLBIpRaw, ok := outputs["cluster_internal_ip"]
+	if !ok {
+		return "", fmt.Errorf("failed to read Internal API LB DNS Name from terraform outputs")
+	}
+
+	// Parse the terraform input values. Determine if the install is using a user configured dns solution.
+	tfvarData := map[string]interface{}{}
+	err = json.Unmarshal(tfvarsFile.Data, &tfvarData)
+	if err != nil {
+		return "", err
+	}
+
+	ignitionBootstrap, ok := tfvarData["ignition_bootstrap"]
+	if !ok {
+		return "", fmt.Errorf("failed to read ignition bootstrap from tfvars")
+	}
+
+	ignData := igntypes.Config{}
+	err = json.Unmarshal([]byte(ignitionBootstrap.(string)), &ignData)
+	if err != nil {
+		return "", err
+	}
+
+	lbConfig, err := lbconfig.GenerateLBConfigOverride(apiIntLBIpRaw.(string), apiLBIpRaw.(string))
+	if err != nil {
+		return "", err
+	}
+	if err := asset.NewDefaultFileWriter(lbConfig).PersistToFile(directory); err != nil {
+		return "", fmt.Errorf("failed to save %s to state file: %w", lbConfig.Name(), err)
+	}
+	path := fmt.Sprintf("/opt/openshift/manifests/%s", lbconfig.ConfigName)
+	ignData.Storage.Files = append(ignData.Storage.Files, ignition.FileFromString(path, "root", 0644, string(lbConfig.File.Data)))
+
+	ignitionOutput, err := json.Marshal(ignData)
+	if err != nil {
+		return "", err
+	}
+
+	// Update the ignition bootstrap variable to include the lbconfig.
+	tfvarData["ignition_bootstrap"] = string(ignitionOutput)
+
+	// Convert the bootstrap data and write the data back to a file. This will overwrite the original tfvars file.
+	jsonBootstrap, err := json.Marshal(tfvarData)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert bootstrap ignition to bytes: %w", err)
+	}
+	tfvarsFile.Data = jsonBootstrap
+
+	// update the value on disk to match
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", directory, tfvarsFile.Filename), jsonBootstrap, 0o600); err != nil {
+		return "", fmt.Errorf("failed to rewrite %s: %w", tfvarsFile.Filename, err)
+	}
+
 	return "", nil
 }

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -73,6 +73,7 @@ type config struct {
 	KeyVaultName                            string `json:"azure_keyvault_name,omitempty"`
 	KeyVaultKeyName                         string `json:"azure_keyvault_key_name,omitempty"`
 	UserAssignedIdentity                    string `json:"azure_user_assigned_identity_key,omitempty"`
+	UserProvisionedDNS                      bool   `json:"azure_user_provisioned_dns,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -97,6 +98,7 @@ type TFVarsSources struct {
 	KeyVault                        azure.KeyVault
 	UserAssignedIdentityKey         string
 	LBPrivate                       bool
+	UserProvisionedDNS              bool
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -198,6 +200,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		KeyVaultName:                            sources.KeyVault.Name,
 		KeyVaultKeyName:                         sources.KeyVault.KeyName,
 		UserAssignedIdentity:                    sources.UserAssignedIdentityKey,
+		UserProvisionedDNS:                      sources.UserProvisionedDNS,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -3,6 +3,8 @@ package azure
 import (
 	"fmt"
 	"strings"
+
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 )
 
 // aro is a setting to enable aro-only modifications
@@ -100,6 +102,13 @@ type Platform struct {
 
 	// CustomerManagedKey has the keys needed to encrypt the storage account.
 	CustomerManagedKey *CustomerManagedKey `json:"customerManagedKey,omitempty"`
+
+	// UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default
+	// provisioned by the Installer.
+	// +kubebuilder:default:="Disabled"
+	// +default="Disabled"
+	// +kubebuilder:validation:Enum="Enabled";"Disabled"
+	UserProvisionedDNS dnstypes.UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
 }
 
 // KeyVault defines an Azure Key Vault.

--- a/pkg/types/dns/dns.go
+++ b/pkg/types/dns/dns.go
@@ -1,0 +1,17 @@
+package dns
+
+// UserProvisionedDNS indicates whether the DNS solution is provisioned by the Installer or the user.
+type UserProvisionedDNS string
+
+const (
+	// UserProvisionedDNSEnabled indicates that the DNS solution is provisioned and provided by the user.
+	UserProvisionedDNSEnabled UserProvisionedDNS = "Enabled"
+
+	// UserProvisionedDNSDisabled indicates that the DNS solution is provisioned by the Installer.
+	UserProvisionedDNSDisabled UserProvisionedDNS = "Disabled"
+)
+
+// ValidUserProvisionedDNSType verifies the userProvisionedDNS string is valid.
+func ValidUserProvisionedDNSType(userProvisionedDNS UserProvisionedDNS) bool {
+	return userProvisionedDNS == UserProvisionedDNSEnabled || userProvisionedDNS == UserProvisionedDNSDisabled
+}

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -1,15 +1,6 @@
 package gcp
 
-// UserProvisionedDNS indicates whether the DNS solution is provisioned by the Installer or the user.
-type UserProvisionedDNS string
-
-const (
-	// UserProvisionedDNSEnabled indicates that the DNS solution is provisioned and provided by the user.
-	UserProvisionedDNSEnabled UserProvisionedDNS = "Enabled"
-
-	// UserProvisionedDNSDisabled indicates that the DNS solution is provisioned by the Installer.
-	UserProvisionedDNSDisabled UserProvisionedDNS = "Disabled"
-)
+import dnstypes "github.com/openshift/installer/pkg/types/dns"
 
 // Platform stores all the global configuration that all machinesets
 // use.
@@ -66,7 +57,7 @@ type Platform struct {
 	// +kubebuilder:default:="Disabled"
 	// +default="Disabled"
 	// +kubebuilder:validation:Enum="Enabled";"Disabled"
-	UserProvisionedDNS UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
+	UserProvisionedDNS dnstypes.UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
 }
 
 // UserLabel is a label to apply to GCP resources created for the cluster.

--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -5,8 +5,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/featuregates"
-	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 // GatedFeatures determines all of the install config fields that should
@@ -26,7 +26,7 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 		},
 		{
 			FeatureGateName: configv1.FeatureGateGCPClusterHostedDNS,
-			Condition:       g.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
+			Condition:       g.UserProvisionedDNS == dns.UserProvisionedDNSEnabled,
 			Field:           field.NewPath("platform", "gcp", "userProvisionedDNS"),
 		},
 	}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/featuregates"
 	"github.com/openshift/installer/pkg/types/gcp"
@@ -372,6 +373,20 @@ func (p *Platform) Name() string {
 		return nutanix.Name
 	default:
 		return ""
+	}
+}
+
+// UserProvisionedDNS returns the value of UserProvisionedDNS on platforms that
+// support custom DNS. For platforms that don't support custom DNS, "Disabled"
+// is returned.
+func (p *Platform) UserProvisionedDNS() dnstypes.UserProvisionedDNS {
+	switch {
+	case p == nil:
+		return dnstypes.UserProvisionedDNSDisabled
+	case p.GCP != nil:
+		return p.GCP.UserProvisionedDNS
+	default:
+		return dnstypes.UserProvisionedDNSDisabled
 	}
 }
 

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -383,6 +383,8 @@ func (p *Platform) UserProvisionedDNS() dnstypes.UserProvisionedDNS {
 	switch {
 	case p == nil:
 		return dnstypes.UserProvisionedDNSDisabled
+	case p.Azure != nil:
+		return p.Azure.UserProvisionedDNS
 	case p.GCP != nil:
 		return p.GCP.UserProvisionedDNS
 	default:

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
@@ -52,7 +53,7 @@ func TestFeatureGates(t *testing.T) {
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.GCP = validGCPPlatform()
-				c.GCP.UserProvisionedDNS = gcp.UserProvisionedDNSEnabled
+				c.GCP.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
 				return c
 			}(),
 			expected: `^platform.gcp.userProvisionedDNS: Forbidden: this field is protected by the GCPClusterHostedDNS feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,


### PR DESCRIPTION
Bring your own DNS for Azure

[Copied from https://github.com/openshift/installer/pull/7631]


```
New functionality for updating ignition data for the bootstrap node. After the terraform stage that establishes the public and private load balancer ips/dns date is applied:

    The output is read / parsed
    The load balancer data is added to a new file
    The bootstrap ignition file is regenerated
    The contents of the ignition file are used to update the file that contains the terraform variables
```

https://issues.redhat.com/browse/CORS-3033
https://issues.redhat.com/browse/CORS-3034
https://issues.redhat.com/browse/CORS-3035
https://issues.redhat.com/browse/CORS-3036
https://issues.redhat.com/browse/CORS-3037
https://issues.redhat.com/browse/CORS-3038
https://issues.redhat.com/browse/CORS-3039
https://issues.redhat.com/browse/CORS-3040
