### PR TITLE
no-jira: Revert "Merge pull request #7823 from patrickdillon/build-capi-altinfra"

### DIFF
--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -9,9 +9,6 @@
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 ARG TAGS="altinfra"
-# Enables building CAPI dependencies in hack/build.sh. Once CAPI is stable
-# the logic in build.sh should no longer be gated and this can be removed.
-ENV OPENSHIFT_INSTALL_CLUSTER_API="true"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh


### PR DESCRIPTION
This reverts commit 5fb7adccb0e98f00561175f0b981e842a11d8e1e, reversing changes made to cf958f1cc19dc51c1b6b1737dbc29a96618579a1.

It's breaking the release images because downloading binaries is not possible in brew.