### PR TITLE
Bug OCPBUGS-29084: OpenStack: Fix dualstack with external load-balancer

### DIFF
--- a/data/data/openstack/masters/private-network.tf
+++ b/data/data/openstack/masters/private-network.tf
@@ -103,14 +103,14 @@ data "openstack_networking_port_ids_v2" "ingress_ports" {
 }
 
 resource "openstack_networking_port_secgroup_associate_v2" "api_port_sg" {
-  count              = var.use_ipv6 ? 1 : 0
+  count              = (! var.openstack_user_managed_load_balancer && var.use_ipv6) ? 1 : 0
   port_id            = data.openstack_networking_port_ids_v2.api_ports.ids[0]
   security_group_ids = [openstack_networking_secgroup_v2.master.id]
   depends_on         = [data.openstack_networking_port_ids_v2.api_ports]
 }
 
 resource "openstack_networking_port_secgroup_associate_v2" "ingress_port_sg" {
-  count              = var.use_ipv6 ? 1 : 0
+  count              = (! var.openstack_user_managed_load_balancer && var.use_ipv6) ? 1 : 0
   port_id            = data.openstack_networking_port_ids_v2.ingress_ports.ids[0]
   security_group_ids = [openstack_networking_secgroup_v2.worker.id]
   depends_on         = [data.openstack_networking_port_ids_v2.ingress_ports]


### PR DESCRIPTION
When the cluster is created with an external load-balancer, no api or ingress VIP Ports exists, but for dual-stack installations we are expecting those Ports to pre-exists, resulting in failure to add security groups to those Ports. This commit fixes the issue by ensuring to only attach the security group when no external lb is configured and dual-stack is used.