### PR TITLE
OCPBUGS-27263:  Bump golang builders to 1.21

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.16
+  tag: rhel-8-release-golang-1.21-openshift-4.16

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ run:
   - ^scripts
   - ^terraform
   - ^upi
-  go: '1.20'
+  go: '1.21'
   modules-download-mode: vendor
   allow-parallel-runners: true
 output:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/installer
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/monitoring v1.15.1

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -5,7 +5,7 @@ ARG libvirt_version="8.0.0"
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers AS providers
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
 ARG libvirt_version
 ARG TAGS="libvirt baremetal"
 RUN dnf install -y libvirt-devel-$libvirt_version && \

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -3,35 +3,35 @@
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers AS providers
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS macbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_amd64 terraform/bin/darwin_amd64
 RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS macarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS macarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_arm64 terraform/bin/darwin_arm64
 RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS linuxbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_amd64 terraform/bin/linux_amd64
 RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS linuxarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_arm64 terraform/bin/linux_arm64
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -3,7 +3,7 @@
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers AS providers
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .


### PR DESCRIPTION
Similar to terraform and altinfra images, we want to move all remaining installer images to golang 1.21
Downstream config change https://github.com/openshift-eng/ocp-build-data/pull/4192 