### PR TITLE
OCPBUGS-28590: gcp: better error msg when service accnt missing

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -168,6 +168,12 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 				return nil, err
 			}
 
+			// The JSON can be `nil` if auth is provided from env
+			// https://pkg.go.dev/golang.org/x/oauth2@v0.17.0/google#Credentials
+			if len(sess.Credentials.JSON) == 0 {
+				return nil, fmt.Errorf("could not extract service account from loaded credentials. Please specify a service account to be used for shared vpc installations in the install-config.yaml")
+			}
+
 			var found bool
 			serviceAccount := make(map[string]interface{})
 			err = json.Unmarshal(sess.Credentials.JSON, &serviceAccount)


### PR DESCRIPTION
The JSON object is not set when the credentials are loaded from the cli, resulting in an unhelpful message about "unexpected end of JSON input". Let's provide a better error message in that case.