### PR TITLE
Pass rhcosImage and mastersSchedulable to the PreProvision hook

### DIFF
--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/rhcos"
 )
 
 // Provider is the base interface that cloud platforms
@@ -26,8 +27,10 @@ type PreProvider interface {
 
 // PreProvisionInput collects the args passed to the PreProvision call.
 type PreProvisionInput struct {
-	InfraID       string
-	InstallConfig *installconfig.InstallConfig
+	InfraID            string
+	InstallConfig      *installconfig.InstallConfig
+	RhcosImage         *rhcos.Image
+	MastersSchedulable bool
 }
 
 // IgnitionProvider handles preconditions for bootstrap ignition and


### PR DESCRIPTION
OpenStack in particular needs:
* to upload the RHCOS image to the OpenStack image registry
* to change how security groups are set, depending on whether Control
  plane nodes are schedulable

Both operations happen in the PreProvision hook in the case of
OpenStack, because CAPO is not (yet) capable of performing them.

Alternative solution to https://github.com/openshift/installer/pull/7967