### PR TITLE
UPI dual-stack backport

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -367,6 +367,7 @@ data["networking"]["machineNetwork"] = machine_net
 data["platform"]["openstack"]["apiVIPs"] = api_vips
 data["platform"]["openstack"]["ingressVIPs"] = ingress_vips
 data["platform"]["openstack"]["controlPlanePort"] = ctrl_plane_port
+data["featureSet"] = "TechPreviewNoUpgrade"
 del data["platform"]["openstack"]["externalDNS"]
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 ```

--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -19,7 +19,7 @@
       - "{{ os_sg_master }}"
       allowed_address_pairs:
       - ip_address: "{{ os_apiVIP }}"
-    when: os_subnet6_range is not defined
+    when: os_subnet6 is not defined
 
   - name: 'Create the bootstrap dualstack server port'
     os_port:
@@ -30,7 +30,7 @@
       allowed_address_pairs:
       - ip_address: "{{ os_apiVIP }}"
       - ip_address: "{{ os_apiVIP6 }}"
-    when: os_subnet6_range is defined
+    when: os_subnet6 is defined
 
   - name: 'Set bootstrap port tag'
     command:

--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -19,6 +19,18 @@
       - "{{ os_sg_master }}"
       allowed_address_pairs:
       - ip_address: "{{ os_apiVIP }}"
+    when: os_subnet6_range is not defined
+
+  - name: 'Create the bootstrap dualstack server port'
+    os_port:
+      name: "{{ os_port_bootstrap }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_sg_master }}"
+      allowed_address_pairs:
+      - ip_address: "{{ os_apiVIP }}"
+      - ip_address: "{{ os_apiVIP6 }}"
+    when: os_subnet6_range is defined
 
   - name: 'Set bootstrap port tag'
     command:

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -10,12 +10,6 @@
       cluster_id_tag: "openshiftClusterID={{ infraID }}"
       primary_cluster_network_tag: "{{ infraID }}-primaryClusterNetwork"
       os_infra_id: "{{ infraID }}"
-      os_network: "{{ infraID }}-network"
-      os_subnet: "{{ infraID }}-nodes"
-      os_router: "{{ infraID }}-external-router"
-      # Port names
-      os_port_api: "{{ infraID }}-api-port"
-      os_port_ingress: "{{ infraID }}-ingress-port"
       os_port_bootstrap: "{{ infraID }}-bootstrap-port"
       os_port_master: "{{ infraID }}-master-port"
       os_port_worker: "{{ infraID }}-worker-port"

--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -21,7 +21,7 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
-    when: os_subnet6_range is not defined
+    when: os_subnet6 is not defined
 
   - name: 'Create the dualstack Compute ports'
     openstack.cloud.port:
@@ -34,7 +34,7 @@
       - ip_address: "{{ os_ingressVIP6 }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
-    when: os_subnet6_range is defined
+    when: os_subnet6 is defined
 
   - name: 'Set Compute ports tag'
     ansible.builtin.command:

--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -21,6 +21,20 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
+    when: os_subnet6_range is not defined
+
+  - name: 'Create the dualstack Compute ports'
+    openstack.cloud.port:
+      name: "{{ item.1 }}-{{ item.0 }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_sg_worker }}"
+      allowed_address_pairs:
+      - ip_address: "{{ os_ingressVIP }}"
+      - ip_address: "{{ os_ingressVIP6 }}"
+    with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
+    register: ports
+    when: os_subnet6_range is defined
 
   - name: 'Set Compute ports tag'
     ansible.builtin.command:

--- a/upi/openstack/control-plane.yaml
+++ b/upi/openstack/control-plane.yaml
@@ -22,7 +22,7 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
-    when: os_subnet6_range is not defined
+    when: os_subnet6 is not defined
 
   - name: 'Create the dualstack Control Plane ports'
     openstack.cloud.port:
@@ -37,7 +37,7 @@
       - ip_address: "{{ os_ingressVIP6 }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
-    when: os_subnet6_range is defined
+    when: os_subnet6 is defined
 
   - name: 'Set Control Plane ports tag'
     ansible.builtin.command:

--- a/upi/openstack/control-plane.yaml
+++ b/upi/openstack/control-plane.yaml
@@ -22,6 +22,22 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
+    when: os_subnet6_range is not defined
+
+  - name: 'Create the dualstack Control Plane ports'
+    openstack.cloud.port:
+      name: "{{ item.1 }}-{{ item.0 }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_sg_master }}"
+      allowed_address_pairs:
+      - ip_address: "{{ os_apiVIP }}"
+      - ip_address: "{{ os_apiVIP6 }}"
+      - ip_address: "{{ os_ingressVIP }}"
+      - ip_address: "{{ os_ingressVIP6 }}"
+    with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+    register: ports
+    when: os_subnet6_range is defined
 
   - name: 'Set Control Plane ports tag'
     ansible.builtin.command:

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -6,6 +6,8 @@ all:
 
       # User-provided values
       os_subnet_range: '10.0.0.0/16'
+      # uncomment for dual stack
+      # os_subnet6_range: 'd2e:6f44:5dd8:c956::/64'
       os_flavor_master: 'm1.xlarge'
       os_flavor_worker: 'm1.large'
       os_image_rhcos: 'rhcos'

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -4,10 +4,15 @@ all:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
+      # Network resource names
+      os_network: ocp-network
+      os_port_api: ocp-api-port
+      os_port_ingress: ocp-ingress-port
+      os_router: ocp-external-router
+      os_subnet: ocp-subnet-v4
+
       # User-provided values
       os_subnet_range: '10.0.0.0/16'
-      # uncomment for dual stack
-      # os_subnet6_range: 'd2e:6f44:5dd8:c956::/64'
       os_flavor_master: 'm1.xlarge'
       os_flavor_worker: 'm1.large'
       os_image_rhcos: 'rhcos'
@@ -63,12 +68,43 @@ all:
       # in case of install failure.
       os_bootstrap_fip: '203.0.113.20'
 
-      # An IP address that will be assigned to the API VIP.
+      # An IPv4 address that will be assigned to the API VIP.
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
+      # This value will be overwritten by the network.yaml playbook.
       os_apiVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(5) }}"
 
-      # An IP address that will be assigned to the ingress VIP.
+      # An IPv4 address that will be assigned to the ingress VIP.
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
+      # This value will be overwritten by the network.yaml playbook.
       os_ingressVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(7) }}"
+
+      # Set control-plane nodes to schedule workloads when number of compute
+      # nodes is zero
+      os_master_schedulable: "{{ os_compute_nodes_number | int == 0 }}"
+
+      # Name of the IPv6 subnet. Uncomment to enable dual-stack support
+      #os_subnet6: ocp-subnet-v6
+
+      # IPv6 subnet CIDR
+      os_subnet6_range: 'fd2e:6f44:5dd8:c956::/64'
+
+      # Modes are one of: slaac, dhcpv6-stateful or dhcpv6-stateless
+      os_subnet6_address_mode: slaac
+      os_subnet6_router_advertisements_mode: slaac
+
+      # IPv6 service subnet cidr
+      service_subnet6_range: 'fd02::/112'
+
+      # IPv6 cluster network details
+      cluster_network6_cidr: 'fd01::/48'
+      cluster_network6_prefix: 64
+
+      # An IPv6 address that will be assigned to the API VIP.
+      # This value will be overwritten by the network.yaml playbook.
+      os_apiVIP6: ""
+
+      # An IPv6 address that will be assigned to the ingress VIP.
+      # This value will be overwritten by the network.yaml playbook.
+      os_ingressVIP6: ""

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -30,9 +30,7 @@
       ip_version: 6
       ipv6_address_mode: "{{ os_subnet6_address_mode }}"
       ipv6_ra_mode: "{{ os_subnet6_router_advertisements_mode }}"
-    when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+    when: os_subnet6 is defined
 
   - name: 'Create the service network'
     openstack.cloud.network:
@@ -118,8 +116,7 @@
       - "{{ os_subnet }}"
       - "{{ os_subnet6 }}"
     when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+    - os_subnet6 is defined
     - os_external_network is defined and os_external_network|length>0
 
   - name: 'Create the API port'
@@ -130,8 +127,7 @@
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_apiVIP }}"
     register: _api_ports
-    when:
-    - os_subnet6_range is not defined
+    when: os_subnet6 is not defined
 
   - set_fact:
       api_ports: "{{ _api_ports }}"
@@ -142,9 +138,7 @@
       name: "{{ os_port_api }}"
       network: "{{ os_network }}"
     register: _api_ports
-    when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+    when: os_subnet6 is defined
 
   - set_fact:
       api_ports: "{{ _api_ports }}"
@@ -158,8 +152,7 @@
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_ingressVIP }}"
     register: _ingress_ports
-    when:
-    - os_subnet6_range is not defined
+    when: os_subnet6 is not defined
 
   - set_fact:
       ingress_ports: "{{ _ingress_ports }}"
@@ -170,9 +163,7 @@
       name: "{{ os_port_ingress }}"
       network: "{{ os_network }}"
     register: _ingress_ports
-    when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+    when: os_subnet6 is defined
 
   - set_fact:
       ingress_ports: "{{ _ingress_ports }}"

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -5,21 +5,15 @@
 # openstacksdk
 # netaddr
 
-- ansible.builtin.import_playbook: common.yaml
-
 - hosts: all
   gather_facts: no
 
   tasks:
-  - name: 'Create the primary cluster network'
+  - name: 'Create the cluster network'
     openstack.cloud.network:
       name: "{{ os_network }}"
 
-  - name: 'Set tags on the  primary cluster network'
-    ansible.builtin.command:
-      cmd: "openstack network set --tag {{ primary_cluster_network_tag }} --tag {{ cluster_id_tag }} {{ os_network }}"
-
-  - name: 'Create the primary cluster subnet'
+  - name: 'Create the cluster IPv4 subnet'
     openstack.cloud.subnet:
       name: "{{ os_subnet }}"
       network_name: "{{ os_network }}"
@@ -28,9 +22,17 @@
       allocation_pool_end: "{{ os_subnet_range | ansible.utils.ipaddr('last_usable') }}"
       dns_nameservers: "{{ os_external_dns }}"
 
-  - name: 'Set tags on  primary cluster subnet'
-    ansible.builtin.command:
-      cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet }}"
+  - name: 'Create the cluster IPv6 subnet'
+    openstack.cloud.subnet:
+      name: "{{ os_subnet6 }}"
+      network_name: "{{ os_network }}"
+      cidr: "{{ os_subnet6_range }}"
+      ip_version: 6
+      ipv6_address_mode: "{{ os_subnet6_address_mode }}"
+      ipv6_ra_mode: "{{ os_subnet6_router_advertisements_mode }}"
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6
 
   - name: 'Create the service network'
     openstack.cloud.network:
@@ -109,49 +111,107 @@
       - "{{ os_subnet }}"
     when: os_external_network is defined and os_external_network|length>0
 
-  - name: 'Set external router tag'
-    ansible.builtin.command:
-      cmd: "openstack router set --tag {{ cluster_id_tag }} {{ os_router }}"
-    when: os_external_network is defined and os_external_network|length>0
+  - name: 'Add IPv6 subnet to the external router'
+    openstack.cloud.router:
+      name: "{{ os_router }}"
+      interfaces:
+      - "{{ os_subnet }}"
+      - "{{ os_subnet6 }}"
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6
+    - os_external_network is defined and os_external_network|length>0
 
   - name: 'Create the API port'
     openstack.cloud.port:
       name: "{{ os_port_api }}"
       network: "{{ os_network }}"
-      security_groups:
-      - "{{ os_sg_master }}"
       fixed_ips:
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_apiVIP }}"
+    register: _api_ports
+    when:
+    - os_subnet6_range is not defined
 
-  - name: 'Set API port tag'
-    ansible.builtin.command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_api }}"
+  - set_fact:
+      api_ports: "{{ _api_ports }}"
+    when: _api_ports.changed
+
+  - name: 'Create the dualstack API port'
+    openstack.cloud.port:
+      name: "{{ os_port_api }}"
+      network: "{{ os_network }}"
+    register: _api_ports
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6
+
+  - set_fact:
+      api_ports: "{{ _api_ports }}"
+    when: _api_ports.changed
 
   - name: 'Create the Ingress port'
     openstack.cloud.port:
       name: "{{ os_port_ingress }}"
       network: "{{ os_network }}"
-      security_groups:
-      - "{{ os_sg_worker }}"
       fixed_ips:
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_ingressVIP }}"
+    register: _ingress_ports
+    when:
+    - os_subnet6_range is not defined
 
-  - name: 'Set the Ingress port tag'
-    ansible.builtin.command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_ingress }}"
+  - set_fact:
+      ingress_ports: "{{ _ingress_ports }}"
+    when: _ingress_ports.changed
 
-  # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
-  # ports, let's use the CLI instead
-  - name: 'Attach the API floating IP to API port'
-    ansible.builtin.command:
-      cmd: "openstack floating ip set --port {{ os_port_api }} {{ os_api_fip }}"
-    when: os_api_fip is defined and os_api_fip|length>0
+  - name: 'Create the dualstack Ingress port'
+    openstack.cloud.port:
+      name: "{{ os_port_ingress }}"
+      network: "{{ os_network }}"
+    register: _ingress_ports
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6
 
-  # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
-  # ports, let's use the CLI instead
-  - name: 'Attach the Ingress floating IP to Ingress port'
-    ansible.builtin.command:
-      cmd: "openstack floating ip set --port {{ os_port_ingress }} {{ os_ingress_fip }}"
-    when: os_ingress_fip is defined and os_ingress_fip|length>0
+  - set_fact:
+      ingress_ports: "{{ _ingress_ports }}"
+    when: _ingress_ports.changed
+
+  - name: 'Populate inventory with API addresses'
+    shell: |
+      python -c 'import yaml
+      path = "inventory.yaml"
+      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
+      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
+      if ipv4 != "False":
+        key = "os_apiVIP"
+        ip = ipv4
+      else:
+        key = "os_apiVIP6"
+        ip = ipv6
+      data = yaml.safe_load(open(path))
+      data["all"]["hosts"]["localhost"][key] = ip
+      open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+    when:
+    - api_ports.port is defined
+    loop: "{{ api_ports.port.fixed_ips }}"
+
+  - name: 'Populate inventory with Ingress addresses'
+    shell: |
+      python -c 'import yaml
+      path = "inventory.yaml"
+      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
+      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
+      if ipv4 != "False":
+        key = "os_ingressVIP"
+        ip = ipv4
+      else:
+        key = "os_ingressVIP6"
+        ip = ipv6
+      data = yaml.safe_load(open(path))
+      data["all"]["hosts"]["localhost"][key] = ip
+      open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+    when:
+    - ingress_ports.port is defined
+    loop: "{{ ingress_ports.port.fixed_ips }}"

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -70,17 +70,6 @@
       port_range_min: 6443
       port_range_max: 6443
 
-  - name: 'Create master-sg IPv6 rule "OpenShift API"'
-    openstack.cloud.security_group_rule:
-      security_group: "{{ os_sg_master }}"
-      ether_type: IPv6
-      protocol: tcp
-      port_range_min: 6443
-      port_range_max: 6443
-    when:
-    - os_subnet6_range is defined
-    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
-
   - name: 'Create master-sg rule "VXLAN"'
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_master }}"
@@ -212,34 +201,12 @@
       port_range_min: 80
       port_range_max: 80
 
-  - name: 'Create worker-sg IPv6 rule "Ingress HTTP"'
-    openstack.cloud.security_group_rule:
-      security_group: "{{ os_sg_worker }}"
-      ether_type: IPv6
-      protocol: tcp
-      port_range_min: 80
-      port_range_max: 80
-    when:
-    - os_subnet6_range is defined
-    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
-
   - name: 'Create worker-sg rule "Ingress HTTPS"'
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
-
-  - name: 'Create worker-sg IPv6 rule "Ingress HTTPS"'
-    openstack.cloud.security_group_rule:
-      security_group: "{{ os_sg_worker }}"
-      ether_type: IPv6
-      protocol: tcp
-      port_range_min: 443
-      port_range_max: 443
-    when:
-    - os_subnet6_range is defined
-    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
 
   - name: 'Create worker-sg rule "router"'
     openstack.cloud.security_group_rule:
@@ -326,3 +293,61 @@
       security_group: "{{ os_sg_worker }}"
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
+
+  - name: 'Create security groups for IPv6'
+    block:
+    - name: 'Create master-sg IPv6 rule "OpenShift API"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_master }}"
+        ether_type: IPv6
+        protocol: tcp
+        port_range_min: 6443
+        port_range_max: 6443
+
+    - name: 'Create worker-sg IPv6 rule "Ingress HTTP"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_worker }}"
+        ether_type: IPv6
+        protocol: tcp
+        port_range_min: 80
+        port_range_max: 80
+
+    - name: 'Create worker-sg IPv6 rule "Ingress HTTPS"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_worker }}"
+        ether_type: IPv6
+        protocol: tcp
+        port_range_min: 443
+        port_range_max: 443
+
+    - name: 'Create master-sg rule "master ingress HTTP (TCP)"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_master }}"
+        ether_type: IPv6
+        protocol: tcp
+        port_range_min: 80
+        port_range_max: 80
+      when: os_master_schedulable is defined and os_master_schedulable
+
+    - name: 'Create master-sg rule "master ingress HTTPS (TCP)"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_master }}"
+        ether_type: IPv6
+        protocol: tcp
+        port_range_min: 443
+        port_range_max: 443
+      when: os_master_schedulable is defined and os_master_schedulable
+
+    - name: 'Create master-sg rule "router"'
+      openstack.cloud.security_group_rule:
+        security_group: "{{ os_sg_master }}"
+        ether_type: IPv6
+        protocol: tcp
+        remote_ip_prefix: "{{ os_subnet_range }}"
+        port_range_min: 1936
+        port_range_max: 1936
+      when: os_master_schedulable is defined and os_master_schedulable
+
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -299,7 +299,7 @@
     - name: 'Create master-sg IPv6 rule "OpenShift API"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_master }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         port_range_min: 6443
         port_range_max: 6443
@@ -307,7 +307,7 @@
     - name: 'Create worker-sg IPv6 rule "Ingress HTTP"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_worker }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         port_range_min: 80
         port_range_max: 80
@@ -315,7 +315,7 @@
     - name: 'Create worker-sg IPv6 rule "Ingress HTTPS"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_worker }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         port_range_min: 443
         port_range_max: 443
@@ -323,7 +323,7 @@
     - name: 'Create master-sg rule "master ingress HTTP (TCP)"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_master }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         port_range_min: 80
         port_range_max: 80
@@ -332,7 +332,7 @@
     - name: 'Create master-sg rule "master ingress HTTPS (TCP)"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_master }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         port_range_min: 443
         port_range_max: 443
@@ -341,12 +341,11 @@
     - name: 'Create master-sg rule "router"'
       openstack.cloud.security_group_rule:
         security_group: "{{ os_sg_master }}"
-        ether_type: IPv6
+        ethertype: IPv6
         protocol: tcp
         remote_ip_prefix: "{{ os_subnet_range }}"
         port_range_min: 1936
         port_range_max: 1936
       when: os_master_schedulable is defined and os_master_schedulable
 
-    when:
-      when: os_subnet6 is defined
+    when: os_subnet6 is defined

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -349,5 +349,4 @@
       when: os_master_schedulable is defined and os_master_schedulable
 
     when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+      when: os_subnet6 is defined

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -70,6 +70,17 @@
       port_range_min: 6443
       port_range_max: 6443
 
+  - name: 'Create master-sg IPv6 rule "OpenShift API"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      ether_type: IPv6
+      protocol: tcp
+      port_range_min: 6443
+      port_range_max: 6443
+    when:
+    - os_subnet6_range is defined
+    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
+
   - name: 'Create master-sg rule "VXLAN"'
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_master }}"
@@ -201,12 +212,34 @@
       port_range_min: 80
       port_range_max: 80
 
+  - name: 'Create worker-sg IPv6 rule "Ingress HTTP"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_worker }}"
+      ether_type: IPv6
+      protocol: tcp
+      port_range_min: 80
+      port_range_max: 80
+    when:
+    - os_subnet6_range is defined
+    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
+
   - name: 'Create worker-sg rule "Ingress HTTPS"'
     openstack.cloud.security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
+
+  - name: 'Create worker-sg IPv6 rule "Ingress HTTPS"'
+    openstack.cloud.security_group_rule:
+      security_group: "{{ os_sg_worker }}"
+      ether_type: IPv6
+      protocol: tcp
+      port_range_min: 443
+      port_range_max: 443
+    when:
+    - os_subnet6_range is defined
+    - "{{ os_subnet6_range|ansible.utils.ipv6 }}"
 
   - name: 'Create worker-sg rule "router"'
     openstack.cloud.security_group_rule:

--- a/upi/openstack/update-network-resources.yaml
+++ b/upi/openstack/update-network-resources.yaml
@@ -1,0 +1,62 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+# netaddr
+
+- ansible.builtin.import_playbook: common.yaml
+
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  - name: 'Set tags on the primary cluster network'
+    ansible.builtin.command:
+      cmd: "openstack network set --tag {{ primary_cluster_network_tag }} --tag {{ cluster_id_tag }} {{ os_network }}"
+
+  - name: 'Set tags on primary cluster subnet IPv4'
+    ansible.builtin.command:
+      cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet }}"
+
+  - name: 'Set tags on primary cluster subnet IPv6'
+    ansible.builtin.command:
+      cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet6 }}"
+    when:
+    - os_subnet6_range is defined
+    - os_subnet6_range|ansible.utils.ipv6
+
+  - name: 'Set tags on the API VIP port'
+    ansible.builtin.command:
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_api }}"
+
+  - name: 'Set tags on the Ingress VIP port'
+    ansible.builtin.command:
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_ingress }}"
+
+  - name: 'Set external router tag'
+    ansible.builtin.command:
+      cmd: "openstack router set --tag {{ cluster_id_tag }} {{ os_router }}"
+    when: os_external_network is defined and os_external_network|length>0
+
+  # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
+  # ports, let's use the CLI instead
+  - name: 'Attach the API floating IP to API port'
+    ansible.builtin.command:
+      cmd: "openstack floating ip set --port {{ os_port_api }} {{ os_api_fip }}"
+    when: os_api_fip is defined and os_api_fip|length>0
+
+  # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
+  # ports, let's use the CLI instead
+  - name: 'Attach the Ingress floating IP to Ingress port'
+    ansible.builtin.command:
+      cmd: "openstack floating ip set --port {{ os_port_ingress }} {{ os_ingress_fip }}"
+    when: os_ingress_fip is defined and os_ingress_fip|length>0
+
+  - name: 'Set security group to api port'
+    ansible.builtin.command:
+      cmd: "openstack port set --security-group {{ os_sg_master }} {{ os_port_api }}"
+
+  - name: 'Set security group to ingress port'
+    ansible.builtin.command:
+      cmd: "openstack port set --security-group {{ os_sg_worker }} {{ os_port_ingress }}"

--- a/upi/openstack/update-network-resources.yaml
+++ b/upi/openstack/update-network-resources.yaml
@@ -22,9 +22,7 @@
   - name: 'Set tags on primary cluster subnet IPv6'
     ansible.builtin.command:
       cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet6 }}"
-    when:
-    - os_subnet6_range is defined
-    - os_subnet6_range|ansible.utils.ipv6
+    when: os_subnet6 is defined
 
   - name: 'Set tags on the API VIP port'
     ansible.builtin.command:


### PR DESCRIPTION
This PR combines all the required commits to enable dual-stack support.
The commits were gathered from the [release-4.15 branch](https://github.com/openshift/installer/commits/release-4.15/upi/openstack).

Note that the docs change is required to make the openstack-upi green. Also, there is a commit that is not available on 4.15, which is needed to set the TechPreviewNoUpgrade flag.