### PR TITLE
OCPBUGS-27192: remove retired serial NCv2 from azure tested instance type list on x86

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -61,7 +61,6 @@
 * `standardMSMediumMemoryv2Family`
 * `StandardNCADSA100v4Family`
 * `Standard NCASv3_T4 Family`
-* `standardNCSv2Family`
 * `standardNCSv3Family`
 * `standardNDSv2Family`
 * `standardNPSFamily`


### PR DESCRIPTION
Based on Azure doc [1], NCv2 series Azure virtual machines (VMs) are retired on September 6, 2023.
Removed it from doc tested_instance_types_x86_64.md on azure platform.

[1] https://learn.microsoft.com/en-us/azure/virtual-machines/ncv2-series   