### PR TITLE
OCPBUGS-29114: Fixed control plane machine set handling of static IPs when AddressesFromPools is not in use.

### DIFF
--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -136,12 +136,19 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		vsphereMachineProvider.Template = ""
 	}
 
+	// Only set AddressesFromPools and Nameservers if AddressesFromPools is > 0, else revert to
+	// the older static IP manifest way.
 	if len(hosts) > 0 {
-		vsphereMachineProvider.Network.Devices = []machineapi.NetworkDeviceSpec{
-			{
-				AddressesFromPools: origProv.Network.Devices[0].AddressesFromPools,
-				Nameservers:        origProv.Network.Devices[0].Nameservers,
-			},
+		if len(origProv.Network.Devices[0].AddressesFromPools) > 0 {
+			vsphereMachineProvider.Network.Devices = []machineapi.NetworkDeviceSpec{
+				{
+					AddressesFromPools: origProv.Network.Devices[0].AddressesFromPools,
+					Nameservers:        origProv.Network.Devices[0].Nameservers,
+				},
+			}
+		} else {
+			// Older static IP config, lets remove network since it'll come from FD
+			vsphereMachineProvider.Network = machineapi.NetworkSpec{}
 		}
 	}
 


### PR DESCRIPTION
[OCPBUGS-29114](https://issues.redhat.com/browse/OCPBUGS-29114)

## Changes
- Fixed logic to set AddressesFromPools and Nameservers only if AddressesFromPools > 0.  Else Nameservers will get set when hosts > 0 but installer is not using AdressesFromPools.