### PR TITLE
PowerVS: MULTIARCH-4030: Reintroduce serviceInstanceGUID install option

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4225,6 +4225,12 @@ spec:
                     description: Region specifies the IBM Cloud colo region where
                       the cluster will be created.
                     type: string
+                  serviceInstanceGUID:
+                    description: ServiceInstanceGUID is the GUID of the Power IAAS
+                      instance created from the IBM Cloud Catalog before the cluster
+                      is completed.  Leave unset to allow the installer to create
+                      a service instance during cluster creation.
+                    type: string
                   userID:
                     description: UserID is the login for the user's IBM Cloud account.
                     type: string

--- a/data/data/powervs/bootstrap/iaas/iaas.tf
+++ b/data/data/powervs/bootstrap/iaas/iaas.tf
@@ -3,5 +3,5 @@ data "ibm_resource_group" "group" {
 }
 
 data "ibm_resource_instance" "powervs_service_instance" {
-  name = "${var.cluster_id}-power-iaas"
+  name = var.service_instance_name == "" ? "${var.cluster_id}-power-iaas" : var.service_instance_name
 }

--- a/data/data/powervs/bootstrap/iaas/variables.tf
+++ b/data/data/powervs/bootstrap/iaas/variables.tf
@@ -7,3 +7,8 @@ variable "resource_group" {
   type        = string
   description = "The name of the Power VS resource group to which the user belongs."
 }
+
+variable "service_instance_name" {
+  type        = string
+  description = "Optionally, the service instance name of an existing object before cluster creation"
+}

--- a/data/data/powervs/bootstrap/main.tf
+++ b/data/data/powervs/bootstrap/main.tf
@@ -61,6 +61,7 @@ module "iaas" {
   # define and pass variables to:
   # data/data/powervs/bootstrap/iaas/variables.tf
   #
-  cluster_id     = var.cluster_id
-  resource_group = var.powervs_resource_group
+  cluster_id            = var.cluster_id
+  resource_group        = var.powervs_resource_group
+  service_instance_name = var.powervs_service_instance_name
 }

--- a/data/data/powervs/cluster/iaas/iaas.tf
+++ b/data/data/powervs/cluster/iaas/iaas.tf
@@ -2,7 +2,15 @@ data "ibm_resource_group" "group" {
   name = var.resource_group
 }
 
-resource "ibm_resource_instance" "powervs_service_instance" {
+data "ibm_resource_instance" "existing_service_instance" {
+  count             = var.service_instance_name != "" ? 1 : 0
+  name              = var.service_instance_name
+  service           = "power-iaas"
+  resource_group_id = data.ibm_resource_group.group.id
+}
+
+resource "ibm_resource_instance" "created_service_instance" {
+  count             = var.service_instance_name == "" ? 1 : 0
   name              = "${var.cluster_id}-power-iaas"
   service           = "power-iaas"
   plan              = "power-virtual-server-group"

--- a/data/data/powervs/cluster/iaas/outputs.tf
+++ b/data/data/powervs/cluster/iaas/outputs.tf
@@ -1,7 +1,11 @@
+output "si_name" {
+  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].name) : one(data.ibm_resource_instance.existing_service_instance[*].name)
+}
+
 output "si_guid" {
-  value = ibm_resource_instance.powervs_service_instance.guid
+  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].guid) : one(data.ibm_resource_instance.existing_service_instance[*].guid)
 }
 
 output "si_crn" {
-  value = ibm_resource_instance.powervs_service_instance.crn
+  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].crn) : one(data.ibm_resource_instance.existing_service_instance[*].crn)
 }

--- a/data/data/powervs/cluster/iaas/variables.tf
+++ b/data/data/powervs/cluster/iaas/variables.tf
@@ -12,3 +12,8 @@ variable "powervs_zone" {
   type        = string
   description = "The Power VS zone in which to create resources."
 }
+
+variable "service_instance_name" {
+  type        = string
+  description = "Optionally, the service instance name of an existing object before cluster creation"
+}

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -56,12 +56,12 @@ module "master" {
   providers = {
     ibm = ibm.powervs
   }
-  source            = "./master"
-  cloud_instance_id = module.iaas.si_guid
-  cluster_id        = var.cluster_id
-  resource_group    = var.powervs_resource_group
-  instance_count    = var.master_count
+  source = "./master"
 
+  cloud_instance_id   = module.iaas.si_guid
+  cluster_id          = var.cluster_id
+  resource_group      = var.powervs_resource_group
+  instance_count      = var.master_count
   api_key             = var.powervs_api_key
   powervs_region      = var.powervs_region
   powervs_zone        = var.powervs_zone
@@ -166,7 +166,8 @@ module "iaas" {
   # define and pass variables to:
   # data/data/powervs/cluster/iaas/variables.tf
   #
-  cluster_id     = var.cluster_id
-  resource_group = var.powervs_resource_group
-  powervs_zone   = var.powervs_zone
+  cluster_id            = var.cluster_id
+  resource_group        = var.powervs_resource_group
+  powervs_zone          = var.powervs_zone
+  service_instance_name = var.powervs_service_instance_name
 }

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -40,6 +40,11 @@ variable "powervs_publish_strategy" {
   default     = "External"
 }
 
+variable "powervs_service_instance_name" {
+  type        = string
+  description = "Optionally, the service instance name of an existing object before cluster creation"
+}
+
 ################################################################
 # Configure storage
 ################################################################

--- a/pkg/asset/cluster/powervs/powervs.go
+++ b/pkg/asset/cluster/powervs/powervs.go
@@ -22,5 +22,6 @@ func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) *powervs.Me
 		Region:               config.Platform.PowerVS.Region,
 		VPCRegion:            config.Platform.PowerVS.VPCRegion,
 		Zone:                 config.Platform.PowerVS.Zone,
+		ServiceInstanceGUID:  config.Platform.PowerVS.ServiceInstanceGUID,
 	}
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -914,6 +914,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 		transitGatewayEnabled := powervsconfig.TransitGatewayEnabledZone(installConfig.Config.Platform.PowerVS.Zone)
 
+		// If a service instance GUID was passed in the install-config.yaml file, then
+		// find the corresponding name for it.  Otherwise, we expect our Terraform to
+		// dynamically create one.
+		serviceInstanceName, err := client.ServiceInstanceGUIDToName(ctx, installConfig.Config.PowerVS.ServiceInstanceGUID)
+		if err != nil {
+			return err
+		}
+
 		osImage := strings.SplitN(string(*rhcosImage), "/", 2)
 		data, err = powervstfvars.TFVars(
 			powervstfvars.TFVarsSources{
@@ -937,6 +945,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				PublishStrategy:       installConfig.Config.Publish,
 				EnableSNAT:            len(installConfig.Config.DeprecatedImageContentSources) == 0 && len(installConfig.Config.ImageDigestSources) == 0,
 				TransitGatewayEnabled: transitGatewayEnabled,
+				ServiceInstanceName:   serviceInstanceName,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -185,6 +185,11 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
+		err = powervsconfig.ValidateServiceInstance(client, ic.Config)
+		if err != nil {
+			return err
+		}
 	case external.Name, libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -40,7 +40,7 @@ type API interface {
 	GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error)
 	ListResourceGroups(ctx context.Context) (*resourcemanagerv2.ResourceGroupList, error)
 	ListServiceInstances(ctx context.Context) ([]string, error)
-	ServiceInstanceIDToCRN(ctx context.Context, id string) (string, error)
+	ServiceInstanceGUIDToName(ctx context.Context, id string) (string, error)
 	GetDatacenterCapabilities(ctx context.Context, region string) (map[string]bool, error)
 }
 
@@ -669,8 +669,8 @@ func TransitGatewayEnabledZone(zone string) bool {
 	return zone == "dal10"
 }
 
-// ServiceInstanceIDToCRN returns the CRN of the matching service instance GUID which was passed in.
-func (c *Client) ServiceInstanceIDToCRN(ctx context.Context, id string) (string, error) {
+// ServiceInstanceGUIDToName returns the name of the matching service instance GUID which was passed in.
+func (c *Client) ServiceInstanceGUIDToName(ctx context.Context, id string) (string, error) {
 	var (
 		options   *resourcecontrollerv2.ListResourceInstancesOptions
 		resources *resourcecontrollerv2.ResourceInstancesList
@@ -724,10 +724,10 @@ func (c *Client) ServiceInstanceIDToCRN(ctx context.Context, id string) (string,
 
 			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
 				if resourceInstance.GUID != nil && *resourceInstance.GUID == id {
-					if resourceInstance.CRN == nil {
+					if resourceInstance.Name == nil {
 						return "", nil
 					}
-					return *resourceInstance.CRN, nil
+					return *resourceInstance.Name, nil
 				}
 			}
 		}

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -233,19 +233,19 @@ func (mr *MockAPIMockRecorder) ListServiceInstances(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceInstances", reflect.TypeOf((*MockAPI)(nil).ListServiceInstances), ctx)
 }
 
-// ServiceInstanceIDToCRN mocks base method.
-func (m *MockAPI) ServiceInstanceIDToCRN(ctx context.Context, id string) (string, error) {
+// ServiceInstanceGUIDToName mocks base method.
+func (m *MockAPI) ServiceInstanceGUIDToName(ctx context.Context, id string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceInstanceIDToCRN", ctx, id)
+	ret := m.ctrl.Call(m, "ServiceInstanceGUIDToName", ctx, id)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceInstanceIDToCRN indicates an expected call of ServiceInstanceIDToCRN.
-func (mr *MockAPIMockRecorder) ServiceInstanceIDToCRN(ctx, id interface{}) *gomock.Call {
+// ServiceInstanceGUIDToName indicates an expected call of ServiceInstanceGUIDToName.
+func (mr *MockAPIMockRecorder) ServiceInstanceGUIDToName(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceInstanceIDToCRN", reflect.TypeOf((*MockAPI)(nil).ServiceInstanceIDToCRN), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceInstanceGUIDToName", reflect.TypeOf((*MockAPI)(nil).ServiceInstanceGUIDToName), ctx, id)
 }
 
 // SetVPCServiceURLForRegion mocks base method.

--- a/pkg/asset/machines/powervs/machines.go
+++ b/pkg/asset/machines/powervs/machines.go
@@ -118,34 +118,69 @@ func provider(clusterID string, platform *powervs.Platform, mpool *powervs.Machi
 
 	dhcpNetRegex := fmt.Sprintf("^DHCPSERVER.*%s.*_Private$", clusterID)
 
-	serviceName := fmt.Sprintf("%s-power-iaas", clusterID)
+	var config *machinev1.PowerVSMachineProviderConfig
 
-	//Setting only the mandatory parameters
-	config := &machinev1.PowerVSMachineProviderConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PowerVSMachineProviderConfig",
-			APIVersion: machinev1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{},
-		ServiceInstance: machinev1.PowerVSResource{
-			Type: machinev1.PowerVSResourceTypeName,
-			Name: &serviceName,
-		},
-		Image: machinev1.PowerVSResource{
-			Type: machinev1.PowerVSResourceTypeName,
-			Name: &image,
-		},
-		UserDataSecret: &machinev1.PowerVSSecretReference{
-			Name: userDataSecret,
-		},
-		CredentialsSecret: &machinev1.PowerVSSecretReference{
-			Name: "powervs-credentials",
-		},
-		SystemType:    mpool.SysType,
-		ProcessorType: mpool.ProcType,
-		Processors:    mpool.Processors,
-		MemoryGiB:     mpool.MemoryGiB,
-		KeyPairName:   fmt.Sprintf("%s-key", clusterID),
+	// If a service instance GUID was not passed in the install-config.yaml file, then
+	// we tell the machine provider to use a specific name via XXXTypeName.  Otherwide,
+	// we tell the machine provider the given GUID via XXXTypeID.
+	if platform.ServiceInstanceGUID == "" {
+		serviceName := fmt.Sprintf("%s-power-iaas", clusterID)
+
+		// Setting only the mandatory parameters
+		config = &machinev1.PowerVSMachineProviderConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PowerVSMachineProviderConfig",
+				APIVersion: machinev1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{},
+			ServiceInstance: machinev1.PowerVSResource{
+				Type: machinev1.PowerVSResourceTypeName,
+				Name: &serviceName,
+			},
+			Image: machinev1.PowerVSResource{
+				Type: machinev1.PowerVSResourceTypeName,
+				Name: &image,
+			},
+			UserDataSecret: &machinev1.PowerVSSecretReference{
+				Name: userDataSecret,
+			},
+			CredentialsSecret: &machinev1.PowerVSSecretReference{
+				Name: "powervs-credentials",
+			},
+			SystemType:    mpool.SysType,
+			ProcessorType: mpool.ProcType,
+			Processors:    mpool.Processors,
+			MemoryGiB:     mpool.MemoryGiB,
+			KeyPairName:   fmt.Sprintf("%s-key", clusterID),
+		}
+	} else {
+		// Setting only the mandatory parameters
+		config = &machinev1.PowerVSMachineProviderConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PowerVSMachineProviderConfig",
+				APIVersion: machinev1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{},
+			ServiceInstance: machinev1.PowerVSResource{
+				Type: machinev1.PowerVSResourceTypeID,
+				ID:   &platform.ServiceInstanceGUID,
+			},
+			Image: machinev1.PowerVSResource{
+				Type: machinev1.PowerVSResourceTypeName,
+				Name: &image,
+			},
+			UserDataSecret: &machinev1.PowerVSSecretReference{
+				Name: userDataSecret,
+			},
+			CredentialsSecret: &machinev1.PowerVSSecretReference{
+				Name: "powervs-credentials",
+			},
+			SystemType:    mpool.SysType,
+			ProcessorType: mpool.ProcType,
+			Processors:    mpool.Processors,
+			MemoryGiB:     mpool.MemoryGiB,
+			KeyPairName:   fmt.Sprintf("%s-key", clusterID),
+		}
 	}
 	if network != "" {
 		config.Network = machinev1.PowerVSResource{

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -271,7 +271,16 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			vpcSubnets = append(vpcSubnets, fmt.Sprintf("vpc-subnet-%s", clusterID.InfraID))
 		}
 
-		serviceName := fmt.Sprintf("%s-power-iaas", clusterID.InfraID)
+		var (
+			serviceGUID string
+			serviceName string
+		)
+
+		if installConfig.Config.PowerVS.ServiceInstanceGUID == "" {
+			serviceName = fmt.Sprintf("%s-power-iaas", clusterID.InfraID)
+		} else {
+			serviceGUID = installConfig.Config.PowerVS.ServiceInstanceGUID
+		}
 
 		powervsConfig, err := powervsmanifests.CloudProviderConfig(
 			clusterID.InfraID,
@@ -280,6 +289,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			vpcRegion,
 			installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
 			vpcSubnets,
+			serviceGUID,
 			serviceName,
 			installConfig.Config.PowerVS.Region,
 			installConfig.Config.PowerVS.Zone,

--- a/pkg/asset/manifests/powervs/cloudproviderconfig.go
+++ b/pkg/asset/manifests/powervs/cloudproviderconfig.go
@@ -38,7 +38,7 @@ type provider struct {
 }
 
 // CloudProviderConfig generates the cloud provider config for the IBM Power VS platform.
-func CloudProviderConfig(infraID string, accountID string, vpcName string, region string, resourceGroupName string, subnets []string, cloudInstName string, pvsRegion string, pvsZone string) (string, error) {
+func CloudProviderConfig(infraID string, accountID string, vpcName string, region string, resourceGroupName string, subnets []string, cloudInstGUID string, cloudInstName string, pvsRegion string, pvsZone string) (string, error) {
 	config := &config{
 		Global: global{
 			Version: "1.1.0",
@@ -56,7 +56,7 @@ func CloudProviderConfig(infraID string, accountID string, vpcName string, regio
 			G2VPCName:                vpcName,
 			G2WorkerServiceAccountID: accountID,
 			G2VPCSubnetNames:         strings.Join(subnets, ","),
-			PowerVSCloudInstanceID:   "",
+			PowerVSCloudInstanceID:   cloudInstGUID,
 			PowerVSCloudInstanceName: cloudInstName,
 			PowerVSRegion:            pvsRegion,
 			PowerVSZone:              pvsZone,

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -40,6 +40,7 @@ type config struct {
 	PublishStrategy       string `json:"powervs_publish_strategy"`
 	EnableSNAT            bool   `json:"powervs_enable_snat"`
 	TransitGatewayEnabled bool   `json:"powervs_transit_gateway_enabled"`
+	ServiceInstanceName   string `json:"powervs_service_instance_name"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -64,6 +65,7 @@ type TFVarsSources struct {
 	PublishStrategy       types.PublishingStrategy
 	EnableSNAT            bool
 	TransitGatewayEnabled bool
+	ServiceInstanceName   string
 }
 
 // TFVars generates Power VS-specific Terraform variables launching the cluster.
@@ -119,6 +121,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PublishStrategy:       string(sources.PublishStrategy),
 		EnableSNAT:            sources.EnableSNAT,
 		TransitGatewayEnabled: sources.TransitGatewayEnabled,
+		ServiceInstanceName:   sources.ServiceInstanceName,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/powervs/metadata.go
+++ b/pkg/types/powervs/metadata.go
@@ -9,4 +9,5 @@ type Metadata struct {
 	Region               string `json:"region"`
 	VPCRegion            string `json:"vpcRegion"`
 	Zone                 string `json:"zone"`
+	ServiceInstanceGUID  string `json:"serviceInstanceGUID"`
 }

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -46,4 +46,10 @@ type Platform struct {
 	// platform configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// ServiceInstanceGUID is the GUID of the Power IAAS instance created from the IBM Cloud Catalog
+	// before the cluster is completed.  Leave unset to allow the installer to create a service
+	// instance during cluster creation.
+	// +optional
+	ServiceInstanceGUID string `json:"serviceInstanceGUID,omitempty"`
 }

--- a/pkg/types/powervs/validation/platform.go
+++ b/pkg/types/powervs/validation/platform.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/powervs"
@@ -35,5 +36,14 @@ func ValidatePlatform(p *powervs.Platform, fldPath *field.Path) field.ErrorList 
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
+
+	// validate ServiceInstanceGUID
+	if p.ServiceInstanceGUID != "" {
+		_, err := uuid.Parse(p.ServiceInstanceGUID)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("ServiceInstanceGUID"), p.ServiceInstanceGUID, "ServiceInstanceGUID must be a valid UUID"))
+		}
+	}
+
 	return allErrs
 }

--- a/pkg/types/powervs/validation/platform_test.go
+++ b/pkg/types/powervs/validation/platform_test.go
@@ -91,6 +91,33 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			valid: true,
 		},
+		{
+			name: "ServiceInstanceID: Valid Power VS ServiceInstanceID empty",
+			platform: func() *powervs.Platform {
+				p := validMinimalPlatform()
+				p.ServiceInstanceGUID = ""
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name: "ServiceInstanceID: Valid Power VS ServiceInstanceID",
+			platform: func() *powervs.Platform {
+				p := validMinimalPlatform()
+				p.ServiceInstanceGUID = "05d5dbfd-2a62-4d01-b37b-71211be442f6"
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name: "ServiceInstanceID: Invalid Power VS ServiceInstanceID",
+			platform: func() *powervs.Platform {
+				p := validMinimalPlatform()
+				p.ServiceInstanceGUID = "abc123"
+				return p
+			}(),
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
We were made aware of a valid use of bring-your-own service instance recently. Therefore, reintroduce serviceInstanceGUID to install-config.yaml since there is a use case for it now.

https://issues.redhat.com/browse/MULTIARCH-4030