### PR TITLE
OCPBUGS-29765: Fills CIS or DNS CRN in Metadata, never both

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -151,7 +151,7 @@ func (a *InstallConfig) finish(filename string) error {
 		a.IBMCloud = icibmcloud.NewMetadata(a.Config)
 	}
 	if a.Config.PowerVS != nil {
-		a.PowerVS = icpowervs.NewMetadata(a.Config.BaseDomain)
+		a.PowerVS = icpowervs.NewMetadata(a.Config)
 	}
 	if a.Config.VSphere != nil {
 		a.VSphere = icvsphere.NewMetadata()

--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -24,7 +24,8 @@ type MetadataAPI interface {
 // do not need to be user-supplied (e.g. because it can be retrieved
 // from external APIs).
 type Metadata struct {
-	BaseDomain string
+	BaseDomain      string
+	PublishStrategy types.PublishingStrategy
 
 	accountID      string
 	apiKey         string
@@ -36,8 +37,8 @@ type Metadata struct {
 }
 
 // NewMetadata initializes a new Metadata object.
-func NewMetadata(baseDomain string) *Metadata {
-	return &Metadata{BaseDomain: baseDomain}
+func NewMetadata(config *types.InstallConfig) *Metadata {
+	return &Metadata{BaseDomain: config.BaseDomain, PublishStrategy: config.Publish}
 }
 
 // AccountID returns the IBM Cloud account ID associated with the authentication
@@ -105,7 +106,7 @@ func (m *Metadata) CISInstanceCRN(ctx context.Context) (string, error) {
 		m.client = client
 	}
 
-	if m.cisInstanceCRN == "" {
+	if m.PublishStrategy == types.ExternalPublishingStrategy && m.cisInstanceCRN == "" {
 		m.cisInstanceCRN, err = m.client.GetInstanceCRNByName(ctx, m.BaseDomain, types.ExternalPublishingStrategy)
 		if err != nil {
 			return "", err
@@ -135,7 +136,7 @@ func (m *Metadata) DNSInstanceCRN(ctx context.Context) (string, error) {
 		m.client = client
 	}
 
-	if m.dnsInstanceCRN == "" {
+	if m.PublishStrategy == types.InternalPublishingStrategy && m.dnsInstanceCRN == "" {
 		m.dnsInstanceCRN, err = m.client.GetInstanceCRNByName(ctx, m.BaseDomain, types.InternalPublishingStrategy)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Implementing the [same fix](#7987) as IBM Cloud proposes for PowerVS.