### PR TITLE
CORS-2840: images/altinfra: enable CAPI builds

### DIFF
--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -9,6 +9,9 @@
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 ARG TAGS="altinfra"
+# Enables building CAPI dependencies in hack/build.sh. Once CAPI is stable
+# the logic in build.sh should no longer be gated and this can be removed.
+ENV OPENSHIFT_INSTALL_CLUSTER_API="true"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh


### PR DESCRIPTION
Enable building CAPI providers & dependencies by default in the `installer-altinfra` image.

https://github.com/openshift/release/pull/46602 is enabling a CAPI variant job. 

It seems we should hold off on enabling CAPI builds until we get terraform builds under control in the `installer` image.

/cc @r4f4 
/cc @vincepri 
