### PR TITLE
OCPBUGS-27788: PowerVS: COS region configurable

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -484,7 +484,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		vsphere.ConfigMasters(machines, clusterID.InfraID)
 	case powervstypes.Name:
-		mpool := defaultPowerVSMachinePoolPlatform()
+		mpool := defaultPowerVSMachinePoolPlatform(ic)
 		mpool.Set(ic.Platform.PowerVS.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.PowerVS)
 		// Only the service instance is guaranteed to exist and be passed via the install config

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -190,7 +190,19 @@ func osImage(config *types.InstallConfig) (string, error) {
 		}
 
 		if streamArch.Images.PowerVS != nil {
-			vpcRegion := powervs.Regions[config.Platform.PowerVS.Region].VPCRegion
+			var (
+				vpcRegion string
+				err       error
+			)
+			if config.Platform.PowerVS.VPCRegion != "" {
+				vpcRegion = config.Platform.PowerVS.VPCRegion
+			} else {
+				vpcRegion = powervs.Regions[config.Platform.PowerVS.Region].VPCRegion
+			}
+			vpcRegion, err = powervs.COSRegionForVPCRegion(vpcRegion)
+			if err != nil {
+				return "", fmt.Errorf("%s: No Power COS region found", st.FormatPrefix(archName))
+			}
 			img := streamArch.Images.PowerVS.Regions[vpcRegion]
 			logrus.Debug("Power VS using image ", img.Object)
 			return fmt.Sprintf("%s/%s", img.Bucket, img.Object), nil

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -110,36 +110,6 @@ func fetchUserDetails(bxSession *bxsession.Session, generation int) (*User, erro
 	return &user, nil
 }
 
-// GetRegion converts from a zone into a region.
-func GetRegion(zone string) (region string, err error) {
-	err = nil
-	switch {
-	case strings.HasPrefix(zone, "dal"), strings.HasPrefix(zone, "us-south"):
-		region = "us-south"
-	case strings.HasPrefix(zone, "sao"):
-		region = "sao"
-	case strings.HasPrefix(zone, "us-east"):
-		region = "us-east"
-	case strings.HasPrefix(zone, "tor"):
-		region = "tor"
-	case strings.HasPrefix(zone, "eu-de-"):
-		region = "eu-de"
-	case strings.HasPrefix(zone, "lon"):
-		region = "lon"
-	case strings.HasPrefix(zone, "syd"):
-		region = "syd"
-	case strings.HasPrefix(zone, "tok"):
-		region = "tok"
-	case strings.HasPrefix(zone, "osa"):
-		region = "osa"
-	case strings.HasPrefix(zone, "mon"):
-		region = "mon"
-	default:
-		return "", fmt.Errorf("region not found for the zone: %s", zone)
-	}
-	return
-}
-
 // ClusterUninstaller holds the various options for the cluster we want to delete.
 type ClusterUninstaller struct {
 	APIKey         string

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -74,9 +74,9 @@ type TFVarsSources struct {
 func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterConfig := sources.MasterConfigs[0]
 
-	cosRegion, err := powervstypes.VPCRegionForPowerVSRegion(sources.Region)
+	cosRegion, err := powervstypes.COSRegionForVPCRegion(sources.VPCRegion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find COS region for PowerVS region")
+		return nil, fmt.Errorf("failed to find COS region for VPC region")
 	}
 
 	var processor, dnsGUID string

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -14,6 +14,7 @@ import (
 type Region struct {
 	Description string
 	VPCRegion   string
+	COSRegion   string
 	Zones       []string
 	SysTypes    []string
 }
@@ -23,30 +24,35 @@ var Regions = map[string]Region{
 	"dal": {
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
+		COSRegion:   "us-south",
 		Zones:       []string{"dal10"},
 		SysTypes:    []string{"s922", "e980"},
 	},
 	"eu-de": {
 		Description: "Frankfurt, Germany",
 		VPCRegion:   "eu-de",
+		COSRegion:   "eu-de",
 		Zones:       []string{"eu-de-1", "eu-de-2"},
 		SysTypes:    []string{"s922", "e980"},
 	},
 	"mad": {
 		Description: "Madrid, Spain",
 		VPCRegion:   "eu-es",
+		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones:       []string{"mad02", "mad04"},
 		SysTypes:    []string{"s1022"},
 	},
 	"sao": {
 		Description: "São Paulo, Brazil",
 		VPCRegion:   "br-sao",
+		COSRegion:   "br-sao",
 		Zones:       []string{"sao04"},
 		SysTypes:    []string{"s922", "e980"},
 	},
 	"wdc": {
 		Description: "Washington DC, USA",
 		VPCRegion:   "us-east",
+		COSRegion:   "us-east",
 		Zones:       []string{"wdc06", "wdc07"},
 		SysTypes:    []string{"s922", "e980"},
 	},
@@ -135,4 +141,34 @@ func AllKnownSysTypes() sets.Set[string] {
 		sysTypes.Insert(region.SysTypes...)
 	}
 	return sysTypes
+}
+
+// COSRegionForVPCRegion returns the corresponding COS region for the given VPC region.
+func COSRegionForVPCRegion(vpcRegion string) (string, error) {
+	for r := range Regions {
+		if vpcRegion == Regions[r].VPCRegion {
+			return Regions[r].COSRegion, nil
+		}
+	}
+
+	return "", fmt.Errorf("COS region corresponding to a VPC region %s not found ", vpcRegion)
+}
+
+// COSRegionForPowerVSRegion returns the IBM COS region for the specified PowerVS region.
+func COSRegionForPowerVSRegion(region string) (string, error) {
+	if r, ok := Regions[region]; ok {
+		return r.COSRegion, nil
+	}
+
+	return "", fmt.Errorf("COS region corresponding to a PowerVS region %s not found ", region)
+}
+
+// ValidateCOSRegion validates that given COS region is known/tested.
+func ValidateCOSRegion(region string) bool {
+	for r := range Regions {
+		if region == Regions[r].COSRegion {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
In PowerVS, a region might not support COS objects.  Therefore, introduce a mapping.

Also, in making the Madrid region deployable, a number of bugs were found besides the big one of needing to use a different COS region.