### PR TITLE
OCPBUGS-29587: Power VS: Fix service instance list

### DIFF
--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -663,7 +663,7 @@ func (c *Client) ListServiceInstances(ctx context.Context) ([]string, error) {
 				continue
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
+			if resourceInstance.Type != nil && (*resourceInstance.Type == "service_instance" || *resourceInstance.Type == "composite_instance") {
 				serviceInstances = append(serviceInstances, fmt.Sprintf("%s %s", *resource.Name, *resource.GUID))
 			}
 		}
@@ -738,7 +738,7 @@ func (c *Client) ServiceInstanceGUIDToName(ctx context.Context, id string) (stri
 				continue
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
+			if resourceInstance.Type != nil && (*resourceInstance.Type == "service_instance" || *resourceInstance.Type == "composite_instance") {
 				if resourceInstance.GUID != nil && *resourceInstance.GUID == id {
 					if resourceInstance.Name == nil {
 						return "", nil


### PR DESCRIPTION
Due to a change in how Power VS workspaces are cataloged, new service instances are not picked up by the installer.  This patch expands the filter to include the new catalog name.