### PR TITLE
CORS-3139:  Move CAPI behind infrastructure provider interface

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -5,31 +5,23 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
 	"github.com/openshift/installer/pkg/asset/cluster/azure"
 	"github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
-	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	"github.com/openshift/installer/pkg/asset/machines"
 	capimanifests "github.com/openshift/installer/pkg/asset/manifests/clusterapi"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/quota"
-	"github.com/openshift/installer/pkg/clusterapi"
 	infra "github.com/openshift/installer/pkg/infrastructure/platform"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 	typesazure "github.com/openshift/installer/pkg/types/azure"
@@ -72,6 +64,9 @@ func (c *Cluster) Dependencies() []asset.Asset {
 		&password.KubeadminPassword{},
 		&capimanifests.Cluster{},
 		&kubeconfig.AdminClient{},
+		&bootstrap.Bootstrap{},
+		&machine.Master{},
+		&machines.ClusterAPI{},
 	}
 }
 
@@ -98,31 +93,14 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		return errors.New("cluster cannot be created with bootstrapInPlace set")
 	}
 
-	// Check if we're using Cluster API.
-	if capiutils.IsEnabled(installConfig) {
-		// TODO(vincepri): The context should be passed down from the caller,
-		// although today the Asset interface doesn't allow it, refactor once it does.
-		ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
-		go func() {
-			<-ctx.Done()
-			cancel()
-			clusterapi.System().Teardown()
-		}()
-
-		return c.provisionWithClusterAPI(ctx, parents, installConfig, clusterID)
-	}
-
-	// Otherwise, use the normal path.
-	return c.provision(installConfig, clusterID, terraformVariables, parents)
-}
-
-func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, terraformVariables *tfvars.TerraformVariables, parents asset.Parents) error {
 	platform := installConfig.Config.Platform.Name()
 
 	if azure := installConfig.Config.Platform.Azure; azure != nil && azure.CloudName == typesazure.StackCloud {
 		platform = typesazure.StackTerraformName
 	}
 
+	// TODO(padillon): determine whether CAPI handles tagging shared subnets, in which case we should be able
+	// to encapsulate these into the terraform package.
 	logrus.Infof("Creating infrastructure resources...")
 	switch platform {
 	case typesaws.Name:
@@ -151,137 +129,6 @@ func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterI
 		return fmt.Errorf("%s: %w", asset.ClusterCreationError, err)
 	}
 
-	return nil
-}
-
-func (c *Cluster) provisionWithClusterAPI(ctx context.Context, parents asset.Parents, installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID) error {
-	capiManifests := &capimanifests.Cluster{}
-	clusterKubeconfigAsset := &kubeconfig.AdminClient{}
-	parents.Get(
-		capiManifests,
-		clusterKubeconfigAsset,
-	)
-
-	// Only need the objects--not the files.
-	manifests := []client.Object{}
-	for _, m := range capiManifests.RuntimeFiles() {
-		manifests = append(manifests, m.Object)
-	}
-
-	// Run the CAPI system.
-	capiSystem := clusterapi.System()
-	if err := capiSystem.Run(ctx, installConfig); err != nil {
-		return fmt.Errorf("failed to run cluster api system: %w", err)
-	}
-
-	// Grab the client.
-	cl := capiSystem.Client()
-
-	// Create all the manifests and store them.
-	for _, m := range manifests {
-		m.SetNamespace(capiutils.Namespace)
-		if err := cl.Create(context.Background(), m); err != nil {
-			return fmt.Errorf("failed to create manifest: %w", err)
-		}
-		logrus.Infof("Created manifest %+T, namespace=%s name=%s", m, m.GetNamespace(), m.GetName())
-	}
-
-	// Pass cluster kubeconfig and store it in; this is usually the role of a bootstrap provider.
-	{
-		key := client.ObjectKey{
-			Name:      clusterID.InfraID,
-			Namespace: capiutils.Namespace,
-		}
-		cluster := &clusterv1.Cluster{}
-		if err := cl.Get(context.Background(), key, cluster); err != nil {
-			return err
-		}
-		// Create the secret.
-		clusterKubeconfig := clusterKubeconfigAsset.Files()[0].Data
-		secret := utilkubeconfig.GenerateSecret(cluster, clusterKubeconfig)
-		if err := cl.Create(context.Background(), secret); err != nil {
-			return err
-		}
-	}
-
-	// Wait for the load balancer to be ready by checking the control plane endpoint
-	// on the cluster object.
-	var cluster *clusterv1.Cluster
-	{
-		if err := wait.ExponentialBackoff(wait.Backoff{
-			Duration: time.Second * 10,
-			Factor:   float64(1.5),
-			Steps:    32,
-		}, func() (bool, error) {
-			c := &clusterv1.Cluster{}
-			if err := cl.Get(context.Background(), client.ObjectKey{
-				Name:      clusterID.InfraID,
-				Namespace: capiutils.Namespace,
-			}, c); err != nil {
-				if apierrors.IsNotFound(err) {
-					return false, nil
-				}
-				return false, err
-			}
-			cluster = c
-			return cluster.Spec.ControlPlaneEndpoint.IsValid(), nil
-		}); err != nil {
-			return err
-		}
-		if cluster == nil {
-			return errors.New("error occurred during load balancer ready check")
-		}
-		if cluster.Spec.ControlPlaneEndpoint.Host == "" {
-			return errors.New("control plane endpoint is not set")
-		}
-	}
-
-	// Run the post-provisioning steps for the platform we're on.
-	// TODO(vincepri): The following should probably be in a separate package with a clear
-	// interface and multiple hooks at different stages of the cluster lifecycle.
-	switch installConfig.Config.Platform.Name() {
-	case typesaws.Name:
-		ssn, err := installConfig.AWS.Session(context.TODO())
-		if err != nil {
-			return fmt.Errorf("failed to create session: %w", err)
-		}
-		client := awsconfig.NewClient(ssn)
-		r53cfg := awsconfig.GetR53ClientCfg(ssn, "")
-		err = client.CreateOrUpdateRecord(installConfig.Config, cluster.Spec.ControlPlaneEndpoint.Host, r53cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create route53 records: %w", err)
-		}
-		logrus.Infof("Created Route53 records to control plane load balancer.")
-	default:
-	}
-
-	// For each manifest we created, retrieve it and store it in the asset.
-	for _, m := range manifests {
-		key := client.ObjectKey{
-			Name:      m.GetName(),
-			Namespace: m.GetNamespace(),
-		}
-		if err := cl.Get(context.Background(), key, m); err != nil {
-			return fmt.Errorf("failed to get manifest: %w", err)
-		}
-
-		gvk, err := cl.GroupVersionKindFor(m)
-		if err != nil {
-			return fmt.Errorf("failed to get GVK for manifest: %w", err)
-		}
-		fileName := fmt.Sprintf("%s-%s-%s.yaml", gvk.Kind, m.GetNamespace(), m.GetName())
-		objData, err := yaml.Marshal(m)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to create infrastructure manifest %s from InstallConfig", fileName)
-			return errors.Wrapf(err, errMsg)
-		}
-		c.FileList = append(c.FileList, &asset.File{
-			Filename: fileName,
-			Data:     objData,
-		})
-	}
-
-	logrus.Infof("Cluster API resources have been created. Waiting for cluster to become ready...")
 	return nil
 }
 

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
 	"github.com/openshift/installer/pkg/asset/cluster/azure"
 	"github.com/openshift/installer/pkg/asset/cluster/openstack"
+	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
@@ -67,7 +68,7 @@ func (c *Cluster) Dependencies() []asset.Asset {
 		&installconfig.PlatformPermsCheck{},
 		&installconfig.PlatformProvisionCheck{},
 		&quota.PlatformQuotaCheck{},
-		&TerraformVariables{},
+		&tfvars.TerraformVariables{},
 		&password.KubeadminPassword{},
 		&capimanifests.Cluster{},
 		&kubeconfig.AdminClient{},
@@ -82,7 +83,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
-	terraformVariables := &TerraformVariables{}
+	terraformVariables := &tfvars.TerraformVariables{}
 	parents.Get(clusterID, installConfig, terraformVariables)
 
 	if fs := installConfig.Config.FeatureSet; strings.HasSuffix(string(fs), "NoUpgrade") {
@@ -115,7 +116,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	return c.provision(installConfig, clusterID, terraformVariables)
 }
 
-func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, terraformVariables *TerraformVariables) error {
+func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, terraformVariables *tfvars.TerraformVariables) error {
 	platform := installConfig.Config.Platform.Name()
 
 	if azure := installConfig.Config.Platform.Azure; azure != nil && azure.CloudName == typesazure.StackCloud {

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -113,10 +113,10 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	}
 
 	// Otherwise, use the normal path.
-	return c.provision(installConfig, clusterID, terraformVariables)
+	return c.provision(installConfig, clusterID, terraformVariables, parents)
 }
 
-func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, terraformVariables *tfvars.TerraformVariables) error {
+func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, terraformVariables *tfvars.TerraformVariables, parents asset.Parents) error {
 	platform := installConfig.Config.Platform.Name()
 
 	if azure := installConfig.Config.Platform.Azure; azure != nil && azure.CloudName == typesazure.StackCloud {
@@ -139,16 +139,11 @@ func (c *Cluster) provision(installConfig *installconfig.InstallConfig, clusterI
 		}
 	}
 
-	tfvarsFiles := []*asset.File{}
-	for _, file := range terraformVariables.Files() {
-		tfvarsFiles = append(tfvarsFiles, file)
-	}
-
 	provider, err := infra.ProviderForPlatform(platform, installConfig.Config.EnabledFeatureGates())
 	if err != nil {
 		return fmt.Errorf("error getting infrastructure provider: %w", err)
 	}
-	files, err := provider.Provision(InstallDir, tfvarsFiles)
+	files, err := provider.Provision(InstallDir, parents)
 	if files != nil {
 		c.FileList = append(c.FileList, files...) // append state files even in case of failure
 	}

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -2,8 +2,6 @@ package cluster
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/cluster/gcp"
 	"github.com/openshift/installer/pkg/asset/cluster/ibmcloud"
 	"github.com/openshift/installer/pkg/asset/cluster/libvirt"
+	clustermetadata "github.com/openshift/installer/pkg/asset/cluster/metadata"
 	"github.com/openshift/installer/pkg/asset/cluster/nutanix"
 	"github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/cluster/ovirt"
@@ -37,10 +36,6 @@ import (
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
-)
-
-const (
-	metadataFileName = "metadata.json"
 )
 
 // Metadata contains information needed to destroy clusters.
@@ -119,7 +114,7 @@ func (m *Metadata) Generate(parents asset.Parents) (err error) {
 	}
 
 	m.File = &asset.File{
-		Filename: metadataFileName,
+		Filename: clustermetadata.FileName,
 		Data:     data,
 	}
 
@@ -138,20 +133,4 @@ func (m *Metadata) Files() []*asset.File {
 // the disk.
 func (m *Metadata) Load(f asset.FileFetcher) (found bool, err error) {
 	return false, nil
-}
-
-// LoadMetadata loads the cluster metadata from an asset directory.
-func LoadMetadata(dir string) (*types.ClusterMetadata, error) {
-	path := filepath.Join(dir, metadataFileName)
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var metadata *types.ClusterMetadata
-	if err = json.Unmarshal(raw, &metadata); err != nil {
-		return nil, errors.Wrapf(err, "failed to Unmarshal data from %q to types.ClusterMetadata", path)
-	}
-
-	return metadata, err
 }

--- a/pkg/asset/cluster/metadata/metadata.go
+++ b/pkg/asset/cluster/metadata/metadata.go
@@ -1,0 +1,31 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+const (
+	// FileName is the filename for the cluster metadata.json file.
+	FileName = "metadata.json"
+)
+
+// Load loads the cluster metadata from an asset directory.
+func Load(dir string) (*types.ClusterMetadata, error) {
+	path := filepath.Join(dir, FileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata *types.ClusterMetadata
+	if err = json.Unmarshal(raw, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to Unmarshal data from %q to types.ClusterMetadata: %w", path, err)
+	}
+
+	return metadata, err
+}

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -1,4 +1,4 @@
-package cluster
+package tfvars
 
 import (
 	"context"

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -102,7 +102,7 @@ func (t *TerraformVariables) Name() string {
 	return tfvarsAssetName
 }
 
-// Dependencies returns the dependency of the TerraformVariable
+// Dependencies returns the dependency of the TerraformVariable.
 func (t *TerraformVariables) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
@@ -121,6 +121,8 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 }
 
 // Generate generates the terraform.tfvars file.
+//
+//nolint:gocyclo // legacy, pre-linter cyclomatic complexity
 func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	ctx := context.TODO()
 	clusterID := &installconfig.ClusterID{}
@@ -263,7 +265,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		masterConfigs := make([]*machinev1beta1.AWSMachineProviderConfig, len(masters))
 		for i, m := range masters {
-			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AWSMachineProviderConfig)
+			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AWSMachineProviderConfig) //nolint:errcheck // legacy, pre-linter
 		}
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
@@ -271,7 +273,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		workerConfigs := make([]*machinev1beta1.AWSMachineProviderConfig, len(workers))
 		for i, m := range workers {
-			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AWSMachineProviderConfig)
+			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AWSMachineProviderConfig) //nolint:errcheck // legacy, pre-linter
 		}
 		osImage := strings.SplitN(string(*rhcosImage), ",", 2)
 		osImageID := osImage[0]
@@ -360,7 +362,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		masterConfigs := make([]*machinev1beta1.AzureMachineProviderSpec, len(masters))
 		for i, m := range masters {
-			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec)
+			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
@@ -368,7 +370,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		workerConfigs := make([]*machinev1beta1.AzureMachineProviderSpec, len(workers))
 		for i, w := range workers {
-			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec)
+			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 		client := aztypes.NewClient(session)
 		hyperVGeneration, err := client.GetHyperVGenerationVersion(context.TODO(), masterConfigs[0].VMSize, masterConfigs[0].Location, "")
@@ -475,7 +477,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		masterConfigs := make([]*machinev1beta1.GCPMachineProviderSpec, len(masters))
 		for i, m := range masters {
-			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.GCPMachineProviderSpec)
+			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1beta1.GCPMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
@@ -483,7 +485,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		workerConfigs := make([]*machinev1beta1.GCPMachineProviderSpec, len(workers))
 		for i, w := range workers {
-			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.GCPMachineProviderSpec)
+			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.GCPMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 		preexistingnetwork := installConfig.Config.GCP.Network != ""
 
@@ -561,7 +563,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		masterConfigs := make([]*ibmcloudprovider.IBMCloudMachineProviderSpec, len(masters))
 		for i, m := range masters {
-			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*ibmcloudprovider.IBMCloudMachineProviderSpec)
+			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*ibmcloudprovider.IBMCloudMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
@@ -569,7 +571,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		workerConfigs := make([]*ibmcloudprovider.IBMCloudMachineProviderSpec, len(workers))
 		for i, w := range workers {
-			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*ibmcloudprovider.IBMCloudMachineProviderSpec)
+			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*ibmcloudprovider.IBMCloudMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
 
 		// Set existing network (boolean of whether one is being used)
@@ -896,7 +898,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 		masterConfigs := make([]*machinev1.PowerVSMachineProviderConfig, len(masters))
 		for i, m := range masters {
-			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig)
+			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig) //nolint:errcheck // legacy, pre-linter
 		}
 
 		client, err := powervsconfig.NewClient()
@@ -935,7 +937,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			}
 			vpcZone = *sn.Zone.Name
 		} else {
-			rand.Seed(time.Now().UnixNano())
+			rand.New(rand.NewSource(time.Now().UnixNano()))           //nolint:gosec // we don't need a crypto secure number
 			vpcZone = fmt.Sprintf("%s-%d", vpcRegion, rand.Intn(2)+1) //nolint:gosec // we don't need a crypto secure number
 		}
 
@@ -1031,7 +1033,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		controlPlaneConfigs := make([]*machinev1beta1.VSphereMachineProviderSpec, len(controlPlanes))
 		for i, c := range controlPlanes {
 			var clusterMo mo.ClusterComputeResource
-			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1beta1.VSphereMachineProviderSpec)
+			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1beta1.VSphereMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 
 			rpObj, err := finder.ResourcePool(ctx, controlPlaneConfigs[i].Workspace.ResourcePool)
 			if err != nil {
@@ -1100,18 +1102,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
-
 	case nutanix.Name:
-		if rhcosImage == nil {
-			return errors.New("unable to retrieve rhcos image")
-		}
 		controlPlanes, err := mastersAsset.Machines()
 		if err != nil {
 			return errors.Wrapf(err, "error getting control plane machines")
 		}
 		controlPlaneConfigs := make([]*machinev1.NutanixMachineProviderConfig, len(controlPlanes))
 		for i, c := range controlPlanes {
-			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1.NutanixMachineProviderConfig)
+			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1.NutanixMachineProviderConfig) //nolint:errcheck // legacy, pre-linter
 		}
 
 		imgURI := string(*rhcosImage)

--- a/pkg/asset/manifests/capiutils/manifest.go
+++ b/pkg/asset/manifests/capiutils/manifest.go
@@ -6,6 +6,11 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 )
 
+const (
+	// ManifestDir defines the directory name for Cluster API manifests.
+	ManifestDir = "cluster-api"
+)
+
 // GenerateClusterAssetsOutput is the output of GenerateClusterAssets.
 type GenerateClusterAssetsOutput struct {
 	Manifests         []*asset.RuntimeFile

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -1,7 +1,6 @@
 package clusterapi
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +17,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/manifests/aws"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
@@ -168,13 +166,6 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 
 	// Append the infrastructure manifests.
 	c.FileList = append(c.FileList, out.Manifests...)
-
-	// Generate the machines for the cluster, and append them to the list of manifests.
-	mc, err := machines.GenerateClusterAPI(context.TODO(), installConfig, clusterID, rhcosImage)
-	if err != nil {
-		return errors.Wrap(err, "failed to generate machines")
-	}
-	c.FileList = append(c.FileList, mc.Manifests...)
 
 	// Create the infrastructure manifests.
 	for _, m := range c.FileList {

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -30,10 +30,6 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 )
 
-const (
-	manifestDir = "cluster-api"
-)
-
 var _ asset.WritableRuntimeAsset = (*Cluster)(nil)
 
 // Cluster generates manifests for target cluster
@@ -77,7 +73,7 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(manifestDir), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(capiutils.ManifestDir), 0755); err != nil {
 		return err
 	}
 
@@ -188,11 +184,11 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 		}
 		m.Data = objData
 
-		// If the filename is already a path, do not append the manifestDir.
-		if filepath.Dir(m.Filename) == manifestDir {
+		// If the filename is already a path, do not append the manifest dir.
+		if filepath.Dir(m.Filename) == capiutils.ManifestDir {
 			continue
 		}
-		m.Filename = filepath.Join(manifestDir, m.Filename)
+		m.Filename = filepath.Join(capiutils.ManifestDir, m.Filename)
 	}
 
 	asset.SortManifestFiles(c.FileList)
@@ -215,15 +211,15 @@ func (c *Cluster) RuntimeFiles() []*asset.RuntimeFile {
 
 // Load returns the openshift asset from disk.
 func (c *Cluster) Load(f asset.FileFetcher) (bool, error) {
-	yamlFileList, err := f.FetchByPattern(filepath.Join(manifestDir, "*.yaml"))
+	yamlFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.yaml"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.yaml files")
 	}
-	ymlFileList, err := f.FetchByPattern(filepath.Join(manifestDir, "*.yml"))
+	ymlFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.yml"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.yml files")
 	}
-	jsonFileList, err := f.FetchByPattern(filepath.Join(manifestDir, "*.json"))
+	jsonFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.json"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.json files")
 	}

--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -3,6 +3,7 @@ package targets
 import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster"
+	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -66,7 +67,7 @@ var (
 		&cluster.Metadata{},
 		&machine.MasterIgnitionCustomizations{},
 		&machine.WorkerIgnitionCustomizations{},
-		&cluster.TerraformVariables{},
+		&tfvars.TerraformVariables{},
 		&kubeconfig.AdminClient{},
 		&password.KubeadminPassword{},
 		&tls.JournalCertKey{},

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/installer/pkg/asset/cluster"
+	"github.com/openshift/installer/pkg/asset/cluster/metadata"
 	openstackasset "github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/clusterapi"
@@ -30,7 +30,7 @@ import (
 
 // Destroy uses Terraform to remove bootstrap resources.
 func Destroy(ctx context.Context, dir string) (err error) {
-	metadata, err := cluster.LoadMetadata(dir)
+	metadata, err := metadata.Load(dir)
 	if err != nil {
 		return err
 	}

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -9,19 +9,13 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset/cluster/metadata"
 	openstackasset "github.com/openshift/installer/pkg/asset/cluster/openstack"
-	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
-	"github.com/openshift/installer/pkg/clusterapi"
 	osp "github.com/openshift/installer/pkg/destroy/openstack"
 	infra "github.com/openshift/installer/pkg/infrastructure/platform"
 	ibmcloudtfvars "github.com/openshift/installer/pkg/tfvars/ibmcloud"
-	"github.com/openshift/installer/pkg/types"
 	typesazure "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/featuregates"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
@@ -33,10 +27,6 @@ func Destroy(ctx context.Context, dir string) (err error) {
 	metadata, err := metadata.Load(dir)
 	if err != nil {
 		return err
-	}
-
-	if sys := clusterapi.System(); sys.State() == clusterapi.SystemStateRunning {
-		return destroyBoostrapMachine(ctx, sys.Client(), metadata)
 	}
 
 	platform := metadata.Platform()
@@ -90,17 +80,5 @@ func Destroy(ctx context.Context, dir string) (err error) {
 		return fmt.Errorf("error destroying bootstrap resources %w", err)
 	}
 
-	return nil
-}
-
-func destroyBoostrapMachine(ctx context.Context, c client.Client, metadata *types.ClusterMetadata) error {
-	if err := c.Delete(ctx, &clusterv1.Machine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      capiutils.GenerateBoostrapMachineName(metadata.InfraID),
-			Namespace: capiutils.Namespace,
-		},
-	}); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to delete bootstrap machine: %w", err)
-	}
 	return nil
 }

--- a/pkg/destroy/destroyer.go
+++ b/pkg/destroy/destroyer.go
@@ -4,13 +4,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/openshift/installer/pkg/asset/cluster"
+	"github.com/openshift/installer/pkg/asset/cluster/metadata"
 	"github.com/openshift/installer/pkg/destroy/providers"
 )
 
 // New returns a Destroyer based on `metadata.json` in `rootDir`.
 func New(logger logrus.FieldLogger, rootDir string) (providers.Destroyer, error) {
-	metadata, err := cluster.LoadMetadata(rootDir)
+	metadata, err := metadata.Load(rootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -11,13 +11,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/openshift/installer/pkg/asset/cluster"
+	"github.com/openshift/installer/pkg/asset/cluster/metadata"
 	"github.com/openshift/installer/pkg/gather/providers"
 )
 
 // New returns a Gather based on `metadata.json` in `rootDir`.
 func New(logger logrus.FieldLogger, serialLogBundle string, bootstrap string, masters []string, rootDir string) (providers.Gather, error) {
-	metadata, err := cluster.LoadMetadata(rootDir)
+	metadata, err := metadata.Load(rootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -88,7 +88,6 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 	// TODO(vincepri): The context should be passed down from the caller,
 	// although today the Asset interface doesn't allow it, refactor once it does.
 	ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
-	defer cancel()
 	go func() {
 		<-ctx.Done()
 		cancel()
@@ -323,6 +322,9 @@ func (i *InfraProvider) DestroyBootstrap(dir string) error {
 			return fmt.Errorf("failed to delete bootstrap machine: %w", err)
 		}
 	}
+	logrus.Infof("Finished destroying bootstrap resources")
+	clusterapi.System().Teardown()
+
 	return nil
 }
 

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -1,0 +1,350 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/cluster/metadata"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
+	"github.com/openshift/installer/pkg/asset/machines"
+	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	capimanifests "github.com/openshift/installer/pkg/asset/manifests/clusterapi"
+	"github.com/openshift/installer/pkg/clusterapi"
+	"github.com/openshift/installer/pkg/infrastructure"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Ensure that clusterapi.InfraProvider implements
+// the infrastructure.Provider interface, which is the
+// interface the installer uses to call this provider.
+var _ infrastructure.Provider = (*InfraProvider)(nil)
+
+// InfraProvider implements common Cluster API logic and
+// contains the platform CAPI provider, which is called
+// in the lifecycle defined by the Provider interface.
+type InfraProvider struct {
+	impl Provider
+}
+
+// InitializeProvider returns a ClusterAPI provider implementation
+// for a specific cloud platform.
+func InitializeProvider(platform Provider) infrastructure.Provider {
+	return &InfraProvider{impl: platform}
+}
+
+// Provision creates cluster resources by applying CAPI manifests to a locally running control plane.
+//
+//nolint:gocyclo
+func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
+	capiManifestsAsset := &capimanifests.Cluster{}
+	capiMachinesAsset := &machines.ClusterAPI{}
+	clusterKubeconfigAsset := &kubeconfig.AdminClient{}
+	clusterID := &installconfig.ClusterID{}
+	installConfig := &installconfig.InstallConfig{}
+	bootstrapIgnAsset := &bootstrap.Bootstrap{}
+	masterIgnAsset := &machine.Master{}
+	parents.Get(
+		capiManifestsAsset,
+		clusterKubeconfigAsset,
+		clusterID,
+		installConfig,
+		bootstrapIgnAsset,
+		masterIgnAsset,
+		capiMachinesAsset,
+	)
+
+	fileList := []*asset.File{}
+
+	// Collect cluster and non-machine-related infra manifests
+	// to be applied during the initial stage.
+	infraManifests := []client.Object{}
+	for _, m := range capiManifestsAsset.RuntimeFiles() {
+		infraManifests = append(infraManifests, m.Object)
+	}
+
+	// Machine manifests will be applied after the infra
+	// manifests and subsequent hooks.
+	machineManifests := []client.Object{}
+	for _, m := range capiMachinesAsset.RuntimeFiles() {
+		machineManifests = append(machineManifests, m.Object)
+	}
+
+	// TODO(vincepri): The context should be passed down from the caller,
+	// although today the Asset interface doesn't allow it, refactor once it does.
+	ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		cancel()
+		clusterapi.System().Teardown()
+	}()
+
+	if p, ok := i.impl.(PreProvider); ok {
+		preProvisionInput := PreProvisionInput{
+			InfraID:       clusterID.InfraID,
+			InstallConfig: installConfig,
+		}
+
+		if err := p.PreProvision(ctx, preProvisionInput); err != nil {
+			return fileList, fmt.Errorf("failed during pre-provisioning: %w", err)
+		}
+	} else {
+		logrus.Debugf("No pre-provisioning requirements for the %s provider", i.impl.Name())
+	}
+
+	// Run the CAPI system.
+	capiSystem := clusterapi.System()
+	if err := capiSystem.Run(ctx, installConfig); err != nil {
+		return fileList, fmt.Errorf("failed to run cluster api system: %w", err)
+	}
+
+	// Grab the client.
+	cl := capiSystem.Client()
+
+	// Create the infra manifests.
+	for _, m := range infraManifests {
+		m.SetNamespace(capiutils.Namespace)
+		if err := cl.Create(ctx, m); err != nil {
+			return fileList, fmt.Errorf("failed to create infrastructure manifest: %w", err)
+		}
+		logrus.Infof("Created manifest %+T, namespace=%s name=%s", m, m.GetNamespace(), m.GetName())
+	}
+
+	// Pass cluster kubeconfig and store it in; this is usually the role of a bootstrap provider.
+	{
+		key := client.ObjectKey{
+			Name:      clusterID.InfraID,
+			Namespace: capiutils.Namespace,
+		}
+		cluster := &clusterv1.Cluster{}
+		if err := cl.Get(ctx, key, cluster); err != nil {
+			return fileList, err
+		}
+		// Create the secret.
+		clusterKubeconfig := clusterKubeconfigAsset.Files()[0].Data
+		secret := utilkubeconfig.GenerateSecret(cluster, clusterKubeconfig)
+		if err := cl.Create(ctx, secret); err != nil {
+			return fileList, err
+		}
+	}
+
+	// Wait for successful provisioning by checking the InfrastructureReady
+	// status on the cluster object.
+	var cluster *clusterv1.Cluster
+	{
+		if err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+			Duration: time.Second * 10,
+			Factor:   float64(1.5),
+			Steps:    32,
+		}, func(ctx context.Context) (bool, error) {
+			c := &clusterv1.Cluster{}
+			if err := cl.Get(ctx, client.ObjectKey{
+				Name:      clusterID.InfraID,
+				Namespace: capiutils.Namespace,
+			}, c); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			cluster = c
+			return cluster.Status.InfrastructureReady, nil
+		}); err != nil {
+			return fileList, err
+		}
+		if cluster == nil {
+			return fileList, fmt.Errorf("error occurred during load balancer ready check")
+		}
+		if cluster.Spec.ControlPlaneEndpoint.Host == "" {
+			return fileList, fmt.Errorf("control plane endpoint is not set")
+		}
+	}
+
+	if p, ok := i.impl.(InfraReadyProvider); ok {
+		infraReadyInput := InfraReadyInput{
+			Client:        cl,
+			InstallConfig: installConfig,
+			InfraID:       clusterID.InfraID,
+		}
+
+		if err := p.InfraReady(ctx, infraReadyInput); err != nil {
+			return fileList, fmt.Errorf("failed provisioning resources after infrastructure ready: %w", err)
+		}
+	} else {
+		logrus.Debugf("No infrastructure ready requirements for the %s provider", i.impl.Name())
+	}
+
+	bootstrapIgnData, err := injectInstallInfo(bootstrapIgnAsset.Files()[0].Data)
+	if err != nil {
+		return nil, fmt.Errorf("unable to inject installation info: %w", err)
+	}
+
+	// The cloud-platform may need to override the default
+	// bootstrap ignition behavior.
+	if p, ok := i.impl.(IgnitionProvider); ok {
+		ignInput := IgnitionInput{
+			BootstrapIgnData: bootstrapIgnData,
+			InfraID:          clusterID.InfraID,
+			InstallConfig:    installConfig,
+		}
+
+		if bootstrapIgnData, err = p.Ignition(ctx, ignInput); err != nil {
+			return fileList, fmt.Errorf("failed preparing ignition data: %w", err)
+		}
+	} else {
+		logrus.Debugf("No Ignition requirements for the %s provider", i.impl.Name())
+	}
+	bootstrapIgnSecret := IgnitionSecret(bootstrapIgnData, clusterID.InfraID, "bootstrap")
+	masterIgnSecret := IgnitionSecret(masterIgnAsset.Files()[0].Data, clusterID.InfraID, "master")
+	machineManifests = append(machineManifests, bootstrapIgnSecret, masterIgnSecret)
+
+	// Create the machine manifests.
+	for _, m := range machineManifests {
+		m.SetNamespace(capiutils.Namespace)
+		if err := cl.Create(ctx, m); err != nil {
+			return fileList, fmt.Errorf("failed to create control-plane manifest: %w", err)
+		}
+		logrus.Infof("Created manifest %+T, namespace=%s name=%s", m, m.GetNamespace(), m.GetName())
+	}
+
+	{
+		masterCount := int64(1)
+		if reps := installConfig.Config.ControlPlane.Replicas; reps != nil {
+			masterCount = *reps
+		}
+
+		logrus.Debugf("Waiting for machines to provision")
+		if err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+			Duration: time.Second * 10,
+			Factor:   float64(1.5),
+			Steps:    32,
+		}, func(ctx context.Context) (bool, error) {
+			for i := int64(0); i < masterCount; i++ {
+				machine := &clusterv1.Machine{}
+				if err := cl.Get(ctx, client.ObjectKey{
+					Name:      fmt.Sprintf("%s-%s-%d", clusterID.InfraID, "master", i),
+					Namespace: capiutils.Namespace,
+				}, machine); err != nil {
+					if apierrors.IsNotFound(err) {
+						logrus.Debugf("Not found")
+						return false, nil
+					}
+					return false, err
+				}
+				if machine.Status.Phase != string(clusterv1.MachinePhaseProvisioned) &&
+					machine.Status.Phase != string(clusterv1.MachinePhaseRunning) {
+					return false, nil
+				} else if machine.Status.Phase == string(clusterv1.MachinePhaseFailed) {
+					return false, fmt.Errorf("machine %s failed to provision: %q", machine.Name, *machine.Status.FailureMessage)
+				}
+				logrus.Debugf("Machine %s is ready. Phase: %s", machine.Name, machine.Status.Phase)
+			}
+			return true, nil
+		}); err != nil {
+			return fileList, err
+		}
+	}
+
+	if p, ok := i.impl.(PostProvider); ok {
+		postMachineInput := PostProvisionInput{
+			Client:        cl,
+			InstallConfig: installConfig,
+			InfraID:       clusterID.InfraID,
+		}
+
+		if err = p.PostProvision(ctx, postMachineInput); err != nil {
+			return fileList, fmt.Errorf("failed during post-machine creation hook: %w", err)
+		}
+	}
+
+	// For each manifest we created, retrieve it and store it in the asset.
+	manifests := []client.Object{}
+	manifests = append(manifests, infraManifests...)
+	manifests = append(manifests, machineManifests...)
+	for _, m := range manifests {
+		key := client.ObjectKey{
+			Name:      m.GetName(),
+			Namespace: m.GetNamespace(),
+		}
+		if err := cl.Get(ctx, key, m); err != nil {
+			return fileList, fmt.Errorf("failed to get manifest: %w", err)
+		}
+
+		gvk, err := cl.GroupVersionKindFor(m)
+		if err != nil {
+			return fileList, fmt.Errorf("failed to get GVK for manifest: %w", err)
+		}
+		fileName := fmt.Sprintf("%s-%s-%s.yaml", gvk.Kind, m.GetNamespace(), m.GetName())
+		objData, err := yaml.Marshal(m)
+		if err != nil {
+			return fileList, fmt.Errorf("failed to create infrastructure manifest %s from InstallConfig: %w", fileName, err)
+		}
+		fileList = append(fileList, &asset.File{
+			Filename: fileName,
+			Data:     objData,
+		})
+	}
+
+	logrus.Infof("Cluster API resources have been created. Waiting for cluster to become ready...")
+	return fileList, nil
+}
+
+// DestroyBootstrap destroys the temporary bootstrap resources.
+func (i *InfraProvider) DestroyBootstrap(dir string) error {
+	metadata, err := metadata.Load(dir)
+	if err != nil {
+		return err
+	}
+
+	// TODO(padillon): start system if not running
+	if sys := clusterapi.System(); sys.State() == clusterapi.SystemStateRunning {
+		if err := sys.Client().Delete(context.TODO(), &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capiutils.GenerateBoostrapMachineName(metadata.InfraID),
+				Namespace: capiutils.Namespace,
+			},
+		}); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to delete bootstrap machine: %w", err)
+		}
+	}
+	return nil
+}
+
+// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
+func (i *InfraProvider) ExtractHostAddresses(dir string, config *types.InstallConfig, ha *infrastructure.HostAddresses) error {
+	return nil
+}
+
+// IgnitionSecret provides the basic formatting for creating the
+// ignition secret.
+func IgnitionSecret(ign []byte, infraID, role string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", infraID, role),
+			Namespace: capiutils.Namespace,
+			Labels: map[string]string{
+				"cluster.x-k8s.io/cluster-name": infraID,
+			},
+		},
+		Data: map[string][]byte{
+			"format": []byte("ignition"),
+			"value":  ign,
+		},
+	}
+}

--- a/pkg/infrastructure/clusterapi/helpers.go
+++ b/pkg/infrastructure/clusterapi/helpers.go
@@ -2,9 +2,9 @@ package clusterapi
 
 import (
 	"encoding/json"
+	"fmt"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
@@ -12,23 +12,23 @@ import (
 
 // injectInstallInfo adds information about the installer and its invoker as a
 // ConfigMap to the provided bootstrap Ignition config.
-func injectInstallInfo(bootstrap []byte) (string, error) {
+func injectInstallInfo(bootstrap []byte) ([]byte, error) {
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(bootstrap, &config); err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal bootstrap Ignition config")
+		return nil, fmt.Errorf("failed to unmarshal bootstrap Ignition config: %w", err)
 	}
 
 	cm, err := openshiftinstall.CreateInstallConfigMap("openshift-install")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate openshift-install config")
+		return nil, fmt.Errorf("failed to generate openshift-install config: %w", err)
 	}
 
 	config.Storage.Files = append(config.Storage.Files, ignition.FileFromString("/opt/openshift/manifests/openshift-install.yaml", "root", 0644, cm))
 
 	ign, err := ignition.Marshal(config)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal bootstrap Ignition config")
+		return nil, fmt.Errorf("failed to marshal bootstrap Ignition config: %w", err)
 	}
 
-	return string(ign), nil
+	return ign, nil
 }

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -1,0 +1,79 @@
+package clusterapi
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+)
+
+// Provider is the base interface that cloud platforms
+// should implement for the CAPI infrastructure provider.
+type Provider interface {
+	// Name provides the name for the cloud platform.
+	Name() string
+}
+
+// PreProvider defines the PreProvision hook, which is called prior to
+// CAPI infrastructure provisioning.
+type PreProvider interface {
+	// PreProvision is called before provisioning using CAPI controllers has begun
+	// and should be used to create dependencies needed for CAPI provisioning,
+	// such as IAM roles or policies.
+	PreProvision(ctx context.Context, in PreProvisionInput) error
+}
+
+// PreProvisionInput collects the args passed to the PreProvision call.
+type PreProvisionInput struct {
+	InfraID       string
+	InstallConfig *installconfig.InstallConfig
+}
+
+// IgnitionProvider handles preconditions for bootstrap ignition and
+// generates ignition data for the CAPI bootstrap ignition secret.
+//
+// WARNING! Low-level primitive. Use only if absolutely necessary.
+type IgnitionProvider interface {
+	Ignition(ctx context.Context, in IgnitionInput) ([]byte, error)
+}
+
+// IgnitionInput collects the args passed to the IgnitionProvider call.
+type IgnitionInput struct {
+	BootstrapIgnData []byte
+	InfraID          string
+	InstallConfig    *installconfig.InstallConfig
+}
+
+// InfraReadyProvider defines the InfraReady hook, which is
+// called after the initial infrastructure manifests have been created
+// and InfrastructureReady == true on the cluster status, and before
+// IgnitionProvider hook and creation of the control-plane machines.
+type InfraReadyProvider interface {
+	// InfraReady is called once cluster.Status.InfrastructureReady
+	// is true, typically after load balancers have been provisioned. It can be used
+	// to create DNS records.
+	InfraReady(ctx context.Context, in InfraReadyInput) error
+}
+
+// InfraReadyInput collects the args passed to the InfraReady call.
+type InfraReadyInput struct {
+	// Client is the client for kube-apiserver running locally on the installer host.
+	// It can be used to read the status of the cluster object on the local control plane.
+	Client        client.Client
+	InstallConfig *installconfig.InstallConfig
+	InfraID       string
+}
+
+// PostProvider defines the PostProvision hook, which is called after
+// machine provisioning has completed.
+type PostProvider interface {
+	PostProvision(ctx context.Context, in PostProvisionInput) error
+}
+
+// PostProvisionInput collects the args passed to the PostProvision hook.
+type PostProvisionInput struct {
+	Client        client.Client
+	InstallConfig *installconfig.InstallConfig
+	InfraID       string
+}

--- a/pkg/infrastructure/provider.go
+++ b/pkg/infrastructure/provider.go
@@ -10,9 +10,9 @@ import (
 type Provider interface {
 	// Provision creates the infrastructure resources for the stage.
 	// dir: the path of the install dir
-	// vars: cluster configuration input variables, such as terraform variables files
+	// parents: the parent assets, which can be used to obtain any cluser asset dependencies
 	// returns a slice of File assets, which will be appended to the cluster asset file list.
-	Provision(dir string, vars []*asset.File) ([]*asset.File, error)
+	Provision(dir string, parents asset.Parents) ([]*asset.File, error)
 
 	// DestroyBootstrap destroys the temporary bootstrap resources.
 	DestroyBootstrap(dir string) error

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/infrastructure"
 	"github.com/openshift/installer/pkg/lineprinter"
 	"github.com/openshift/installer/pkg/metrics/timer"
@@ -35,7 +36,11 @@ func InitializeProvider(stages []Stage) infrastructure.Provider {
 
 // Provision implements pkg/infrastructure/provider.Provision. Provision iterates
 // through each of the stages and applies the Terraform config for the stage.
-func (p *Provider) Provision(dir string, vars []*asset.File) ([]*asset.File, error) {
+func (p *Provider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
+	tfVars := &tfvars.TerraformVariables{}
+	parents.Get(tfVars)
+	vars := tfVars.Files()
+
 	fileList := []*asset.File{}
 	terraformDir := filepath.Join(dir, "terraform")
 	if err := os.Mkdir(terraformDir, 0777); err != nil {


### PR DESCRIPTION
This PR:

- moves the CAPI implementation behind the infrastructure provider interface
- adds an interface/platform for various cloud providers to implement

Moving the CAPI implementation behind the infrastructure provider platform encapsulates CAPI implementation details. It also allows [pkg/infrastructure/platform](https://github.com/openshift/installer/tree/master/pkg/infrastructure/platform) to be the canonical source of truth of which infrastructure provider a cloud platform is using.

The `CAPIInfraHelper` interface provides a simple implementation for cloud platforms to interact with the CAPI provisioning pattern. This is intended to be a baseline interface that can be build upon and extended. It is not intended to be complete, but intends to be flexible enough to allow handling needs that will arise across multiple cloud platforms.