### PR TITLE
OCPBUGS-23458: force destroy bootstrap ign

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -45,8 +45,9 @@ data "aws_partition" "current" {}
 data "aws_ebs_default_kms_key" "current" {}
 
 resource "aws_s3_bucket" "ignition" {
-  count  = var.aws_preserve_bootstrap_ignition ? 0 : 1
-  bucket = var.aws_ignition_bucket
+  count         = var.aws_preserve_bootstrap_ignition ? 0 : 1
+  bucket        = var.aws_ignition_bucket
+  force_destroy = true
 
   tags = merge(
     {


### PR DESCRIPTION
If S3 versioning is enabled, destroy may fail with:

  BucketNotEmpty: The bucket you tried to delete is
  not empty. You must delete all versions in the bucket.

Adding the[ force_destroy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#force_destroy) attribute should destroy the bucket, even with versioning enabled.