### PR TITLE
OCPBUGS-27156: GCP Destroy cleanup correct zones/records

### DIFF
--- a/pkg/asset/cluster/gcp/gcp.go
+++ b/pkg/asset/cluster/gcp/gcp.go
@@ -10,10 +10,16 @@ import (
 
 // Metadata converts an install configuration to GCP metadata.
 func Metadata(config *types.InstallConfig) *gcp.Metadata {
+	// leave the private zone domain blank when not using a pre-created private zone
+	privateZoneDomain := fmt.Sprintf("%s.", config.ClusterDomain())
+	if config.GCP.Network == "" || config.GCP.NetworkProjectID == "" {
+		privateZoneDomain = ""
+	}
+
 	return &gcp.Metadata{
 		Region:            config.Platform.GCP.Region,
 		ProjectID:         config.Platform.GCP.ProjectID,
 		NetworkProjectID:  config.Platform.GCP.NetworkProjectID,
-		PrivateZoneDomain: fmt.Sprintf("%s.", config.ClusterDomain()),
+		PrivateZoneDomain: privateZoneDomain,
 	}
 }


### PR DESCRIPTION


** The cluster domain was added to the metadata previously to find private zones that were not created by the installer. The records were added to a private zone in this domain. The problem occurs when clusters with the same name are used for installation. The infra ID is not used during the zone creation or zone lookup. The same zone (with the same domain) is assumed to be the one the installer (destroyer) is looking for. The fix includes skipping the addition of the domain to the metadata so that it is not used for comparison on destroy.