### PR TITLE
no-jira: pkg/asset: safety nets to keep installer from crashing

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -72,6 +72,9 @@ type RuntimeFile struct {
 // directory.
 func PersistToFile(asset WritableAsset, directory string) error {
 	for _, f := range asset.Files() {
+		if f == nil {
+			panic("asset.Files() returned nil")
+		}
 		path := filepath.Join(directory, f.Filename)
 		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return errors.Wrap(err, "failed to create dir")

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -114,7 +114,9 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		return fmt.Errorf("error getting infrastructure provider: %w", err)
 	}
 	files, err := provider.Provision(InstallDir, tfvarsFiles)
-	c.FileList = append(c.FileList, files...) // append state files even in case of failure
+	if files != nil {
+		c.FileList = append(c.FileList, files...) // append state files even in case of failure
+	}
 	if err != nil {
 		return fmt.Errorf("%s: %w", asset.ClusterCreationError, err)
 	}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -56,7 +56,9 @@ func (p *Provider) Provision(dir string, vars []*asset.File) ([]*asset.File, err
 		outputs, stateFile, err := applyStage(stage.Platform(), stage, terraformDirPath, vars)
 		if err != nil {
 			// Write the state file to the install directory even if the apply failed.
-			fileList = append(fileList, stateFile)
+			if stateFile != nil {
+				fileList = append(fileList, stateFile)
+			}
 			return fileList, fmt.Errorf("failure applying terraform for %q stage: %w", stage.Name(), err)
 		}
 		vars = append(vars, outputs)


### PR DESCRIPTION
if provider.Provision() returns nil for files, it's appended to the filelist. When the asset store attempts to iterate of this, it joins a nil file to a directory thus segfaulting.