### PR TITLE
CORS-2315: GCP: Skip populating Private/Public Zones within DNS manifest

### DIFF
--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -148,6 +148,13 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			}
 		}
 	case gcptypes.Name:
+		// We donot want to configure cloud DNS when `UserProvisionedDNS` is enabled.
+		// So, do not set PrivateZone and PublicZone fields in the DNS manifest.
+		if installConfig.Config.GCP.UserProvisionedDNS == gcptypes.UserProvisionedDNSEnabled {
+			config.Spec.PublicZone = &configv1.DNSZone{ID: ""}
+			config.Spec.PrivateZone = &configv1.DNSZone{ID: ""}
+			break
+		}
 		client, err := icgcp.NewClient(context.Background())
 		if err != nil {
 			return err


### PR DESCRIPTION
When custom-dns is enabled, do not populate the Private and Public zones within the DNS manifest. This will indicate to the Ingress operator to not configure the cloud DNS.