### PR TITLE
OCPBUGS-26399: Support singular VIP in ACI for BareMetal

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/baremetal_host_bmc_config.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/baremetal_host_bmc_config.txt
@@ -32,8 +32,10 @@ networking:
   - 172.30.0.0/16
 platform:
   baremetal:
+    apiVIP: 192.168.111.5
     apiVips:
       - 192.168.111.5
+    ingressVIP: 192.168.111.4
     ingressVips:
       - 192.168.111.4
     provisioningNetworkInterface: enp1s0
@@ -134,12 +136,14 @@ metadata:
   name: ostest
   namespace: cluster0
 spec:
+  apiVIP: 192.168.111.5
   apiVIPs:
   - 192.168.111.5
   clusterDeploymentRef:
     name: ostest
   imageSetRef:
     name: openshift-was not built correctly
+  ingressVIP: 192.168.111.4
   ingressVIPs:
   - 192.168.111.4
   networking:

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -251,6 +251,8 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 
 			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.BareMetal.APIVIPs
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.BareMetal.IngressVIPs
+			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.BareMetal.APIVIPs[0]
+			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.BareMetal.IngressVIPs[0]
 		} else if installConfig.Config.Platform.VSphere != nil {
 			vspherePlatform := vsphere.Platform{}
 			if len(installConfig.Config.Platform.VSphere.APIVIPs) > 1 {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -87,6 +87,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodExternalPlatformACI := getGoodACI()
 	goodExternalPlatformACI.Spec.APIVIPs = nil
 	goodExternalPlatformACI.Spec.IngressVIPs = nil
+	goodExternalPlatformACI.Spec.APIVIP = ""
+	goodExternalPlatformACI.Spec.IngressVIP = ""
 	val := true
 	goodExternalPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType
@@ -109,6 +111,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	val = true
 	goodExternalOCIPlatformACI.Spec.APIVIPs = nil
 	goodExternalOCIPlatformACI.Spec.IngressVIPs = nil
+	goodExternalOCIPlatformACI.Spec.APIVIP = ""
+	goodExternalOCIPlatformACI.Spec.IngressVIP = ""
 	goodExternalOCIPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalOCIPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType
 	goodExternalOCIPlatformACI.Spec.ExternalPlatformSpec = &hiveext.ExternalPlatformSpec{

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -485,6 +485,8 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 			},
 			APIVIPs:      []string{"192.168.122.10"},
 			IngressVIPs:  []string{"192.168.122.11"},
+			APIVIP:       "192.168.122.10",
+			IngressVIP:   "192.168.122.11",
 			PlatformType: hiveext.BareMetalPlatformType,
 		},
 	}


### PR DESCRIPTION
As the appliance e2e [jobs](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-appliance-master-e2e-compact-ipv4-static) are still deploying OCP 4.14, in which the singular variant of APIVIP/IngressVIP is required, we still need to set these properties in AgentClusterInstall.
We can remove this again later on when the appliance would support newer OCP version.