### PR TITLE
SPLAT-1434: aws: add support of BYO public ipv4 pool

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -249,3 +249,11 @@ resource "aws_security_group_rule" "bootstrap_journald_gateway" {
   from_port   = 19531
   to_port     = 19531
 }
+
+resource "aws_eip" "bootstrap" {
+  domain           = "vpc"
+  instance         = aws_instance.bootstrap.id
+  public_ipv4_pool = var.aws_public_ipv4_pool == "" ? null : var.aws_public_ipv4_pool
+
+  depends_on = [aws_instance.bootstrap]
+}

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -109,6 +109,8 @@ module "vpc" {
   edge_parent_gw_map = var.aws_edge_parent_zones_index
   edge_zones_type    = var.aws_edge_zones_type
 
+  public_ipv4_pool = var.aws_public_ipv4_pool
+
   tags = local.tags
 }
 

--- a/data/data/aws/cluster/vpc/variables.tf
+++ b/data/data/aws/cluster/vpc/variables.tf
@@ -60,3 +60,8 @@ variable "private_subnets" {
   type        = list(string)
   description = "Existing private subnets into which the cluster should be installed."
 }
+
+variable "public_ipv4_pool" {
+  type        = string
+  description = "An Public IPv4 Pool"
+}

--- a/data/data/aws/cluster/vpc/vpc-public.tf
+++ b/data/data/aws/cluster/vpc/vpc-public.tf
@@ -95,6 +95,8 @@ resource "aws_eip" "nat_eip" {
   count = var.public_subnets == null ? length(var.availability_zones) : 0
   vpc   = true
 
+  public_ipv4_pool = var.public_ipv4_pool == "" ? null : var.public_ipv4_pool
+
   tags = merge(
     {
       "Name" = "${var.cluster_id}-eip-${var.availability_zones[count.index]}"

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -227,3 +227,15 @@ a Public Route Table and the default route entry pointing to the carrier gateway
 Example: `{ "us-east-1-nyc-1a"=local-zone, "us-east-1-wl1-nyc-wlz-1"=wavelength-zone }`
 EOF
 }
+
+variable "aws_public_ipv4_pool" {
+  type = string
+
+  description = <<EOF
+(optional) Indicates the installation process to use Public IPv4 address
+that you bring to your AWS account with BYOIP to create resources which consumes
+Elastic IPs when the publish strategy is External.
+EOF
+
+  default = ""
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2287,6 +2287,11 @@ spec:
                       operators to include the specified user tags in the tags of
                       the AWS resources that the operators create.
                     type: boolean
+                  publicIpv4Pool:
+                    description: PublicIpv4Pool is an optional field that can be used
+                      to tell the installation process to use Public IPv4 address
+                      that you bring to your AWS account with BYOIP.
+                    type: string
                   region:
                     description: Region specifies the AWS region where the cluster
                       will be created.

--- a/docs/user/aws/custom_public_ipv4.md
+++ b/docs/user/aws/custom_public_ipv4.md
@@ -1,0 +1,38 @@
+# Install OpenShift on AWS using custom/owned Public IPv4 Pool
+
+Steps to create a cluster on AWS using Public IPv4 address pool
+that you bring to your AWS account with BYOIP.
+
+## Prerequisites
+
+- Public IPv4 Pool Provisioned in the Account
+- Total of ( (Zones*3 ) + 1) of Public IPv4 available in the pool, where: Zones is the total numbber of AWS zones used to deploy the OpenShift cluster.
+    - Example to query the IPv4 pools available in the account, which returns the  `TotalAvailableAddressCount`:
+```
+aws ec2 describe-public-ipv4-pools --region us-east-1
+```
+
+## Steps
+
+- Create the install config setting the field `platform.aws.publicIpv4PoolId`, and create the cluster:
+
+```yaml
+apiVersion: v1
+baseDomain: ${CLUSTER_BASE_DOMAIN}
+metadata:
+  name: ocp-byoip
+platform:
+  aws:
+    region: ${REGION}
+    publicIpv4Pool: ipv4pool-ec2-123456789abcde
+publish: External
+pullSecret: '...'
+sshKey: |
+  '...'
+```
+
+- Create the cluster
+
+```sh
+openshift-install create cluster
+```

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -333,6 +333,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Proxy:                     installConfig.Config.Proxy,
 			PreserveBootstrapIgnition: installConfig.Config.AWS.PreserveBootstrapIgnition,
 			MasterSecurityGroups:      securityGroups,
+			PublicIpv4Pool:            installConfig.Config.AWS.PublicIpv4Pool,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/installconfig/aws/ec2.go
+++ b/pkg/asset/installconfig/aws/ec2.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,4 +28,25 @@ func DescribeSecurityGroups(ctx context.Context, session *session.Session, secur
 		return nil, err
 	}
 	return sgOutput.SecurityGroups, nil
+}
+
+// DescribePublicIpv4Pool returns the ec2 public IPv4 Pool attributes from the given ID.
+func DescribePublicIpv4Pool(ctx context.Context, session *session.Session, region string, poolID string) (*ec2.PublicIpv4Pool, error) {
+	client := ec2.New(session, aws.NewConfig().WithRegion(region))
+
+	cctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	poolOutputs, err := client.DescribePublicIpv4PoolsWithContext(cctx, &ec2.DescribePublicIpv4PoolsInput{PoolIds: []*string{aws.String(poolID)}})
+	if err != nil {
+		return nil, err
+	}
+	if len(poolOutputs.PublicIpv4Pools) == 0 {
+		return nil, fmt.Errorf("public IPv4 Pool not found: %s", poolID)
+	}
+	// it should not happen
+	if len(poolOutputs.PublicIpv4Pools) > 1 {
+		return nil, fmt.Errorf("more than one Public IPv4 Pool: %s", poolID)
+	}
+	return poolOutputs.PublicIpv4Pools[0], nil
 }

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -807,6 +807,17 @@ func TestValidate(t *testing.T) {
 		publicSubnets:  validPublicSubnets(),
 		proxy:          "http://proxy.com",
 		expectErr:      `^\Qplatform.aws.serviceEndpoints[0].url: Invalid value: "http://test": Head "http://test": dial tcp: lookup test\E.*: no such host$`,
+	}, {
+		name: "invalid public ipv4 pool private installation",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfig()
+			c.Publish = types.InternalPublishingStrategy
+			c.Platform.AWS.PublicIpv4Pool = "ipv4pool-ec2-123"
+			c.Platform.AWS.Subnets = []string{}
+			return c
+		}(),
+		availZones: validAvailZones(),
+		expectErr:  `^platform.aws.publicIpv4PoolId: Invalid value: "ipv4pool-ec2-123": publish strategy Internal can't be used with custom Public IPv4 Pools$`,
 	}}
 
 	for _, test := range tests {

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -179,6 +179,9 @@ func Test_PrintFields(t *testing.T) {
     propagateUserTags <boolean>
       PropagateUserTags is a flag that directs in-cluster operators to include the specified user tags in the tags of the AWS resources that the operators create.
 
+    publicIpv4Pool <string>
+      PublicIpv4Pool is an optional field that can be used to tell the installation process to use Public IPv4 address that you bring to your AWS account with BYOIP.
+
     region <string> -required-
       Region specifies the AWS region where the cluster will be created.
 

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -49,6 +49,7 @@ type Config struct {
 	BootstrapMetadataAuthentication string            `json:"aws_bootstrap_instance_metadata_authentication,omitempty"`
 	PreserveBootstrapIgnition       bool              `json:"aws_preserve_bootstrap_ignition"`
 	MasterSecurityGroups            []string          `json:"aws_master_security_groups,omitempty"`
+	PublicIpv4Pool                  string            `json:"aws_public_ipv4_pool"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -80,6 +81,8 @@ type TFVarsSources struct {
 	PreserveBootstrapIgnition bool
 
 	MasterSecurityGroups []string
+
+	PublicIpv4Pool string
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
@@ -207,6 +210,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		WorkerIAMRoleName:         sources.WorkerIAMRoleName,
 		PreserveBootstrapIgnition: sources.PreserveBootstrapIgnition,
 		MasterSecurityGroups:      sources.MasterSecurityGroups,
+		PublicIpv4Pool:            sources.PublicIpv4Pool,
 	}
 
 	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle, sources.Proxy)

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -106,6 +106,11 @@ type Platform struct {
 	// during bootstrap destroy.
 	// +optional
 	PreserveBootstrapIgnition bool `json:"preserveBootstrapIgnition,omitempty"`
+
+	// PublicIpv4Pool is an optional field that can be used to tell the installation process to use
+	// Public IPv4 address that you bring to your AWS account with BYOIP.
+	// +optional
+	PublicIpv4Pool string `json:"publicIpv4Pool,omitempty"`
 }
 
 // ServiceEndpoint store the configuration for services to


### PR DESCRIPTION
Introduce support of AWS BYO IPv4 (Public IPv4 Pool) when creating clusters with publish strategy `External`.

The Public IPv4 Pool is an alternative for customers to mitigate the new AWS charges for Public IPv4 (Elastic IPs) ,provided by Amazon, when the customer has the custom IPv4 pools managed by AWS.

Refs:
- https://issues.redhat.com/browse/SPLAT-1434
- https://issues.redhat.com/browse/OCPSTRAT-1154
- https://github.com/openshift/release/pull/48467