### PR TITLE
OCPBUGS-22410: vsphere-fix convert if only provided name

### DIFF
--- a/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
+++ b/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
@@ -45,7 +45,7 @@ func StartSimulator(setVersionToSupported bool) (*simulator.Server, error) {
 	}
 
 	model.Folder = 1
-	model.Datacenter = 2
+	model.Datacenter = 5
 	model.OpaqueNetwork = 1
 	err := model.Create()
 	if err != nil {

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -1,10 +1,16 @@
 package conversion
 
 import (
-	"fmt"
-	"strings"
+	"context"
+	"errors"
+	"net/url"
+	"path"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/soap"
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -21,11 +27,59 @@ const (
 	GeneratedFailureDomainZone string = "generated-zone"
 )
 
-// ConvertInstallConfig modifies a given platform spec for the new requirements.
-func ConvertInstallConfig(config *types.InstallConfig) error {
-	platform := config.Platform.VSphere
+// GetFinder connects to vCenter via SOAP and returns the Finder object if the SOAP
+// connection is successful. If the connection fails it returns nil.
+// Errors are mostly ignored to support AI and agent installers.
+func GetFinder(server, username, password string) (*find.Finder, error) {
+	var finder *find.Finder
 
-	// Scenario: IPI or 4.12 Zonal IPI w/o vcenters defined
+	if server != "" && password != "" && username != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		u, err := soap.ParseURL(server)
+		if err != nil {
+			return nil, err
+		}
+		u.User = url.UserPassword(username, password)
+
+		client, err := govmomi.NewClient(ctx, u, false)
+		if err != nil {
+			// If bogus authentication is provided in the scenario of AI or assisted
+			// just provide warning message. If this is IPI or UPI validation will
+			// catch and halt on incorrect authentication.
+			localLogger.Warnf("unable to log into vCenter %s, %v", server, err)
+			return nil, nil
+		}
+		finder = find.NewFinder(client.Client, true)
+	}
+
+	return finder, nil
+}
+
+func findViaPathOrName(finder *find.Finder, objectPath, objectFindPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	elements, err := finder.ManagedObjectListChildren(ctx, objectFindPath)
+	if err != nil {
+		return "", err
+	}
+
+	for _, e := range elements {
+		if e.Path == objectPath {
+			return objectPath, nil
+		}
+
+		if path.Base(e.Path) == path.Base(objectPath) {
+			return e.Path, nil
+		}
+	}
+	return "", errors.New("unable to find object")
+}
+
+// fixNoVCentersScenario this function creates the VCenters slice
+// with existing legacy vcenter authentication and configuration.
+func fixNoVCentersScenario(platform *vsphere.Platform) {
 	if len(platform.VCenters) == 0 {
 		createVCenters(platform)
 
@@ -44,23 +98,40 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 			}
 		}
 	}
+}
 
-	// Scenario: Fields are not paths
+func fixTechPreviewZonalFailureDomainsScenario(platform *vsphere.Platform, finder *find.Finder) error {
 	if len(platform.FailureDomains) > 0 {
+		var err error
+
 		for i := range platform.FailureDomains {
-			platform.FailureDomains[i].Topology.ComputeCluster = setComputeClusterPath(platform.FailureDomains[i].Topology.ComputeCluster,
-				platform.FailureDomains[i].Topology.Datacenter)
+			computeCluster := platform.FailureDomains[i].Topology.ComputeCluster
+			datastore := platform.FailureDomains[i].Topology.Datastore
+			folder := platform.FailureDomains[i].Topology.Folder
+			datacenter := platform.FailureDomains[i].Topology.Datacenter
 
-			platform.FailureDomains[i].Topology.Datastore = setDatastorePath(platform.FailureDomains[i].Topology.Datastore,
-				platform.FailureDomains[i].Topology.Datacenter)
+			platform.FailureDomains[i].Topology.ComputeCluster, err = SetObjectPath(finder, "host", computeCluster, datacenter)
+			if err != nil {
+				return err
+			}
 
-			platform.FailureDomains[i].Topology.Folder = setFolderPath(platform.FailureDomains[i].Topology.Folder,
-				platform.FailureDomains[i].Topology.Datacenter)
+			platform.FailureDomains[i].Topology.Datastore, err = SetObjectPath(finder, "datastore", datastore, datacenter)
+			if err != nil {
+				return err
+			}
+
+			platform.FailureDomains[i].Topology.Folder, err = SetObjectPath(finder, "vm", folder, datacenter)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	return nil
+}
 
-	// Scenario: legacy UPI or IPI
+func fixLegacyPlatformScenario(platform *vsphere.Platform, finder *find.Finder) error {
 	if len(platform.FailureDomains) == 0 {
+		var err error
 		localLogger.Warn("vsphere topology fields are now deprecated; please use failureDomains")
 
 		platform.FailureDomains = make([]vsphere.FailureDomain, 1)
@@ -71,38 +142,92 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 
 		platform.FailureDomains[0].Topology.Datacenter = platform.DeprecatedDatacenter
 		platform.FailureDomains[0].Topology.ResourcePool = platform.DeprecatedResourcePool
-		platform.FailureDomains[0].Topology.ComputeCluster = setComputeClusterPath(platform.DeprecatedCluster, platform.DeprecatedDatacenter)
 		platform.FailureDomains[0].Topology.Networks = make([]string, 1)
 		platform.FailureDomains[0].Topology.Networks[0] = platform.DeprecatedNetwork
-		platform.FailureDomains[0].Topology.Datastore = setDatastorePath(platform.DeprecatedDefaultDatastore, platform.DeprecatedDatacenter)
-		platform.FailureDomains[0].Topology.Folder = setFolderPath(platform.DeprecatedFolder, platform.DeprecatedDatacenter)
+
+		platform.FailureDomains[0].Topology.ComputeCluster, err = SetObjectPath(finder, "host", platform.DeprecatedCluster, platform.DeprecatedDatacenter)
+		if err != nil {
+			return err
+		}
+
+		platform.FailureDomains[0].Topology.Datastore, err = SetObjectPath(finder, "datastore", platform.DeprecatedDefaultDatastore, platform.DeprecatedDatacenter)
+		if err != nil {
+			return err
+		}
+
+		platform.FailureDomains[0].Topology.Folder, err = SetObjectPath(finder, "vm", platform.DeprecatedFolder, platform.DeprecatedDatacenter)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ConvertInstallConfig modifies a given platform spec for the new requirements.
+func ConvertInstallConfig(config *types.InstallConfig) error {
+	platform := config.Platform.VSphere
+
+	fixNoVCentersScenario(platform)
+	finder, err := GetFinder(platform.VCenters[0].Server, platform.VCenters[0].Username, platform.VCenters[0].Password)
+	if err != nil {
+		return err
+	}
+	err = fixTechPreviewZonalFailureDomainsScenario(platform, finder)
+	if err != nil {
+		return err
+	}
+	err = fixLegacyPlatformScenario(platform, finder)
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func setComputeClusterPath(cluster, datacenter string) string {
-	if cluster != "" && !strings.HasPrefix(cluster, "/") {
-		localLogger.Warnf("computeCluster as a non-path is now deprecated; please use the form: /%s/host/%s", datacenter, cluster)
-		return fmt.Sprintf("/%s/host/%s", datacenter, cluster)
-	}
-	return cluster
-}
+// SetObjectPath based on the pathType will either determine the path for the type via
+// a simple join of the datacenter, pathType and objectPath if finder is nil
+// or via a connection to vCenter find of all child objects under the
+// datacenter and pathType.
+// pathType must only be "host", "vm", or "datastore".
+func SetObjectPath(finder *find.Finder, pathType, objectPath, datacenter string) (string, error) {
+	if objectPath != "" && !path.IsAbs(objectPath) {
+		var joinedObjectPath string
+		var joinedObjectFindPath string
+		var paramName string
 
-func setDatastorePath(datastore, datacenter string) string {
-	if datastore != "" && !strings.HasPrefix(datastore, "/") {
-		localLogger.Warnf("datastore as a non-path is now deprecated; please use the form: /%s/datastore/%s", datacenter, datastore)
-		return fmt.Sprintf("/%s/datastore/%s", datacenter, datastore)
-	}
-	return datastore
-}
+		switch pathType {
+		case "host":
+			paramName = "computeCluster"
+		case "vm":
+			paramName = "folder"
+		case "datastore":
+			paramName = "datastore"
+		default:
+			return "", errors.New("pathType can only be host, datastore or vm")
+		}
 
-func setFolderPath(folder, datacenter string) string {
-	if folder != "" && !strings.HasPrefix(folder, "/") {
-		localLogger.Warnf("folder as a non-path is now deprecated; please use the form: /%s/vm/%s", datacenter, folder)
-		return fmt.Sprintf("/%s/vm/%s", datacenter, folder)
+		joinedObjectFindPath = path.Join("/", datacenter, pathType, "...")
+		joinedObjectPath = path.Join("/", datacenter, pathType, objectPath)
+
+		if finder == nil {
+			localLogger.Warnf("%s as a non-path is now deprecated; please use the joined form: %s", paramName, joinedObjectPath)
+			return joinedObjectPath, nil
+		}
+
+		newObjectPath, err := findViaPathOrName(finder, joinedObjectPath, joinedObjectFindPath)
+		if err != nil {
+			return "", err
+		}
+
+		if objectPath != newObjectPath {
+			localLogger.Debugf("%s path changed from %s to %s", paramName, objectPath, newObjectPath)
+		}
+		localLogger.Warnf("%s as a non-path is now deprecated; please use the discovered form: %s", paramName, newObjectPath)
+
+		return newObjectPath, nil
 	}
-	return folder
+
+	return objectPath, nil
 }
 
 func createVCenters(platform *vsphere.Platform) {


### PR DESCRIPTION
In 4.12 and prior versions of the installer
allowed non-pathed names of vCenter objects.
In 4.13+ that is no longer allowed and absolute full paths are required.
This change is causing issues with ACM/Hive. The
only resolution (not ideal) is to connect
to vCenter and determine from potentially only the objects name to determine the absolute full path.