### PR TITLE
MULTIARCH-4076: PowerVS: Default region bug fix

### DIFF
--- a/pkg/asset/installconfig/powervs/regions.go
+++ b/pkg/asset/installconfig/powervs/regions.go
@@ -73,7 +73,7 @@ func GetRegion(defaultRegion string) (string, error) {
 	var region string
 	li := sort.SearchStrings(shortRegions, defaultRegion)
 	if li == len(shortRegions) || shortRegions[li] != defaultRegion {
-		defaultRegion = ""
+		defaultRegion = "dal"
 	} else {
 		defaultRegion = longRegions[li]
 	}


### PR DESCRIPTION
If I press the enter key at the first option in the region survey
? Region  [Use arrows to move, type to filter, ? for more help]
\> Account Region 1
\> Account Region 2

I get the following error
X Sorry, your reply was invalid: invalid region ""

This patch fixes this error.