### PR TITLE
no-jira: hack: drop hardcoded -j8 in make invocations.

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -44,13 +44,13 @@ MODE="${MODE:-release}"
 # Build terraform binaries before setting environment variables since it messes up make
 if test "${SKIP_TERRAFORM}" != y && ! (echo "${TAGS}" | grep -q -e 'aro' -e 'altinfra')
 then
-  make -j8 -C terraform all
+  make -C terraform all
   copy_terraform_to_mirror # Copy terraform parts to embedded mirror.
 fi
 
 # build cluster-api binaries
 if [ -n "${OPENSHIFT_INSTALL_CLUSTER_API}" ]; then
-  make -j8 -C cluster-api all
+  make -C cluster-api all
   copy_cluster_api_to_mirror
 fi
 


### PR DESCRIPTION
Parallel builds can be achieved by setting the MAKEFLAGS env var. Hardcoding the value is causing some container builds to fail in CI with
```
{  error occurred handling build openstack-installer-amd64: build not successful after 5 attempts: [the build openstack-installer-amd64 failed after 7m36s with reason BuildPodEvicted: The node was low on resource: memory. Threshold quantity: 100Mi, available: 65128Ki. Container docker-build was using 10522940Ki, request is 5Gi, has larger consumption of memory. , the build openstack-installer-amd64 failed after 6m31s with reason BuildPodEvicted: The node was low on resource: memory. Threshold quantity: 100Mi, available: 53452Ki. Container docker-build was using 10936476Ki, request is 5Gi, has larger consumption of memory.
```