### PR TITLE
CORS-3026: CAPI Installation Platform Onboarding docs

### DIFF
--- a/cluster-api/providers/README.md
+++ b/cluster-api/providers/README.md
@@ -1,0 +1,42 @@
+# Cluster API Infrastructure Providers
+
+This directory contains the Cluster API infrastructure providers leveraged
+by the Installer to provision cluster infrastructure without an external
+control plane.
+
+## Adding a new terraform provider
+
+To add a new Cluster API provider, create a directory under ./cluster-api/providers. For example, if you want to add a
+provider named mycloud, then you would create the ./cluster-api/providers/mycloud directory.
+
+Create a tools.go file with an unnamed import to the main package of the provider. 
+Add a go.mod file with a require statement to the provider module.
+
+For example, let's say that you are adding the mycloud provider. The mycloud provider is in the
+github.com/openshift/cluster-api-provider-mycloud repository. The main package is
+github.com/openshift/cluster-api-provider-mycloud. The version is v1.2.3.
+
+```go
+// ./cluster-api/providers/mycloud/tools.go
+package main
+
+import (
+	_ "github.com/openshift/cluster-api-provider-mycloud"
+)
+```
+
+```go
+// ./cluster-api/providers/mycloud/go.mod
+module github.com/openshift/installer/cluster-api/providers/mycloud
+
+go 1.20
+
+require github.com/openshift/cluster-api-provider-mycloud v1.2.3
+```
+
+After creating the directory and adding the tools.go and go.mod file, run the following command.
+1. `make -C terraform go-mod-tidy-vendor.mycloud`
+
+When there is a tools.go file, the Makefile will build the provider from the package referenced in the unnamed
+import in the tools.go file. For the example mycloud provider, the provider will be built from the
+./cluster-api/providers/mycloud/vendor/github.com/openshift/cluster-api-provider-mycloud directory.

--- a/docs/dev/cluster-api.md
+++ b/docs/dev/cluster-api.md
@@ -1,6 +1,7 @@
 # Cluster API
 
 The installer uses Cluster API controllers through a local control plane powered by `kube-apiserver` and `etcd` running locally.
+For more details, see the [enhancement][enhancement].
 
 ### Local control plane
 
@@ -33,3 +34,96 @@ To build an `openshift-install` binary with Cluster API bundled:
 - Set `export OPENSHIFT_INSTALL_CLUSTER_API=y`
     - Optionally `export SKIP_TERRAFORM=y` if you don't need to use Terraform.
 - Run `./hack/build.sh`, the binary is then produced in `bin/openshift-install`.
+
+### Platform Onboarding
+
+This is a general guide for onboarding a new platform to provision infrastructure with cluster api.
+
+#### CAPI Cloud Provider Controller Dependencies
+
+Providers are vendored to [`cluster-api/providers/<name>`][providerDir]. The README contains
+detailed guidelines on how to vendor a new platform.
+
+#### CAPI Cloud Provider CRDs
+
+To add the CRDs for the CAPI cloud provider to the local control plane, add them to the
+[`/data/data/cluster-api`][crdDir] dir. Typically these CRDs are published as an
+`infrastructure-components.yaml` file as part of the release of the CAPI controller. The
+yaml files in this directory will automatically be added to the Installer's local
+control plane.
+
+#### Run the CAPI Controller
+
+In order for the Installer to run the controller, which was added in a previous step, add
+the details for the controller in [this switch case in pkg/clusterapi/system.go][runController].
+The controller will be unpacked and run based on the provider name; flags and environment variables
+can be specified.
+
+#### Create Cluster API Manifests
+
+Next you need to add manifests to configure the infrastructure provisioned by the provider. The
+cluster and any additional non-machine manifests should be added to platform-specific subpackages
+of the `manifests` package. Introduce your platform in the [platform switch statement][clusterManifests]
+and then add your implementation (see [AWS for an example][awsCluster].)
+
+Machine manifests should be added similarly but in the [machines package][machineManifests]. If there is
+existing code for your platform to generate master machines, it will serve as a good foundation for
+generating these manifests. Note that when generating machine manifests, there will be a pair:
+a general CAPI machine manifest, which handles the common bootstrapping pattern, and a platform-specific
+machine manifest. [AWS machine manifests][awsMachines] offer an example.
+
+NOTE: At the time of writing, the Installer will not produce manifests when you run
+`openshift-install create manifests`. You can enable the Installer to write these to disk by adding
+the `&clusterapi.Cluster{}` and the `&machines.ClusterAPI{}` targets in the [`manifests`][manifestsTarget],
+similar to this [PR][manifestsPR]. This functionality has not merged yet, because it has been buggy
+when running `create manifests` in conjunction with `create cluster`.
+
+#### Implement Cluster API Provider Interface
+
+Finally, add a [cluster-api provider interface][capiInterface] implementation for the platform. Initially
+it should be fine to create an empty, simple provider which only implements the simple interface. Add
+your new provider, behind a feature gate, to the [platform.go switch][platform] and add the exact
+same code in [platform_altinfra.go][altinfra]. Make sure to use the `FeatureGateInstallClusterAPI`
+feature gate:
+
+```go
+		if fg.Enabled(configv1.FeatureGateInstallClusterAPI) {
+            //return interface implementation
+		}
+```
+
+The `platform_altinfra.go` file uses a build tag to produce a separate altinfra image, which is
+free of Terraform. We are also using this to expedite testing of cluster API while we implement
+build dependencies needed in the main installer image.
+
+#### Extend Cluster API Provider Interface
+
+Once the "empty" provider is in place, that should be sufficient to allow the Installer to
+apply the cluster API manifests and start provisioning resources! The Installer defines
+additional hooks which you can implement in the provider to setup additional prerequisites
+or provision resources out of band. The enhancement discusses this in more detail. Here is a
+summary from the enhancement which describes the hooks, and how they run in relation to
+the CAPI provisioning:
+
+* PreProvision Hook - handle prequisites: e.g. IAM role creation, OS Disk upload
+* Provision Infrastructure - create `cluster` manifest on local control plane
+* InfraReady Hook - handle requirements in between cluster infrastructure and machine provisioning
+* Ignition Hook - similar to InfraReady but specifically for generating (bootstrap) ignition
+* Provision Machines - create bootstrap ignition and control-plane machines
+* PostProvision Hook - post-provision requirements, such as DNS record creation
+
+You can extend your platform implementation to implement these hooks as needed.
+
+[enhancement]: https://github.com/openshift/enhancements/pull/1528 #TODO(padillon): update when merged
+[providerDir]: https://github.com/openshift/installer/tree/master/cluster-api/providers
+[crdDir]: https://github.com/openshift/installer/tree/master/data/data/cluster-api
+[runController]: https://github.com/openshift/installer/blob/master/pkg/clusterapi/system.go#L120
+[clusterManifests]: https://github.com/openshift/installer/blob/master/pkg/asset/manifests/clusterapi/cluster.go
+[awsCluster]: https://github.com/openshift/installer/blob/master/pkg/asset/manifests/aws/cluster.go
+[machineManifests]: https://github.com/openshift/installer/blob/master/pkg/asset/machines/clusterapi.go
+[awsMachines]: https://github.com/openshift/installer/blob/master/pkg/asset/machines/aws/awsmachines.go
+[manifestsTarget]: https://github.com/openshift/installer/blob/master/pkg/asset/targets/targets.go#L26
+[manifestsPR]: https://github.com/openshift/installer/pull/7774/files
+[capiInterface]: https://github.com/openshift/installer/blob/master/pkg/infrastructure/clusterapi/types.go#L15-L18
+[platform]: https://github.com/openshift/installer/blob/master/pkg/infrastructure/platform/platform.go
+[altinfra]: https://github.com/openshift/installer/blob/master/pkg/infrastructure/platform/platform_altinfra.go


### PR DESCRIPTION
Adds a developer guide for onboarding a new platform to the cluster-api provisioning flow.