### PR TITLE
OCPBUGS-25191: ic: azure: fix retrieving marketplace image

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -330,7 +330,10 @@ func (c *Client) GetMarketplaceImage(ctx context.Context, region, publisher, off
 	defer cancel()
 
 	image, err := client.Get(ctx, region, publisher, offer, sku, version)
-	return image, fmt.Errorf("could not get marketplace image: %w", err)
+	if err != nil {
+		return image, fmt.Errorf("could not get marketplace image: %w", err)
+	}
+	return image, nil
 }
 
 // AreMarketplaceImageTermsAccepted tests whether the terms have been accepted for the specified marketplace VM image.


### PR DESCRIPTION
When https://github.com/openshift/installer/pull/7778 replaced `errors.Wrap` by `fmt.Errorf` it introduced a bug when retrieving a marketplace image in the client interface because of their different behaviors. `errors.Wrap(err, ...)` returns `nil` when `err` is `nil` whereas `fmt.Errorf` always returns an error. Unfortunately this was not caught in the unit tests since the client calls are mocked.

This bug resulted in the following error:
```
ERROR failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: [controlPlane.platform.azure.osImage: Invalid value: azure.OSImage{Plan:"", Publisher:"redhat", Offer:"rh-ocp-worker", SKU:"rh-ocp-worker", Version:"413.92.2023101700"}: could not get marketplace image: %!w(<nil>), compute[0].platform.azure.osImage: Invalid value: azure.OSImage{Plan:"", Publisher:"redhat", Offer:"rh-ocp-worker", SKU:"rh-ocp-worker", Version:"413.92.2023101700"}: could not get marketplace image: %!w(<nil>)]
```