### PR TITLE
OCPBUGS-24241: Pin openstack.cloud version.

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -172,7 +172,7 @@ The Ansible Collections are not packaged (yet) on recent versions of OSP and RHE
 installed instead of Ansible 2.9. So the collections need to be installed from `ansible-galaxy`.
 
 ```sh
-ansible-galaxy collection install openstack.cloud ansible.utils community.general
+ansible-galaxy collection install "openstack.cloud:<2.0.0" ansible.utils community.general
 ```
 
 ## OpenShift Configuration Directory


### PR DESCRIPTION
When following this guide using RHEL or older Fedora there is an issue with the openstack.cloud with latest version (2.0.0) as it will need openstacksdk in version 1.0 or higher, which is unavailable in mentioned Linux distribution.