### PR TITLE
OCPBUGS-29626: update RHCOS 4.14 bootimage metadata to 414.92.202402130420-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.14",
   "metadata": {
-    "last-modified": "2024-01-17T23:32:16Z",
+    "last-modified": "2024-02-16T19:00:59Z",
     "generator": "plume cosa2stream efa00a6"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-aws.aarch64.vmdk.gz",
-                "sha256": "2358ce80917f26dd3e53c748f78e9be40b0af0f92235534ef16de8636f836432",
-                "uncompressed-sha256": "daee989bb688e93a0e9c6a15000c00f4ef5a45456c165a8460d079388eb38922"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-aws.aarch64.vmdk.gz",
+                "sha256": "4849b2ce3dbac2e0fc9cea99454c3454ab547cd6085554f6c165f299f55944c6",
+                "uncompressed-sha256": "a81923562cd39a867ec6a75c71b9b3104ad6ca0a743b23d2511f756cf2d4fb0c"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-azure.aarch64.vhd.gz",
-                "sha256": "db31063440c5ebf31229a6e44b626dc299328774e2c0204871acd7351ed4204e",
-                "uncompressed-sha256": "ddfccea37e0da7053f19d8683da2d866edab8da788a156861b0ce7b4bcb0692c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-azure.aarch64.vhd.gz",
+                "sha256": "84edeb4279c63971c83eb95661b2ee4de50fedd1cb139a84e14562edd394c400",
+                "uncompressed-sha256": "5de76009fa4fa62f6a1fb41963cb37e40668aa6b9b00a6c80284d3f50eea1af1"
               }
             }
           }
         },
         "gcp": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-gcp.aarch64.tar.gz",
-                "sha256": "f445304147a502ea3cb056c21d0237ac08d94102951b6b7996b4dabe1a46a5a4",
-                "uncompressed-sha256": "bc4ff0c8a3348220fb5fdd816c0566c363766c66d8c8a2c43ab3424a97f82369"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-gcp.aarch64.tar.gz",
+                "sha256": "ec3e22d3ea9223cae95a82ed3985f093fb0d446cc42f9a06bb600e87307f0381",
+                "uncompressed-sha256": "b05d7cb2a4d83891f6ce8fc173e1ed7bf1b94b81252b07604cbf10c0442bc10d"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-metal4k.aarch64.raw.gz",
-                "sha256": "2e258468fbd61f34db7e3e57c6580dc4f7bb39599e37a1c62a3fe1e02d2469fb",
-                "uncompressed-sha256": "ed705c6308096e405b3b33c1bb31883422fe76f382705219af18002dabd760e7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-metal4k.aarch64.raw.gz",
+                "sha256": "86974fad8c330dd01780971030588f087c50d6bd68ecee9bac60474d43cd376b",
+                "uncompressed-sha256": "9d4c7623c776daee5605363710c89190b743b9519739b51075891e57c444b350"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-live.aarch64.iso",
-                "sha256": "8d664f166c4838209e45f19f32476b4136c4087366d42b58c0cc4d74aa40af6b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-live.aarch64.iso",
+                "sha256": "cfde5552618278837418b935915a97a28a722ef1ed04f3045f2f2726b2abe7c7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-live-kernel-aarch64",
-                "sha256": "9316ec6fd602258d621c7eb260445712a9708bdab188b06480ca7721ee5ddf3c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-live-kernel-aarch64",
+                "sha256": "9fe18b78439d0a3bfac7d4c1cdd2526b6e796937c6704ae17fe6b103b330c15f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-live-initramfs.aarch64.img",
-                "sha256": "13996aedbda18ff5df888096a7dcb1fafa801a2bda8cdabd0374da1e4ec4d2fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-live-initramfs.aarch64.img",
+                "sha256": "3cd0562ec432c1021f8be1bc62b40905f943a84900bdc5dc26cfb8fa56ea3cf6"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-live-rootfs.aarch64.img",
-                "sha256": "eb20221e4ffd5f274a6432d12c2f330637e973d73c31c112dd6877c08a168917"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-live-rootfs.aarch64.img",
+                "sha256": "b181651cc2969b653630deccfa3e9c99bc54c6b4283ed004459e58f4435caf4f"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-metal.aarch64.raw.gz",
-                "sha256": "1307258e2e7d38f260b953a5cd92c60750193e0a8bb8448203ea42f366c37946",
-                "uncompressed-sha256": "bbfabd96be62bfa6df7362c34ed212de1f60b352ac2eefd1daf121a66a911c39"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-metal.aarch64.raw.gz",
+                "sha256": "3594a879ca74ce83c7485fc9e345e5dc987266c8106847bcb3c71443ea505e20",
+                "uncompressed-sha256": "d0f73fc85a1ed45efb729e392cef3f808fb015b3b5c4bed61e16f52de1ebd4ba"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-openstack.aarch64.qcow2.gz",
-                "sha256": "69f74b71a0d8438b6c652fd1920d8feee4f3d5538097f9cb74e972f2930c862f",
-                "uncompressed-sha256": "a79e1727ea9fe33224aa29a25ca8f862e6664f9dae1f4c4c07987aaa18fe0425"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-openstack.aarch64.qcow2.gz",
+                "sha256": "5bd6fc7fe12f4304f67d4c3621c6da938a26d208d2cf028092b621b5e552f7b2",
+                "uncompressed-sha256": "d72f75fd74ec7508583185b44212c0df155435b1b5679a692648d1e9190dc7b2"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/aarch64/rhcos-414.92.202401110948-0-qemu.aarch64.qcow2.gz",
-                "sha256": "cf079fe66e04a92b40d8c4ed0ef813789a14e12b3204caab4023da35ec6208d2",
-                "uncompressed-sha256": "7e09fd93edf3eca9c13b1105ed3aa0b7612b1c5ff1b92146da7e7608c4606e92"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/aarch64/rhcos-414.92.202402130420-0-qemu.aarch64.qcow2.gz",
+                "sha256": "22a60b7e91a7061024b7cb599f6dcb8d5ade8fa844926eefb1d60480dd6ce0d5",
+                "uncompressed-sha256": "2892900720a0eae7a186037fdf6c248b898f443a1632f728f0e955cc6cd288c5"
               }
             }
           }
@@ -111,213 +111,217 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0f58a38b1c4f69627"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0c7abceb2a1e9fe9d"
             },
             "ap-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0403a8626b9db8037"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0aaaafd5c43c7f909"
             },
             "ap-northeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-095eef858527f05ed"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0d920c2825a80dd73"
             },
             "ap-northeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0a137547880d333f0"
+              "release": "414.92.202402130420-0",
+              "image": "ami-081bfbff8c48cdf32"
             },
             "ap-northeast-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-01f701678a30345bb"
+              "release": "414.92.202402130420-0",
+              "image": "ami-09ff7b1fae8fa54df"
             },
             "ap-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0a217d5dc37eaecb3"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0166b140c9f7ce84b"
             },
             "ap-south-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-084b05a81156f9e1b"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0587d51e4263a4fa2"
             },
             "ap-southeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-00bb8b8a424433e18"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0074bc46004ab9960"
             },
             "ap-southeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-08581c58e770d5cdc"
+              "release": "414.92.202402130420-0",
+              "image": "ami-03fe61685be908d16"
             },
             "ap-southeast-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0099668932c11cf78"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0bf6a37cb7eab7489"
             },
             "ap-southeast-4": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-084ba92784910ce86"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0897f8c5e0906d223"
             },
             "ca-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0087a66421acdf8aa"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0b103c92876e3f398"
+            },
+            "ca-west-1": {
+              "release": "414.92.202402130420-0",
+              "image": "ami-0d5eb6438d0114030"
             },
             "eu-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-02fd6c8904e6163b6"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0cb5dcbf8787a53a1"
             },
             "eu-central-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-05a76752b97dd2d8f"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0127373b73d39c545"
             },
             "eu-north-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0e1c90bc76cda7836"
+              "release": "414.92.202402130420-0",
+              "image": "ami-09b46bbe6befd4ba9"
             },
             "eu-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-04d5fd2c9c7ed71e4"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0644be767aea7bc3d"
             },
             "eu-south-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-045f72edede682ca7"
+              "release": "414.92.202402130420-0",
+              "image": "ami-098be5096dee0301c"
             },
             "eu-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-014f431ac126e9f3e"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0688bedc3a4a5cd23"
             },
             "eu-west-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0b9308a049795a945"
+              "release": "414.92.202402130420-0",
+              "image": "ami-08b8ef4df7d5ddde2"
             },
             "eu-west-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0fe7a5834def5a3bb"
+              "release": "414.92.202402130420-0",
+              "image": "ami-070062031b370b566"
             },
             "il-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-01928aa76628e135c"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0420ed3e00d55baab"
             },
             "me-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-07538705dd62ee25c"
+              "release": "414.92.202402130420-0",
+              "image": "ami-01f3bd8961c77cca6"
             },
             "me-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0bbc03ffbbd55ca5d"
+              "release": "414.92.202402130420-0",
+              "image": "ami-04edd80e262622e06"
             },
             "sa-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-07a81ca21ee869c32"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0cf6791a687beed36"
             },
             "us-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-00d2e9e999d647e18"
+              "release": "414.92.202402130420-0",
+              "image": "ami-04dc2db8c446fb64b"
             },
             "us-east-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-096d1309c99242d45"
+              "release": "414.92.202402130420-0",
+              "image": "ami-09ae1644593c40acd"
             },
             "us-gov-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-097b043e63070a95e"
+              "release": "414.92.202402130420-0",
+              "image": "ami-082ffc0dc07201992"
             },
             "us-gov-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-05b3d137fc15eb015"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0a680bc84372e9368"
             },
             "us-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-061ecc0bebd0b6cf5"
+              "release": "414.92.202402130420-0",
+              "image": "ami-02d4fffbdd29db588"
             },
             "us-west-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0f8a2236a10107b78"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0458011ee70172ff4"
             }
           }
         },
         "gcp": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-414-92-202401110948-0-gcp-aarch64"
+          "name": "rhcos-414-92-202402130420-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202401110948-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202401110948-0-azure.aarch64.vhd"
+          "release": "414.92.202402130420-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202402130420-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-metal4k.ppc64le.raw.gz",
-                "sha256": "3603aaaee56db1be402ce4038b4e6d0e802cc40f9c94c01b192c2d902d12fee0",
-                "uncompressed-sha256": "9b3b7129c77d7b996ce565128e9d5c6443059a107174873c59a8fefccb298f3a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-metal4k.ppc64le.raw.gz",
+                "sha256": "e59c27a9071b581d5900cd7380e331a5aef21ba0b5b33c444dcc230d3f158b42",
+                "uncompressed-sha256": "87382fcabcd5651a345d3f3e5df7ec18bb44f8d1328f03c33ecb9fbbad8f5427"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-live.ppc64le.iso",
-                "sha256": "c58947eb902cef0e420dc9832e85e802425aa0e58d30d2be8decf0416696e0c0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-live.ppc64le.iso",
+                "sha256": "d696632933c64d45d6058f42fc24170badc365be04b95798b208a56478c41412"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-live-kernel-ppc64le",
-                "sha256": "d6d5c5f3513fb31198cf0b65f5146512cbea8275eb32b3d5415f4d5b0d0b7edf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-live-kernel-ppc64le",
+                "sha256": "a5628ed30d2f6b5d0a128e8f32dd3a1af3ca1d264210148a46c386de123eca3f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-live-initramfs.ppc64le.img",
-                "sha256": "68c697e34d3f2d1d4f1acaa97097a4bd848d5fb13c451664384bc2bc9a63edc1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-live-initramfs.ppc64le.img",
+                "sha256": "21a40e8e39832d33718747eb3f8d198b9695cc5c08e9fc621e38bab10b8c19ea"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-live-rootfs.ppc64le.img",
-                "sha256": "f723088009d5c5baa6f78d85ebf514932bac6cd660572b386548503128fc27a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-live-rootfs.ppc64le.img",
+                "sha256": "281e5ed5d04f43854ac3e78f27e7c6f1b789fa6a48ac7934a9f0687ebd4b9190"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-metal.ppc64le.raw.gz",
-                "sha256": "31620e5f56287a18172b60dba1dda030750bae3e452c8b0fbf3978b0d8d44448",
-                "uncompressed-sha256": "1eda139c7d744422a554721687197ad2b3c1b05be011a68f346b54ae1bf972b9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-metal.ppc64le.raw.gz",
+                "sha256": "b9025851c09939625de75290317aa6892dbce692be8297e95d9bf5147b0aadb0",
+                "uncompressed-sha256": "ba2ecf3f2db3af998f8986ca0c34e8410c56cac2b31b58838a1228de0802f8b2"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "774df281b03ea1248695dd4d5d73cf7946969700829f4dae38bf698d7ffb958e",
-                "uncompressed-sha256": "b42f1f334d4d975f3f2a6ef16810754c642bcc3392ab86e8d445b7ac70f6d397"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "29fd06d125af2e5294be533b55ea53ab42c8752033d17085668c6791cea166af",
+                "uncompressed-sha256": "23a38a62b19423ed3d9cb559c274707e56520adfd5461168c4e2454df542955e"
               }
             }
           }
         },
         "powervs": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-powervs.ppc64le.ova.gz",
-                "sha256": "da4191afe95057fac2f9b793789913895b7cf0a2f4deb5851b212fd53ef83d71",
-                "uncompressed-sha256": "07c1cee2bdb738ed648cf5d83e79a67cfd154edec6450b86d297753be3e897d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-powervs.ppc64le.ova.gz",
+                "sha256": "d25954d47c5e024dd482f0bb349185cfcd39b6d0b70e7a62ea6351b3af0ea850",
+                "uncompressed-sha256": "73a19a7e2fed7912cba126beeeebed2881aeaff7b7647ba474ca05e26b5ced13"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/ppc64le/rhcos-414.92.202309201615-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "e33287787c27b9684756749bb9c9a88f3e831ccde73dd0690803b6f5ac9bf8c5",
-                "uncompressed-sha256": "a3c20c4bc06aec9a7e9766c9a7cbf8468858c8b7f7e79b3f1eb884f74461e54c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/ppc64le/rhcos-414.92.202402130420-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "f587f472f361569d90e43bd68daa4a7ac888b7ae63858081ccf5f76aa5b3f022",
+                "uncompressed-sha256": "6c5e11dd6f4e3bc857540630651052e4f004655f686610710528a53803a98df8"
               }
             }
           }
@@ -327,58 +331,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
+            },
+            "eu-es": {
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
+              "bucket": "rhcos-powervs-images-eu-es",
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "414.92.202309201615-0",
-              "object": "rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz",
+              "release": "414.92.202402130420-0",
+              "object": "rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202309201615-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-414-92-202402130420-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -387,88 +397,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "9d9bfb5db4eb7b65e6855e99c61e96c3b713b24ba5e8771902ac4343286138ee",
-                "uncompressed-sha256": "0cfac834c7a04f1d3b765a336f2b63514c2f460f0d0381abc3c08cc18f6e6a42"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "398e07f9fe60334ff77c5a3101043e711899df0cbbe0a5e322996dd887615061",
+                "uncompressed-sha256": "9379a94404ae99245a6748581f8c0840a44b0cc322e8fa6283c97aae8ef94251"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-metal4k.s390x.raw.gz",
-                "sha256": "9771a204c1629fd753bdfaee4c086046e23e5724ba62c7620d359bbfa8ea7302",
-                "uncompressed-sha256": "09b26ec60f847b7315d72915fa9f9dfd690e00b9037e983862423595b179a8aa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-metal4k.s390x.raw.gz",
+                "sha256": "ec71daaa6a630f68a5b871fbcc71dcefa06e56a52fef6be0f76f862b5354fabd",
+                "uncompressed-sha256": "8d3a601afe927d6e104820d06dcc74a29c9d9c16e738ad4b665235b5e7a6f5d0"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-live.s390x.iso",
-                "sha256": "01e334a31be033af22ae58c0c3ebb933a18fd983649537f7cd0454c1f6e1094d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-live.s390x.iso",
+                "sha256": "71017566bee6ec0e21b6caafa131645a124b3cc95396401934fc96c0ac5e8eec"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-live-kernel-s390x",
-                "sha256": "e9ec1d0851ffa0c888028b6a3867e3ac91376550098ac7ae5a4cbe4cedfd5e4b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-live-kernel-s390x",
+                "sha256": "97ce28b1d5742956aed6097eab8e8021627f27b580c483ee4f6cb5b57eec7fb0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-live-initramfs.s390x.img",
-                "sha256": "f1dc01e772624249d35adf581e15b0783cacae856a1cd9a4a8431f9fb2e0e832"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-live-initramfs.s390x.img",
+                "sha256": "cd601cdbe5a6feb81cd8ed1de25e3d36a9fac8c7e347f9b1c7d184caf882c99f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-live-rootfs.s390x.img",
-                "sha256": "7fb4f7868ee8b1ab6e7a50dc9d294913c740a9c64b38443cb6f6ad17542cb088"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-live-rootfs.s390x.img",
+                "sha256": "faf33bb48e442897a287ed78b7eb9d25a8bc5a2c822a2d58ce6f039a978a10a4"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-metal.s390x.raw.gz",
-                "sha256": "500dca79b89807f6d1c93bae19044e030de3952164b6851d8b03b8653ee3aa39",
-                "uncompressed-sha256": "9c7489a299b52dc8009ec84e17adee253295587712d33c7f5e4dc46706592ba5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-metal.s390x.raw.gz",
+                "sha256": "0b2c908f2261260b26ae2a0a784555df21f8fcaf04d7e5b4c0ec67ebc4140e10",
+                "uncompressed-sha256": "1ffbb50b16f483d7059a529e70f167e9b4cd6e1849e64434e24a15d86f3f4e49"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-openstack.s390x.qcow2.gz",
-                "sha256": "a513f64626f1e929a1b1acb4e67f53e9a9bd0860efc268f273cd73e219fa6965",
-                "uncompressed-sha256": "5572cc4943c817a9a2e616fd7645cc32fcf54eb1f52cea57021d6767c94a583a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-openstack.s390x.qcow2.gz",
+                "sha256": "c82280055c17af516cdcfd10f2813539ba4c7bc92a9769ba358f3cd7e624f9c2",
+                "uncompressed-sha256": "3116ca7528acb683b7a2cee87e17e430ea5d1bc228241b3bacf1bc2f9c80116b"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-qemu.s390x.qcow2.gz",
-                "sha256": "42b9429df0588b8f8a0310024c86b21173f983d956f207334702b6e07e775085",
-                "uncompressed-sha256": "5275027e53695714e66515ef5fd006f33ac8ca11b2eeaca286c413584f428f4c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-qemu.s390x.qcow2.gz",
+                "sha256": "0cfc49ad423a8f7c9305dc18291b0af8d2c0f4cc230a2620ae8e236c05ba3614",
+                "uncompressed-sha256": "5f57de11433eaf30406d7817307eb7e67aaf284e8169d63ec24ea52a07138273"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "414.92.202309201615-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202309201615-0/s390x/rhcos-414.92.202309201615-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "7f82fc3a07549005dd143c14a8665050ed6f64c526a57e994442ccd1daa8a76d",
-                "uncompressed-sha256": "f2d2dd4990189f10c799c3f0067d42199da33cc652881656e9d0c91f6477cf9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/s390x/rhcos-414.92.202402130420-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "5ad2c13fee14d54749deea4859e5ca3b306c677945a51d415eea75d066bc1fa6",
+                "uncompressed-sha256": "63430a9a452a1df2ef9c5e33e062c5c30999d84345fd8d2ab27066d6630b146c"
               }
             }
           }
@@ -479,169 +489,169 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "762355ebf0f9169e4fb41aa02b4fd13eed897b867f70d623a9bb701bb80838dd",
-                "uncompressed-sha256": "35d168a0e341d3913fd55cc4911e0ed0156e02c672bce1048060d59c81678391"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "72c93756b32fb55b49b12b776424b06d8141fee9c14518a5429b1eea69ce3b70",
+                "uncompressed-sha256": "f8359765374f8cd6ef986b3d7a37d0305fc9a25d6630b5b8e5490fe0a463a942"
               }
             }
           }
         },
         "aws": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-aws.x86_64.vmdk.gz",
-                "sha256": "1009cde7a450ec21ccdb60528fcb222d1a362c592fbe18aba5241ed7d58f746e",
-                "uncompressed-sha256": "1e7e5223304b8b61b961ae3f1e08c8ee650c70b0f250c38a87b349cca58a68e9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-aws.x86_64.vmdk.gz",
+                "sha256": "0251240c4785142db4813678ce4e589d42e3ff60c77c4e80b47bec23476d9175",
+                "uncompressed-sha256": "e4f71b8240ae2a0abad8bcb18bb117cb4ef3bd4bc3a8cc1d431d25832356eb12"
               }
             }
           }
         },
         "azure": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-azure.x86_64.vhd.gz",
-                "sha256": "3fb0215fc25a507914849327b0ac8dd2f454e2aa5d13e156dd782b503e0a4f68",
-                "uncompressed-sha256": "0acf53b6a27179d00d5b5cab5ae61801aa8523c30b347008601c3adb18bee640"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-azure.x86_64.vhd.gz",
+                "sha256": "87d820897986580aab4bd76b35efe5a4e7a33b21c79ee7274abd7a1ec782ad5a",
+                "uncompressed-sha256": "3f7bef5209e99f61b7fb79f12eec9c437061f5c9883414f8a27d29c410c43f7c"
               }
             }
           }
         },
         "azurestack": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-azurestack.x86_64.vhd.gz",
-                "sha256": "db3bee6ace0c2cfdba027ce50d32ad2dabf8e07b20e0ea103ef3268ca3d80157",
-                "uncompressed-sha256": "e96ef654719d194d4de7fcd07fdbe55a80c6318b6498ba15a809c7b61228c620"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-azurestack.x86_64.vhd.gz",
+                "sha256": "9f4b8e17993657c2d536ef06eeeb03fb97e9cf2abb5644647dbd13780a5711f2",
+                "uncompressed-sha256": "3419a14c239dadb4b143c83b081df6d1131c41bd84540763be8e6939b462d051"
               }
             }
           }
         },
         "gcp": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-gcp.x86_64.tar.gz",
-                "sha256": "00dcd0fd55c8bafef71823c5da502239832df64486d4f2034294a358a0bc719e",
-                "uncompressed-sha256": "a62f9f23187d7519c1354d3cf6e1b73ac1e865ae7d6e68f14f90ccc6c9880f3b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-gcp.x86_64.tar.gz",
+                "sha256": "3cb60489beda6f9bd41f97caa88ceb63de66579c37790cb9e27e7b7db7825941",
+                "uncompressed-sha256": "9ba8b13d38ee935da275906aff176c2e2732e961e6c4e6879752c830841d082b"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "3cb09eeaa9f543af05776df5c175b13bb440a719092109bc091396edb08d9966",
-                "uncompressed-sha256": "3ef16bafca31af3cd98b3f735167e1c3ca2e8d97b1ea37d837b31b543b98692e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "cb01a1439f4fe23db4e4ce35512665f0ee65e96f470904be94091fddf0945e92",
+                "uncompressed-sha256": "8199f9387deb5bf94938bb6a7e6847fe5c6399a324f16115bfe099fa0698ecfd"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-kubevirt.x86_64.ociarchive",
-                "sha256": "6f93cedde870cd57531fbd7c6a700ee7a1d6cea3726054dc22fdbf95f7f0b1b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-kubevirt.x86_64.ociarchive",
+                "sha256": "eee189578ee20f634647230847d2611399686873334a4cecceadca56cbf9453f"
               }
             }
           }
         },
         "metal": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-metal4k.x86_64.raw.gz",
-                "sha256": "00b3fea2e52c13f87165d71f6bd4816e356461578eae050e1798a9a9e27bae14",
-                "uncompressed-sha256": "9e9edc2b0190037ebc1d593ef5dcf839754a24584e56245eb7075b3a571ec1b4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-metal4k.x86_64.raw.gz",
+                "sha256": "4a58fffdc1261e49d02a1a4f9db1d4652b02b08626a8826b16f2be2196be40aa",
+                "uncompressed-sha256": "142e5375c7715189cabaab6285462f1d81abf0aab066c8fa74e76c73de358240"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-live.x86_64.iso",
-                "sha256": "4114ebb84ca04bfcba8a030c664e3279fac7e11e48bdad15a474180c892ab699"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-live.x86_64.iso",
+                "sha256": "4fa1a811a63c73a2c647cc00c40920eb85f1dfebef0042bdc8d33c4a492641c9"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-live-kernel-x86_64",
-                "sha256": "2dbfd689a856edd4292e7b4a467526089d136791fb0f4d38dfef8ed92447b481"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-live-kernel-x86_64",
+                "sha256": "7071c938ef59b5c2402c2f9a14172a9c13ed2edb05097bee7a8841755d069b99"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-live-initramfs.x86_64.img",
-                "sha256": "268e016202deb518f78cd753655cf8e6c95d106b9c71840561443751e4cbb9f5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-live-initramfs.x86_64.img",
+                "sha256": "694e434817d45d8ef76c5070519ced6adad322ba8800641499f04b3f9c7cb305"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-live-rootfs.x86_64.img",
-                "sha256": "5bbb86320c0444a69d4de76ea4ae442af840760d45b72a74a979df0e6b804e8f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-live-rootfs.x86_64.img",
+                "sha256": "b081b65a88dfc9b6e928261f7005a2379948752d436e6adf0c47bba454f03f68"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-metal.x86_64.raw.gz",
-                "sha256": "9eb2af6d0341a4e8c6f5cc2ab299383dbb008da32a1f480d9bfe0f5191f5b550",
-                "uncompressed-sha256": "8f99c1fe92da774690c61273c68e2cb5616878799714ca6724e7fa9816f3a247"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-metal.x86_64.raw.gz",
+                "sha256": "907f6998a54c83731e2381f4cde601336c0260cdd36b85b68167f6faba5f42a6",
+                "uncompressed-sha256": "996a0c7c7b6fb92b4317127164fc2ef47c4b7a64f22601d64e0252997e82d2e2"
               }
             }
           }
         },
         "nutanix": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-nutanix.x86_64.qcow2",
-                "sha256": "05b523c28edac8bc5b71a242e81dd3ef6a5d69089941b1356030afe4be08b7f6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-nutanix.x86_64.qcow2",
+                "sha256": "53d2c5ac3ef9cb92f4a9297dd3c940c770f64677b9807aacec56a667ae64eb2c"
               }
             }
           }
         },
         "openstack": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-openstack.x86_64.qcow2.gz",
-                "sha256": "a501385770df455fb2e932729a33a0d8b8caf6c72fc6af1cce49ffbbaf49c9ca",
-                "uncompressed-sha256": "e5173a4bdb56ee5280efc1c0b30869e968cf4e71f22aa9d2db18baa3db9528c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-openstack.x86_64.qcow2.gz",
+                "sha256": "b4029327f99a5c8fb5ab3b0d4939ab8894ab609a7745934f299620a534f7878b",
+                "uncompressed-sha256": "dd196d8cd8f4c588995e56e646635623873c22310b42785990efa6a0f6e9e827"
               }
             }
           }
         },
         "qemu": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-qemu.x86_64.qcow2.gz",
-                "sha256": "a63fee3364fe51592895fc29a3a8392883e95fea3a81e17c6e0d316dd6814201",
-                "uncompressed-sha256": "8e28aa77ffb11344089310479bc952a0a5fdac43f58f4edb93b046d81075a7bd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-qemu.x86_64.qcow2.gz",
+                "sha256": "36f5296e03288d657148a083418aef5e8a5634ec45937b186d821443e997cedf",
+                "uncompressed-sha256": "82f1770d718b5e5cdf0e1142ead26f56b0b56e7399ae349fd455d757a0b5931d"
               }
             }
           }
         },
         "vmware": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202401110948-0/x86_64/rhcos-414.92.202401110948-0-vmware.x86_64.ova",
-                "sha256": "46e09d618bc7f01c8aa23328eb0a0e0516e65d5766c079736c561fd5fb41930a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.14-9.2/builds/414.92.202402130420-0/x86_64/rhcos-414.92.202402130420-0-vmware.x86_64.ova",
+                "sha256": "37322c13b62b5040a64e58da78c73ed1d30c9c721f2a441e976e6d09dd824fb6"
               }
             }
           }
@@ -651,266 +661,270 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-6wej0m6qv159wyveufzb"
+              "release": "414.92.202402130420-0",
+              "image": "m-6we1upm9n8azxakfktrh"
             },
             "ap-northeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "m-mj75ouw9373vj6001qfz"
+              "release": "414.92.202402130420-0",
+              "image": "m-mj7574mmck37fkloqvy6"
             },
             "ap-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-a2d5cw7zxj4vsk42vhxo"
+              "release": "414.92.202402130420-0",
+              "image": "m-a2d2srxwwea6kon742ps"
             },
             "ap-southeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-t4n7rf1gviymef8ki2sm"
+              "release": "414.92.202402130420-0",
+              "image": "m-t4n7kmeieer5c5sbi1si"
             },
             "ap-southeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "m-p0w0uz3gcazaeyjk5mw6"
+              "release": "414.92.202402130420-0",
+              "image": "m-p0wcj2q8qtzct69iol6q"
             },
             "ap-southeast-3": {
-              "release": "414.92.202401110948-0",
-              "image": "m-8ps4jcc9m1mexbht1neq"
+              "release": "414.92.202402130420-0",
+              "image": "m-8ps5sv2n83xpe3m91axi"
             },
             "ap-southeast-5": {
-              "release": "414.92.202401110948-0",
-              "image": "m-k1a4qkmbywj0he8wx5wx"
+              "release": "414.92.202402130420-0",
+              "image": "m-k1a94ydabmedf89o7zig"
             },
             "ap-southeast-6": {
-              "release": "414.92.202401110948-0",
-              "image": "m-5ts7lw7loxx5fsqo4wnn"
+              "release": "414.92.202402130420-0",
+              "image": "m-5ts40n0cyw788asoem1n"
             },
             "ap-southeast-7": {
-              "release": "414.92.202401110948-0",
-              "image": "m-0jo6lqq6ct5amn8qapdb"
+              "release": "414.92.202402130420-0",
+              "image": "m-0jo08kxd0nmupy1cev02"
             },
             "cn-beijing": {
-              "release": "414.92.202401110948-0",
-              "image": "m-2ze3s237j1bs0e0dx8l1"
+              "release": "414.92.202402130420-0",
+              "image": "m-2ze6ecol9ibmhpqg0ztk"
             },
             "cn-chengdu": {
-              "release": "414.92.202401110948-0",
-              "image": "m-2vc9pf2ke4dz7hvt62rb"
+              "release": "414.92.202402130420-0",
+              "image": "m-2vc7ler3en7h5cy7dlrs"
             },
             "cn-fuzhou": {
-              "release": "414.92.202401110948-0",
-              "image": "m-gw06ptuxtmku5m79darr"
+              "release": "414.92.202402130420-0",
+              "image": "m-gw06e9tyax0ufknq86j5"
             },
             "cn-guangzhou": {
-              "release": "414.92.202401110948-0",
-              "image": "m-7xv5wmrsmvhlzdo87a8q"
+              "release": "414.92.202402130420-0",
+              "image": "m-7xve9z0hktad1edxqsoc"
             },
             "cn-hangzhou": {
-              "release": "414.92.202401110948-0",
-              "image": "m-bp10m5gxyeb0c80skokm"
+              "release": "414.92.202402130420-0",
+              "image": "m-bp1dc8mvqrja1ca225hi"
             },
             "cn-heyuan": {
-              "release": "414.92.202401110948-0",
-              "image": "m-f8z6gmqdijjj1hsj2i46"
+              "release": "414.92.202402130420-0",
+              "image": "m-f8zivv82dbpow8mk59bw"
             },
             "cn-hongkong": {
-              "release": "414.92.202401110948-0",
-              "image": "m-j6c4mhk3ff8cpclv6ju8"
+              "release": "414.92.202402130420-0",
+              "image": "m-j6cf92amxjoj386qxgba"
             },
             "cn-huhehaote": {
-              "release": "414.92.202401110948-0",
-              "image": "m-hp30esqlt8yr2r65mbbo"
+              "release": "414.92.202402130420-0",
+              "image": "m-hp3ihqlvfguiy9or5uyj"
             },
             "cn-nanjing": {
-              "release": "414.92.202401110948-0",
-              "image": "m-gc72lo2mc5w3ue71fk1u"
+              "release": "414.92.202402130420-0",
+              "image": "m-gc73e1ud3f7idl1a5aq9"
             },
             "cn-qingdao": {
-              "release": "414.92.202401110948-0",
-              "image": "m-m5e2mi1wki4a6lzwna9m"
+              "release": "414.92.202402130420-0",
+              "image": "m-m5eitwpclf6rpy9ws8i0"
             },
             "cn-shanghai": {
-              "release": "414.92.202401110948-0",
-              "image": "m-uf6etvfng2af5f0tefel"
+              "release": "414.92.202402130420-0",
+              "image": "m-uf6chw6yzu0frac5ubg8"
             },
             "cn-shenzhen": {
-              "release": "414.92.202401110948-0",
-              "image": "m-wz9g2k95dplip7esys8p"
+              "release": "414.92.202402130420-0",
+              "image": "m-wz9g05cvasry9ty7fcor"
             },
             "cn-wuhan-lr": {
-              "release": "414.92.202401110948-0",
-              "image": "m-n4a2lo2mc5w3tshp6ybl"
+              "release": "414.92.202402130420-0",
+              "image": "m-n4a3e1ud3f7idf46t4sw"
             },
             "cn-wulanchabu": {
-              "release": "414.92.202401110948-0",
-              "image": "m-0jl1nkbn6zttlljh6m1j"
+              "release": "414.92.202402130420-0",
+              "image": "m-0jleyzoysj6q1ve8pold"
             },
             "cn-zhangjiakou": {
-              "release": "414.92.202401110948-0",
-              "image": "m-8vb9suvga07uaclsfki3"
+              "release": "414.92.202402130420-0",
+              "image": "m-8vb8c5ra9wp32csnuwry"
             },
             "eu-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-gw8beg3ccgpe2nzjkma1"
+              "release": "414.92.202402130420-0",
+              "image": "m-gw81rqh6ypviroih2go0"
             },
             "eu-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-d7o9wlguvnyapnldt5zn"
+              "release": "414.92.202402130420-0",
+              "image": "m-d7o32h2z24d5va45zu8j"
             },
             "me-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-l4vcuivy0e2sehqmqqg8"
+              "release": "414.92.202402130420-0",
+              "image": "m-l4vamp58b8ok39402f8n"
             },
             "me-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-eb399p2y8yn0oa5dfteq"
+              "release": "414.92.202402130420-0",
+              "image": "m-eb3eextoii7cssj3dfmm"
             },
             "us-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-0xicpp44cj3o216s0ofj"
+              "release": "414.92.202402130420-0",
+              "image": "m-0xi0cg516gxfa8c38fq1"
             },
             "us-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "m-rj9ety8ii28q2q7djx56"
+              "release": "414.92.202402130420-0",
+              "image": "m-rj979d2cbek1i2357k49"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0b39fde96c5540eeb"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0b88e328077c742ee"
             },
             "ap-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-03dd885fca7ab2f6e"
+              "release": "414.92.202402130420-0",
+              "image": "ami-068c2a851efe580e0"
             },
             "ap-northeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-06e762bbaa404adcc"
+              "release": "414.92.202402130420-0",
+              "image": "ami-03282ae7a652973b1"
             },
             "ap-northeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0f2cfcf090a1bc6f0"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0e2875240f919a163"
             },
             "ap-northeast-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-068e5202baa3002d5"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0ed48b3b034c07328"
             },
             "ap-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-00950ef4dc2dd5ed0"
+              "release": "414.92.202402130420-0",
+              "image": "ami-091432ab23822a1fc"
             },
             "ap-south-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0597be4abb87943df"
+              "release": "414.92.202402130420-0",
+              "image": "ami-00695b5c3db5d5b10"
             },
             "ap-southeast-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-028a6290bae947f47"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0c7bebc047285a034"
             },
             "ap-southeast-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0baf6ad81cd8c64c6"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0eaa7805dc6127321"
             },
             "ap-southeast-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0cc394a1a5bd65797"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0b4998fcd2d3423f2"
             },
             "ap-southeast-4": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-020f9dc5e3abd1001"
+              "release": "414.92.202402130420-0",
+              "image": "ami-05f2a935ffb7107da"
             },
             "ca-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0ff3520d4dc090fa1"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0d46ee21cbc08eeb3"
+            },
+            "ca-west-1": {
+              "release": "414.92.202402130420-0",
+              "image": "ami-040522f54316e425f"
             },
             "eu-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0a3c9ee65fbe9caed"
+              "release": "414.92.202402130420-0",
+              "image": "ami-04dfa611b3daffc47"
             },
             "eu-central-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0a30b9d73aa57e9e0"
+              "release": "414.92.202402130420-0",
+              "image": "ami-02f22d383a5d9cef0"
             },
             "eu-north-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0dddca79a625d4581"
+              "release": "414.92.202402130420-0",
+              "image": "ami-02474f16e9b419f71"
             },
             "eu-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-02434645fb4af65e9"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0beb528cb5d543663"
             },
             "eu-south-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0b392d40b11c0387e"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0f4f0813874eb6b1a"
             },
             "eu-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0fcfef916936d1c40"
+              "release": "414.92.202402130420-0",
+              "image": "ami-05014718014676152"
             },
             "eu-west-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-01695469be88be7e5"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0489d4c69a3398fb7"
             },
             "eu-west-3": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-05a16dd0c6f2df931"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0b3efd1be933845cf"
             },
             "il-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-03e9cbb4722c66209"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0823df5ab04af4693"
             },
             "me-central-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-026acda5c1a0a92e8"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0bd73c027eb792d59"
             },
             "me-south-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-0f9864782e4b4044a"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0a400502a2bcef7c2"
             },
             "sa-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-047be17af107e1a2a"
+              "release": "414.92.202402130420-0",
+              "image": "ami-09ffd96b44b65e678"
             },
             "us-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-01d27bac546351489"
+              "release": "414.92.202402130420-0",
+              "image": "ami-092150df83e33e22b"
             },
             "us-east-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-098e6989961461421"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0f736c64d5751d7d3"
             },
             "us-gov-east-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-04c4be14cdd48b4c8"
+              "release": "414.92.202402130420-0",
+              "image": "ami-041b0c94a54e6eb39"
             },
             "us-gov-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-08e2edf3d376a41de"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0b4cfdd6b4df5e4f1"
             },
             "us-west-1": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-08fea87cf74dfe205"
+              "release": "414.92.202402130420-0",
+              "image": "ami-0c330fc891d078e30"
             },
             "us-west-2": {
-              "release": "414.92.202401110948-0",
-              "image": "ami-048f13eb7e8f47548"
+              "release": "414.92.202402130420-0",
+              "image": "ami-044ac520ed922529d"
             }
           }
         },
         "gcp": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-414-92-202401110948-0-gcp-x86-64"
+          "name": "rhcos-414-92-202402130420-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "414.92.202401110948-0",
+          "release": "414.92.202402130420-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.14-9.2-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9efa27d10293b1fa94b80044aebbdc6be800818c8ef162ec89d51d12c6d73176"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d9643ead36b1c026be664c9c65c11433c6cdf71bfd93ba229141d134a4a6dd94"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "414.92.202401110948-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202401110948-0-azure.x86_64.vhd"
+          "release": "414.92.202402130420-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202402130420-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.14 boot image metadata. Issues fixed in this bootimage are:

OCPBUGS-29252 - Backport fix for unexpected Azure IMDS status codes

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name 4.14-9.2                    \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=414.92.202402130420-0                                     \
    aarch64=414.92.202402130420-0                                    \
    s390x=414.92.202402130420-0                                      \
    ppc64le=414.92.202402130420-0
```