### PR TITLE
NO-ISSUE: integrationt tests support for env vars substitution

### DIFF
--- a/cmd/openshift-install/agent_internal_integration_test.go
+++ b/cmd/openshift-install/agent_internal_integration_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/vincent-petithory/dataurl"
+
+	"github.com/openshift/installer/pkg/asset/releaseimage"
 )
 
 // This file contains a number of functions useful for
@@ -101,6 +103,14 @@ func runIntegrationTest(t *testing.T, testFolder string) {
 				}
 			}
 
+			// Let's get the current release version, so that
+			// it could be used within the tests
+			pullspec, err := releaseimage.Default()
+			if err != nil {
+				return err
+			}
+			e.Vars = append(e.Vars, fmt.Sprintf("RELEASE_IMAGE=%s", pullspec))
+
 			return nil
 		},
 
@@ -111,6 +121,7 @@ func runIntegrationTest(t *testing.T, testFolder string) {
 			"initrdImgContains":       initrdImgContains,
 			"unconfiguredIgnContains": unconfiguredIgnContains,
 			"unconfiguredIgnCmp":      unconfiguredIgnCmp,
+			"expandFile":              expandFile,
 		},
 	})
 }
@@ -157,7 +168,6 @@ func archiveFileNames(isoPath string) (string, string, error) {
 	return "", "", errors.NotFound(fmt.Sprintf("ISO %s has unrecognized prefix", isoPath))
 }
 
-// [!] ignitionContains `isoPath` `file` check if the specified file `file`
 // [!] unconfiguredIgnContains `file` check if the specified file `file`
 // is stored within the unconfigured ignition Storage Files.
 func unconfiguredIgnContains(ts *testscript.TestScript, neg bool, args []string) {
@@ -200,6 +210,7 @@ func ignitionStorageContains(ts *testscript.TestScript, neg bool, args []string)
 // [!] isoCmp `isoPath` `isoFile` `expectedFile` check that the content of the file
 // `isoFile` - extracted from the ISO embedded configuration file referenced
 // by `isoPath` - matches the content of the local file `expectedFile`.
+// Environment variables in in `expectedFile` are substituted before the comparison.
 func isoCmp(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) != 3 {
 		ts.Fatalf("usage: isocmp isoPath file1 file2")
@@ -227,6 +238,7 @@ func isoCmp(ts *testscript.TestScript, neg bool, args []string) {
 // [!] unconfiguredIgnCmp `fileInIgn` `expectedFile` check that the content
 // of the file `fileInIgn` extracted from the unconfigured ignition
 // configuration file matches the content of the local file `expectedFile`.
+// Environment variables in in `expectedFile` are substituted before the comparison.
 func unconfiguredIgnCmp(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) != 2 {
 		ts.Fatalf("usage: iunconfiguredIgnCmp file1 file2")
@@ -238,6 +250,7 @@ func unconfiguredIgnCmp(ts *testscript.TestScript, neg bool, args []string) {
 // [!] ignitionStorageCmp `ignPath` `ignFile` `expectedFile` check that the content of the file
 // `ignFile` - extracted from the ignition configuration file referenced
 // by `ignPath` - matches the content of the local file `expectedFile`.
+// Environment variables in in `expectedFile` are substituted before the comparison.
 func ignitionStorageCmp(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) != 3 {
 		ts.Fatalf("usage: ignitionStorageCmp ignPath file1 file2")
@@ -267,9 +280,34 @@ func readIgnition(ts *testscript.TestScript, ignPath string) (config igntypes.Co
 	return config, err
 }
 
+// [!] expandFile `file...` can be used to substitute environment variables
+// references for each file specified
+func expandFile(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) != 1 {
+		ts.Fatalf("usage: expandFile file...")
+	}
+
+	workDir := ts.Getenv("WORK")
+	for _, f := range args {
+		fileName := filepath.Join(workDir, f)
+		data, err := os.ReadFile(fileName)
+		ts.Check(err)
+
+		newData := expand(ts, data)
+		err = os.WriteFile(fileName, []byte(newData), 0)
+		ts.Check(err)
+	}
+}
+
+func expand(ts *testscript.TestScript, s []byte) string {
+	return os.Expand(string(s), func(key string) string {
+		return ts.Getenv(key)
+	})
+}
+
 func byteCompare(ts *testscript.TestScript, neg bool, aData, eData []byte, aFilePath, eFilePath string) {
 	aText := string(aData)
-	eText := string(eData)
+	eText := expand(ts, eData)
 
 	eq := aText == eText
 	if neg {

--- a/cmd/openshift-install/agent_internal_integration_test.go
+++ b/cmd/openshift-install/agent_internal_integration_test.go
@@ -210,7 +210,7 @@ func ignitionStorageContains(ts *testscript.TestScript, neg bool, args []string)
 // [!] isoCmp `isoPath` `isoFile` `expectedFile` check that the content of the file
 // `isoFile` - extracted from the ISO embedded configuration file referenced
 // by `isoPath` - matches the content of the local file `expectedFile`.
-// Environment variables in in `expectedFile` are substituted before the comparison.
+// Environment variables in `expectedFile` are substituted before the comparison.
 func isoCmp(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) != 3 {
 		ts.Fatalf("usage: isocmp isoPath file1 file2")
@@ -281,7 +281,7 @@ func readIgnition(ts *testscript.TestScript, ignPath string) (config igntypes.Co
 }
 
 // [!] expandFile `file...` can be used to substitute environment variables
-// references for each file specified
+// references for each file specified.
 func expandFile(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) != 1 {
 		ts.Fatalf("usage: expandFile file...")

--- a/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
@@ -100,7 +100,7 @@ metadata:
   name: openshift-was not built correctly
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 status: {}
 -- expected/pull-secret.yaml --
 apiVersion: v1

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -101,7 +101,7 @@ metadata:
   name: openshift-was not built correctly
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 status: {}
 -- expected/infraenv.yaml --
 metadata:

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/configurations/from-ztp-manifests.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/configurations/from-ztp-manifests.txt
@@ -3,6 +3,8 @@
 # and not using
 # install-config.yaml and agent-config.yaml.
 
+expandFile cluster-manifests/cluster-image-set.yaml
+
 exec openshift-install agent create unconfigured-ignition --dir $WORK
 
 exists $WORK/unconfigured-agent.ign
@@ -45,14 +47,14 @@ metadata:
   name: cluster0-image-set
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 
 -- expected/cluster-image-set.yaml --
 metadata:
   name: cluster0-image-set
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 
 -- expected/infraenv.yaml --
 metadata:

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/manifests/default_manifests.txt
@@ -53,7 +53,7 @@ metadata:
   name: openshift-was not built correctly
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 status: {}
 -- expected/infraenv.yaml --
 metadata:

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-cluster-image-set-allowed.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-cluster-image-set-allowed.txt
@@ -44,5 +44,5 @@ metadata:
   creationTimestamp: null
   name: openshift-was not built correctly
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 status: {}

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-infraenv.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-infraenv.txt
@@ -1,5 +1,7 @@
 # Missing infraenv.yaml should be detected.
 
+expandFile cluster-manifests/cluster-image-set.yaml
+
 ! exec openshift-install agent create unconfigured-ignition --dir $WORK
 
 stderr 'failed to generate asset "InfraEnv Config": missing configuration or manifest file'
@@ -13,7 +15,7 @@ metadata:
   name: cluster0-image-set
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 
 -- cluster-manifests/pull-secret.yaml --
 apiVersion: v1

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-pull-secret.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/validations/missing-pull-secret.txt
@@ -1,5 +1,7 @@
 # Missing pull-secret.yaml should be detected.
 
+expandFile cluster-manifests/cluster-image-set.yaml
+
 ! exec openshift-install agent create unconfigured-ignition --dir $WORK
 
 stderr 'failed to generate asset "Agent PullSecret": missing configuration or manifest file'
@@ -23,5 +25,5 @@ metadata:
   name: cluster0-image-set
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.14
+  releaseImage: $RELEASE_IMAGE
 


### PR DESCRIPTION
This patch modifies the integration tests custom comparison functions to allow env vars substitutions into the expected file (in a similar fashion to the standard testscript [cmpenv](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) function).

A new custom function `expandFile` has been added to allow en var replacement for the actual files.

In addition, it adds the `RELEASE_IMAGE` env var to the integration tests execution environment referring the current release image pullspec. This will allow to avoid hard-coding the release image pullspec in the integration tests, which is causing a test failure every time the default release image is updated.

Relates to https://github.com/openshift/installer/pull/7874