### PR TITLE
SPLAT-1460: Make vSphere default ResourcePool formatting not contain double slash.

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_with-credentials.txt
@@ -67,7 +67,7 @@ rendezvousIP: 192.168.111.20
 -- expected/agent-cluster-install.yaml --
 metadata:
   annotations:
-    agent-install.openshift.io/install-config-overrides: '{"platform":{"vsphere":{"vcenters":[{"server":"vcenter.openshift.com","user":"testUser","password":"testPassword","datacenters":["testDatacenter"]}],"failureDomains":[{"name":"testfailureDomain","region":"testRegion","zone":"testZone","server":"vcenter.openshift.com","topology":{"datacenter":"testDatacenter","computeCluster":"/testDatacenter/host/testComputecluster","networks":["testNetwork"],"datastore":"/testDatacenter/datastore/testDatastore","resourcePool":"/testDatacenter/host/testComputecluster//Resources","folder":"/testDatacenter/vm/testFolder"}}]}}}'
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"vsphere":{"vcenters":[{"server":"vcenter.openshift.com","user":"testUser","password":"testPassword","datacenters":["testDatacenter"]}],"failureDomains":[{"name":"testfailureDomain","region":"testRegion","zone":"testZone","server":"vcenter.openshift.com","topology":{"datacenter":"testDatacenter","computeCluster":"/testDatacenter/host/testComputecluster","networks":["testNetwork"],"datastore":"/testDatacenter/datastore/testDatastore","resourcePool":"/testDatacenter/host/testComputecluster/Resources","folder":"/testDatacenter/vm/testFolder"}}]}}}'
   creationTimestamp: null
   name: ostest
   namespace: cluster0

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -867,7 +867,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 								ComputeCluster: "/testDataCenter/host/testCluster",
 								Networks:       []string{""},
 								Datastore:      "/testDataCenter/datastore/testDefaultDataStore",
-								ResourcePool:   "/testDataCenter/host/testCluster//Resources",
+								ResourcePool:   "/testDataCenter/host/testCluster/Resources",
 								Folder:         "/testDataCenter/vm/testFolder",
 							},
 						}},

--- a/pkg/types/vsphere/defaults/platform.go
+++ b/pkg/types/vsphere/defaults/platform.go
@@ -1,7 +1,7 @@
 package defaults
 
 import (
-	"fmt"
+	"path"
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -16,7 +16,7 @@ func SetPlatformDefaults(p *vsphere.Platform, installConfig *types.InstallConfig
 	// and cluster.
 	for i := range p.FailureDomains {
 		if p.FailureDomains[i].Topology.ResourcePool == "" && p.FailureDomains[i].Topology.ComputeCluster != "" {
-			p.FailureDomains[i].Topology.ResourcePool = fmt.Sprintf("%s/%s", p.FailureDomains[i].Topology.ComputeCluster, "/Resources")
+			p.FailureDomains[i].Topology.ResourcePool = path.Join(p.FailureDomains[i].Topology.ComputeCluster, "Resources")
 		}
 	}
 }

--- a/pkg/types/vsphere/defaults/platform_test.go
+++ b/pkg/types/vsphere/defaults/platform_test.go
@@ -16,16 +16,81 @@ func defaultPlatform() *vsphere.Platform {
 	return &vsphere.Platform{}
 }
 
+func validPlatform() *vsphere.Platform {
+	return &vsphere.Platform{
+		VCenters: []vsphere.VCenter{
+			{
+				Server:   "test-vcenter",
+				Port:     443,
+				Username: "test-username",
+				Password: "test-password",
+				Datacenters: []string{
+					"test-datacenter",
+				},
+			},
+		},
+		FailureDomains: []vsphere.FailureDomain{
+			{
+				Name:   "test-east-1a",
+				Region: "test-east",
+				Zone:   "test-east-1a",
+				Server: "test-vcenter",
+				Topology: vsphere.Topology{
+					Datacenter:     "test-datacenter",
+					ComputeCluster: "/test-datacenter/host/test-cluster",
+					Datastore:      "/test-datacenter/datastore/test-datastore",
+					Networks:       []string{"test-portgroup"},
+					ResourcePool:   "/test-datacenter/host/test-cluster/Resources",
+					Folder:         "/test-datacenter/vm/test-folder",
+				},
+			},
+			{
+				Name:   "test-east-2a",
+				Region: "test-east",
+				Zone:   "test-east-2a",
+				Server: "test-vcenter",
+				Topology: vsphere.Topology{
+					Datacenter:     "test-datacenter",
+					ComputeCluster: "/test-datacenter/host/test-cluster",
+					Datastore:      "/test-datacenter/datastore/test-datastore",
+					Networks:       []string{"test-portgroup"},
+					ResourcePool:   "/test-datacenter/host/test-cluster/Resources",
+					Folder:         "/test-datacenter/vm/test-folder",
+				},
+			},
+		},
+	}
+}
+
 func TestSetPlatformDefaults(t *testing.T) {
 	cases := []struct {
-		name     string
-		platform *vsphere.Platform
-		expected *vsphere.Platform
+		name       string
+		platform   *vsphere.Platform
+		expected   *vsphere.Platform
+		expectedRP string
 	}{
 		{
 			name:     "empty",
 			platform: &vsphere.Platform{},
 			expected: defaultPlatform(),
+		},
+		{
+			name:       "completed",
+			platform:   validPlatform(),
+			expected:   validPlatform(),
+			expectedRP: "/test-datacenter/host/test-cluster/Resources",
+		},
+		{
+			name: "incomplete",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				for _, fd := range p.FailureDomains {
+					fd.Topology.ResourcePool = ""
+				}
+				return p
+			}(),
+			expected:   validPlatform(),
+			expectedRP: "/test-datacenter/host/test-cluster/Resources",
 		},
 	}
 	for _, tc := range cases {
@@ -37,6 +102,10 @@ func TestSetPlatformDefaults(t *testing.T) {
 			}
 			SetPlatformDefaults(tc.platform, ic)
 			assert.Equal(t, tc.expected, tc.platform, "unexpected platform")
+
+			for _, fd := range tc.platform.FailureDomains {
+				assert.Equal(t, tc.expectedRP, fd.Topology.ResourcePool, "invalid resource pool")
+			}
 		})
 	}
 }


### PR DESCRIPTION
[SPLAT-1460](https://issues.redhat.com/browse/SPLAT-1460)

## Changes
- Modified default ResourcePool definition to prevent double "/" in path