### PR TITLE
no-jira: image: infra-providers: use base image instead of builder

### DIFF
--- a/images/infrastructure-providers/Dockerfile
+++ b/images/infrastructure-providers/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 make -C terraform
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15
+FROM registry.ci.openshift.org/ocp/builder:base
 WORKDIR /go/src/github.com/openshift/installer
 COPY --from=macbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 COPY --from=macarmbuilder /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/


### PR DESCRIPTION
We don't need a builder image to just copy the binaries built in previous layers. Use `base` instead for the final container image.