### PR TITLE
ARO-4744: Do not run platform validation on ARO

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -185,6 +185,11 @@ func (a *InstallConfig) platformValidation() error {
 		return alibabacloud.Validate(client, a.Config)
 	}
 	if a.Config.Platform.Azure != nil {
+		if a.Config.Platform.Azure.IsARO() {
+			// ARO performs platform validation in the Resource Provider before
+			// the Installer is called
+			return nil
+		}
 		client, err := a.Azure.Client()
 		if err != nil {
 			return err


### PR DESCRIPTION
This validation is performed in the ARO Resource Provider, before the Installer is called. We've had this duplicate validation fail intermittently, and so this PR disables it for ARO specifically.