### PR TITLE
no-jira:  images/altinfra: allow CAPI ARG

### DIFF
--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -9,6 +9,7 @@
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS builder
 ARG TAGS="altinfra"
+ARG OPENSHIFT_INSTALL_CLUSTER_API=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh


### PR DESCRIPTION
Allows the OPENSHIFT_INSTALL_CLUSTER_API ARG to be set at a build time. Enabling this as an ARG in the Dockerfile will allow this ARG to be set in CI--but not by ART. Setting OPENSHIFT_INSTALL_CLUSTER_API will currently break ART/OSBS because etcd and kube-apiserver dependencies are being obtained over the network, which is possible in CI but not in ART.

Enabling CI will allow teams to progress while we determine how to obtain the etcd and kube-apiserver dependencies. Handling these dependencies is tracked in:
https://issues.redhat.com/browse/CORS-3191