### PR TITLE
OCPBUGS-28705: [azure] update tested x86 instance type on 4.15

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -48,6 +48,7 @@
 * `standardGSFamily`
 * `standardHBrsv2Family`
 * `standardHBSFamily`
+* `standardHBv4Family`
 * `standardHCSFamily`
 * `standardHXFamily`
 * `standardLASv3Family`
@@ -55,10 +56,12 @@
 * `standardLSv2Family`
 * `standardLSv3Family`
 * `standardMDSMediumMemoryv2Family`
+* `standardMDSMediumMemoryv3Family`
 * `standardMIDSMediumMemoryv2Family`
 * `standardMISMediumMemoryv2Family`
 * `standardMSFamily`
 * `standardMSMediumMemoryv2Family`
+* `standardMSMediumMemoryv3Family`
 * `StandardNCADSA100v4Family`
 * `Standard NCASv3_T4 Family`
 * `standardNCSv3Family`


### PR DESCRIPTION
Doc updates:

add new families which are verified on 4.15 nightly build:
- standardHBv4Family
- standardMDSMediumMemoryv3Family
- standardMSMediumMemoryv3Family