### PR TITLE
OCPBUGS-26052: aws: altinfra: fix role creation in C2S

### DIFF
--- a/pkg/infrastructure/aws/instance.go
+++ b/pkg/infrastructure/aws/instance.go
@@ -36,6 +36,7 @@ type instanceInputOptions struct {
 	instanceProfileARN string
 	volumeType         string
 	metadataAuth       string
+	partitionDNSSuffix string
 	volumeSize         int64
 	volumeIOPS         int64
 	isEncrypted        bool


### PR DESCRIPTION
When creating the instance role assume policy, we need to take into account that the ec2 service endpoint will differ according to the partition. This should fix the following error when deploying on C2S regions:

```
level=error msg=failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to create bootstrap resources: failed to create bootstrap instance profile: failed to create role (yunjiang-14c2a-t4wp7-bootstrap-role): RequestCanceled: request context canceled
```

because the installer is trying to use the regular `ec2.amazonaws.com` service suffix instead of the appropriate one.