### PR TITLE
CORS-2890: aws/machines: add CAPI sg, subnet filters

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -201,7 +201,8 @@ func provider(in *machineProviderInput) (*machineapi.AWSMachineProviderConfig, e
 	if in.role == "master" {
 		cpFilter := machineapi.Filter{
 			Name:   "tag:Name",
-			Values: []string{fmt.Sprintf("%s-controlplane", in.clusterID)}}
+			Values: []string{fmt.Sprintf("%s-controlplane", in.clusterID)},
+		}
 		sgFilters = append(sgFilters, cpFilter)
 	}
 


### PR DESCRIPTION
Adds filters to the machine api machinesets so they will recognize CAPI-created security groups and subnets. Adds these filters in addition to the Terraform-specific filters, which should be subsequently removed.