### PR TITLE
OCPBUGS-23140, OCPBUGS-23305: Soften VIP validations for external load-balancer

### DIFF
--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1679,6 +1679,24 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "platform.baremetal.apiVIPs: Invalid value: \"192.168.222.1\": IP expected to be in one of the machine networks: 10.0.0.0/16,fe80::/10",
 		},
 		{
+			name: "apivip_v4_not_in_machinenetwork_cidr_usermanaged_loadbalancer",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
+				c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					{CIDR: *ipnet.MustParseCIDR("fe80::/10")},
+				}
+				c.Platform = types.Platform{
+					BareMetal: validBareMetalPlatform(),
+				}
+				c.Platform.BareMetal.LoadBalancer = &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged}
+				c.Platform.BareMetal.APIVIPs = []string{"192.168.222.1"}
+
+				return c
+			}(),
+		},
+		{
 			name: "apivip_v6_not_in_machinenetwork_cidr",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -1960,6 +1978,21 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: "platform.baremetal.apiVIPs: Invalid value: \"fe80::1\": VIP for API must not be one of the Ingress VIPs",
+		},
+		{
+			name: "identical_apivip_ingressvip_usermanaged_loadbalancer",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
+				c.Platform = types.Platform{
+					BareMetal: validBareMetalPlatform(),
+				}
+				c.Platform.BareMetal.LoadBalancer = &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged}
+				c.Platform.BareMetal.APIVIPs = []string{"fe80::1"}
+				c.Platform.BareMetal.IngressVIPs = []string{"fe80::1"}
+
+				return c
+			}(),
 		},
 		{
 			name: "identical_apivips_ingressvips_multiple_ips",


### PR DESCRIPTION
Currently for cluster-managed load balancer we have a set of validations ensuring that API and Ingress VIP are placed in a correct subnet as well as they do not overlap.

For user-managed load balancer those validations are too strong as customers may have external load balancers placed outside of networks where cluster nodes live. Similarly, they may reuse the same IP for API and Ingress VIP, and distribute traffic via other means (e.g. using the port for the connection).

With this PR we are softening the validations if the configuration used is indicating that external load balancer is used.

Closes: OCPBUGS-23140
Closes: OCPBUGS-23305