### PR TITLE
CORS-2890: pkg/infrastructure/aws: add initial CAPI provider

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -1,0 +1,14 @@
+package clusterapi
+
+import (
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+)
+
+var _ clusterapi.Provider = (*Provider)(nil)
+
+// Provider implements AWS CAPI installation.
+type Provider struct{}
+
+// Name gives the name of the provider, AWS.
+func (*Provider) Name() string { return awstypes.Name }

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/infrastructure"
 	awsinfra "github.com/openshift/installer/pkg/infrastructure/aws"
+	awscapi "github.com/openshift/installer/pkg/infrastructure/aws/clusterapi"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
 	"github.com/openshift/installer/pkg/terraform"
@@ -43,6 +44,9 @@ import (
 func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastructure.Provider, error) {
 	switch platform {
 	case awstypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(&awscapi.Provider{}), nil
+		}
 		if fg.Enabled(configv1.FeatureGateInstallAlternateInfrastructureAWS) {
 			return awsinfra.InitializeProvider(), nil
 		}

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/infrastructure"
 	"github.com/openshift/installer/pkg/infrastructure/aws"
+	awscapi "github.com/openshift/installer/pkg/infrastructure/aws/clusterapi"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -22,6 +23,9 @@ import (
 func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastructure.Provider, error) {
 	switch platform {
 	case awstypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(&awscapi.Provider{}), nil
+		}
 		return aws.InitializeProvider(), nil
 	case azuretypes.Name:
 		panic("not implemented")


### PR DESCRIPTION
Adds the initial, empty provider for the AWS CAPI install process. This should allow basic running of the CAPI provider and a foundation for building the rest of the supporting infrastructure provisioning. 

Right now this will panic because we're missing the manifests and rhcos image from the `parents` passed to the CAPI provider. Several PRs floating around have fixes. #8011 has the fix and looks ready to merge soon.