### PR TITLE
no-jira: build: drop vsphereprivate build workaround

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -34,18 +34,9 @@ copy_terraform_to_mirror() {
 check_module_changes() {
 	binpath="$1"
 	srcpath="$2"
-	build_hash="$(go version -m "${binpath}" | grep 'vcs.revision' | cut -f2 -d'=')"
-	# If it's a locally developed provider
-	if test -n "${build_hash}"; then
-		# Check if a provider has changed based on git changes since the
-		# revision the provider was last built
-		git diff --name-only --exit-code "${build_hash}.." -- "${srcpath}"
-	# If it's an imported module
-	else
-		# Check if a provider has changed based on its go.mod git hash
-		version_info="$(go version -m "${binpath}" | grep -Eo 'main.builtGoModHash=[a-fA-F0-9]+' | cut -f2 -d'=')"
-		test "${version_info}" == "$(git hash-object "${srcpath}/go.mod")"
-	fi
+	# Check if a provider has changed based on its go.mod git hash
+	version_info="$(go version -m "${binpath}" | grep -Eo 'main.builtGoModHash=[a-fA-F0-9]+' | cut -f2 -d'=')"
+	test "${version_info}" == "$(git hash-object "${srcpath}/go.mod")"
 }
 
 # Build terraform and providers only if needed


### PR DESCRIPTION
Initially we were using the provider's module version in the go.sum file to determine if a provider needed to be rebuilt. Since vsphereprivate is locally developed, not an imported module, it required special treatment. Now that we are using the `go.mod` git hash to check if a terraform provider needs to be rebuilt, we don't need to give vsphereprivate special treatment. Unfortunately, this implementation detail slipped through even though we changed the approach.

If we don't drop the workaround, the build script will think `vsphereprivate` always needs to be rebuilt since it's comparing values that will never match.