### PR TITLE
CORS-3274: GCP: add africa-south1 region to the survey as supported region

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -17,6 +17,7 @@ var (
 	// name of the region.
 	Regions = map[string]string{
 		// List from: https://cloud.google.com/compute/docs/regions-zones/
+		"africa-south1":           "Johannesburg, South Africa",
 		"asia-east1":              "Changhua County, Taiwan",
 		"asia-east2":              "Hong Kong",
 		"asia-northeast1":         "Tokyo, Japan",


### PR DESCRIPTION
Add the africa-south1 GCP region that was not previously listed as a supported region for the installer to use.