### PR TITLE
IBMCloud: Set IBM TF visibility based on URLs

### DIFF
--- a/data/data/ibmcloud/bootstrap/common.tf
+++ b/data/data/ibmcloud/bootstrap/common.tf
@@ -1,8 +1,7 @@
 locals {
   description = "Created By OpenShift Installer"
-  # If any Service Endpoints are being overridden, set visibility to 'private'
-  # for IBM Terraform Provider to use the endpoints JSON file.
-  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  # If specified, set visibility to 'private' for IBM Terraform Provider
+  endpoint_visibility = var.ibmcloud_terraform_private_visibility ? "private" : "public"
   public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],

--- a/data/data/ibmcloud/master/common.tf
+++ b/data/data/ibmcloud/master/common.tf
@@ -1,8 +1,7 @@
 locals {
   description = "Created By OpenShift Installer"
-  # If any Service Endpoints are being overridden, set visibility to 'private'
-  # for IBM Terraform Provider to use the endpoints JSON file.
-  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  # If specified, set visibility to 'private' for IBM Terraform Provider
+  endpoint_visibility = var.ibmcloud_terraform_private_visibility ? "private" : "public"
   public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],

--- a/data/data/ibmcloud/network/common.tf
+++ b/data/data/ibmcloud/network/common.tf
@@ -1,8 +1,7 @@
 locals {
   description = "Created By OpenShift Installer"
-  # If any Service Endpoints are being overridden, set visibility to 'private'
-  # for IBM Terraform Provider to use the endpoints JSON file.
-  endpoint_visibility = var.ibmcloud_endpoints_json_file != "" ? "private" : "public"
+  # If specified, set visibility to 'private' for IBM Terraform Provider
+  endpoint_visibility = var.ibmcloud_terraform_private_visibility ? "private" : "public"
   public_endpoints    = var.ibmcloud_publish_strategy == "External" ? true : false
   tags = concat(
     ["kubernetes.io_cluster_${var.cluster_id}:owned"],

--- a/data/data/ibmcloud/variables-ibmcloud.tf
+++ b/data/data/ibmcloud/variables-ibmcloud.tf
@@ -51,6 +51,12 @@ variable "ibmcloud_image_filepath" {
   description = "The file path to the RHCOS image"
 }
 
+variable "ibmcloud_terraform_private_visibility" {
+  type        = bool
+  description = "Specified whether the IBM Cloud terraform provider visibility mode should be private, for endpoint usage."
+  default     = false
+}
+
 #######################################
 # Top-level module variables (optional)
 #######################################

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -57,17 +57,15 @@ func Destroy(dir string) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed generating endpoint override JSON data for bootstrap destroy: %w", err)
 		}
-		// Since there are ServiceEndpoints, we expect JSON data to be generated.
-		if jsonData == nil {
-			return fmt.Errorf("no endpoint override JSON data generated for set of endpoint overrides")
-		}
 
 		// If JSON data was generated, create the JSON file for IBM Cloud Terraform provider to use during destroy.
-		endpointsFilePath := filepath.Join(dir, ibmcloudtfvars.IBMCloudEndpointJSONFileName)
-		if err := os.WriteFile(endpointsFilePath, jsonData, 0o600); err != nil {
-			return fmt.Errorf("failed to write IBM Cloud service endpoint override JSON file for bootstrap destroy: %w", err)
+		if jsonData != nil {
+			endpointsFilePath := filepath.Join(dir, ibmcloudtfvars.IBMCloudEndpointJSONFileName)
+			if err := os.WriteFile(endpointsFilePath, jsonData, 0o600); err != nil {
+				return fmt.Errorf("failed to write IBM Cloud service endpoint override JSON file for bootstrap destroy: %w", err)
+			}
+			logrus.Debugf("generated ibm endpoint overrides file: %s", endpointsFilePath)
 		}
-		logrus.Debugf("generated ibm endpoint overrides file: %s", endpointsFilePath)
 	}
 
 	fg := featuregates.FeatureGateFromFeatureSets(configv1.FeatureSets, metadata.FeatureSet, metadata.CustomFeatureSet)

--- a/pkg/tfvars/ibmcloud/ibmcloud.go
+++ b/pkg/tfvars/ibmcloud/ibmcloud.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/rhcos/cache"
@@ -28,46 +29,48 @@ type DedicatedHost struct {
 }
 
 type config struct {
-	Auth                      `json:",inline"`
-	BootstrapInstanceType     string          `json:"ibmcloud_bootstrap_instance_type,omitempty"`
-	CISInstanceCRN            string          `json:"ibmcloud_cis_crn,omitempty"`
-	ComputeSubnets            []string        `json:"ibmcloud_compute_subnets,omitempty"`
-	ControlPlaneBootVolumeKey string          `json:"ibmcloud_control_plane_boot_volume_key"`
-	ControlPlaneSubnets       []string        `json:"ibmcloud_control_plane_subnets,omitempty"`
-	DNSInstanceID             string          `json:"ibmcloud_dns_id,omitempty"`
-	EndpointsJSONFile         string          `json:"ibmcloud_endpoints_json_file,omitempty"`
-	ExtraTags                 []string        `json:"ibmcloud_extra_tags,omitempty"`
-	ImageFilePath             string          `json:"ibmcloud_image_filepath,omitempty"`
-	MasterAvailabilityZones   []string        `json:"ibmcloud_master_availability_zones"`
-	MasterInstanceType        string          `json:"ibmcloud_master_instance_type,omitempty"`
-	MasterDedicatedHosts      []DedicatedHost `json:"ibmcloud_master_dedicated_hosts,omitempty"`
-	NetworkResourceGroupName  string          `json:"ibmcloud_network_resource_group_name,omitempty"`
-	PreexistingVPC            bool            `json:"ibmcloud_preexisting_vpc,omitempty"`
-	PublishStrategy           string          `json:"ibmcloud_publish_strategy,omitempty"`
-	Region                    string          `json:"ibmcloud_region,omitempty"`
-	ResourceGroupName         string          `json:"ibmcloud_resource_group_name,omitempty"`
-	VPC                       string          `json:"ibmcloud_vpc,omitempty"`
-	VPCPermitted              bool            `json:"ibmcloud_vpc_permitted,omitempty"`
-	WorkerAvailabilityZones   []string        `json:"ibmcloud_worker_availability_zones"`
-	WorkerDedicatedHosts      []DedicatedHost `json:"ibmcloud_worker_dedicated_hosts,omitempty"`
+	Auth                       `json:",inline"`
+	BootstrapInstanceType      string          `json:"ibmcloud_bootstrap_instance_type,omitempty"`
+	CISInstanceCRN             string          `json:"ibmcloud_cis_crn,omitempty"`
+	ComputeSubnets             []string        `json:"ibmcloud_compute_subnets,omitempty"`
+	ControlPlaneBootVolumeKey  string          `json:"ibmcloud_control_plane_boot_volume_key"`
+	ControlPlaneSubnets        []string        `json:"ibmcloud_control_plane_subnets,omitempty"`
+	DNSInstanceID              string          `json:"ibmcloud_dns_id,omitempty"`
+	EndpointsJSONFile          string          `json:"ibmcloud_endpoints_json_file,omitempty"`
+	ExtraTags                  []string        `json:"ibmcloud_extra_tags,omitempty"`
+	ImageFilePath              string          `json:"ibmcloud_image_filepath,omitempty"`
+	MasterAvailabilityZones    []string        `json:"ibmcloud_master_availability_zones"`
+	MasterInstanceType         string          `json:"ibmcloud_master_instance_type,omitempty"`
+	MasterDedicatedHosts       []DedicatedHost `json:"ibmcloud_master_dedicated_hosts,omitempty"`
+	NetworkResourceGroupName   string          `json:"ibmcloud_network_resource_group_name,omitempty"`
+	PreexistingVPC             bool            `json:"ibmcloud_preexisting_vpc,omitempty"`
+	PublishStrategy            string          `json:"ibmcloud_publish_strategy,omitempty"`
+	Region                     string          `json:"ibmcloud_region,omitempty"`
+	ResourceGroupName          string          `json:"ibmcloud_resource_group_name,omitempty"`
+	TerraformPrivateVisibility bool            `json:"ibmcloud_terraform_private_visibility,omitempty"`
+	VPC                        string          `json:"ibmcloud_vpc,omitempty"`
+	VPCPermitted               bool            `json:"ibmcloud_vpc_permitted,omitempty"`
+	WorkerAvailabilityZones    []string        `json:"ibmcloud_worker_availability_zones"`
+	WorkerDedicatedHosts       []DedicatedHost `json:"ibmcloud_worker_dedicated_hosts,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	Auth                     Auth
-	CISInstanceCRN           string
-	DNSInstanceID            string
-	EndpointsJSONFile        string
-	ImageURL                 string
-	MasterConfigs            []*ibmcloudprovider.IBMCloudMachineProviderSpec
-	MasterDedicatedHosts     []DedicatedHost
-	NetworkResourceGroupName string
-	PreexistingVPC           bool
-	PublishStrategy          types.PublishingStrategy
-	ResourceGroupName        string
-	VPCPermitted             bool
-	WorkerConfigs            []*ibmcloudprovider.IBMCloudMachineProviderSpec
-	WorkerDedicatedHosts     []DedicatedHost
+	Auth                       Auth
+	CISInstanceCRN             string
+	DNSInstanceID              string
+	EndpointsJSONFile          string
+	ImageURL                   string
+	MasterConfigs              []*ibmcloudprovider.IBMCloudMachineProviderSpec
+	MasterDedicatedHosts       []DedicatedHost
+	NetworkResourceGroupName   string
+	PreexistingVPC             bool
+	PublishStrategy            types.PublishingStrategy
+	ResourceGroupName          string
+	TerraformPrivateVisibility bool
+	VPCPermitted               bool
+	WorkerConfigs              []*ibmcloudprovider.IBMCloudMachineProviderSpec
+	WorkerDedicatedHosts       []DedicatedHost
 }
 
 // TFVars generates ibmcloud-specific Terraform variables launching the cluster.
@@ -102,27 +105,28 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	}
 
 	cfg := &config{
-		Auth:                      sources.Auth,
-		BootstrapInstanceType:     masterConfig.Profile,
-		CISInstanceCRN:            sources.CISInstanceCRN,
-		ComputeSubnets:            workerSubnets,
-		ControlPlaneBootVolumeKey: masterConfig.BootVolume.EncryptionKey,
-		ControlPlaneSubnets:       masterSubnets,
-		DNSInstanceID:             sources.DNSInstanceID,
-		EndpointsJSONFile:         sources.EndpointsJSONFile,
-		ImageFilePath:             cachedImage,
-		MasterAvailabilityZones:   masterAvailabilityZones,
-		MasterDedicatedHosts:      sources.MasterDedicatedHosts,
-		MasterInstanceType:        masterConfig.Profile,
-		NetworkResourceGroupName:  sources.NetworkResourceGroupName,
-		PreexistingVPC:            sources.PreexistingVPC,
-		PublishStrategy:           string(sources.PublishStrategy),
-		Region:                    masterConfig.Region,
-		ResourceGroupName:         sources.ResourceGroupName,
-		VPC:                       vpc,
-		VPCPermitted:              sources.VPCPermitted,
-		WorkerAvailabilityZones:   workerAvailabilityZones,
-		WorkerDedicatedHosts:      sources.WorkerDedicatedHosts,
+		Auth:                       sources.Auth,
+		BootstrapInstanceType:      masterConfig.Profile,
+		CISInstanceCRN:             sources.CISInstanceCRN,
+		ComputeSubnets:             workerSubnets,
+		ControlPlaneBootVolumeKey:  masterConfig.BootVolume.EncryptionKey,
+		ControlPlaneSubnets:        masterSubnets,
+		DNSInstanceID:              sources.DNSInstanceID,
+		EndpointsJSONFile:          sources.EndpointsJSONFile,
+		ImageFilePath:              cachedImage,
+		MasterAvailabilityZones:    masterAvailabilityZones,
+		MasterDedicatedHosts:       sources.MasterDedicatedHosts,
+		MasterInstanceType:         masterConfig.Profile,
+		NetworkResourceGroupName:   sources.NetworkResourceGroupName,
+		PreexistingVPC:             sources.PreexistingVPC,
+		PublishStrategy:            string(sources.PublishStrategy),
+		Region:                     masterConfig.Region,
+		ResourceGroupName:          sources.ResourceGroupName,
+		TerraformPrivateVisibility: sources.TerraformPrivateVisibility,
+		VPC:                        vpc,
+		VPCPermitted:               sources.VPCPermitted,
+		WorkerAvailabilityZones:    workerAvailabilityZones,
+		WorkerDedicatedHosts:       sources.WorkerDedicatedHosts,
 
 		// TODO: IBM: Future support
 		// ExtraTags:               masterConfig.Tags,
@@ -141,15 +145,15 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 	endpointContents := ibmcloudtypes.EndpointsJSON{}
 	for _, endpoint := range endpoints {
 		switch endpoint.Name {
+		// COS endpoint is not used in Terraform
 		case configv1.IBMCloudServiceCOS:
-			endpointContents.IBMCloudEndpointCOS = &ibmcloudtypes.EndpointsVisibility{
-				Private: map[string]string{
-					region: endpoint.URL,
-				},
-			}
+			continue
 		case configv1.IBMCloudServiceCIS:
 			endpointContents.IBMCloudEndpointCIS = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
+					region: endpoint.URL,
+				},
+				Public: map[string]string{
 					region: endpoint.URL,
 				},
 			}
@@ -158,10 +162,16 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 				Private: map[string]string{
 					region: endpoint.URL,
 				},
+				Public: map[string]string{
+					region: endpoint.URL,
+				},
 			}
 		case configv1.IBMCloudServiceGlobalSearch:
 			endpointContents.IBMCloudEndpointGlobalSearch = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
+					region: endpoint.URL,
+				},
+				Public: map[string]string{
 					region: endpoint.URL,
 				},
 			}
@@ -170,10 +180,16 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 				Private: map[string]string{
 					region: endpoint.URL,
 				},
+				Public: map[string]string{
+					region: endpoint.URL,
+				},
 			}
 		case configv1.IBMCloudServiceHyperProtect:
 			endpointContents.IBMCloudEndpointHyperProtect = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
+					region: endpoint.URL,
+				},
+				Public: map[string]string{
 					region: endpoint.URL,
 				},
 			}
@@ -182,10 +198,16 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 				Private: map[string]string{
 					region: endpoint.URL,
 				},
+				Public: map[string]string{
+					region: endpoint.URL,
+				},
 			}
 		case configv1.IBMCloudServiceKeyProtect:
 			endpointContents.IBMCloudEndpointKeyProtect = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
+					region: endpoint.URL,
+				},
+				Public: map[string]string{
 					region: endpoint.URL,
 				},
 			}
@@ -194,16 +216,25 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 				Private: map[string]string{
 					region: endpoint.URL,
 				},
+				Public: map[string]string{
+					region: endpoint.URL,
+				},
 			}
 		case configv1.IBMCloudServiceResourceManager:
 			endpointContents.IBMCloudEndpointResourceManager = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
 					region: endpoint.URL,
 				},
+				Public: map[string]string{
+					region: endpoint.URL,
+				},
 			}
 		case configv1.IBMCloudServiceVPC:
 			endpointContents.IBMCloudEndpointVPC = &ibmcloudtypes.EndpointsVisibility{
 				Private: map[string]string{
+					region: endpoint.URL,
+				},
+				Public: map[string]string{
 					region: endpoint.URL,
 				},
 			}
@@ -216,9 +247,11 @@ func CreateEndpointJSON(endpoints []configv1.IBMCloudServiceEndpoint, region str
 		return nil, fmt.Errorf("failure building service endpoint override JSON data: %w", err)
 	}
 
-	// If the JSON contains no data, none was populated (jsonData == "{}"), but endpoints is not empty (initial check), that should cause an error (endpoints provided are not supported)
+	// If the JSON contains no data, none was populated (jsonData == "{}"), but endpoints is not empty, we assume the Services are not required for Terraform (e.g., COS)
+	// Log this as a warning, but continue as if no service endpoints were provided
 	if len(jsonData) <= 2 {
-		return nil, fmt.Errorf("unsupported endpoints provided: %s", endpoints)
+		logrus.Warnf("no terraform endpoint json was created for services: %s", endpoints)
+		return nil, nil
 	}
 	return jsonData, nil
 }

--- a/pkg/types/ibmcloud/platform.go
+++ b/pkg/types/ibmcloud/platform.go
@@ -93,7 +93,7 @@ type EndpointsJSON struct {
 	IBMCloudEndpointResourceManager *EndpointsVisibility `json:"IBMCLOUD_RESOURCE_MANAGEMENT_API_ENDPOINT,omitempty"`
 
 	// IBMCloudEndpointVPC contains endpoint mapping for IBM Cloud VPC.
-	IBMCloudEndpointVPC *EndpointsVisibility `json:"IBMCLOUDIS_NG_API_ENDPOINT,omitempty"`
+	IBMCloudEndpointVPC *EndpointsVisibility `json:"IBMCLOUD_IS_NG_API_ENDPOINT,omitempty"`
 }
 
 // EndpointsVisibility contains region mapped endpoint for a service.
@@ -101,6 +101,10 @@ type EndpointsVisibility struct {
 	// Private is a string-string map of a region name to endpoint URL
 	// To prevent maintaining a list of supported regions here, we simply use a map instead of a struct
 	Private map[string]string `json:"private"`
+
+	// Public is a string-string map of a region name to endpoint URL
+	// To prevent maintaining a list of supported regions here, we simply use a map instead of a struct
+	Public map[string]string `json:"public"`
 }
 
 // CheckServiceEndpointOverride checks whether a service has an override endpoint.


### PR DESCRIPTION
Set the IBM Cloud Terraform visibility mode based on whether any ServiceEndpoints are suspected to be private (or direct for COS), based on their URL's.