### PR TITLE
OCPBUGS-29425: PowerVS Fix next start search

### DIFF
--- a/pkg/destroy/powervs/cloud-sshkey.go
+++ b/pkg/destroy/powervs/cloud-sshkey.go
@@ -75,12 +75,19 @@ func (o *ClusterUninstaller) listCloudSSHKeys() (cloudResources, error) {
 			o.Logger.Debugf("listCloudSSHKeys: Limit = %v", *sshKeyCollection.Limit)
 		}
 		if sshKeyCollection.Next != nil {
-			o.Logger.Debugf("listCloudSSHKeys: Next = %v", *sshKeyCollection.Next.Href)
-			listKeysOptions.SetStart(*sshKeyCollection.Next.Href)
+			start, err := sshKeyCollection.GetNextStart()
+			if err != nil {
+				o.Logger.Debugf("listCloudSSHKeys: err = %v", err)
+				return nil, fmt.Errorf("listCloudSSHKeys: failed to GetNextStart: %w", err)
+			}
+			if start != nil {
+				o.Logger.Debugf("listCloudSSHKeys: start = %v", *start)
+				listKeysOptions.SetStart(*start)
+			}
+		} else {
+			o.Logger.Debugf("listCloudSSHKeys: Next = nil")
+			moreData = false
 		}
-
-		moreData = sshKeyCollection.Next != nil
-		o.Logger.Debugf("listCloudSSHKeys: moreData = %v", moreData)
 	}
 	if !foundOne {
 		o.Logger.Debugf("listCloudSSHKeys: NO matching sshKey against: %s", o.InfraID)
@@ -104,11 +111,19 @@ func (o *ClusterUninstaller) listCloudSSHKeys() (cloudResources, error) {
 				o.Logger.Debugf("listCloudSSHKeys: Limit = %v", *sshKeyCollection.Limit)
 			}
 			if sshKeyCollection.Next != nil {
-				o.Logger.Debugf("listCloudSSHKeys: Next = %v", *sshKeyCollection.Next.Href)
-				listKeysOptions.SetStart(*sshKeyCollection.Next.Href)
+				start, err := sshKeyCollection.GetNextStart()
+				if err != nil {
+					o.Logger.Debugf("listCloudSSHKeys: err = %v", err)
+					return nil, fmt.Errorf("listCloudSSHKeys: failed to GetNextStart: %w", err)
+				}
+				if start != nil {
+					o.Logger.Debugf("listCloudSSHKeys: start = %v", *start)
+					listKeysOptions.SetStart(*start)
+				}
+			} else {
+				o.Logger.Debugf("listCloudSSHKeys: Next = nil")
+				moreData = false
 			}
-			moreData = sshKeyCollection.Next != nil
-			o.Logger.Debugf("listCloudSSHKeys: moreData = %v", moreData)
 		}
 	}
 

--- a/pkg/destroy/powervs/cloud-transit-gateways.go
+++ b/pkg/destroy/powervs/cloud-transit-gateways.go
@@ -72,14 +72,19 @@ func (o *ClusterUninstaller) listTransitGateways() (cloudResources, error) {
 			o.Logger.Debugf("listTransitGateways: Limit = %v", *gatewayCollection.Limit)
 		}
 		if gatewayCollection.Next != nil {
-			o.Logger.Debugf("listTransitGateways: Next = %+v", *gatewayCollection.Next)
-			listTransitGatewaysOptions.SetStart(*gatewayCollection.Next.Start)
+			start, err := gatewayCollection.GetNextStart()
+			if err != nil {
+				o.Logger.Debugf("listTransitGateways: err = %v", err)
+				return nil, fmt.Errorf("listTransitGateways: failed to GetNextStart: %w", err)
+			}
+			if start != nil {
+				o.Logger.Debugf("listTransitGateways: start = %v", *start)
+				listTransitGatewaysOptions.SetStart(*start)
+			}
 		} else {
 			o.Logger.Debugf("listTransitGateways: Next = nil")
+			moreData = false
 		}
-
-		moreData = gatewayCollection.Next != nil
-		o.Logger.Debugf("listTransitGateways: moreData = %v", moreData)
 	}
 	if !foundOne {
 		o.Logger.Debugf("listTransitGateways: NO matching transit gateway against: %s", o.InfraID)
@@ -105,13 +110,19 @@ func (o *ClusterUninstaller) listTransitGateways() (cloudResources, error) {
 				o.Logger.Debugf("listTransitGateways: Limit = %v", *gatewayCollection.Limit)
 			}
 			if gatewayCollection.Next != nil {
-				o.Logger.Debugf("listTransitGateways: Next = %+v", *gatewayCollection.Next)
-				listTransitGatewaysOptions.SetStart(*gatewayCollection.Next.Start)
+				start, err := gatewayCollection.GetNextStart()
+				if err != nil {
+					o.Logger.Debugf("listTransitGateways: err = %v", err)
+					return nil, fmt.Errorf("listTransitGateways: failed to GetNextStart: %w", err)
+				}
+				if start != nil {
+					o.Logger.Debugf("listTransitGateways: start = %v", *start)
+					listTransitGatewaysOptions.SetStart(*start)
+				}
 			} else {
 				o.Logger.Debugf("listTransitGateways: Next = nil")
+				moreData = false
 			}
-			moreData = gatewayCollection.Next != nil
-			o.Logger.Debugf("listTransitGateways: moreData = %v", moreData)
 		}
 	}
 
@@ -302,17 +313,22 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 			o.Logger.Debugf("listTransitConnections: Limit = %v", *transitConnectionCollections.Limit)
 		}
 		if transitConnectionCollections.Next != nil {
-			o.Logger.Debugf("listTransitConnections: Next = %+v", *transitConnectionCollections.Next)
-			listConnectionsOptions.SetStart(*transitConnectionCollections.Next.Start)
+			start, err := transitConnectionCollections.GetNextStart()
+			if err != nil {
+				o.Logger.Debugf("listTransitConnections: err = %v", err)
+				return nil, fmt.Errorf("listTransitConnections: failed to GetNextStart: %w", err)
+			}
+			if start != nil {
+				o.Logger.Debugf("listTransitConnections: start = %v", *start)
+				listConnectionsOptions.SetStart(*start)
+			}
 		} else {
 			o.Logger.Debugf("listTransitConnections: Next = nil")
+			moreData = false
 		}
-
-		moreData = transitConnectionCollections.Next != nil
-		o.Logger.Debugf("listTransitConnections: moreData = %v", moreData)
 	}
 	if !foundOne {
-		o.Logger.Debugf("listTransitGateways: NO matching transit connections against: %s", o.InfraID)
+		o.Logger.Debugf("listTransitConnections: NO matching transit connections against: %s", o.InfraID)
 
 		listConnectionsOptions = o.tgClient.NewListConnectionsOptions()
 		listConnectionsOptions.SetLimit(perPage)
@@ -337,13 +353,19 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 				o.Logger.Debugf("listTransitConnections: Limit = %v", *transitConnectionCollections.Limit)
 			}
 			if transitConnectionCollections.Next != nil {
-				o.Logger.Debugf("listTransitConnections: Next = %+v", *transitConnectionCollections.Next)
-				listConnectionsOptions.SetStart(*transitConnectionCollections.Next.Start)
+				start, err := transitConnectionCollections.GetNextStart()
+				if err != nil {
+					o.Logger.Debugf("listTransitConnections: err = %v", err)
+					return nil, fmt.Errorf("listTransitConnections: failed to GetNextStart: %w", err)
+				}
+				if start != nil {
+					o.Logger.Debugf("listTransitConnections: start = %v", *start)
+					listConnectionsOptions.SetStart(*start)
+				}
 			} else {
 				o.Logger.Debugf("listTransitConnections: Next = nil")
+				moreData = false
 			}
-			moreData = transitConnectionCollections.Next != nil
-			o.Logger.Debugf("listTransitConnections: moreData = %v", moreData)
 		}
 	}
 

--- a/pkg/destroy/powervs/publicgateway.go
+++ b/pkg/destroy/powervs/publicgateway.go
@@ -105,12 +105,19 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 			o.Logger.Debugf("listPublicGateways: Limit = %v", *publicGatewayCollection.Limit)
 		}
 		if publicGatewayCollection.Next != nil {
-			o.Logger.Debugf("listPublicGateways: Next = %v", *publicGatewayCollection.Next.Href)
-			listPublicGatewaysOptions.SetStart(*publicGatewayCollection.Next.Href)
+			start, err := publicGatewayCollection.GetNextStart()
+			if err != nil {
+				o.Logger.Debugf("listPublicGateways: err = %v", err)
+				return nil, fmt.Errorf("listPublicGateways: failed to GetNextStart: %w", err)
+			}
+			if start != nil {
+				o.Logger.Debugf("listPublicGateways: start = %v", *start)
+				listPublicGatewaysOptions.SetStart(*start)
+			}
+		} else {
+			o.Logger.Debugf("listPublicGateways: Next = nil")
+			moreData = false
 		}
-
-		moreData = publicGatewayCollection.Next != nil
-		o.Logger.Debugf("listPublicGateways: moreData = %v", moreData)
 	}
 	if !foundOne {
 		o.Logger.Debugf("listPublicGateways: NO matching publicGateway against: %s", o.InfraID)
@@ -134,11 +141,19 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 				o.Logger.Debugf("listPublicGateways: Limit = %v", *publicGatewayCollection.Limit)
 			}
 			if publicGatewayCollection.Next != nil {
-				o.Logger.Debugf("listPublicGateways: Next = %v", *publicGatewayCollection.Next.Href)
-				listPublicGatewaysOptions.SetStart(*publicGatewayCollection.Next.Href)
+				start, err := publicGatewayCollection.GetNextStart()
+				if err != nil {
+					o.Logger.Debugf("listPublicGateways: err = %v", err)
+					return nil, fmt.Errorf("listPublicGateways: failed to GetNextStart: %w", err)
+				}
+				if start != nil {
+					o.Logger.Debugf("listPublicGateways: start = %v", *start)
+					listPublicGatewaysOptions.SetStart(*start)
+				}
+			} else {
+				o.Logger.Debugf("listPublicGateways: Next = nil")
+				moreData = false
 			}
-			moreData = publicGatewayCollection.Next != nil
-			o.Logger.Debugf("listPublicGateways: moreData = %v", moreData)
 		}
 	}
 


### PR DESCRIPTION
Some destroy functions for PowerVS objects had an incorrect method to get the next starting point for continuing searching for objects that match the name.