### PR TITLE
NO-ISSUE: test fix to support slightly different nmstate error messages

### DIFF
--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -155,7 +155,7 @@ func TestIgnition_addStaticNetworkConfig(t *testing.T) {
 					NetworkYaml: "interfaces:\n- ipv4:\n    address:\n    - ip: bad-ip\n      prefix-length: 24\n    enabled: true\n  mac-address: 52:54:01:aa:aa:a1\n  name: eth0\n  state: up\n  type: ethernet\n",
 				},
 			},
-			expectedError:    "failed to create StaticNetwork config data: failed to create static config for host 0: failed to execute 'nmstatectl gc', error: invalid IP address syntax",
+			expectedError:    ".*invalid IP address syntax",
 			expectedFileList: nil,
 		},
 	}


### PR DESCRIPTION
It looks like the error message for an invalid IP is slightly different between `nmstatectl` `2.2.23` (used in base rhel9) and `2.2.12` (used in base rhel8)
