### PR TITLE
OCPBUGS-27454: baremetal: correct external_http_url for v6-only BMCs

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -699,7 +699,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err = baremetaltfvars.TFVars(
 			*installConfig.Config.ControlPlane.Replicas,
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
-			installConfig.Config.Platform.BareMetal.APIVIPs[0],
+			installConfig.Config.Platform.BareMetal.APIVIPs,
 			imageCacheIP,
 			string(*rhcosBootstrapImage),
 			installConfig.Config.Platform.BareMetal.ExternalBridge,

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
+	"strings"
 
 	baremetalhost "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
@@ -13,6 +15,7 @@ import (
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/pkg/errors"
+	utilsnet "k8s.io/utils/net"
 	"sigs.k8s.io/yaml"
 )
 
@@ -46,12 +49,75 @@ func init() {
 	imageDownloader = cache.DownloadImageFile
 }
 
+func externalURLs(apiVIPs []string) (externalURLv4 string, externalURLv6 string) {
+	if len(apiVIPs) > 1 {
+		// IPv6 BMCs may not be able to reach IPv4 servers, use the right callback URL for them.
+		externalURL := fmt.Sprintf("http://%s/", net.JoinHostPort(apiVIPs[1], "80"))
+		if utilsnet.IsIPv6String(apiVIPs[1]) {
+			externalURLv6 = externalURL
+		}
+		if utilsnet.IsIPv4String(apiVIPs[1]) {
+			externalURLv4 = externalURL
+		}
+	}
+
+	return
+}
+
+// NOTE(dtantsur): this is a verbatim copy of the code from baremetal-operator
+// that was not exposed in the version we vendor in 4.12.
+func getParsedURL(address string) (parsedURL *url.URL, err error) {
+	// Start by assuming "type://host:port"
+	parsedURL, err = url.Parse(address)
+	if err != nil {
+		// We failed to parse the URL, but it may just be a host or
+		// host:port string (which the URL parser rejects because ":"
+		// is not allowed in the first segment of a
+		// path. Unfortunately there is no error class to represent
+		// that specific error, so we have to guess.
+		if strings.Contains(address, ":") {
+			// If we can parse host:port, carry on with those
+			// values. Otherwise, report the original parser error.
+			_, _, err2 := net.SplitHostPort(address)
+			if err2 != nil {
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
+			}
+		}
+		parsedURL = &url.URL{
+			Scheme: "ipmi",
+			Host:   address,
+		}
+	} else {
+		// Successfully parsed the URL
+		if parsedURL.Opaque != "" {
+			parsedURL, err = url.Parse(strings.Replace(address, ":", "://", 1))
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to parse BMC address information")
+
+			}
+		}
+		if parsedURL.Scheme == "" {
+			if parsedURL.Hostname() == "" {
+				// If there was no scheme at all, the hostname was
+				// interpreted as a path.
+				parsedURL, err = url.Parse(strings.Join([]string{"ipmi://", address}, ""))
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to parse BMC address information")
+				}
+			}
+		}
+	}
+	return parsedURL, nil
+}
+
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(numControlPlaneReplicas int64, libvirtURI, apiVIP, imageCacheIP, bootstrapOSImage, externalBridge, externalMAC, provisioningBridge, provisioningMAC string, platformHosts []*baremetal.Host, hostFiles []*asset.File, image, ironicUsername, ironicPassword, ignition string) ([]byte, error) {
+func TFVars(numControlPlaneReplicas int64, libvirtURI string, apiVIPs []string, imageCacheIP, bootstrapOSImage, externalBridge, externalMAC, provisioningBridge, provisioningMAC string, platformHosts []*baremetal.Host, hostFiles []*asset.File, image, ironicUsername, ironicPassword, ignition string) ([]byte, error) {
 	bootstrapOSImage, err := imageDownloader(bootstrapOSImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached bootstrap libvirt image")
 	}
+
+	externalURLv4, externalURLv6 := externalURLs(apiVIPs)
 
 	var masters, rootDevices, properties, driverInfos, instanceInfos []map[string]interface{}
 	var deploySteps []string
@@ -80,8 +146,14 @@ func TFVars(numControlPlaneReplicas int64, libvirtURI, apiVIP, imageCacheIP, boo
 		// BMC Driver Info
 		accessDetails, err := bmc.NewAccessDetails(host.BMC.Address, host.BMC.DisableCertificateVerification)
 		if err != nil {
+			// Some valid BMC addresses
 			return nil, err
 		}
+		bmcURL, err := getParsedURL(host.BMC.Address)
+		if err != nil {
+			return nil, err
+		}
+
 		credentials := bmc.Credentials{
 			Username: host.BMC.Username,
 			Password: host.BMC.Password,
@@ -90,6 +162,12 @@ func TFVars(numControlPlaneReplicas int64, libvirtURI, apiVIP, imageCacheIP, boo
 		driverInfo["deploy_kernel"] = fmt.Sprintf("http://%s/images/ironic-python-agent.kernel", net.JoinHostPort(imageCacheIP, "80"))
 		driverInfo["deploy_ramdisk"] = fmt.Sprintf("http://%s/%s.initramfs", net.JoinHostPort(imageCacheIP, "8084"), host.Name)
 		driverInfo["deploy_iso"] = fmt.Sprintf("http://%s/%s.iso", net.JoinHostPort(imageCacheIP, "8084"), host.Name)
+		if externalURLv6 != "" && utilsnet.IsIPv6String(bmcURL.Hostname()) {
+			driverInfo["external_http_url"] = externalURLv6
+		}
+		if externalURLv4 != "" && utilsnet.IsIPv4String(bmcURL.Hostname()) {
+			driverInfo["external_http_url"] = externalURLv4
+		}
 
 		var raidConfig, bmhFirmwareConfig, biosSettings []byte
 		var bmcFirmwareConfig *bmc.FirmwareConfig
@@ -213,10 +291,11 @@ func TFVars(numControlPlaneReplicas int64, libvirtURI, apiVIP, imageCacheIP, boo
 			})
 	}
 
+	ironicIP := apiVIPs[0]
 	cfg := &config{
 		LibvirtURI:       libvirtURI,
-		IronicURI:        fmt.Sprintf("http://%s/v1", net.JoinHostPort(apiVIP, "6385")),
-		InspectorURI:     fmt.Sprintf("http://%s/v1", net.JoinHostPort(apiVIP, "5050")),
+		IronicURI:        fmt.Sprintf("http://%s/v1", net.JoinHostPort(ironicIP, "6385")),
+		InspectorURI:     fmt.Sprintf("http://%s/v1", net.JoinHostPort(ironicIP, "5050")),
 		BootstrapOSImage: bootstrapOSImage,
 		IronicUsername:   ironicUsername,
 		IronicPassword:   ironicPassword,

--- a/pkg/tfvars/baremetal/baremetal_test.go
+++ b/pkg/tfvars/baremetal/baremetal_test.go
@@ -168,7 +168,7 @@ func TestMastersSelectionByRole(t *testing.T) {
 			data, err := TFVars(
 				tc.numControlPlaneReplicas,
 				tc.libvirtURI,
-				tc.apiVIP,
+				[]string{tc.apiVIP},
 				tc.imageCacheIP,
 				tc.bootstrapOSImage,
 				tc.externalBridge,
@@ -297,7 +297,7 @@ func TestRAIDBIOSConfig(t *testing.T) {
 			data, err := TFVars(
 				tc.numControlPlaneReplicas,
 				tc.libvirtURI,
-				tc.apiVIP,
+				[]string{tc.apiVIP},
 				tc.imageCacheIP,
 				tc.bootstrapOSImage,
 				tc.externalBridge,
@@ -332,6 +332,203 @@ func TestRAIDBIOSConfig(t *testing.T) {
 	}
 }
 
+func TestDriverInfo(t *testing.T) {
+	cases := []struct {
+		scenario string
+
+		numControlPlaneReplicas int64
+		apiVIPs                 []string
+		platformHosts           []*baremetal.Host
+		hostFiles               []*asset.File
+
+		expectedError       string
+		expectedDriverInfos []map[string]string
+	}{
+		{
+			scenario: "v4-only",
+
+			numControlPlaneReplicas: 2,
+			apiVIPs:                 []string{"192.0.2.42"},
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				host("master-1", "master"),
+			),
+			hostFiles: hostFiles(
+				files("master-0", nil),
+				files("master-1", nil),
+			),
+
+			expectedDriverInfos: []map[string]string{
+				{
+					"deploy_kernel":     "http://192.0.2.42:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://192.0.2.42:8084/master-0.initramfs",
+					"external_http_url": "",
+				},
+				{
+					"deploy_kernel":     "http://192.0.2.42:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://192.0.2.42:8084/master-1.initramfs",
+					"external_http_url": "",
+				},
+			},
+		},
+		{
+			scenario: "v6-only",
+
+			numControlPlaneReplicas: 2,
+			apiVIPs:                 []string{"2001:db8::1"},
+			platformHosts: platformHosts(
+				hostv6("master-0", "master"),
+				hostv6("master-1", "master"),
+			),
+			hostFiles: hostFiles(
+				files("master-0", nil),
+				files("master-1", nil),
+			),
+
+			expectedDriverInfos: []map[string]string{
+				{
+					"deploy_kernel":     "http://[2001:db8::1]:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://[2001:db8::1]:8084/master-0.initramfs",
+					"external_http_url": "",
+				},
+				{
+					"deploy_kernel":     "http://[2001:db8::1]:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://[2001:db8::1]:8084/master-1.initramfs",
+					"external_http_url": "",
+				},
+			},
+		},
+		{
+			scenario: "v4-primary",
+
+			numControlPlaneReplicas: 3,
+			apiVIPs:                 []string{"192.0.2.42", "2001:db8::1"},
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				hostv6("master-1", "master"),
+				// DNS names are not resolved, the right networking is assumed
+				&baremetal.Host{
+					Name:            "master-2",
+					Role:            "master",
+					HardwareProfile: "default",
+					BMC: baremetal.BMC{
+						Address: "redfish+http://example.com:8000/redfish/v1/Systems/e4427260-6250-4df9-9e8a-120f78a46aa6",
+					},
+				},
+			),
+			hostFiles: hostFiles(
+				files("master-0", nil),
+				files("master-1", nil),
+				files("master-2", nil),
+			),
+
+			expectedDriverInfos: []map[string]string{
+				{
+					"deploy_kernel":     "http://192.0.2.42:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://192.0.2.42:8084/master-0.initramfs",
+					"external_http_url": "",
+				},
+				{
+					"deploy_kernel":     "http://192.0.2.42:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://192.0.2.42:8084/master-1.initramfs",
+					"external_http_url": "http://[2001:db8::1]:80/",
+				},
+				{
+					"deploy_kernel":     "http://192.0.2.42:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://192.0.2.42:8084/master-2.initramfs",
+					"external_http_url": "",
+				},
+			},
+		},
+		{
+			scenario: "v6-primary",
+
+			numControlPlaneReplicas: 3,
+			apiVIPs:                 []string{"2001:db8::1", "192.0.2.42"},
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				hostv6("master-1", "master"),
+				&baremetal.Host{
+					Name:            "master-2",
+					Role:            "master",
+					HardwareProfile: "default",
+					BMC: baremetal.BMC{
+						Address: "redfish+http://example.com:8000/redfish/v1/Systems/e4427260-6250-4df9-9e8a-120f78a46aa6",
+					},
+				},
+			),
+			hostFiles: hostFiles(
+				files("master-0", nil),
+				files("master-1", nil),
+				files("master-2", nil),
+			),
+
+			expectedDriverInfos: []map[string]string{
+				{
+					"deploy_kernel":     "http://[2001:db8::1]:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://[2001:db8::1]:8084/master-0.initramfs",
+					"external_http_url": "http://192.0.2.42:80/",
+				},
+				{
+					"deploy_kernel":     "http://[2001:db8::1]:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://[2001:db8::1]:8084/master-1.initramfs",
+					"external_http_url": "",
+				},
+				{
+					"deploy_kernel":     "http://[2001:db8::1]:80/images/ironic-python-agent.kernel",
+					"deploy_ramdisk":    "http://[2001:db8::1]:8084/master-2.initramfs",
+					"external_http_url": "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			imageDownloader = func(baseURL string) (string, error) {
+				return "", nil
+			}
+
+			data, err := TFVars(
+				tc.numControlPlaneReplicas,
+				"",
+				tc.apiVIPs,
+				tc.apiVIPs[0],
+				"",
+				"",
+				"",
+				"",
+				"",
+				tc.platformHosts,
+				tc.hostFiles,
+				"",
+				"",
+				"",
+				"")
+
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expectedError, err)
+			}
+
+			var cfg struct {
+				// Simpler type since we know the values are strings currently
+				DriverInfos []map[string]string `json:"driver_infos"`
+			}
+			err = json.Unmarshal(data, &cfg)
+			assert.NoError(t, err)
+
+			assert.Equal(t, len(tc.expectedDriverInfos), len(cfg.DriverInfos))
+			for i, driverInfo := range tc.expectedDriverInfos {
+				for name, value := range driverInfo {
+					assert.Equal(t, value, cfg.DriverInfos[i][name])
+				}
+			}
+		})
+	}
+}
+
 func host(name, tag string) *baremetal.Host {
 	return &baremetal.Host{
 		Name:            name,
@@ -339,6 +536,17 @@ func host(name, tag string) *baremetal.Host {
 		HardwareProfile: "default",
 		BMC: baremetal.BMC{
 			Address: "redfish+http://192.168.111.1:8000/redfish/v1/Systems/e4427260-6250-4df9-9e8a-120f78a46aa6",
+		},
+	}
+}
+
+func hostv6(name, tag string) *baremetal.Host {
+	return &baremetal.Host{
+		Name:            name,
+		Role:            tag,
+		HardwareProfile: "default",
+		BMC: baremetal.BMC{
+			Address: "redfish+http://[2001:db8::1]:8000/redfish/v1/Systems/e4427260-6250-4df9-9e8a-120f78a46aa6",
 		},
 	}
 }


### PR DESCRIPTION
Currently, in v4-primary dual-stack deployments, Ironic always uses its
v4 server URL as the image URL to pass to BMCs. If a BMC only has IPv6
networking, it is not going to work. This change checks the IP family
of the BMC and provides the correct external_http_url.

Differences in the backport:
* getParsedURL copied from baremetal-operator to avoid catching up with
  a long history of changes in baremetal-operator before this function
  became public.
* port 80 was used instead of 6180 before 4.13.

(cherry picked from commit 99c460281991b7814fa412735fee406571211316)
