### PR TITLE
OCPBUGS-14257: normalize ISO files extensions to three chars

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,7 +18,8 @@ import (
 )
 
 const (
-	agentISOFilename = "agent.%s.iso"
+	agentISOFilename    = "agent.%s.iso"
+	iso9660Level1ExtLen = 3
 )
 
 // AgentImage is an asset that generates the bootable image used to install clusters.
@@ -174,6 +176,34 @@ func (a *AgentImage) appendKargs(kargs []byte) error {
 	return nil
 }
 
+// normalizeFilesExtension scans the extracted ISO files and trims
+// the file extensions longer than three chars.
+func (a *AgentImage) normalizeFilesExtension() error {
+	return filepath.WalkDir(a.tmpPath, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(p)
+		// ext includes also the dot separator
+		if len(ext) > iso9660Level1ExtLen+1 {
+			// Replaces file extensions longer than three chars
+			np := p[:len(p)-len(ext)] + ext[:iso9660Level1ExtLen+1]
+			err = os.Rename(p, np)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
 // PersistToFile writes the iso image in the assets folder
 func (a *AgentImage) PersistToFile(directory string) error {
 	defer os.RemoveAll(a.tmpPath)
@@ -189,7 +219,11 @@ func (a *AgentImage) PersistToFile(directory string) error {
 	// Remove symlink if it exists
 	os.Remove(agentIsoFile)
 
-	var err error
+	err := a.normalizeFilesExtension()
+	if err != nil {
+		return err
+	}
+
 	// For external platform when the bootArtifactsBaseURL is specified,
 	// output the rootfs file alongside the minimal ISO
 	if a.platform == hiveext.ExternalPlatformType {


### PR DESCRIPTION
In the previous implementation ABI regenerated the ISO image using the content found in a temporary folder. Some of these files had a `.json` extension, and they were stored with that extension, breaking the compatibility with `coreos-installer` commands, in particular the `kargs` one. The issue was that the `coreos-installer` was looking for a [3-chars extension kargs file](https://github.com/coreos/coreos-installer/blob/bc55e5e43e42a0a8cc1192c1f0ae8ac30b7abc8b/src/live/embed.rs#L45), but that file wasn't found (note: also `FEATURES.JSO` and `IGNINFO.JSO` are looked for using 3-chars ext).

This patch normalizes the content of the temp folder used to reassemble the agent ISO so that the files will be compliant to the 3-chars extension length