### PR TITLE
OCPBUGS-26048: Bump default channel to stable-4.16

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.14
+  channel: stable-4.16
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
Prior to the change, the default channel is stable-4.14. The change bumps it to stable-4.16 on master.

```
# oc adm upgrade 
warning: Cannot display available updates:
  Reason: VersionNotFound
  Message: Unable to retrieve available updates: currently reconciling cluster version 4.16.0-0.nightly-2024-01-03-193825 not found in the "stable-4.14" channel

Cluster version is 4.16.0-0.nightly-2024-01-03-193825

Upgradeable=False

  Reason: MissingUpgradeableAnnotation
  Message: Cluster operator cloud-credential should not be upgraded between minor versions: Upgradeable annotation cloudcredential.openshift.io/upgradeable-to on cloudcredential.operator.openshift.io/cluster object needs updating before upgrade. See Manually Creating IAM documentation for instructions on preparing a cluster for upgrade.

Upstream is unset, so the cluster will use an appropriate default.
Channel: stable-4.14
```