### PR TITLE
METAL-829: Set node cpu_arch from bmh

### DIFF
--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -156,8 +156,11 @@ func TFVars(numControlPlaneReplicas int64, libvirtURI, apiVIP, imageCacheIP, boo
 
 		// Properties
 		propertiesMap := map[string]interface{}{
-			"cpu_arch":     "x86_64",
 			"capabilities": bootMode,
+		}
+
+		if bmh.Spec.Architecture != "" {
+			propertiesMap["cpu_arch"] = bmh.Spec.Architecture
 		}
 
 		// Root device hints


### PR DESCRIPTION
Using bmh.Spec.Architecture will be more future proof