### PR TITLE
OCPBUGS-25440: ic: aws: add iam:TagInstanceProfile permission requirement

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -136,6 +136,7 @@ var permissions = map[PermissionGroup][]string{
 		"iam:PutRolePolicy",
 		"iam:RemoveRoleFromInstanceProfile",
 		"iam:SimulatePrincipalPolicy",
+		"iam:TagInstanceProfile",
 		"iam:TagRole",
 
 		// Route53 related perms


### PR DESCRIPTION
Since https://github.com/openshift/installer/pull/7510, IPI installs fail if the permission is missing:
```
level=error msg=Error: creating IAM Instance Profile (ci-op-4hw2rz1v-49c30-zt9vx-worker-profile): AccessDenied: User: arn:aws:iam::301721915996:user/ci-op-4hw2rz1v-49c30-minimal-perm is not authorized to perform: iam:TagInstanceProfile on resource: arn:aws:iam::301721915996:instance-profile/ci-op-4hw2rz1v-49c30-zt9vx-worker-profile because no identity-based policy allows the iam:TagInstanceProfile action
```