### PR TITLE
CORS-3213: Create the GCP cluster manifest

### DIFF
--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -19,11 +19,13 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/aws"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	"github.com/openshift/installer/pkg/asset/manifests/gcp"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/clusterapi"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
 var _ asset.WritableRuntimeAsset = (*Cluster)(nil)
@@ -104,6 +106,12 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 		out, err = azure.GenerateClusterAssets(installConfig, clusterID)
 		if err != nil {
 			return errors.Wrap(err, "failed to generate Azure manifests")
+		}
+	case gcptypes.Name:
+		var err error
+		out, err = gcp.GenerateClusterAssets(installConfig, clusterID)
+		if err != nil {
+			return fmt.Errorf("failed to generate GCP manifests: %w", err)
 		}
 	default:
 		return fmt.Errorf("unsupported platform %q", platform)

--- a/pkg/asset/manifests/gcp/cluster.go
+++ b/pkg/asset/manifests/gcp/cluster.go
@@ -1,0 +1,170 @@
+package gcp
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+	capg "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+// GenerateClusterAssets generates the manifests for the cluster-api.
+func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID) (*capiutils.GenerateClusterAssetsOutput, error) {
+	manifests := []*asset.RuntimeFile{}
+
+	const (
+		description = "Created By OpenShift Installer"
+	)
+
+	networkName := fmt.Sprintf("%s-network", clusterID.InfraID)
+	if installConfig.Config.GCP.Network != "" {
+		networkName = installConfig.Config.GCP.Network
+	}
+
+	masterSubnet := gcp.DefaultSubnetName(clusterID.InfraID, "master")
+	if installConfig.Config.GCP.ControlPlaneSubnet != "" {
+		masterSubnet = installConfig.Config.GCP.ControlPlaneSubnet
+	}
+
+	master := capg.SubnetSpec{
+		Name:        masterSubnet,
+		CidrBlock:   "",
+		Description: ptr.To(description),
+		Region:      installConfig.Config.GCP.Region,
+	}
+
+	workerSubnet := gcp.DefaultSubnetName(clusterID.InfraID, "worker")
+	if installConfig.Config.GCP.ComputeSubnet != "" {
+		workerSubnet = installConfig.Config.GCP.ComputeSubnet
+	}
+
+	worker := capg.SubnetSpec{
+		Name:        workerSubnet,
+		CidrBlock:   "",
+		Description: ptr.To(description),
+		Region:      installConfig.Config.GCP.Region,
+	}
+
+	// Add the CIDR information.
+	machineV4CIDRs := []string{}
+	for _, network := range installConfig.Config.Networking.MachineNetwork {
+		if network.CIDR.IPNet.IP.To4() != nil {
+			machineV4CIDRs = append(machineV4CIDRs, network.CIDR.IPNet.String())
+		}
+	}
+
+	if len(machineV4CIDRs) == 0 {
+		return nil, fmt.Errorf("failed to parse machine CIDRs")
+	}
+
+	_, ipv4Net, err := net.ParseCIDR(machineV4CIDRs[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse machine network CIDR: %w", err)
+	}
+
+	if installConfig.Config.GCP.ControlPlaneSubnet == "" {
+		masterCIDR, err := cidr.Subnet(ipv4Net, 1, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the master subnet %w", err)
+		}
+		master.CidrBlock = masterCIDR.String()
+	}
+
+	if installConfig.Config.GCP.ComputeSubnet == "" {
+		workerCIDR, err := cidr.Subnet(ipv4Net, 1, 1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the worker subnet %w", err)
+		}
+		worker.CidrBlock = workerCIDR.String()
+	}
+
+	subnets := []capg.SubnetSpec{master, worker}
+
+	labels := map[string]string{}
+	labels[fmt.Sprintf("kubernetes-io-cluster-%s", clusterID.InfraID)] = "owned"
+	labels[fmt.Sprintf("capg-cluster-%s", clusterID.InfraID)] = "owned"
+	for _, label := range installConfig.Config.GCP.UserLabels {
+		labels[label.Key] = label.Value
+	}
+
+	gcpCluster := &capg.GCPCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterID.InfraID,
+			Namespace: capiutils.Namespace,
+		},
+		Spec: capg.GCPClusterSpec{
+			Project: installConfig.Config.GCP.ProjectID,
+			Region:  installConfig.Config.GCP.Region,
+			Network: capg.NetworkSpec{
+				// TODO: Need a network project for installs where the network resources will exist in another
+				// project such as shared vpc installs
+				Name:    ptr.To(networkName),
+				Subnets: subnets,
+			},
+			AdditionalLabels: labels,
+			FailureDomains:   findFailureDomains(installConfig),
+		},
+	}
+
+	manifests = append(manifests, &asset.RuntimeFile{
+		Object: gcpCluster,
+		File:   asset.File{Filename: "02_gcp-cluster.yaml"},
+	})
+
+	return &capiutils.GenerateClusterAssetsOutput{
+		Manifests: manifests,
+		InfrastructureRef: &corev1.ObjectReference{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			Kind:       "GCPCluster",
+			Name:       gcpCluster.Name,
+			Namespace:  gcpCluster.Namespace,
+		},
+	}, nil
+}
+
+// findFailureDomains will find the failure domains or availability zones for the GCP platform.
+// When the default machine platform is defined, take any zone from the compute node(s) and
+// any defined in the control plane node(s). When the default machine platform is not defined,
+// only use zones if both the compute and control plane node availability zones exist.
+func findFailureDomains(installConfig *installconfig.InstallConfig) []string {
+	zones := sets.New[string]()
+	defaultMachinePlatformDefined := false
+	if gcpPlatform := installConfig.Config.Platform.GCP; gcpPlatform != nil && gcpPlatform.DefaultMachinePlatform != nil {
+		defaultMachinePlatformDefined = true
+		for _, zone := range gcpPlatform.DefaultMachinePlatform.Zones {
+			zones.Insert(zone)
+		}
+
+		if installConfig.Config.ControlPlane.Platform.GCP != nil {
+			for _, zone := range installConfig.Config.ControlPlane.Platform.GCP.Zones {
+				zones.Insert(zone)
+			}
+		}
+		if installConfig.Config.Compute[0].Platform.GCP != nil {
+			for _, zone := range installConfig.Config.Compute[0].Platform.GCP.Zones {
+				zones.Insert(zone)
+			}
+		}
+	}
+	if !defaultMachinePlatformDefined {
+		if installConfig.Config.ControlPlane.Platform.GCP != nil && installConfig.Config.Compute[0].Platform.GCP != nil {
+			for _, zone := range installConfig.Config.ControlPlane.Platform.GCP.Zones {
+				zones.Insert(zone)
+			}
+			for _, zone := range installConfig.Config.Compute[0].Platform.GCP.Zones {
+				zones.Insert(zone)
+			}
+		}
+	}
+
+	return zones.UnsortedList()
+}


### PR DESCRIPTION
The initial GCP cluster manifest is created when the CAPI Install feature gate is added. The initial state of the cluster manifest is relatively empty, and most of the information will be added to the GCP machine manifest(s).