### PR TITLE
OCPBUGS-28708: update tested Azure Arm64 instance type on 4.15

### DIFF
--- a/docs/user/azure/tested_instance_types_aarch64.md
+++ b/docs/user/azure/tested_instance_types_aarch64.md
@@ -1,3 +1,4 @@
+* `standardBpsv2Family`
 * `standardDPSv5Family`
 * `standardDPDSv5Family`
 * `standardDPLDSv5Family`


### PR DESCRIPTION
Docs update:

add new Arm64 families which are verified on 4.15 nightly build:

- standardBpsv2Family