### PR TITLE
OCPBUGS-28870: IBMCloud: Restrict CIS and DNS Service lookup

### DIFF
--- a/pkg/asset/installconfig/ibmcloud/metadata_test.go
+++ b/pkg/asset/installconfig/ibmcloud/metadata_test.go
@@ -178,7 +178,12 @@ func baseMetadata() *Metadata {
 				Region: region,
 			},
 		},
+		Publish: types.ExternalPublishingStrategy,
 	})
+}
+
+func setInternalPublishingStrategy(m *Metadata) {
+	m.publishStrategy = types.InternalPublishingStrategy
 }
 
 func TestAccountID(t *testing.T) {
@@ -406,6 +411,7 @@ func TestDNSInstance(t *testing.T) {
 	for _, tCase := range testCases {
 		t.Run(tCase.name, func(t *testing.T) {
 			metadata := baseMetadata()
+			setInternalPublishingStrategy(metadata)
 			metadata.client = ibmcloudClient
 			for _, edit := range tCase.edits {
 				edit(metadata)
@@ -438,6 +444,7 @@ func TestSetDNSInstance(t *testing.T) {
 	for _, tCase := range testCases {
 		t.Run(tCase.name, func(t *testing.T) {
 			metadata := baseMetadata()
+			setInternalPublishingStrategy(metadata)
 
 			metadata.dnsInstance = &DNSInstance{
 				ID:  tCase.dnsID,


### PR DESCRIPTION
Restrict when the CIS and DNS Service instances are looked up in IBM Cloud, based on the PublishingStrategy, CIS for External, DNS Services for Internal. Preventing a baseDomain in each service resulting in both instances being found for metadata generation.

Related: https://issues.redhat.com/browse/OCPBUGS-28870