### PR TITLE
SPLAT-1272: Modify the terraform variables to support Nutanix Failure Domains

### DIFF
--- a/data/data/nutanix/bootstrap/main.tf
+++ b/data/data/nutanix/bootstrap/main.tf
@@ -24,7 +24,7 @@ resource "nutanix_image" "bootstrap_ignition" {
 resource "nutanix_virtual_machine" "vm_bootstrap" {
   name                 = "${var.cluster_id}-bootstrap"
   description          = local.description
-  cluster_uuid         = var.nutanix_prism_element_uuid
+  cluster_uuid         = var.nutanix_prism_element_uuids[0]
   num_vcpus_per_socket = 4
   num_sockets          = 1
   memory_size_mib      = 16384
@@ -69,6 +69,6 @@ resource "nutanix_virtual_machine" "vm_bootstrap" {
   }
 
   nic_list {
-    subnet_uuid = var.nutanix_subnet_uuid
+    subnet_uuid = var.nutanix_subnet_uuids[0]
   }
 }

--- a/data/data/nutanix/cluster/main.tf
+++ b/data/data/nutanix/cluster/main.tf
@@ -66,7 +66,7 @@ resource "nutanix_virtual_machine" "vm_master" {
   count = var.master_count
   description = local.description
   name = "${var.cluster_id}-master-${count.index}"
-  cluster_uuid = var.nutanix_prism_element_uuid
+  cluster_uuid = var.nutanix_prism_element_uuids[count.index]
   num_vcpus_per_socket = var.nutanix_control_plane_cores_per_socket
   num_sockets = var.nutanix_control_plane_num_cpus
   memory_size_mib = var.nutanix_control_plane_memory_mib
@@ -107,6 +107,6 @@ resource "nutanix_virtual_machine" "vm_master" {
 
   guest_customization_cloud_init_user_data = base64encode(element(data.ignition_config.master_ignition_config.*.rendered, count.index))
   nic_list {
-    subnet_uuid = var.nutanix_subnet_uuid
+    subnet_uuid = var.nutanix_subnet_uuids[count.index]
   }
 }

--- a/data/data/nutanix/variables-nutanix.tf
+++ b/data/data/nutanix/variables-nutanix.tf
@@ -22,9 +22,10 @@ variable "nutanix_password" {
   description = "Prism Central user password"
 }
 
-variable "nutanix_prism_element_uuid" {
-  type        = string
-  description = "This is the uuid of the Prism Element cluster."
+variable "nutanix_prism_element_uuids" {
+  type        = list(string)
+  default     = []
+  description = "This is the uuids of the Prism Element clusters."
 }
 
 variable "nutanix_image_uri" {
@@ -37,9 +38,10 @@ variable "nutanix_image" {
   description = "This is the name to the image that will be imported into Prism Central."
 }
 
-variable "nutanix_subnet_uuid" {
-  type        = string
-  description = "This is the uuid of the publicly accessible subnet for cluster ingress and access."
+variable "nutanix_subnet_uuids" {
+  type        = list(string)
+  default     = []
+  description = "This is the uuids of the publicly accessible subnets for cluster ingress and access."
 }
 
 variable "nutanix_bootstrap_ignition_image" {


### PR DESCRIPTION
[SPLAT-1272](https://issues.redhat.com//browse/SPLAT-1272): Modify the terraform variables to support Nutanix Failure Domains

For terraform to create the control-plane node VMs with different configurations from the Nutanix Failure Domains, the Nutanix terraform variables need to have the corresponding changes.

Related merged PRs:
https://github.com/openshift/installer/pull/7730