### PR TITLE
AGENT-848: add node-joiner cli tool main

### DIFF
--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/installer/pkg/nodejoiner"
+)
+
+func main() {
+	wd, err := os.Getwd()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	nodesAddCmd := &cobra.Command{
+		Use:   "add-nodes",
+		Short: "Generates an ISO that could be used to boot the configured nodes to let them join an existing cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nodejoiner.NewAddNodesCommand(wd)
+		},
+	}
+
+	nodesMonitorCmd := &cobra.Command{
+		Use:   "monitor-add-nodes",
+		Short: "Monitors the configured nodes while they are joining an existing cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nodejoiner.NewMonitorAddNodesCommand(wd)
+		},
+	}
+
+	rootCmd := &cobra.Command{
+		Use: "node-joiner",
+	}
+
+	rootCmd.AddCommand(nodesAddCmd)
+	rootCmd.AddCommand(nodesMonitorCmd)
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -291,43 +291,10 @@ func newCreateCmd() *cobra.Command {
 	return cmd
 }
 
-func asFileWriter(a asset.WritableAsset) asset.FileWriter {
-	switch v := a.(type) {
-	case asset.FileWriter:
-		return v
-	default:
-		return asset.NewDefaultFileWriter(a)
-	}
-}
-
 func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
 	runner := func(directory string) error {
-		assetStore, err := assetstore.NewStore(directory)
-		if err != nil {
-			return errors.Wrap(err, "failed to create asset store")
-		}
-
-		for _, a := range targets {
-			err := assetStore.Fetch(a, targets...)
-			if err != nil {
-				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
-			}
-
-			err2 := asFileWriter(a).PersistToFile(directory)
-			if err2 != nil {
-				err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
-				if err != nil {
-					logrus.Error(err2)
-					return err
-				}
-				return err2
-			}
-
-			if err != nil {
-				return err
-			}
-		}
-		return nil
+		fetcher := assetstore.NewAssetsFetcher(directory)
+		return fetcher.FetchAndPersist(targets)
 	}
 
 	return func(cmd *cobra.Command, args []string) {

--- a/pkg/asset/store/assetsfetcher.go
+++ b/pkg/asset/store/assetsfetcher.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+// AssetsFetcher it's used to retrieve and resolve a specified set of assets.
+type AssetsFetcher interface {
+	// Fetchs and persists all the writable assets from the configured assets store.
+	FetchAndPersist(assets []asset.WritableAsset) error
+}
+
+type fetcher struct {
+	storeDir string
+}
+
+// NewAssetsFetcher creates a new AssetsFetcher instance for the specified assets store folder.
+func NewAssetsFetcher(storeDir string) AssetsFetcher {
+	return &fetcher{
+		storeDir: storeDir,
+	}
+}
+
+func asFileWriter(a asset.WritableAsset) asset.FileWriter {
+	switch v := a.(type) {
+	case asset.FileWriter:
+		return v
+	default:
+		return asset.NewDefaultFileWriter(a)
+	}
+}
+
+// Fetchs all the writable assets from the configured assets store.
+func (f *fetcher) FetchAndPersist(assets []asset.WritableAsset) error {
+	assetStore, err := NewStore(f.storeDir)
+	if err != nil {
+		return fmt.Errorf("failed to create asset store: %w", err)
+	}
+
+	for _, a := range assets {
+		err := assetStore.Fetch(a, assets...)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to fetch %s", a.Name())
+		}
+
+		err2 := asFileWriter(a).PersistToFile(f.storeDir)
+		if err2 != nil {
+			err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
+			if err != nil {
+				logrus.Error(err2)
+				return err
+			}
+			return err2
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -1,0 +1,12 @@
+package nodejoiner
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/store"
+)
+
+// NewAddNodesCommand creates a new command for add nodes.
+func NewAddNodesCommand(directory string) error {
+	fetcher := store.NewAssetsFetcher(directory)
+	return fetcher.FetchAndPersist([]asset.WritableAsset{})
+}

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -1,0 +1,12 @@
+package nodejoiner
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/store"
+)
+
+// NewMonitorAddNodesCommand creates a new command for monitor add nodes.
+func NewMonitorAddNodesCommand(directory string) error {
+	fetcher := store.NewAssetsFetcher(directory)
+	return fetcher.FetchAndPersist([]asset.WritableAsset{})
+}


### PR DESCRIPTION
This patch introduces the node-joiner tool main with (empty) commands entry points. Since the commands will reuse the existing assets, a new `AssetsFetcher` interface and struct has been introduced to allow sharing the same asset fetcher code already used by the `create` and `agent` commands in the default installer.