### PR TITLE
OCPBUGS-29442: update RHCOS 4.15 bootimage metadata to 415.92.202402130021-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.15",
   "metadata": {
-    "last-modified": "2023-11-27T16:55:54Z",
-    "generator": "plume cosa2stream 3cfe719"
+    "last-modified": "2024-02-13T21:19:23Z",
+    "generator": "plume cosa2stream 743c05b"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-aws.aarch64.vmdk.gz",
-                "sha256": "48849d1a3e5a6b801aa4f2c7b40073627d8c33e71cbde4c0a6463d808f489d72",
-                "uncompressed-sha256": "6c1d5d97e1d21cf2f34bf58835a64110570f15d8ac7d526a124fe9d2d125c293"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-aws.aarch64.vmdk.gz",
+                "sha256": "9f14012bf2dcbf2012adc7790407d2b6437fe4534fa3af9e260c21643fb2de0e",
+                "uncompressed-sha256": "53f634de2b0eba3e6efe12c94a1e2769fe7065b053c2e1a5a4b16e9e9db55090"
               }
             }
           }
         },
         "azure": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-azure.aarch64.vhd.gz",
-                "sha256": "91efcede793c381fca071268f1a89be940152378a4ef566f5cdd1e32c79b81c3",
-                "uncompressed-sha256": "d79e3124bb4ae767d510f12d50946da38f100fa8d78e523595b67be590045181"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-azure.aarch64.vhd.gz",
+                "sha256": "a454fa89839c6a2155de1363bab3ab32b91d563fe7f72a2d80dc3b4c95ad562d",
+                "uncompressed-sha256": "1297125ffae716a164820e1df9f419a4b5f0264aa690868aa71722119b8f5da5"
               }
             }
           }
         },
         "gcp": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-gcp.aarch64.tar.gz",
-                "sha256": "0bde8cfe770d623e5eb77916c60271ffeb76a8ee7b454c8004cb2ac8f8a4b2a2",
-                "uncompressed-sha256": "7f92ee8e3e295b4eb4772fa55ab14ff497e8e9df9d24dd98efbfa7abe4518af9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-gcp.aarch64.tar.gz",
+                "sha256": "b6c2575de1b4ed7696884143e822b103cc252362fe86a32429cdec4382c6ba12",
+                "uncompressed-sha256": "8255edd44e7affab3bb6b314bfa9b49c3c40a1d198ba50513e4e003f250012f3"
               }
             }
           }
         },
         "metal": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-metal4k.aarch64.raw.gz",
-                "sha256": "834d1a9d442f15ed4c84ed577585ec64c1c84d85414c6a47d04cbdeecbc8638f",
-                "uncompressed-sha256": "8afe673f150440e746667655c7679bb141b3570141a347670fb465c6baa61cfd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-metal4k.aarch64.raw.gz",
+                "sha256": "73a221ea7b83763242c8fb3732d83cf68739f0f11719248098fce396d734ba86",
+                "uncompressed-sha256": "834d17c2fc98baed757a2785e03de1a2f1242edfacd5c2db7ee4468f4b7d55b8"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-live.aarch64.iso",
-                "sha256": "a28df83de91c0c48c3dbd24037902554426b28cd4fe789553882bbf59be4b7bb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-live.aarch64.iso",
+                "sha256": "26bc3a1957c3e09d59992ea1f2156c2da2a4610e7be3a09ec42c39356879b8e8"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-live-kernel-aarch64",
-                "sha256": "c5894da9a66505dd32aa45de0756ed6066e289fe8da99a961049a5311e74cf8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-live-kernel-aarch64",
+                "sha256": "9fe18b78439d0a3bfac7d4c1cdd2526b6e796937c6704ae17fe6b103b330c15f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-live-initramfs.aarch64.img",
-                "sha256": "caa22dad546b97e6e9f2033871dec58a5dc2603882eda17777532af6292a78ad"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-live-initramfs.aarch64.img",
+                "sha256": "11b9685fe46ce7bbd33c919acaa6c7efd7a2d127744855fca6a8a3b2c4df7def"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-live-rootfs.aarch64.img",
-                "sha256": "06aaba42b9f7878e03f992c3df549100dc86ccd38d8481665150400c98450ab0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-live-rootfs.aarch64.img",
+                "sha256": "72bebb95a8e29f14b281f16cec93b7e1a91e8e62e94026fc52da1edf798cbdfe"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-metal.aarch64.raw.gz",
-                "sha256": "5a3b324cd42abb2757bf7f4cdeb5ff74d341cde2bf181cc3f11bd54043430e83",
-                "uncompressed-sha256": "f7550e9f9a8094ac6c6f7416115b5f92ac1565d34f9f707631b9d4e4a521edc0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-metal.aarch64.raw.gz",
+                "sha256": "250b256fd6be6565b8ac89b58c39e5df8c20dbf224b39a82c5f8d7b1dcd3c001",
+                "uncompressed-sha256": "7a4801392f5ae84bca8ba8f21c03579ff17f88ae4ed1290e3e08246b93d52c84"
               }
             }
           }
         },
         "openstack": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-openstack.aarch64.qcow2.gz",
-                "sha256": "83a4cba3f2accb92c33d0675fd7606e19f51e5f57663b6b85903a2a638dfec06",
-                "uncompressed-sha256": "626c130de45c05164abf3a029d6b556559ab103af0ee319b496ee3930068b367"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-openstack.aarch64.qcow2.gz",
+                "sha256": "f4f1d0778d1107b8416c7c2ea1d752d51381632f2e0aef44db880a090e92066d",
+                "uncompressed-sha256": "6c8997a7b5b99410058e4bb721948f6caea87c93c10b22f5eaa2afbaacf100ba"
               }
             }
           }
         },
         "qemu": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/aarch64/rhcos-415.92.202311241643-0-qemu.aarch64.qcow2.gz",
-                "sha256": "bd274868dda57932429622a23af76701e742dba55bc8d08d9aabc46d30dc2e09",
-                "uncompressed-sha256": "d6e8e271992df28af8e1093acca5a1e6aae8b124faaf5b4f15f8ca78b15dc20b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/aarch64/rhcos-415.92.202402130021-0-qemu.aarch64.qcow2.gz",
+                "sha256": "18804dc56d7622ee9d4b04d8b9c80296c2f8c42217574edaeef06a2ad613aac5",
+                "uncompressed-sha256": "68864a64c11050fb85c6a6705b7e1ae8d949ec0031e6074a5dca9e867db599a6"
               }
             }
           }
@@ -111,213 +111,217 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-06074e156b4802b6c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-06c7b4e42179544df"
             },
             "ap-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0d72a989351e424e7"
+              "release": "415.92.202402130021-0",
+              "image": "ami-07b6a37fa6d2d2e99"
             },
             "ap-northeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-011d0ec5e0b557ebe"
+              "release": "415.92.202402130021-0",
+              "image": "ami-056d2eef4a3638246"
             },
             "ap-northeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-087a9bd4df7a9947b"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0bd5a7684f0ff4e02"
             },
             "ap-northeast-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-02ab363366b794490"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0fd08063da50de1da"
             },
             "ap-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0eb0ab69ea5ffd50f"
+              "release": "415.92.202402130021-0",
+              "image": "ami-08f1ae2cef8f9690e"
             },
             "ap-south-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0a1aed09ac1c4b8a8"
+              "release": "415.92.202402130021-0",
+              "image": "ami-020ba25cc1ec53b1c"
             },
             "ap-southeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0fb519a4020c30fd0"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0020a1c0964ac8e48"
             },
             "ap-southeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-03f60c06569c39fe8"
+              "release": "415.92.202402130021-0",
+              "image": "ami-07013a63289350c3c"
             },
             "ap-southeast-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-047d510695ebe3b6c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-041d6ca1d57e3190f"
             },
             "ap-southeast-4": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0d0a5c8ee27dacce3"
+              "release": "415.92.202402130021-0",
+              "image": "ami-06539e9cbefc28702"
             },
             "ca-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0cf66c883490cd1d1"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0bb3991641f2b40f6"
+            },
+            "ca-west-1": {
+              "release": "415.92.202402130021-0",
+              "image": "ami-062f36bb73df9bde3"
             },
             "eu-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0a94fbfed10808589"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0908d117c26059e39"
             },
             "eu-central-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-08399888930c7fba2"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0e48c82ffbde67ed2"
             },
             "eu-north-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-037c577f21327d47d"
+              "release": "415.92.202402130021-0",
+              "image": "ami-016614599b38d515e"
             },
             "eu-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0ee702dbedbfcec3c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-01b6cc1f0fd7b431f"
             },
             "eu-south-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-054bef6ee79fad411"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0687e1d98e55e402d"
             },
             "eu-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-02b0a17b959b56cbc"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0bf0b7b1cb052d68d"
             },
             "eu-west-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-012237d422f536670"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0ba0bf567caa63731"
             },
             "eu-west-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-02856db72b2a06a84"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0eab6a7956a66deda"
             },
             "il-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-033b84bfdd0ed4331"
+              "release": "415.92.202402130021-0",
+              "image": "ami-03b3cb1f4869bf21d"
             },
             "me-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0d43b49bccc0684a1"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0a6e1ade3c9e206a1"
             },
             "me-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0f10798b50a30ee59"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0aa0775c68eac9f6f"
             },
             "sa-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-00f2c68ff864658db"
+              "release": "415.92.202402130021-0",
+              "image": "ami-07235eee0bb930c78"
             },
             "us-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0ec0f42eb805ad268"
+              "release": "415.92.202402130021-0",
+              "image": "ami-005808ca73e7b36ff"
             },
             "us-east-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0f6611547142a5991"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0c5c9420f6b992e9e"
             },
             "us-gov-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0a6fefb2d43095cf7"
+              "release": "415.92.202402130021-0",
+              "image": "ami-08c9b2b8d578caf92"
             },
             "us-gov-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-05e8eb93d276328ed"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0bdff65422ba7d95d"
             },
             "us-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0013e89810835730b"
+              "release": "415.92.202402130021-0",
+              "image": "ami-017ad4dd030a04233"
             },
             "us-west-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-03f21e9357af4f946"
+              "release": "415.92.202402130021-0",
+              "image": "ami-068d0af5e3c08e618"
             }
           }
         },
         "gcp": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-415-92-202311241643-0-gcp-aarch64"
+          "name": "rhcos-415-92-202402130021-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "415.92.202311241643-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202311241643-0-azure.aarch64.vhd"
+          "release": "415.92.202402130021-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202402130021-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-metal4k.ppc64le.raw.gz",
-                "sha256": "a4ba00bf6e1fb5e5060dc17899bc1105511c69a8bfd5cccef1b33fabddb0ef11",
-                "uncompressed-sha256": "a42f197d4ec8028f7f30ad9f22fe21a72d178d46a9bcadd4d096c5d323ce08b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-metal4k.ppc64le.raw.gz",
+                "sha256": "2164bf6ded1989964bf379b532248094ce171f2bd65dcda59d509cce193e724e",
+                "uncompressed-sha256": "9325a11f1b413637bd5e536c866217c228f21354d46c35813a4485a4e258c6bb"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-live.ppc64le.iso",
-                "sha256": "afbaa5e9c558ffc3f9f3456a46b4d176d7c85a2e18bf7e466c5364dad398ab8f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-live.ppc64le.iso",
+                "sha256": "41e241d4b8de16a298af4675adcbee14a6cdc1462e8de22c8af956aa2a56a1e3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-live-kernel-ppc64le",
-                "sha256": "79944c070368c341571d8e139610b76775d676da552856d393435793968f8b61"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-live-kernel-ppc64le",
+                "sha256": "a5628ed30d2f6b5d0a128e8f32dd3a1af3ca1d264210148a46c386de123eca3f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-live-initramfs.ppc64le.img",
-                "sha256": "b4510e5777a965bff505cbf6ede5b4af10656f90861090bc256ce18125badedc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-live-initramfs.ppc64le.img",
+                "sha256": "586d7c807102006bff0380f9f040b3f7240184b9fe5dcf4f373553ded0ecde85"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-live-rootfs.ppc64le.img",
-                "sha256": "7ea275ff78e74d6245a1f654d8bcb5d42a7216d62a8572ddfc7803355fd38773"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-live-rootfs.ppc64le.img",
+                "sha256": "8f86c09f390f81e6d0e7f72f54bd96894a6bfeecdd389c8ad6c124210986eb36"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-metal.ppc64le.raw.gz",
-                "sha256": "8a7bf006ac758a6d6c0a70b3eb48a99cf6d29e3be0ba258ca720733659dece85",
-                "uncompressed-sha256": "a0eb0debe7d903ff5e375114dafeb4720d8285d3c36fdfe02dc511007970be40"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-metal.ppc64le.raw.gz",
+                "sha256": "ea2c88f814b619a60c624b96ad544117db701479b6a2d9c86ae31d51c4bc255b",
+                "uncompressed-sha256": "74c93cdc89480bc8db624d8e765dd873dc83d37da4e999977e3611c6cf883c26"
               }
             }
           }
         },
         "openstack": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "acc4ceec02d5468ca46634485eca66e2d58ee45d0cf72a3075a4379e74c73b79",
-                "uncompressed-sha256": "e170dc85de993b3b7837c7e4d136a3432a6244d5001315d0273628cc8f337ccb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "28373dcfc5584ec0752f13361e09de20fd725f1a123cae50ba0a5460b8ee1f15",
+                "uncompressed-sha256": "bb269a86c205ea4e006fb5c664fffe44b033fe90440b391c793d682b779c5a88"
               }
             }
           }
         },
         "powervs": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-powervs.ppc64le.ova.gz",
-                "sha256": "af895356eec06f14656e526492f37fbfa1a201ccafe659f7d9e37e6695ce7f65",
-                "uncompressed-sha256": "2338ed495640a9b1d1ec496a75865d05c6cff837d31157a0f19efa7ce8be7f03"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-powervs.ppc64le.ova.gz",
+                "sha256": "ff782613e19f6caac74f66d9e27e9eb3223fc1978d72ade10ca499788a492356",
+                "uncompressed-sha256": "f3cb1cc404f5527a0f1210957625540bf1a53b1b6e8ded6d6f2b86ecca40ba70"
               }
             }
           }
         },
         "qemu": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/ppc64le/rhcos-415.92.202311241643-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "dacec124b12958fffe46439ba87daa54f15b6ae5d88adca3c26d3f9e174cafe6",
-                "uncompressed-sha256": "3d3372715bfe74d1b77bd1f8cbdc7ddbe41b535a695f74e405a036d804296b83"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/ppc64le/rhcos-415.92.202402130021-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "c2eb58cf7153c0dc7d03e7edfa9ed8676961ad06de8cb30f5e7fdb17db3d2f9e",
+                "uncompressed-sha256": "8a154d9835abe644522d288e792a9862bb872902998e17e969dcead7cecfb097"
               }
             }
           }
@@ -327,64 +331,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "415.92.202311241643-0",
-              "object": "rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz",
+              "release": "415.92.202402130021-0",
+              "object": "rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-415-92-202311241643-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-415-92-202402130021-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -393,88 +397,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "d1e15b2e7e3589c2bc44b3d72744ac4603881eba8a57c7d689a3b5fc23ad259e",
-                "uncompressed-sha256": "7d855389e867f39e5e3fb3702469f38b904718c2d9415ff6178c596447bbf9d8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "e32b85c62cb64beb704d707f89baff2434f363fcee199e8ee5dac380c0c63b8b",
+                "uncompressed-sha256": "61c36178463edc5d3a53a2b01b19efc23a2b9605a4ef94ef4b6be3c7a7b29827"
               }
             }
           }
         },
         "metal": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-metal4k.s390x.raw.gz",
-                "sha256": "e7daa6eb0d874b0ed06df04385484713aa59e5dbc30e486060542cf40d177816",
-                "uncompressed-sha256": "a8dd41cc93d1e91fb35cdb44e9f011ecd8f4fddca80c6960648acd151773003e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-metal4k.s390x.raw.gz",
+                "sha256": "ac8353bee6e5a105dd85fc4092b157f50163b33501417c413740acd93b00e08f",
+                "uncompressed-sha256": "82b17a408f08f9a5b2e93012fe6ab41630065bf0a11591db73bf533e62278870"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-live.s390x.iso",
-                "sha256": "dbf966f69cdee4dd94fcd4af0de554edae03f38d6afbd8861870a0d5f3667d2d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-live.s390x.iso",
+                "sha256": "1f85a92791247146eccea0b75b14ca60fa68df072c9cf50f5949e02626dac330"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-live-kernel-s390x",
-                "sha256": "67e3926c8c7c750cdf939b0db6ad0728b79625dc20d7a898deecd6fb09c4c102"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-live-kernel-s390x",
+                "sha256": "97ce28b1d5742956aed6097eab8e8021627f27b580c483ee4f6cb5b57eec7fb0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-live-initramfs.s390x.img",
-                "sha256": "156c2b9e88cb0071de0c45bce495fa925c13a456cbf5f055622ad35dc635c19d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-live-initramfs.s390x.img",
+                "sha256": "f465f7dd9ee2051b96dad8af64cdd95266029785e6633913287ecf1fcac2dbdc"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-live-rootfs.s390x.img",
-                "sha256": "f1bee3ce1ce457050e93841dec034a63255b92a3e68e81908ec977e8035bb095"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-live-rootfs.s390x.img",
+                "sha256": "cb7be64f450ef6e05f31a3b419d806a825f1bff2a2ac6eb115b41994ade1e3fe"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-metal.s390x.raw.gz",
-                "sha256": "a9c24ab2ef887591d80fc251a00bde4734de6336f69139f31f0f2eb2b50e2a8d",
-                "uncompressed-sha256": "8e35422c4ab7a9d408c2e1a16002df79cfc3d8b85cf9c046187fbcdbec5f7e16"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-metal.s390x.raw.gz",
+                "sha256": "ba941e0e2b6399b5a7182e2c74f57630509099407a38c956151b3e4beefac178",
+                "uncompressed-sha256": "69ba249c9ccf8476b5c02c2a3f3e4d7107db533ff71d8255cbd828cd0163fbbc"
               }
             }
           }
         },
         "openstack": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-openstack.s390x.qcow2.gz",
-                "sha256": "9d594e6a09d8e545557b4e04342748ab0d1451378562ce23399d46ebe178a989",
-                "uncompressed-sha256": "4ce19e961d039279a991d82d0fb029606007b106909686573cfab50dd2ebe1a3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-openstack.s390x.qcow2.gz",
+                "sha256": "a69516a6e0515733560035cd1f24c55da1d80254fa5adb736b6a7b5cb90e99a6",
+                "uncompressed-sha256": "a8da49638d658bd7230a8971a9293f992afa0ae0a6f1de599d6850d141b32bda"
               }
             }
           }
         },
         "qemu": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-qemu.s390x.qcow2.gz",
-                "sha256": "0d752d36491cc910f88a92bcbd2d35709aaa6ef544f7916b6c9eb4465548fe7a",
-                "uncompressed-sha256": "f89bd7eef18148a5a7c03d861571c607ebbcb1502c816613007df17e46d7ed68"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-qemu.s390x.qcow2.gz",
+                "sha256": "837506d261d4f3ffb644b51e89a605e45bb48ea9bac2a267873e96cd514cb344",
+                "uncompressed-sha256": "26745315bb02197b76873e43f9b4fffce00147d02d56ba18067d5110bcb1cedb"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/s390x/rhcos-415.92.202311241643-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "29eefd37b2d5a2b59c818a18eb0022f947446e6b5ce4b9371a1743fd765c1054",
-                "uncompressed-sha256": "af8e36abcc539a4440e6048bd0d830dbfcde9fd44ea6d5135d1d74a334208dcf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/s390x/rhcos-415.92.202402130021-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "28fa9f2317165974a8f4e447ee60844cfe510f892ecf6a109cfd40ef8bd3a388",
+                "uncompressed-sha256": "d6513a5d7aefb09179639b65138929e1bfa3ad21ed14eea5721cb65e30ece321"
               }
             }
           }
@@ -485,169 +489,169 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "c953d25cc83cff8a9aae3d00063a487c3fbfc0f03184ea36b39116492c836d84",
-                "uncompressed-sha256": "376c061d9c181d0c7209b95500caf2b0ae4c069c74da094174ce20cfca4adf61"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "fd75efdc5317bafd62b2704db24cedbe7db32f537829c4da9c7904a3956d24fa",
+                "uncompressed-sha256": "99027193011c334f5618ed6d9683f540d5c64e5c5cfe3327b71939abc8dee99b"
               }
             }
           }
         },
         "aws": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-aws.x86_64.vmdk.gz",
-                "sha256": "cfd62ab1b436cda67d5bfe4d058c014aa3648506e396d9e039d7567055c7da90",
-                "uncompressed-sha256": "a1b0afe7f9c01a8293f626df6c83f2faaed74369469b2ba8f43efc217fcaa811"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-aws.x86_64.vmdk.gz",
+                "sha256": "d8c838d338f92eb69daf75a911ab71054f0504157a44c70cd138308992fab867",
+                "uncompressed-sha256": "496aaf46b4445462ba0c6c51b45397ad4e78400d5f8ffcd465b533181e2afad3"
               }
             }
           }
         },
         "azure": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-azure.x86_64.vhd.gz",
-                "sha256": "513dd38164d4576238c836f9a25521327ad2b0820b51b7b53faddf1992c51c00",
-                "uncompressed-sha256": "8e0be8b2a787a10ae6e85a44755f52cab05a41b8b6b526093afd445c1580b9c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-azure.x86_64.vhd.gz",
+                "sha256": "cf02521eaff0832302c161f7abca1cf1d0e101aa3e04f220fe7bbca3653b9c84",
+                "uncompressed-sha256": "d6232eb31f71f39cabf3cef2598f683e720b19f4ccb701496614c41e23171287"
               }
             }
           }
         },
         "azurestack": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-azurestack.x86_64.vhd.gz",
-                "sha256": "e9ad403f7e582fe84eabadf520c4ec300e8c9bd628bd944d315d13546516c290",
-                "uncompressed-sha256": "fb8cbc9b93e5d4fe8695718e394b97b3f2fe0b56273b554f94cf9c5e7c4246fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-azurestack.x86_64.vhd.gz",
+                "sha256": "53ab7ce6d9ca84e0a2d7ebba289f07303ccb51544003c3ab2b3e291a5cc798e5",
+                "uncompressed-sha256": "0788f878480870074c6a5432c933ce8c623cc992f00d5fe8175cc240c2cf1388"
               }
             }
           }
         },
         "gcp": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-gcp.x86_64.tar.gz",
-                "sha256": "c539cbb353ec8ff1ea7def11f20f5a38f3b1333c0173a810dee80c8ede703463",
-                "uncompressed-sha256": "4f58bbc44ea99af7047c77cfdd72b1d132f652aac0249b02aafcaeb5460dd27f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-gcp.x86_64.tar.gz",
+                "sha256": "946e764f9591285ba6ed2ed36f2718ca98a4205b24f1ba003c1f040700f59e05",
+                "uncompressed-sha256": "76a4fec7f36d398f5ea177e79dc96501e7ef8dd65f3e60b699648a3ed3a750c6"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "6b562dee8431bec3b93adeac1cfefcd5e812d41e3b7d78d3e28319870ffc9eae",
-                "uncompressed-sha256": "5a0f9479505e525a30367b6a6a6547c86a8f03136f453c1da035f3aa5daa8bc9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "ab766ca7e02db411285e3d329637de85ad956ee7676190d9b94ea8f5c8ee7ff4",
+                "uncompressed-sha256": "c8ce347afc995cf1f604f967b5fdd8023ea60dff6dbb87865f9aa40d52f30076"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-kubevirt.x86_64.ociarchive",
-                "sha256": "53ab45c591189bf8198e05e39866f808117cc636b33bfe638fdc8370a1a4312e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-kubevirt.x86_64.ociarchive",
+                "sha256": "5160a66ad521951b8c73f2f39a4e525ff8ec1787d0b9a5c86cbf0aace2eb90a3"
               }
             }
           }
         },
         "metal": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-metal4k.x86_64.raw.gz",
-                "sha256": "055d5cd05520a596b156825c25733420797b848b9c1a1faf74027fb1ac196721",
-                "uncompressed-sha256": "72d052891d5a87b0ebb37304da74adabec7c78bf54ba3a5d88b77d2c29c7b24f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-metal4k.x86_64.raw.gz",
+                "sha256": "c11144c2069eab3aa5403c0bb085f7d384597b36f337454f39cffedc8218e4be",
+                "uncompressed-sha256": "f0e25b30c713b4c9674cb8ffc87980b3713e49d94b4cff67399acd97e4e2015e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-live.x86_64.iso",
-                "sha256": "fa9e2840cd26c6181768e0a7e2126c10f3b3da1d017025e683b4b567d8f51581"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-live.x86_64.iso",
+                "sha256": "778314524d89c99b97536393762f17178e0855773845db3f00771bcfa000c691"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-live-kernel-x86_64",
-                "sha256": "0416a4f51dc590ac8af3f5acb8a01fc82dd9c85a2006aa526f39c12dbbaf4eb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-live-kernel-x86_64",
+                "sha256": "7071c938ef59b5c2402c2f9a14172a9c13ed2edb05097bee7a8841755d069b99"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-live-initramfs.x86_64.img",
-                "sha256": "ae828d8126aaba8b7b252182f34fca704b36943fd85f801ab23e9658bc8ce155"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-live-initramfs.x86_64.img",
+                "sha256": "f7c610c4df56a841a811f70ecf81fb79a7c98a6c23866bdb0c3ee4479abcb72f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-live-rootfs.x86_64.img",
-                "sha256": "9ac062ef148d6f373c611a787c1a42a56a3f9b703c4cad0ff177ecb8801eee4e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-live-rootfs.x86_64.img",
+                "sha256": "107a553b5a9c2ae94e78c26c2da700420ebf3235f17b959b35f7dd64b93e7fdd"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-metal.x86_64.raw.gz",
-                "sha256": "1714917fd6e5f37843a92ac9175653b6f324fec34485b42e1af4a85f81e36a84",
-                "uncompressed-sha256": "bc934eec7198c9c9866ef834b3d0c0f2049661842efd15b4940ed9e9cad1aad3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-metal.x86_64.raw.gz",
+                "sha256": "8a2aa5987f3aca3d4805c60b3fece8e0d4e5f5f68fad0716d42fedc688f774e8",
+                "uncompressed-sha256": "7275497838558d53d302ac6ba28c0272fb7dc23bdc223ac16ea8fea58e7b6cfd"
               }
             }
           }
         },
         "nutanix": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-nutanix.x86_64.qcow2",
-                "sha256": "548622462fc7db4398abf26a446665ce5a4dff34d761f115ec7873871886eded"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-nutanix.x86_64.qcow2",
+                "sha256": "302b636f7855927686a530c5368b7d08d316388ea0aa2165e8107c5af3c6767f"
               }
             }
           }
         },
         "openstack": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-openstack.x86_64.qcow2.gz",
-                "sha256": "a1cdc78cfac9a95722e2db52ac5d3e9b8c0cfaf7ce6af1a104876b87968c24b1",
-                "uncompressed-sha256": "fcb834ec5facdc76797dfd917a70ba28d680e49c866242ef3319a9ec1ae32912"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-openstack.x86_64.qcow2.gz",
+                "sha256": "bcdc9a316bf3bcea506ad8ba7ff484a85dc442fe958c81ffc9ca98d44d4fabdf",
+                "uncompressed-sha256": "2154e6a6171f40226f8806101e348a99d4ca9bee0676799cbc9e7788be1f6d3f"
               }
             }
           }
         },
         "qemu": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-qemu.x86_64.qcow2.gz",
-                "sha256": "c1f267abf9b7d4f988d645d4bd573837b8605659b911ebe4629e61053f190578",
-                "uncompressed-sha256": "06a9328f4aa9648c95045faaac8962027c6a4cadbbac7a5d8b3f5bf1750fcdd5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-qemu.x86_64.qcow2.gz",
+                "sha256": "b1f5853dd33ac7b793d11c743126b28318f6f9717a6fb545a292342779d41406",
+                "uncompressed-sha256": "ce7d49412b3967ed5d9bce2792d86838a54e40de2a3c460f74912ae1605e83b9"
               }
             }
           }
         },
         "vmware": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-vmware.x86_64.ova",
-                "sha256": "38d16424a9b6170ae4efbb356a17471aecff717ed50eac764d9574ef817ec43e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202402130021-0/x86_64/rhcos-415.92.202402130021-0-vmware.x86_64.ova",
+                "sha256": "9b3d5a598928ec52b0d32092d0a9a41f0ec8a238eb9fff8563266b9351919e20"
               }
             }
           }
@@ -657,266 +661,270 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-6we8n2bay6gr6izubok1"
+              "release": "415.92.202402130021-0",
+              "image": "m-6we1upm9n8ayg4ogblo1"
             },
             "ap-northeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "m-mj7imhhrvn5kxxv9zmwq"
+              "release": "415.92.202402130021-0",
+              "image": "m-mj7574mmck35xf75goc6"
             },
             "ap-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-a2d7qt4mb9femjbj58kc"
+              "release": "415.92.202402130021-0",
+              "image": "m-a2d5tqyl98x6ju475lwn"
             },
             "ap-southeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-t4nb9w9szj3s88tfs1s7"
+              "release": "415.92.202402130021-0",
+              "image": "m-t4n0g1z9dsf2zf8gwajq"
             },
             "ap-southeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "m-p0w5rje60u7yygdyg124"
+              "release": "415.92.202402130021-0",
+              "image": "m-p0w59unwidvo5wctp42l"
             },
             "ap-southeast-3": {
-              "release": "415.92.202311241643-0",
-              "image": "m-8psg4b5m9qnxlwu3arhh"
+              "release": "415.92.202402130021-0",
+              "image": "m-8psgxj5g11xs9zac7o02"
             },
             "ap-southeast-5": {
-              "release": "415.92.202311241643-0",
-              "image": "m-k1a6afya0fpytl34tjqp"
+              "release": "415.92.202402130021-0",
+              "image": "m-k1a43rbxmcylrt9ct4e1"
             },
             "ap-southeast-6": {
-              "release": "415.92.202311241643-0",
-              "image": "m-5ts8bw2wggkauwz3l2wm"
+              "release": "415.92.202402130021-0",
+              "image": "m-5ts40n0cyw76pbsofksc"
             },
             "ap-southeast-7": {
-              "release": "415.92.202311241643-0",
-              "image": "m-0joc2e43rrr1ck2e3649"
+              "release": "415.92.202402130021-0",
+              "image": "m-0jobuw7234en15rx041b"
             },
             "cn-beijing": {
-              "release": "415.92.202311241643-0",
-              "image": "m-2zehw8j1q2yf3jex54ch"
+              "release": "415.92.202402130021-0",
+              "image": "m-2zei1nbqtlchz4q7hlr9"
             },
             "cn-chengdu": {
-              "release": "415.92.202311241643-0",
-              "image": "m-2vc80xtaa3wcy05kny2h"
+              "release": "415.92.202402130021-0",
+              "image": "m-2vc40i2yyp8bihpvprrd"
             },
             "cn-fuzhou": {
-              "release": "415.92.202311241643-0",
-              "image": "m-gw0hi3w90zm7zi463bup"
+              "release": "415.92.202402130021-0",
+              "image": "m-gw00z5t9jf44eo6v74lg"
             },
             "cn-guangzhou": {
-              "release": "415.92.202311241643-0",
-              "image": "m-7xv99hr9kwqyer92mzte"
+              "release": "415.92.202402130021-0",
+              "image": "m-7xv5ea7bu7x9s532gwl1"
             },
             "cn-hangzhou": {
-              "release": "415.92.202311241643-0",
-              "image": "m-bp191jk4d97luqmqfexr"
+              "release": "415.92.202402130021-0",
+              "image": "m-bp13q4kqw9s1eyg4t1s5"
             },
             "cn-heyuan": {
-              "release": "415.92.202311241643-0",
-              "image": "m-f8z65ngusncmnrmfix3w"
+              "release": "415.92.202402130021-0",
+              "image": "m-f8z2kxhpicbifrym0kjg"
             },
             "cn-hongkong": {
-              "release": "415.92.202311241643-0",
-              "image": "m-j6cgn6y6limjcsh52yba"
+              "release": "415.92.202402130021-0",
+              "image": "m-j6c9jt03ht78y8shbn6x"
             },
             "cn-huhehaote": {
-              "release": "415.92.202311241643-0",
-              "image": "m-hp3fqlgyfpiptws0t94p"
+              "release": "415.92.202402130021-0",
+              "image": "m-hp326v6l6jx3cdt43var"
             },
             "cn-nanjing": {
-              "release": "415.92.202311241643-0",
-              "image": "m-gc71oa5ivjjz2r91ejbz"
+              "release": "415.92.202402130021-0",
+              "image": "m-gc70z5t9jf44fftarw91"
             },
             "cn-qingdao": {
-              "release": "415.92.202311241643-0",
-              "image": "m-m5ef7hek75cdlyl63xsd"
+              "release": "415.92.202402130021-0",
+              "image": "m-m5e16j2znysptsgrqxal"
             },
             "cn-shanghai": {
-              "release": "415.92.202311241643-0",
-              "image": "m-uf60qtfrn52e6wbyqjt4"
+              "release": "415.92.202402130021-0",
+              "image": "m-uf64s6kuljhakq7t67fw"
             },
             "cn-shenzhen": {
-              "release": "415.92.202311241643-0",
-              "image": "m-wz94p79md713m57m53gn"
+              "release": "415.92.202402130021-0",
+              "image": "m-wz9j922tkfn2xqoze073"
             },
             "cn-wuhan-lr": {
-              "release": "415.92.202311241643-0",
-              "image": "m-n4ad0d1szot5kfd1k1sy"
+              "release": "415.92.202402130021-0",
+              "image": "m-n4a0z5t9jf44ei9ruyo3"
             },
             "cn-wulanchabu": {
-              "release": "415.92.202311241643-0",
-              "image": "m-0jlhtivnodw7j6nllx45"
+              "release": "415.92.202402130021-0",
+              "image": "m-0jleyzoysj6oja7gj16e"
             },
             "cn-zhangjiakou": {
-              "release": "415.92.202311241643-0",
-              "image": "m-8vbea5xydvb4274retmp"
+              "release": "415.92.202402130021-0",
+              "image": "m-8vb38b00cs4dykk5tom2"
             },
             "eu-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-gw87gfry6vcfgspbezf2"
+              "release": "415.92.202402130021-0",
+              "image": "m-gw882pu91iizr3npw5kj"
             },
             "eu-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-d7o4r83yvewbldunoptj"
+              "release": "415.92.202402130021-0",
+              "image": "m-d7o9lqtdrp0frvv0u61v"
             },
             "me-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-l4v7i28230c42y6mfkl0"
+              "release": "415.92.202402130021-0",
+              "image": "m-l4v5b0xnebvo6yoeg3lq"
             },
             "me-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-eb30unbjpyazka1fenjk"
+              "release": "415.92.202402130021-0",
+              "image": "m-eb33oda90uj23h1djl91"
             },
             "us-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-0xif460it3gnh06sl30l"
+              "release": "415.92.202402130021-0",
+              "image": "m-0xi9ubqnd98lzf7cx6vy"
             },
             "us-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "m-rj997who1c03gg0j0326"
+              "release": "415.92.202402130021-0",
+              "image": "m-rj95nr9zjufzzx656mu5"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0f3638a490962a95c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0493ec0f0a451f83b"
             },
             "ap-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-04e9c00c967a87da9"
+              "release": "415.92.202402130021-0",
+              "image": "ami-050a6d164705e7f62"
             },
             "ap-northeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-029b997a9a4fb278e"
+              "release": "415.92.202402130021-0",
+              "image": "ami-00910c337e0f52cff"
             },
             "ap-northeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-05396fd60562a5211"
+              "release": "415.92.202402130021-0",
+              "image": "ami-07e98d33de2b93ac0"
             },
             "ap-northeast-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-08f52a572a7e32cae"
+              "release": "415.92.202402130021-0",
+              "image": "ami-09bc0a599f4b3c483"
             },
             "ap-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-07943489b124179d2"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0ba603a7f9d41228e"
             },
             "ap-south-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0dabb9c2df10a6d99"
+              "release": "415.92.202402130021-0",
+              "image": "ami-03130aecb5d7459cc"
             },
             "ap-southeast-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0ef6923209ca8a892"
+              "release": "415.92.202402130021-0",
+              "image": "ami-026c056e0a25e5a04"
             },
             "ap-southeast-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0707f7568fabbc6ac"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0d471f504ff6d9a0f"
             },
             "ap-southeast-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-09d45c114723913e7"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0c1b9a0721cbb3291"
             },
             "ap-southeast-4": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0ae9b3fa71c17128d"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0ef23bfe787efe11e"
             },
             "ca-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-017dd94c0abc26f04"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0163965a05b75f976"
+            },
+            "ca-west-1": {
+              "release": "415.92.202402130021-0",
+              "image": "ami-035233096b6f9f603"
             },
             "eu-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0c1d9e7fc36ac23c8"
+              "release": "415.92.202402130021-0",
+              "image": "ami-01edb54011f870f0c"
             },
             "eu-central-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0fb275ac2bd702f3c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0bc500d6056a3b104"
             },
             "eu-north-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0616df0a3102027da"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0ab155e935177f16a"
             },
             "eu-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-04247b5572044877d"
+              "release": "415.92.202402130021-0",
+              "image": "ami-051b4c06b21f5a328"
             },
             "eu-south-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-09992c43c24ea1761"
+              "release": "415.92.202402130021-0",
+              "image": "ami-096644e5555c23b19"
             },
             "eu-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0075e033ba6f4f0ca"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0faeeeb3d2b1aa07c"
             },
             "eu-west-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-04db2d14a02c343a1"
+              "release": "415.92.202402130021-0",
+              "image": "ami-00bb1522dc71b604f"
             },
             "eu-west-3": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0c672a733e97c1f3d"
+              "release": "415.92.202402130021-0",
+              "image": "ami-01e5397bd2b795bd3"
             },
             "il-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0a2e7df92075ec3ba"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0b32feb5d77c64e61"
             },
             "me-central-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0610f187d33b944fe"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0a5158a3e68ab7e88"
             },
             "me-south-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-04aef8c2d5a636ac1"
+              "release": "415.92.202402130021-0",
+              "image": "ami-024864ad1b799dbba"
             },
             "sa-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0a52b849e09061256"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0c402ffb0c4b7edc0"
             },
             "us-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-069c6393f1e585510"
+              "release": "415.92.202402130021-0",
+              "image": "ami-057df4d0cb8cbae0d"
             },
             "us-east-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0e1a1a2292fbb483d"
+              "release": "415.92.202402130021-0",
+              "image": "ami-07566e5da1fd297f8"
             },
             "us-gov-east-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-04dde06a4aca1917c"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0fe03a7e289354670"
             },
             "us-gov-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-060798c48ab1ca672"
+              "release": "415.92.202402130021-0",
+              "image": "ami-06b7cc6445c5da732"
             },
             "us-west-1": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0937c28bc307b7398"
+              "release": "415.92.202402130021-0",
+              "image": "ami-02d20001c5b9df1e9"
             },
             "us-west-2": {
-              "release": "415.92.202311241643-0",
-              "image": "ami-0c7e9ed212e2153d3"
+              "release": "415.92.202402130021-0",
+              "image": "ami-0dfba457127fba98c"
             }
           }
         },
         "gcp": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-415-92-202311241643-0-gcp-x86-64"
+          "name": "rhcos-415-92-202402130021-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "415.92.202311241643-0",
+          "release": "415.92.202402130021-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.15-9.2-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6ae6015fec8edc8c46248e2f7beba7ef1ce00efe7c050f71f9658043435f7715"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c1ddb9e1c28dc391a8fbfeb0b2681e06d9b226380047f583b7eca4494a3ea05b"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "415.92.202311241643-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202311241643-0-azure.x86_64.vhd"
+          "release": "415.92.202402130021-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202402130021-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.15 boot image metadata. Notable fixes in the boot image for:

- fix for unexpected Azure IMDS status codes
- Addition of ca-west-1 AMIs

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name 4.15-9.2                    \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=415.92.202402130021-0                                      \
    aarch64=415.92.202402130021-0                                     \
    s390x=415.92.202402130021-0                                       \
    ppc64le=415.92.202402130021-0
```