### PR TITLE
OCPBUGS-25600: aws: validate instance arch

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/pkg/errors"
 
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 )
@@ -64,7 +63,7 @@ func describeAvailabilityZones(ctx context.Context, session *session.Session, re
 	}
 	resp, err := client.DescribeAvailabilityZonesWithContext(ctx, input)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching zones")
+		return nil, fmt.Errorf("fetching zones: %w", err)
 	}
 
 	return resp.AvailabilityZones, nil
@@ -75,7 +74,7 @@ func describeAvailabilityZones(ctx context.Context, session *session.Session, re
 func filterZonesByType(ctx context.Context, session *session.Session, region string, zoneType string) ([]string, error) {
 	azs, err := describeAvailabilityZones(ctx, session, region, []string{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "fetching %s", zoneType)
+		return nil, fmt.Errorf("fetching %s: %w", zoneType, err)
 	}
 	zones := []string{}
 	for _, zone := range azs {
@@ -85,7 +84,7 @@ func filterZonesByType(ctx context.Context, session *session.Session, region str
 	}
 
 	if len(zones) == 0 {
-		return nil, errors.Errorf("no zones with type %s in %s", zoneType, region)
+		return nil, fmt.Errorf("no zones with type %s in %s", zoneType, region)
 	}
 
 	return zones, nil
@@ -118,7 +117,7 @@ func edgeZones(ctx context.Context, session *session.Session, region string) ([]
 func describeFilteredZones(ctx context.Context, session *session.Session, region string, zones []string) ([]*ec2.AvailabilityZone, error) {
 	azs, err := describeAvailabilityZones(ctx, session, region, zones)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fetching %s", zones)
+		return nil, fmt.Errorf("fetching %s: %w", zones, err)
 	}
 
 	return azs, nil

--- a/pkg/asset/installconfig/aws/basedomain.go
+++ b/pkg/asset/installconfig/aws/basedomain.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -11,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -45,7 +46,7 @@ func GetBaseDomain() (string, error) {
 			return !lastPage
 		},
 	); err != nil {
-		return "", errors.Wrap(err, "list hosted zones")
+		return "", fmt.Errorf("list hosted zones: %w", err)
 	}
 
 	publicZones := make([]string, 0, len(publicZoneMap))
@@ -69,12 +70,12 @@ func GetBaseDomain() (string, error) {
 			choice := ans.(core.OptionAnswer).Value
 			i := sort.SearchStrings(publicZones, choice)
 			if i == len(publicZones) || publicZones[i] != choice {
-				return errors.Errorf("invalid base domain %q", choice)
+				return fmt.Errorf("invalid base domain %q", choice)
 			}
 			return nil
 		}),
 	); err != nil {
-		return "", errors.Wrap(err, "failed UserInput")
+		return "", fmt.Errorf("failed UserInput: %w", err)
 	}
 
 	return domain, nil
@@ -95,10 +96,10 @@ func GetPublicZone(sess *session.Session, name string) (*route53.HostedZone, err
 
 	client := route53.New(sess)
 	if err := client.ListHostedZonesPages(&route53.ListHostedZonesInput{}, f); err != nil {
-		return nil, errors.Wrap(err, "listing hosted zones")
+		return nil, fmt.Errorf("listing hosted zones: %w", err)
 	}
 	if res == nil {
-		return nil, errors.Errorf("No public route53 zone found matching name %q", name)
+		return nil, fmt.Errorf("No public route53 zone found matching name %q", name)
 	}
 	return res, nil
 }

--- a/pkg/asset/installconfig/aws/basedomain.go
+++ b/pkg/asset/installconfig/aws/basedomain.go
@@ -19,8 +19,8 @@ import (
 // IsForbidden returns true if and only if the input error is an HTTP
 // 403 error from the AWS API.
 func IsForbidden(err error) bool {
-	requestError, ok := err.(awserr.RequestFailure)
-	return ok && requestError.StatusCode() == http.StatusForbidden
+	var requestError awserr.RequestFailure
+	return errors.As(err, &requestError) && requestError.StatusCode() == http.StatusForbidden
 }
 
 // GetBaseDomain returns a base domain chosen from among the account's
@@ -99,7 +99,7 @@ func GetPublicZone(sess *session.Session, name string) (*route53.HostedZone, err
 		return nil, fmt.Errorf("listing hosted zones: %w", err)
 	}
 	if res == nil {
-		return nil, fmt.Errorf("No public route53 zone found matching name %q", name)
+		return nil, fmt.Errorf("no public route53 zone found matching name %q", name)
 	}
 	return res, nil
 }

--- a/pkg/asset/installconfig/aws/instancetypes.go
+++ b/pkg/asset/installconfig/aws/instancetypes.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/pkg/errors"
 )
 
 // InstanceType holds metadata for an instance type.
@@ -31,7 +31,7 @@ func instanceTypes(ctx context.Context, session *session.Session, region string)
 			}
 			return !lastPage
 		}); err != nil {
-		return nil, errors.Wrap(err, "fetching instance types")
+		return nil, fmt.Errorf("fetching instance types: %w", err)
 	}
 
 	return types, nil

--- a/pkg/asset/installconfig/aws/instancetypes.go
+++ b/pkg/asset/installconfig/aws/instancetypes.go
@@ -13,6 +13,7 @@ import (
 type InstanceType struct {
 	DefaultVCpus int64
 	MemInMiB     int64
+	Arches       []string
 }
 
 // instanceTypes retrieves a list of instance types for the given region.
@@ -27,6 +28,7 @@ func instanceTypes(ctx context.Context, session *session.Session, region string)
 				types[*info.InstanceType] = InstanceType{
 					DefaultVCpus: aws.Int64Value(info.VCpuInfo.DefaultVCpus),
 					MemInMiB:     aws.Int64Value(info.MemoryInfo.SizeInMiB),
+					Arches:       aws.StringValueSlice(info.ProcessorInfo.SupportedArchitectures),
 				}
 			}
 			return !lastPage

--- a/pkg/asset/installconfig/aws/platform.go
+++ b/pkg/asset/installconfig/aws/platform.go
@@ -7,7 +7,6 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/types/aws"
@@ -69,7 +68,7 @@ func Platform() (*aws.Platform, error) {
 				choice := regionTransform(ans).(core.OptionAnswer).Value
 				i := sort.SearchStrings(shortRegions, choice)
 				if i == len(shortRegions) || shortRegions[i] != choice {
-					return errors.Errorf("invalid region %q", choice)
+					return fmt.Errorf("invalid region %q", choice)
 				}
 				return nil
 			}),

--- a/pkg/asset/installconfig/aws/route53.go
+++ b/pkg/asset/installconfig/aws/route53.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awss "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -46,7 +45,7 @@ func (c *Client) GetHostedZone(hostedZone string, cfg *aws.Config) (*route53.Get
 	// validate that the hosted zone exists
 	hostedZoneOutput, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(hostedZone)})
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get hosted zone: %s", hostedZone)
+		return nil, fmt.Errorf("could not get hosted zone: %s: %w", hostedZone, err)
 	}
 	return hostedZoneOutput, nil
 }
@@ -58,7 +57,7 @@ func (c *Client) ValidateZoneRecords(zone *route53.HostedZone, zoneName string, 
 	problematicRecords, err := c.GetSubDomainDNSRecords(zone, ic, cfg)
 	if err != nil {
 		allErrs = append(allErrs, field.InternalError(zonePath,
-			errors.Wrapf(err, "could not list record sets for domain %q", zoneName)))
+			fmt.Errorf("could not list record sets for domain %q: %w", zoneName, err)))
 	}
 
 	if len(problematicRecords) > 0 {
@@ -79,7 +78,7 @@ func (c *Client) GetSubDomainDNSRecords(hostedZone *route53.HostedZone, ic *type
 
 	// validate that the domain of the hosted zone is the cluster domain or a parent of the cluster domain
 	if !isHostedZoneDomainParentOfClusterDomain(hostedZone, dottedClusterDomain) {
-		return nil, errors.Errorf("hosted zone domain %q is not a parent of the cluster domain %q", *hostedZone.Name, dottedClusterDomain)
+		return nil, fmt.Errorf("hosted zone domain %q is not a parent of the cluster domain %q", *hostedZone.Name, dottedClusterDomain)
 	}
 
 	r53 := route53.New(c.ssn, cfg)
@@ -132,7 +131,7 @@ func isHostedZoneDomainParentOfClusterDomain(hostedZone *route53.HostedZone, dot
 func (c *Client) GetBaseDomain(baseDomainName string) (*route53.HostedZone, error) {
 	baseDomainZone, err := GetPublicZone(c.ssn, baseDomainName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not find public zone: %s", baseDomainName)
+		return nil, fmt.Errorf("could not find public zone: %s: %w", baseDomainName, err)
 	}
 	return baseDomainZone, nil
 }

--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	typesaws "github.com/openshift/installer/pkg/types/aws"
@@ -73,15 +72,15 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 					continue
 				}
 				if subnet.SubnetArn == nil {
-					lastError = errors.Errorf("%s has no ARN", *subnet.SubnetId)
+					lastError = fmt.Errorf("%s has no ARN", *subnet.SubnetId)
 					return false
 				}
 				if subnet.VpcId == nil {
-					lastError = errors.Errorf("%s has no VPC", *subnet.SubnetId)
+					lastError = fmt.Errorf("%s has no VPC", *subnet.SubnetId)
 					return false
 				}
 				if subnet.AvailabilityZone == nil {
-					lastError = errors.Errorf("%s has not availability zone", *subnet.SubnetId)
+					lastError = fmt.Errorf("%s has not availability zone", *subnet.SubnetId)
 					return false
 				}
 
@@ -89,7 +88,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 					subnetGroups.VPC = *subnet.VpcId
 					vpcFromSubnet = *subnet.SubnetId
 				} else if *subnet.VpcId != subnetGroups.VPC {
-					lastError = errors.Errorf("all subnets must belong to the same VPC: %s is from %s, but %s is from %s", *subnet.SubnetId, *subnet.VpcId, vpcFromSubnet, subnetGroups.VPC)
+					lastError = fmt.Errorf("all subnets must belong to the same VPC: %s is from %s, but %s is from %s", *subnet.SubnetId, *subnet.VpcId, vpcFromSubnet, subnetGroups.VPC)
 					return false
 				}
 				metas[aws.StringValue(subnet.SubnetId)] = Subnet{
@@ -108,7 +107,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		err = lastError
 	}
 	if err != nil {
-		return subnetGroups, errors.Wrap(err, "describing subnets")
+		return subnetGroups, fmt.Errorf("describing subnets: %w", err)
 	}
 
 	var routeTables []*ec2.RouteTable
@@ -126,12 +125,12 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		},
 	)
 	if err != nil {
-		return subnetGroups, errors.Wrap(err, "describing route tables")
+		return subnetGroups, fmt.Errorf("describing route tables: %w", err)
 	}
 
 	azs, err := client.DescribeAvailabilityZonesWithContext(ctx, &ec2.DescribeAvailabilityZonesInput{ZoneNames: zoneNames})
 	if err != nil {
-		return subnetGroups, errors.Wrap(err, "describing availability zones")
+		return subnetGroups, fmt.Errorf("describing availability zones: %w", err)
 	}
 	for _, az := range azs.AvailabilityZones {
 		availabilityZones[*az.ZoneName] = az
@@ -142,7 +141,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 	for _, id := range ids {
 		meta, ok := metas[id]
 		if !ok {
-			return subnetGroups, errors.Errorf("failed to find %s", id)
+			return subnetGroups, fmt.Errorf("failed to find %s", id)
 		}
 
 		isPublic, err := isSubnetPublic(routeTables, id)
@@ -153,8 +152,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 
 		zoneName := meta.Zone.Name
 		if _, ok := availabilityZones[zoneName]; !ok {
-			errMsg := fmt.Sprintf("unable to read properties of zone name %s from the list %v", zoneName, zoneNames)
-			return subnetGroups, errors.Wrap(err, errMsg)
+			return subnetGroups, fmt.Errorf("unable to read properties of zone name %s from the list %v: %w", zoneName, zoneNames, err)
 		}
 		zone := availabilityZones[zoneName]
 		meta.Zone.Type = aws.StringValue(zone.ZoneType)

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/pkg/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -390,7 +390,7 @@ func validateServiceEndpoints(fldPath *field.Path, region string, services []aws
 	for _, service := range requiredServices {
 		_, err := resolver.EndpointFor(service, region, endpoints.StrictMatchingOption)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed to find endpoint for service %q", service))
+			errs = append(errs, fmt.Errorf("failed to find endpoint for service %q: %w", service, err))
 		}
 	}
 	if err := utilerrors.NewAggregate(errs); err != nil {
@@ -481,7 +481,7 @@ func ValidateForProvisioning(client API, ic *types.InstallConfig, metadata *Meta
 		zonePath = field.NewPath("aws", "hostedZone")
 		zoneOutput, err := client.GetHostedZone(zoneName, r53cfg)
 		if err != nil {
-			errMsg := errors.Wrapf(err, "unable to retrieve hosted zone").Error()
+			errMsg := fmt.Errorf("unable to retrieve hosted zone: %w", err).Error()
 			return field.ErrorList{
 				field.Invalid(zonePath, zoneName, errMsg),
 			}.ToAggregate()

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -983,7 +982,7 @@ func TestGetSubDomainDNSRecords(t *testing.T) {
 
 			if test.expectedErr != "" {
 				if test.problematicRecords == nil {
-					route53Client.EXPECT().GetSubDomainDNSRecords(&validDomainOutput, ic, gomock.Any()).Return(nil, errors.Errorf(test.expectedErr)).AnyTimes()
+					route53Client.EXPECT().GetSubDomainDNSRecords(&validDomainOutput, ic, gomock.Any()).Return(nil, fmt.Errorf(test.expectedErr)).AnyTimes()
 				} else {
 					// mimic the results of what should happen in the internal function passed to
 					// ListResourceRecordSetsPages by GetSubDomainDNSRecords. Skip certain problematicRecords
@@ -994,7 +993,7 @@ func TestGetSubDomainDNSRecords(t *testing.T) {
 							returnedProblems = append(returnedProblems, pr)
 						}
 					}
-					route53Client.EXPECT().GetSubDomainDNSRecords(&validDomainOutput, ic, gomock.Any()).Return(returnedProblems, errors.Errorf(test.expectedErr)).AnyTimes()
+					route53Client.EXPECT().GetSubDomainDNSRecords(&validDomainOutput, ic, gomock.Any()).Return(returnedProblems, fmt.Errorf(test.expectedErr)).AnyTimes()
 				}
 			} else {
 				route53Client.EXPECT().GetSubDomainDNSRecords(&validDomainOutput, ic, gomock.Any()).Return(nil, nil).AnyTimes()

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -210,14 +211,17 @@ func validInstanceTypes() map[string]InstanceType {
 		"t2.small": {
 			DefaultVCpus: 1,
 			MemInMiB:     2048,
+			Arches:       []string{ec2.ArchitectureTypeX8664},
 		},
 		"m5.large": {
 			DefaultVCpus: 2,
 			MemInMiB:     8192,
+			Arches:       []string{ec2.ArchitectureTypeX8664},
 		},
 		"m5.xlarge": {
 			DefaultVCpus: 4,
 			MemInMiB:     16384,
+			Arches:       []string{ec2.ArchitectureTypeX8664},
 		},
 	}
 }
@@ -566,7 +570,7 @@ func TestValidate(t *testing.T) {
 			ic.Compute = []types.MachinePool{edgePool}
 			return ic
 		}(),
-		expectErr: `^compute\[0\]\.platform\.aws: Required value: edge compute pools are only supported on the AWS platform$`,
+		expectErr: `^\[compute\[0\]\.platform\.aws: Required value: edge compute pools are only supported on the AWS platform, compute\[0\].platform.aws: Required value: zone is required when using edge machine pools\]$`,
 	}, {
 		name: "invalid edge pool missing subnets on availability zones",
 		installConfig: func() *types.InstallConfig {

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/aws/mock"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -68,7 +68,7 @@ func validInstallConfig() *types.InstallConfig {
 		},
 		ControlPlane: &types.MachinePool{
 			Architecture: types.ArchitectureAMD64,
-			Replicas:     pointer.Int64Ptr(3),
+			Replicas:     ptr.To[int64](3),
 			Platform: types.MachinePoolPlatform{
 				AWS: &aws.MachinePool{
 					Zones: []string{"a", "b", "c"},
@@ -78,7 +78,7 @@ func validInstallConfig() *types.InstallConfig {
 		Compute: []types.MachinePool{{
 			Name:         types.MachinePoolComputeRoleName,
 			Architecture: types.ArchitectureAMD64,
-			Replicas:     pointer.Int64Ptr(3),
+			Replicas:     ptr.To[int64](3),
 			Platform: types.MachinePoolPlatform{
 				AWS: &aws.MachinePool{
 					Zones: []string{"a", "b", "c"},
@@ -725,7 +725,7 @@ func TestValidate(t *testing.T) {
 			c := validInstallConfig()
 			c.Platform.AWS.Region = "us-gov-east-1"
 			c.ControlPlane.Platform.AWS.AMIID = "custom-ami"
-			c.Compute[0].Replicas = pointer.Int64Ptr(0)
+			c.Compute[0].Replicas = ptr.To[int64](0)
 			return c
 		}(),
 		availZones:     validAvailZones(),


### PR DESCRIPTION
Add precheck if node architecture and vm type are consistent for aws as it works on azure.

Also fixed some technical debt along the way:
* replaced deprecated k8s.io/util/pointer package
* replaced deprecated sets syntax
* replaced deprecated errors package usage