### PR TITLE
SPLAT-1465: capv - add additional extra configs

### DIFF
--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -88,6 +88,8 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 
 		customVMXKeys := map[string]string{
 			"guestinfo.hostname": machine.Name,
+			"guestinfo.domain":   strings.TrimSuffix(config.ClusterDomain(), "."),
+			"stealclock.enable":  "TRUE",
 		}
 
 		vsphereMachine := &capv.VSphereMachine{


### PR DESCRIPTION
This PR includes two additional extra configs to capv machines:
- guestinfo.domain
- stealclock.enable

These options were set in terraform and need to be enabled for capv-based machines.