### PR TITLE
OCPBUGS-26434: Redact platform passwords in agent-gather output

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -28,9 +28,10 @@ function gather_agent_data() {
 	( >&2 echo -n "Gathering agent installation data" )
 	mkdir -p "${ARTIFACTS_DIR}/etc"
 	cp -a /etc/assisted{,-service} "${ARTIFACTS_DIR}/etc/"
-	# Redact pull secrets
+	# Redact pull secrets and platform passwords
 	for manifest in "${ARTIFACTS_DIR}"/etc/assisted/manifests/*; do
 		sed -i -e '/"auth":/ s/: *"[A-Za-z0-9+/]*=*"/: "<redacted>"/g' "${manifest}"
+		sed -i -e '/install-config-overrides/ s/"password":"[^"]*/"password":"<redacted>/g' "${manifest}"
 	done
 	( >&2 echo -n ".")
 	mkdir "${ARTIFACTS_DIR}/etc/containers"


### PR DESCRIPTION
Redact the platform passwords stored in agent-cluster-install when included in the agent-gather output.