### PR TITLE
OCPBUGS-27241: baremetal: correct external_http_url for v6-only BMCs

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -703,7 +703,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err = baremetaltfvars.TFVars(
 			*installConfig.Config.ControlPlane.Replicas,
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
-			installConfig.Config.Platform.BareMetal.APIVIPs[0],
+			installConfig.Config.Platform.BareMetal.APIVIPs,
 			imageCacheIP,
 			string(*rhcosBootstrapImage),
 			installConfig.Config.Platform.BareMetal.ExternalBridge,


### PR DESCRIPTION
Currently, in v4-primary dual-stack deployments, Ironic always uses its v4 server URL as the image URL to pass to BMCs. If a BMC only has IPv6 networking, it is not going to work. This change checks the IP family of the BMC and provides the correct external_http_url.