### PR TITLE
CORS-3242: PowerVS: Replace deprecated primary_ipv4_address with primary_ip list item

### DIFF
--- a/data/data/powervs/cluster/dns/dns.tf
+++ b/data/data/powervs/cluster/dns/dns.tf
@@ -71,7 +71,7 @@ resource "ibm_dns_resource_record" "proxy_vsi_record" {
   zone_id     = local.dns_zone.zone_id
   type        = "A"
   name        = "proxy.${var.cluster_domain}"
-  rdata       = ibm_is_instance.dns_vm_vsi[0].primary_network_interface[0].primary_ipv4_address
+  rdata       = ibm_is_instance.dns_vm_vsi[0].primary_network_interface[0].primary_ip[0].address
   ttl         = 60
 }
 

--- a/data/data/powervs/cluster/dns/outputs.tf
+++ b/data/data/powervs/cluster/dns/outputs.tf
@@ -1,3 +1,3 @@
 output "dns_server" {
-  value = var.publish_strategy == "Internal" ? ibm_is_instance.dns_vm_vsi[0].primary_network_interface[0].primary_ipv4_address : "1.1.1.1"
+  value = var.publish_strategy == "Internal" ? ibm_is_instance.dns_vm_vsi[0].primary_network_interface[0].primary_ip[0].address : "1.1.1.1"
 }


### PR DESCRIPTION
`primary_ipv4_address` is deprecated in favor of `primary_ip[*].address`. Replace it with the new attribute.