### PR TITLE
OCPBUGS-29584: PowerVS: handle composite_instance

### DIFF
--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -751,11 +751,16 @@ func (o *ClusterUninstaller) ServiceInstanceNameToGUID(ctx context.Context, name
 				return "", fmt.Errorf("failed to get instance, response is: %v", response)
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
-				if resourceInstance.GUID != nil && *resourceInstance.Name == name {
-					return *resourceInstance.GUID, nil
-				}
+			if resourceInstance.Type == nil || resourceInstance.GUID == nil {
+				continue
 			}
+			if *resourceInstance.Type != "service_instance" && *resourceInstance.Type != "composite_instance" {
+				continue
+			}
+			if *resourceInstance.Name != name {
+				continue
+			}
+			return *resourceInstance.GUID, nil
 		}
 
 		// Based on: https://cloud.ibm.com/apidocs/resource-controller/resource-controller?code=go#list-resource-instances

--- a/pkg/destroy/powervs/serviceinstance.go
+++ b/pkg/destroy/powervs/serviceinstance.go
@@ -121,16 +121,24 @@ func (o *ClusterUninstaller) listServiceInstances() (cloudResources, error) {
 				o.Logger.Debugf("listServiceInstances: type: %v", *resourceInstance.Type)
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
-				if strings.Contains(*resource.Name, o.InfraID) {
-					result = append(result, cloudResource{
-						key:      *resource.ID,
-						name:     *resource.Name,
-						status:   *resource.GUID,
-						typeName: serviceInstanceTypeName,
-						id:       *resource.ID,
-					})
-				}
+			if resourceInstance.Type == nil || resourceInstance.GUID == nil {
+				continue
+			}
+			if *resourceInstance.Type != "service_instance" && *resourceInstance.Type != "composite_instance" {
+				continue
+			}
+			if !strings.Contains(*resource.Name, o.InfraID) {
+				continue
+			}
+
+			if strings.Contains(*resource.Name, o.InfraID) {
+				result = append(result, cloudResource{
+					key:      *resource.ID,
+					name:     *resource.Name,
+					status:   *resource.GUID,
+					typeName: serviceInstanceTypeName,
+					id:       *resource.ID,
+				})
 			}
 		}
 


### PR DESCRIPTION
When the IPI installer creates a service instance for the user, PowerVS will now have the type as composite_instance rather than service_instance.  Fixup delete cluster to account for this change.