### PR TITLE
CORS-2785: images: decouple installer and installer-artifacts

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -25,8 +25,11 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.15:installer
+FROM registry.ci.openshift.org/ocp/4.15:base
 COPY --from=macbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install
 COPY --from=macarmbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac_arm64/openshift-install
 COPY --from=linuxbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/linux_amd64/openshift-install
 COPY --from=linuxarmbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/linux_arm64/openshift-install
+
+# We're not really an operator, we're just getting some data into the release image.
+LABEL io.openshift.release.operator=true

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -25,11 +25,18 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN go run -mod=vendor hack/build-coreos-manifest.go
+
 FROM registry.ci.openshift.org/ocp/4.15:base
 COPY --from=macbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install
 COPY --from=macarmbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac_arm64/openshift-install
 COPY --from=linuxbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/linux_amd64/openshift-install
 COPY --from=linuxarmbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/linux_arm64/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
 
 # We're not really an operator, we're just getting some data into the release image.
 LABEL io.openshift.release.operator=true


### PR DESCRIPTION
The installer-artifacts image depends on the installer image, which means they cannot be built in parallel. The effect of this dependency is that the installer-artifacts image contains the linux amd64 builds in addition to the mac/linux amd64/arm64 builds present in the installer-artifacts image.

Breaking the dependency results in a more efficient build process because they can be built in parallel as well as no duplication of the linux amd64 binary in the release image (before this change the binary would be present in both images within the release image).

The risk, though, is that clients are inconsistently grabbing the linux amd64 binary from either image, rather than only the installer image, in which case we would break any client trying to get that binary from the installer-artifacts image.