### PR TITLE
OCPBUGS-23499: update RHCOS 4.13 bootimage metadata to 413.92.202401100947-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-08-09T01:27:30Z",
-    "generator": "plume cosa2stream 1461c56"
+    "last-modified": "2024-01-17T23:43:20Z",
+    "generator": "plume cosa2stream 331f68c"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-aws.aarch64.vmdk.gz",
-                "sha256": "007803e8283e2a90883cf94e8622a02b6eb2823bf49b9ac1f28439aac2a1ba75",
-                "uncompressed-sha256": "2c46f6f412e247d2f774d030d7f57c42a1cbcb266b59fa96290384c73a43c030"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-aws.aarch64.vmdk.gz",
+                "sha256": "b57a539ed7b32853f156833b586e616fde642c7d91ef6261e171a58bb577b037",
+                "uncompressed-sha256": "70f58d7f73e3cbe3a310c88a47505cf04507b0ab9d7ee696d62522919fb34c16"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-azure.aarch64.vhd.gz",
-                "sha256": "7ad7ac62a0bafd3538adcd66e107df20d3449420aa2513003dbcbdab3a750bd5",
-                "uncompressed-sha256": "a877aab3acbc595dd25a60f3ce743c15b151a110fec2bde656036fd75279079e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-azure.aarch64.vhd.gz",
+                "sha256": "e3a1ce2e6017bee0fcca1c3e7401577a91b3b3105596632ecfa6ad6d5432a1a2",
+                "uncompressed-sha256": "73722902acd811a1eef3c38ada35555303bc9e46173c5d030d843cb533e206b7"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-gcp.aarch64.tar.gz",
-                "sha256": "ab528e6b63e20143c9438bd6cb48733f52f835cd26b35f883c95e353fe24a572",
-                "uncompressed-sha256": "b15061fd29539d693721ed76314fcfcfb521e6a5f3cee5a9436e54ef7ef7d901"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-gcp.aarch64.tar.gz",
+                "sha256": "45e08b5d5c9f322e325edd6639ca52bdf842e5d856fff0d4855e834b38f0209e",
+                "uncompressed-sha256": "4bf5d01c14d45227975eb7cf7e7adff97b533f27eb35997b6c16d474f99b8a48"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-metal4k.aarch64.raw.gz",
-                "sha256": "1592e9380a81a82de4c74a6a5384215c70e01c8cdabe93f45ceecfb2bd5febc3",
-                "uncompressed-sha256": "6dc23543c8c33153adf5ad2882952085fe629d694c22416af8039b2319a17d8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-metal4k.aarch64.raw.gz",
+                "sha256": "aef06950f5b902ec9eed9da60f1b74ecf846685a37b7bdc588832a110c026c81",
+                "uncompressed-sha256": "ec00c78659cd5c52dac6dfecfd099b528f7f1a794d9b3e2b4671cc55f6b7c8ef"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-live.aarch64.iso",
-                "sha256": "04df18c3c12198b4a749693e453157907e73c3cb383055470e9ec515b90496fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-live.aarch64.iso",
+                "sha256": "252234164db0b14f35c75056c749480095ba18a9e960ac4e8b935ab1bf0d1ce3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-live-kernel-aarch64",
-                "sha256": "b4117ceb0128cf1f37ce4607efd1451deb7104f261a3303e7ad69abc5de53ca3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-live-kernel-aarch64",
+                "sha256": "9316ec6fd602258d621c7eb260445712a9708bdab188b06480ca7721ee5ddf3c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-live-initramfs.aarch64.img",
-                "sha256": "c50f0a64ac94da9ce8a6de47123a9953b8ea47ea42dc1fe0f20d26fde181bd86"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-live-initramfs.aarch64.img",
+                "sha256": "1af65f682129b009ee317d35e237ef769b889fabe3229c0f585acdedf6c1ffc2"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-live-rootfs.aarch64.img",
-                "sha256": "a64e8e71f7f9edda7d127a7c72f9f792ec8634fa8d27ef2b65c18e0355083532"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-live-rootfs.aarch64.img",
+                "sha256": "3fafc59f03f9f6adf0947ded5f88b3db78582675436fc084e5f7724f6138940f"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-metal.aarch64.raw.gz",
-                "sha256": "a1a94366dfd346cb63d89c8eb466a508016fb18fe3ed6706c066fe308feb7c94",
-                "uncompressed-sha256": "eba8a1cf8524e439dbaf81e22e49ea3dd905e97bb3a7647dbace85b18134347f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-metal.aarch64.raw.gz",
+                "sha256": "610786aad3f750eb45983073cfc6f70fc28448866c543a76389dd4f706ba53d8",
+                "uncompressed-sha256": "838f19d41fe3e6875797554ebdd0b36e160dcecf276fcb19a743ed892a25b530"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-openstack.aarch64.qcow2.gz",
-                "sha256": "4a22e9c8ff68fab15bdc3fda41c44c0b3619a70416655428750ebc7e59e754c9",
-                "uncompressed-sha256": "e9d748ec0b6eff01d31655ae5d3727145b925b3c1563b9f6cb0d58dc6697232f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-openstack.aarch64.qcow2.gz",
+                "sha256": "bea43ba16347064506b0b42ef9e7204be0f634ecb3af8beb1791397a1ea825c3",
+                "uncompressed-sha256": "99f9adf6dde8bdd01a9b47926277435a55f7e3a2d5959186cdb4863498b7dbc7"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/aarch64/rhcos-413.92.202307260246-0-qemu.aarch64.qcow2.gz",
-                "sha256": "55d26170abecb9ef177e256dba0e1894318e1df18b3606998f6e516c7532d06e",
-                "uncompressed-sha256": "1b6506310948c87079516c9d90cc3923b6efe1445c334d9dffb481722f89149d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/aarch64/rhcos-413.92.202401100947-0-qemu.aarch64.qcow2.gz",
+                "sha256": "cbcd56c863731bc11d64d2b04f525abc17294c070d2ed7e2788f73c06bdb9cdd",
+                "uncompressed-sha256": "273acbfd121bc5bc1e610f39840359c8089cbe338813ffaf6dcae7c07f8ae940"
               }
             }
           }
@@ -111,213 +111,213 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-04e04a7ff1d2d0192"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0edd7f7a84b890c7e"
             },
             "ap-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-04c548c3a32e30602"
+              "release": "413.92.202401100947-0",
+              "image": "ami-06a3fa2c6bfd1971f"
             },
             "ap-northeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-00434d83fd845caff"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0b79791d09e32a667"
             },
             "ap-northeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0e5870bf9f0b7fab2"
+              "release": "413.92.202401100947-0",
+              "image": "ami-07bf896be4e2b0b83"
             },
             "ap-northeast-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-08db216d83835a713"
+              "release": "413.92.202401100947-0",
+              "image": "ami-097e020d3c3bc3cad"
             },
             "ap-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-058bd61884c1f48ec"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0c60a099d5969ba79"
             },
             "ap-south-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0f1f7d99b9c8eb425"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0d1af476660b49b5f"
             },
             "ap-southeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-05a9d7183f84e3d3e"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0f1ca25df4a71db1b"
             },
             "ap-southeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0e667f624f9a49639"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0f434c898c7546e57"
             },
             "ap-southeast-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-08f13c207c815a501"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0fbdb325d5bcfa917"
             },
             "ap-southeast-4": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-01386fad92ece7394"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0b9684fdf09299805"
             },
             "ca-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-060aed001be2b6732"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0957b73ebee795b97"
             },
             "eu-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0bc5c51507e61a02e"
+              "release": "413.92.202401100947-0",
+              "image": "ami-082b62d406eabe190"
             },
             "eu-central-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-07fe43a3315522f21"
+              "release": "413.92.202401100947-0",
+              "image": "ami-079d9fa020fa33af1"
             },
             "eu-north-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0e0c77605abe4aefc"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0731d494d2ec6de5f"
             },
             "eu-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-05172b689b064038b"
+              "release": "413.92.202401100947-0",
+              "image": "ami-072ad6b62d0a6f282"
             },
             "eu-south-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0c96d707ed5ce1cb5"
+              "release": "413.92.202401100947-0",
+              "image": "ami-00d2273393fa155e7"
             },
             "eu-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0bd6927edbc784311"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0479e4b330d1a4c39"
             },
             "eu-west-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-008880d45afc6bd2e"
+              "release": "413.92.202401100947-0",
+              "image": "ami-07892a1ed7bebf5f5"
             },
             "eu-west-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-06201ccd5e773fac8"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0432f95dcf3481a63"
             },
             "il-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-04f6f6ef3e0d5fce5"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0780f1f3d2fdf7327"
             },
             "me-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-028cc44b38087fcc5"
+              "release": "413.92.202401100947-0",
+              "image": "ami-05a1dec02972ed51d"
             },
             "me-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0ce5b848e6d5bfb5b"
+              "release": "413.92.202401100947-0",
+              "image": "ami-00b8edaed63aceae9"
             },
             "sa-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-062f5666fb3b7da53"
+              "release": "413.92.202401100947-0",
+              "image": "ami-013cbd9e3e0f1aeba"
             },
             "us-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0fedc476830c11b76"
+              "release": "413.92.202401100947-0",
+              "image": "ami-03ea070846e6bc08c"
             },
             "us-east-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0c402831b6a301f78"
+              "release": "413.92.202401100947-0",
+              "image": "ami-04f46ef2ee440fee5"
             },
             "us-gov-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0bb69157d11d55370"
+              "release": "413.92.202401100947-0",
+              "image": "ami-084126bfbf4e68612"
             },
             "us-gov-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0a970e8e32ae9731e"
+              "release": "413.92.202401100947-0",
+              "image": "ami-094d20e890dc4d5c8"
             },
             "us-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-08caae442c38d04b6"
+              "release": "413.92.202401100947-0",
+              "image": "ami-004907e8cde052d07"
             },
             "us-west-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-096e87e98fcb99116"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0714c4c2a4facd8dd"
             }
           }
         },
         "gcp": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-92-202307260246-0-gcp-aarch64"
+          "name": "rhcos-413-92-202401100947-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202307260246-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202307260246-0-azure.aarch64.vhd"
+          "release": "413.92.202401100947-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202401100947-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-metal4k.ppc64le.raw.gz",
-                "sha256": "5b6d09f74b06e57d92145f39c7e6569617076554863eb51cf640f7293c03b314",
-                "uncompressed-sha256": "9bfe56bec06f6c913340f5553c14fc2094041c4b8f669d29d02dada98a9c78d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-metal4k.ppc64le.raw.gz",
+                "sha256": "179878ab7f97054b71644025123fd892ac323acb6ddb4c8862c2c01ec6e4190c",
+                "uncompressed-sha256": "a4c5de4a2301e071c1b3ee288a1db4f4e06ae9fb6fc1e00e2b0ec488ac0083c3"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-live.ppc64le.iso",
-                "sha256": "663906d3bb0985eb1c3b5d97b3a0050264fae5efc70cb318f285f980b18af6a8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-live.ppc64le.iso",
+                "sha256": "ee9da5a9dc94251b3ca38b00ac5f3f18d558aae3b7dce597692a673432591873"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-live-kernel-ppc64le",
-                "sha256": "d3272e48fffa376771775a0e916236d64721201d4530ba5fd1aea2c29ddf64cd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-live-kernel-ppc64le",
+                "sha256": "f644e7534d914ec0194968a9faeb253ad580a045c9dbcea06c73eee5bb6c7b69"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-live-initramfs.ppc64le.img",
-                "sha256": "18de5308874bd1bdf8a40cd7b33e221298bdcfab3750577ce8287d5a000ebe0d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-live-initramfs.ppc64le.img",
+                "sha256": "32d17672c95716360d31c8019d138c68d7f416c4f9c13634d8230140717676e0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-live-rootfs.ppc64le.img",
-                "sha256": "6b0db97b29170514c8a545cb89b0261c0616aedcb45e761c56a6d1a43397f301"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-live-rootfs.ppc64le.img",
+                "sha256": "70e50d04c2cb2c1d4d3f9132b319908d604a5a647da360a35eb7b073b6f96d83"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-metal.ppc64le.raw.gz",
-                "sha256": "6538f962d4f307c1192bce06cd2f2d246aa701264a59b706b33e70e633586488",
-                "uncompressed-sha256": "42249d6ff8114cdad3b6fbaeee5a18c4c9c77369ea29059a9500e1af1b7ea2f6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-metal.ppc64le.raw.gz",
+                "sha256": "337020acb98d9d26e81636875e48dfa7b17989661415263ec7cb84273759694a",
+                "uncompressed-sha256": "902234f5914fc9d7cbd901066b40d871da71be77030b4ccb7fbf4c70fc9b80a9"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "391452119828de9d2aaaf55577b15cf0ab7e66b5a19430b0936ba9c0bbfa8c90",
-                "uncompressed-sha256": "12c8256d3f3189a817cceb72a1ad968ff8b81b4e82415891cf4637f24a3d2f14"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "70fa5f60f02538dbb704db4a1b496eb9185926ea4e51a424b42a94b3f16a2a4f",
+                "uncompressed-sha256": "03fb8f2d9ef5395e6efe3880c38b5328ed08aeda250fc23db6c54eb046e91c04"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-powervs.ppc64le.ova.gz",
-                "sha256": "69f052c0904b30dee3bc17a714afd2322a1fafc85f5c7a6ea06a33307584b795",
-                "uncompressed-sha256": "40cd39f9759a4c655e51647bb67eb5d8ff6f6b6dc38c18438f5017fbdccd54a4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-powervs.ppc64le.ova.gz",
+                "sha256": "9aedaf9fdf84004335a01e8295d026f8fcbebec62c54863808b8fd57d86e85a0",
+                "uncompressed-sha256": "3cb6111144a44a1ce8b8677d61365c05b8ac3077e52583f947a1a6dfab247ca3"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/ppc64le/rhcos-413.92.202307260246-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "7e5c23cbb5bb21bbd520f243af5357bbf426884fce891fd1579a0091560c5e0c",
-                "uncompressed-sha256": "9c1710aa21d435a13f7bc5c7c0c59cae6a37b5ebfdfb961368e0b4926d3b05e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/ppc64le/rhcos-413.92.202401100947-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "f1fb9b0dfb029d475397e09f74a7c5592372e181fd0f776dd9deece556f24d2b",
+                "uncompressed-sha256": "4477ca11b70c7ccdcbf9ea6bf57e0cb736fb1d9f5e55c1370ccf965cba902b73"
               }
             }
           }
@@ -327,58 +327,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
+            },
+            "eu-es": {
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
+              "bucket": "rhcos-powervs-images-eu-es",
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.92.202307260246-0",
-              "object": "rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202401100947-0",
+              "object": "rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202307260246-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202401100947-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -387,88 +393,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "fce3936cc61e908f218fe7c12cd2a86d9227ba81c6257ae8fa887aa37a314de7",
-                "uncompressed-sha256": "ea907c9ea1d4dc6780d1233ffcd0bbaec50e9ae767f4de8a468f9618e04114fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "8d003a18e9c27c924d03c24015a29a5485da2f6b87e5486bc300e7076204d33f",
+                "uncompressed-sha256": "4c875bc0ef413bb0994545caa31bd79e54dc8ca9e10cefcfc620e54091d699b7"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-metal4k.s390x.raw.gz",
-                "sha256": "074285cdcfb065f6671f6972cd27eb6a6ee6b9031e8d5f9f564a199a643649ed",
-                "uncompressed-sha256": "b6ed18dac25ed7bac5e7d6a0e478180999e422241af3522c62a311ed7c718cc6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-metal4k.s390x.raw.gz",
+                "sha256": "4b6349cc8c78dd25b01a1e1d5438d4e352f37cbbde739208157c1c45b04ccfaa",
+                "uncompressed-sha256": "5018bf934050d6f8d07b00e7e655748dd36f315bb29bc3b9a0caa3aaebbea680"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-live.s390x.iso",
-                "sha256": "604b30ed3a9506933db14f3a91138742e91e69516e1fb6d6727fccf746417f82"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-live.s390x.iso",
+                "sha256": "ef826c987099ab7a40d658a5b27e9d39b95095e885a853cb6ae283b3bc671da8"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-live-kernel-s390x",
-                "sha256": "12c2d7645ac857c7c5d803aa764b30e18a70d5e524aab11ed0d807274cdc2862"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-live-kernel-s390x",
+                "sha256": "7e34f2c4203fcff64bfa3ad1a091c08259233ef013ba1652fd6d97fce630c396"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-live-initramfs.s390x.img",
-                "sha256": "111bad29cb5f113807b76f98f0d886aa3c8a98d02d094a34542da6ec6af899ac"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-live-initramfs.s390x.img",
+                "sha256": "314f0c72433663023865c21a603be336538b3fc8cdc70f7fb1a3da6494864d71"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-live-rootfs.s390x.img",
-                "sha256": "3030fcc5069ee26030c5e75d4c5e95ef6b0bf37987a23934c21baaaa03f5de16"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-live-rootfs.s390x.img",
+                "sha256": "47ee455b9f28c000f5368b81fdd7fec479beef15a17eaad41151e885f487d54e"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-metal.s390x.raw.gz",
-                "sha256": "ce19641a53eb1d8a8bb6dda8c9cc1c96b0a8ae59c026785789a7c55b405defa9",
-                "uncompressed-sha256": "f56455320f1befed8a68591e963e7d3bc3958118046a6135a0b3cd3a1ce16dd8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-metal.s390x.raw.gz",
+                "sha256": "c34c25fbac335aa22d34e38d65449e1bb0c422e442b4c1de251ff3a21db523eb",
+                "uncompressed-sha256": "c1fb760502d14eb071b8442a71946a265636a06855f652780e086ed1223fa128"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-openstack.s390x.qcow2.gz",
-                "sha256": "f65ac00decdd67dccff7e48ed717e6ee970c6fc703d6212f0893e3599f6c915d",
-                "uncompressed-sha256": "723e0bf81301e86ca340f3a76432aae0ac733fbf9b4ab3a02e71626cdc2ba1a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-openstack.s390x.qcow2.gz",
+                "sha256": "904e07c11ce484bb9b750713bc7a757a511a3c99096edeee01d4a934ae089b3a",
+                "uncompressed-sha256": "3f451edc90461e64bd746faca3ea5d59585e530a577c23cb499180a8d1f051fb"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-qemu.s390x.qcow2.gz",
-                "sha256": "b1119118a36d9fe15379e93233fbbd157ff333ab456ee24d477cad2aa4fb37f4",
-                "uncompressed-sha256": "919a3c92ee36d74c4f15b60c4995b15d2e47a42e3f1bbe764ee602b77092e2c9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-qemu.s390x.qcow2.gz",
+                "sha256": "6c3ad0bf2313cdab85ac834a06abf63fe02c451a6d194af20ea18590bf6f5d44",
+                "uncompressed-sha256": "2263f5ee90a470a06f5e3441f59249445b61414fdabc6698ed5905951c287bfe"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/s390x/rhcos-413.92.202307260246-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "ad44605cdfc40bc1ebefda2742a41d7b742fe4733fa3fe5e3dc0c9864ec8b168",
-                "uncompressed-sha256": "ce386ab4675f04963f9adf4a9d05f0caa06f3286e4946c9d32d2846768e5bbb6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/s390x/rhcos-413.92.202401100947-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "8cd8e2e970b613d16b68e2796e18f9f1644afbab009f35542fad7af5081163ae",
+                "uncompressed-sha256": "4514a46ee3edc0670476e694b56f4af13b11c6c0fc18af30b89e3de2dfe3cc19"
               }
             }
           }
@@ -479,158 +485,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "41b3eba70399bb7039fef639085fe5cffd82c1dcc2bb14834f001384ea38f5e2",
-                "uncompressed-sha256": "e92132e6027724cb9ea6c86ce0990e3c38567015f0e2fa92a8da71a48d4e7aa4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "69b2d3dd6effa48af6f7c32ff6a3c4a2d779788478e6474a634e9b3abf62759b",
+                "uncompressed-sha256": "9f654d2e3c6dff92524262797c70382a0846b75130854acd3da29fbd357a633f"
               }
             }
           }
         },
         "aws": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-aws.x86_64.vmdk.gz",
-                "sha256": "35e81d69a5bc98c91adca7b417debcd40fead4bddad25c8a94dff83fa0ebbb00",
-                "uncompressed-sha256": "d3be589bfb658b5d8c3787b6013146f2dc7e83be3fd8940ce7313ee6750d97ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-aws.x86_64.vmdk.gz",
+                "sha256": "e84885270de6c4b8b942ac6600c53e32f00b2fb799ff05623901a32bd57ba4c3",
+                "uncompressed-sha256": "bb7c24607b60adc65ae220c31cd5d9bc0125ecd960643827338c1e4536410a36"
               }
             }
           }
         },
         "azure": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-azure.x86_64.vhd.gz",
-                "sha256": "baf95b972ad379f61713a65fc0e7d5f1a442155e45a7fc64c6449df105ceea4d",
-                "uncompressed-sha256": "fa9fc45061f85b9edfd38d42b68c29a111943368caba2113bf2c36920e8ef88d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-azure.x86_64.vhd.gz",
+                "sha256": "d1e1bd04f368192462fe2467e7c5e0232ca38a849528851b01dcea68837b6e0a",
+                "uncompressed-sha256": "e24e42becdf1e101e8b8fdfd1261386139dd113af52876ab1cea0fd227ac5b5c"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-azurestack.x86_64.vhd.gz",
-                "sha256": "a116ae3347ea551a75016fa957e68b249c4b08aa450c94d195db1e4f11caaf68",
-                "uncompressed-sha256": "e743367f18d45359338b275122c2c43d23dbd0eb843b7521a19f33e96d5e50c5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-azurestack.x86_64.vhd.gz",
+                "sha256": "dfc3f0f2ff3ced6039977231e3ccbb295d5e94c77e838a1db68ddb68a9a25a53",
+                "uncompressed-sha256": "7791b24a6b441a88d8515568deb23ee1cc007305e6c48a8318f3e0d6db8455e2"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-gcp.x86_64.tar.gz",
-                "sha256": "9cabd21342dd528a7b4251494b3122215aeb046efc38589123b9d40ded61c311",
-                "uncompressed-sha256": "9a48bcc660440528bade06b1b3d1a0eb92f57d40173a523802dba917691b7857"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-gcp.x86_64.tar.gz",
+                "sha256": "33091afcc2dd62c72fddc6908ef0cf7e1de0b664a107f026e2fba900df665b86",
+                "uncompressed-sha256": "09dec293c0c9ca19d385b072e3d5029a17e6f5423aba6d7eea411510cc93557f"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "ef824cfd5449e0dd1ed6405a03f1ed929eb1275fda49440e46bae0090abf0177",
-                "uncompressed-sha256": "df3b7735651c0c14d38d180fba576beb1d969da76bf63c9698e5b19767b306ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "8144549488c7e8ea21299d77727a9d91754fe64fceee711315ab6dc75b8c7d1a",
+                "uncompressed-sha256": "d50721622a58d15f8904ccb39018938de6ea9b7fbfbf7128d346759e0558a947"
               }
             }
           }
         },
         "metal": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-metal4k.x86_64.raw.gz",
-                "sha256": "8618f82d294b3a50902ad32405ae54f07e1153019ed1d69ec82b536b841f50a7",
-                "uncompressed-sha256": "3aabc2ac21fd3caa1aa438d3a8a94ad88575ccb78da2dd31fc3dd839fb701f6e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-metal4k.x86_64.raw.gz",
+                "sha256": "4280ffef246fa745a9594c3c71aa2eb388dd913829ef5d0b30e242e3fb28db19",
+                "uncompressed-sha256": "18b78cd5b689958815fdfbc044a52ffafed097113882f0c28eb6d9baf4d48da2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-live.x86_64.iso",
-                "sha256": "8e4ce37c0c627bd8a735abe513a86943bb4cd1b17c9ac78eacabae81fa5f13ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-live.x86_64.iso",
+                "sha256": "e284f04631ade6be9322ee360510512f2169926d7881718ed3d18fcc0988190a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-live-kernel-x86_64",
-                "sha256": "47546ba548ca0a202aefee0fdba5f011a6913520ec36f924b4f0bc367f8ff055"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-live-kernel-x86_64",
+                "sha256": "2dbfd689a856edd4292e7b4a467526089d136791fb0f4d38dfef8ed92447b481"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-live-initramfs.x86_64.img",
-                "sha256": "8a995a398e98f3fcc45fc5be352a1f5caf2da29c3a71419d1c10c47e989034f3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-live-initramfs.x86_64.img",
+                "sha256": "95df40cbaeaa353997768368b5bb4a16d565abbccedc7d2e6e95bbcb4a11ce5f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-live-rootfs.x86_64.img",
-                "sha256": "340172fd75c241d9aebcc6460a7eeeded420b67cda3f1e49e549d2d0cba854e5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-live-rootfs.x86_64.img",
+                "sha256": "c19b6e83b394c0ff480dbb8badf34d445b0826eb454850b0b52636bf0c1569f6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-metal.x86_64.raw.gz",
-                "sha256": "d9b008f1d69251a125cb65738a19c536e378fbecfa90d0f3725d77755f0f5473",
-                "uncompressed-sha256": "70a4aa770e011794447d8d3f47ebc23b861fb207c220be74ee0df042cd6bd5d1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-metal.x86_64.raw.gz",
+                "sha256": "d6453749983e1eca45c6a366e14a1dfd194b4c766bc3857a26603a8eb65a6847",
+                "uncompressed-sha256": "9fc3563fba104a89d586082c3cea550d855f6049f04953dc84a9bc40f6812c58"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-nutanix.x86_64.qcow2",
-                "sha256": "304f4e04dda1411a61f288f17f265989e361e15d75f876a364705e29e1880f15"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-nutanix.x86_64.qcow2",
+                "sha256": "a1af49242958ec5787db2a0d4d132a4181e6558fde3c8be0cb3271c742230a04"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-openstack.x86_64.qcow2.gz",
-                "sha256": "40aaa565bd8d38c7d0a5ea8845bbd324f7fd677181492407337a5187d8a7a39a",
-                "uncompressed-sha256": "55360e9d25c7f9ca82baf6191ce4538c0cf04b910a6d1aa04ad476d0aeda0550"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-openstack.x86_64.qcow2.gz",
+                "sha256": "ee27fe5cf49de7d9330a2e6729ba472dd894ab65439eb5fc2ee9049854508596",
+                "uncompressed-sha256": "0b035cbda0ea1873afb5f135cdf499848c68adf81797bc06800d9b29b8083eda"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-qemu.x86_64.qcow2.gz",
-                "sha256": "6c407eaf8394fb49ee707485ed2ad334d625dec2b722b74b547a3c2f628fb6b8",
-                "uncompressed-sha256": "c5872aefd8ca9313d1ab87aee6e2ef836714baac730383404c7974d0acee1d48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-qemu.x86_64.qcow2.gz",
+                "sha256": "87b955538149811c01273f5f8956743c3d1ae64c29d6adcf0c59471486b46c7e",
+                "uncompressed-sha256": "9c030c70535c19cffd6ccb43d5337b4d270a4a224bd1932fb0b1c3e399e4134a"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202307260246-0/x86_64/rhcos-413.92.202307260246-0-vmware.x86_64.ova",
-                "sha256": "4b2caacc4d5dc69aabe3733a86e0a5ac0b41bbe1c090034c4fa33faf582a0476"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202401100947-0/x86_64/rhcos-413.92.202401100947-0-vmware.x86_64.ova",
+                "sha256": "b73b73268190eff675540e696bb663eccef1c1a693b81c14479330458233cccc"
               }
             }
           }
@@ -640,257 +646,261 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-6we70j4kchivhbtiy0fw"
+              "release": "413.92.202401100947-0",
+              "image": "m-6weej9yalxzm2oaepsps"
             },
             "ap-northeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "m-mj79ngpxfthk4oom6ofr"
+              "release": "413.92.202401100947-0",
+              "image": "m-mj7ih2xqykjlia50rej7"
             },
             "ap-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-a2dj09v5umw230ynn6vu"
+              "release": "413.92.202401100947-0",
+              "image": "m-a2db2lari7g3gn8tphla"
             },
             "ap-southeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-t4n81m8ma6q7uprjpscv"
+              "release": "413.92.202401100947-0",
+              "image": "m-t4n9vgo4qcw3hb9u3nzc"
             },
             "ap-southeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "m-p0w9xaty4vxjj930cifl"
+              "release": "413.92.202401100947-0",
+              "image": "m-p0waavwwkmnq39ckfd2e"
             },
             "ap-southeast-3": {
-              "release": "413.92.202307260246-0",
-              "image": "m-8psajmfoz8jg5h7mryvy"
+              "release": "413.92.202401100947-0",
+              "image": "m-8ps5kyjlrhd86qt5dd66"
             },
             "ap-southeast-5": {
-              "release": "413.92.202307260246-0",
-              "image": "m-k1ai8c0n8033kezl9ykf"
+              "release": "413.92.202401100947-0",
+              "image": "m-k1aif3sfv703cd4yygsd"
             },
             "ap-southeast-6": {
-              "release": "413.92.202307260246-0",
-              "image": "m-5tsa4cww6o4whfq0x9ws"
+              "release": "413.92.202401100947-0",
+              "image": "m-5tsb0vbs3e0c065xpk7v"
             },
             "ap-southeast-7": {
-              "release": "413.92.202307260246-0",
-              "image": "m-0jobbpmx5t2eir68par7"
+              "release": "413.92.202401100947-0",
+              "image": "m-0jog056fbbuxys3kgc6r"
             },
             "cn-beijing": {
-              "release": "413.92.202307260246-0",
-              "image": "m-2ze8jdoplzcphrb5lkby"
+              "release": "413.92.202401100947-0",
+              "image": "m-2zeie3n7i0l7owmolo59"
             },
             "cn-chengdu": {
-              "release": "413.92.202307260246-0",
-              "image": "m-2vc4qq6m67zs5s5dpfit"
+              "release": "413.92.202401100947-0",
+              "image": "m-2vc6az6hhufcq7p3as8c"
             },
             "cn-fuzhou": {
-              "release": "413.92.202307260246-0",
-              "image": "m-gw0e8qss9levf9nwostm"
+              "release": "413.92.202401100947-0",
+              "image": "m-gw0j8xjevivwupqqf26e"
             },
             "cn-guangzhou": {
-              "release": "413.92.202307260246-0",
-              "image": "m-7xv267onrvgo5p0dgm5y"
+              "release": "413.92.202401100947-0",
+              "image": "m-7xvicq8g78m33ppuxry6"
             },
             "cn-hangzhou": {
-              "release": "413.92.202307260246-0",
-              "image": "m-bp159yqg22k05fczjnx1"
+              "release": "413.92.202401100947-0",
+              "image": "m-bp1605iwejf63e21zil1"
             },
             "cn-heyuan": {
-              "release": "413.92.202307260246-0",
-              "image": "m-f8zjb84sd22fkh9pxv68"
+              "release": "413.92.202401100947-0",
+              "image": "m-f8z0qytudoqhu62pnazj"
             },
             "cn-hongkong": {
-              "release": "413.92.202307260246-0",
-              "image": "m-j6cincsxegutih9a4bey"
+              "release": "413.92.202401100947-0",
+              "image": "m-j6c8ooknv8akdo49bz6s"
             },
             "cn-huhehaote": {
-              "release": "413.92.202307260246-0",
-              "image": "m-hp3hxhdkr70brxwn1uzb"
+              "release": "413.92.202401100947-0",
+              "image": "m-hp39rt701b3ew31881bi"
             },
             "cn-nanjing": {
-              "release": "413.92.202307260246-0",
-              "image": "m-gc748qx0901grl1emjse"
+              "release": "413.92.202401100947-0",
+              "image": "m-gc7azce3qem7kkixr525"
             },
             "cn-qingdao": {
-              "release": "413.92.202307260246-0",
-              "image": "m-m5e5pbldfmygehg2gv88"
+              "release": "413.92.202401100947-0",
+              "image": "m-m5ech46895ugt658sblm"
             },
             "cn-shanghai": {
-              "release": "413.92.202307260246-0",
-              "image": "m-uf666edi2c0xsjzki8be"
+              "release": "413.92.202401100947-0",
+              "image": "m-uf6f4ctc2ipbke47ca4x"
             },
             "cn-shenzhen": {
-              "release": "413.92.202307260246-0",
-              "image": "m-wz9g59zmcbmema03r4nh"
+              "release": "413.92.202401100947-0",
+              "image": "m-wz906rwhfq80sxw0dfic"
+            },
+            "cn-wuhan-lr": {
+              "release": "413.92.202401100947-0",
+              "image": "m-n4ad5eb1vxkqawsfj0ve"
             },
             "cn-wulanchabu": {
-              "release": "413.92.202307260246-0",
-              "image": "m-0jlaoib1kswh0y3v07gc"
+              "release": "413.92.202401100947-0",
+              "image": "m-0jlgc88c9xk3tp2r1gra"
             },
             "cn-zhangjiakou": {
-              "release": "413.92.202307260246-0",
-              "image": "m-8vbgwcuib1sn3gxnn7zh"
+              "release": "413.92.202401100947-0",
+              "image": "m-8vb8qywoeki13evyj1gx"
             },
             "eu-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-gw868vtcsyvwu5z62090"
+              "release": "413.92.202401100947-0",
+              "image": "m-gw81kr0k65mrruz93yat"
             },
             "eu-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-d7o5vn1yb41hyzxvd8hx"
+              "release": "413.92.202401100947-0",
+              "image": "m-d7oczi3mvk9d962tz98f"
             },
             "me-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-l4v9q6qcglxp88serj0r"
+              "release": "413.92.202401100947-0",
+              "image": "m-l4vc2thxn491se71zamb"
             },
             "me-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-eb339giw4uqm7rrjepss"
+              "release": "413.92.202401100947-0",
+              "image": "m-eb3bjm6onp9qfegnqy4u"
             },
             "us-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-0xi47o9jo3qd492etdi6"
+              "release": "413.92.202401100947-0",
+              "image": "m-0xi7rtoc0z9tgolyy13t"
             },
             "us-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "m-rj92u4e0ppfcnfeq5w6w"
+              "release": "413.92.202401100947-0",
+              "image": "m-rj99d2l64d288k2pov8v"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-08f7a7d504ae96ec5"
+              "release": "413.92.202401100947-0",
+              "image": "ami-02c646f2385780497"
             },
             "ap-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-019ca94648dd51777"
+              "release": "413.92.202401100947-0",
+              "image": "ami-049fbbbb3e0aafc27"
             },
             "ap-northeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0604c9177702ad090"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0e30f03b3e9e00ab8"
             },
             "ap-northeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0b898bf81fb51ce5c"
+              "release": "413.92.202401100947-0",
+              "image": "ami-06046cadddfe8d995"
             },
             "ap-northeast-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-02e006495f0343c52"
+              "release": "413.92.202401100947-0",
+              "image": "ami-07fd741de5f675654"
             },
             "ap-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-02dc4344a5f0f4271"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0737f4f112343d7c8"
             },
             "ap-south-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-03919a3434eda3342"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0dcb501a477eaf795"
             },
             "ap-southeast-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-018d89f3c609c2bf1"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0482824fa4a35d699"
             },
             "ap-southeast-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-082fc739cd53efade"
+              "release": "413.92.202401100947-0",
+              "image": "ami-023eda536b8498959"
             },
             "ap-southeast-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-02b783c7d9fd9075a"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0b719060346a02c68"
             },
             "ap-southeast-4": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-04a9e4e54418bbcfc"
+              "release": "413.92.202401100947-0",
+              "image": "ami-03fd0d817096531ad"
             },
             "ca-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0a5d4ef52bf1a7fd8"
+              "release": "413.92.202401100947-0",
+              "image": "ami-08b494a3e5f461dbc"
             },
             "eu-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-049413f8308dfb598"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0b614773fa27e578d"
             },
             "eu-central-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0c8a47ed50a5916dc"
+              "release": "413.92.202401100947-0",
+              "image": "ami-065065861671914c4"
             },
             "eu-north-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-08c9a2a77eacc2f63"
+              "release": "413.92.202401100947-0",
+              "image": "ami-09a51d705ca5595bc"
             },
             "eu-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0e5e31a7cedf2c1dc"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0c6a305e66bc00d63"
             },
             "eu-south-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-09538255b6cb07b15"
+              "release": "413.92.202401100947-0",
+              "image": "ami-02054396d9db59c00"
             },
             "eu-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0f3501a206e6049d7"
+              "release": "413.92.202401100947-0",
+              "image": "ami-007a353fea999ea67"
             },
             "eu-west-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0fde64a8245f38430"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0bd018e8be9d526c9"
             },
             "eu-west-3": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0700abf2efe60e203"
+              "release": "413.92.202401100947-0",
+              "image": "ami-08970464af38bfdab"
             },
             "il-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-04b59c15e64c3807d"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0c6267bf5bc6ed9ce"
             },
             "me-central-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0314fbcb7444cca84"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0fab8a4496cf146d2"
             },
             "me-south-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-09bf546cd28c5ed99"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0ddcaccfea5956179"
             },
             "sa-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-045b0160560e5cb75"
+              "release": "413.92.202401100947-0",
+              "image": "ami-034b7ac69488334ce"
             },
             "us-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0b56cb92505dea7ed"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0f780871daf8fc10d"
             },
             "us-east-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0ed3f273b2e74f814"
+              "release": "413.92.202401100947-0",
+              "image": "ami-05633d373d2067b59"
             },
             "us-gov-east-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-089539ee75034f240"
+              "release": "413.92.202401100947-0",
+              "image": "ami-07ff276cad82e71ff"
             },
             "us-gov-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0579973eae69af570"
+              "release": "413.92.202401100947-0",
+              "image": "ami-005c8c04aa6e9bed3"
             },
             "us-west-1": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0c884556a735564a7"
+              "release": "413.92.202401100947-0",
+              "image": "ami-0acf27669c73b6172"
             },
             "us-west-2": {
-              "release": "413.92.202307260246-0",
-              "image": "ami-0cca6eccff332ee4d"
+              "release": "413.92.202401100947-0",
+              "image": "ami-01501867230498273"
             }
           }
         },
         "gcp": {
-          "release": "413.92.202307260246-0",
+          "release": "413.92.202401100947-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-92-202307260246-0-gcp-x86-64"
+          "name": "rhcos-413-92-202401100947-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.92.202307260246-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202307260246-0-azure.x86_64.vhd"
+          "release": "413.92.202401100947-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202401100947-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 boot image metadata. Issues resolved in this bootimage are:

OCPBUGS-23501 - Failed to mount gcp volume with "failed to find and re-link disk"
OCPBUGS-23907 - No way to enable FIPS in RHCOS Live ISO

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name 4.13-9.2                    \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=413.92.202401100947-0                                      \
    aarch64=413.92.202401100947-0                                     \
    s390x=413.92.202401100947-0                                       \
    ppc64le=413.92.202401100947-0
```