### PR TITLE
OCPBUGS-24956: Add cloud credential capability validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -212,10 +212,8 @@ func ValidateInstallConfig(c *types.InstallConfig, usingAgentMethod bool) field.
 		if !enabledCaps.Has(configv1.ClusterVersionCapabilityCloudCredential) {
 			// check if platform is cloud
 			if c.None == nil && c.BareMetal == nil {
-				if c.CredentialsMode != types.ManualCredentialsMode {
-					allErrs = append(allErrs, field.Invalid(field.NewPath("credentialsMode"), c.CredentialsMode,
-						"credentialsMode must be set to Manual when CloudCredentials capability is disabled on a cloud platform"))
-				}
+				allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities"), c.Capabilities,
+					"disabling CloudController capability available only for baremetal platforms"))
 			}
 		}
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2318,7 +2318,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 		},
 		{
-			name: "CloudCredential is disabled in cloud",
+			name: "CloudCredential is disabled in cloud aws",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Capabilities = &types.Capabilities{
@@ -2326,18 +2326,20 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: "credentialsMode must be set to Manual when CloudCredentials capability is disabled on a cloud platform",
+			expectedError: "disabling CloudController capability available only for baremetal platforms",
 		},
 		{
-			name: "CloudCredential is disabled in cloud,but CredentialsMode is set to Manual",
+			name: "CloudCredential is disabled in cloud gcp",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.CredentialsMode = types.ManualCredentialsMode
+				c.GCP = validGCPPlatform()
+				c.AWS = nil
 				c.Capabilities = &types.Capabilities{
 					BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
 				}
 				return c
 			}(),
+			expectedError: "disabling CloudController capability available only for baremetal platforms",
 		},
 		{
 			name: "CloudCredential is enabled in baremetal",


### PR DESCRIPTION
disabling cloud credential available only for baremetal clusters. This requirement came from QE because CCO has issues with upgrades right now, so we need to guard users from breaking clusters
.