### PR TITLE
Add "USSec" as a valid name for Azure platform cloudName

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2467,6 +2467,7 @@ spec:
                     - AzureChinaCloud
                     - AzureGermanCloud
                     - AzureStackCloud
+                    - USSec
                     type: string
                   clusterOSImage:
                     description: ClusterOSImage is the url of a storage blob in the


### PR DESCRIPTION
Government customers can't create install-config.yaml and integrate OpenShift on Azure secret cloud because the installer doesn't recognize "USSec" as a cloudName.

Requesting to add "USSec" as a valid value for cloudName in Azure.