### PR TITLE
no-jira: images: libvirt: add oc to libvirt CI image

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -1,5 +1,6 @@
 # This Dockerfile is a used by CI to publish an installer image for creating libvirt clusters
-# It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
+# It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments and
+# oc for getting assets from an existing cluster to spin up multi-architecture compute clusters on libvirt.
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers as providers
 
@@ -12,10 +13,13 @@ COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
+FROM registry.ci.openshift.org/ocp/4.16:cli as cli
+
 FROM quay.io/centos/centos:stream
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+COPY --from=cli /usr/bin/oc /bin/oc
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
For multi-architecture compute deployments for s390x on libvirt, we need to extract cluster state and correct assets for spinning up nodes on a second architecture via oc, then spin up nodes with libvirt client. oc can be helpful for this purpose.

This is analogous to the UPI installer image (images/installer/Dockerfile.upi.ci#L14,L20)