### PR TITLE
SPLAT-1459: capv machines only full clone

### DIFF
--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -104,6 +104,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			},
 			Spec: capv.VSphereMachineSpec{
 				VirtualMachineCloneSpec: capv.VirtualMachineCloneSpec{
+					CloneMode:     capv.FullClone,
 					CustomVMXKeys: customVMXKeys,
 					Network: capv.NetworkSpec{
 						Devices: capvNetworkDevices,


### PR DESCRIPTION
We currently do not support linked-clones and
probably shouldn't only in very certain cases (test/dev). At this time statically defining `FullClone`.