### PR TITLE
MULTIARCH-4158: pkg/infrastructure/powervs: add initial CAPI provider

### DIFF
--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -12,6 +12,7 @@ import (
 	awscapi "github.com/openshift/installer/pkg/infrastructure/aws/clusterapi"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
+	powervscapi "github.com/openshift/installer/pkg/infrastructure/powervs/clusterapi"
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages/aws"
@@ -70,6 +71,9 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 	case nutanixtypes.Name:
 		return terraform.InitializeProvider(nutanix.PlatformStages), nil
 	case powervstypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(&powervscapi.Provider{}), nil
+		}
 		return terraform.InitializeProvider(powervs.PlatformStages), nil
 	case openstacktypes.Name:
 		return terraform.InitializeProvider(openstack.PlatformStages), nil

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -12,11 +12,13 @@ import (
 	awscapi "github.com/openshift/installer/pkg/infrastructure/aws/clusterapi"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
+	powervscapi "github.com/openshift/installer/pkg/infrastructure/powervs/clusterapi"
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/featuregates"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -40,6 +42,11 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
 			return clusterapi.InitializeProvider(vspherecapi.Provider{}), nil
 		}
+	case powervstypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(powervscapi.Provider{}), nil
+		}
+		return nil, nil
 	}
 	return nil, fmt.Errorf("platform %q is not supported in the altinfra Installer build", platform)
 }

--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -1,0 +1,25 @@
+package clusterapi
+
+import (
+	"context"
+
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
+)
+
+// Provider is the vSphere implementation of the clusterapi InfraProvider.
+type Provider struct {
+	clusterapi.InfraProvider
+}
+
+var _ clusterapi.PreProvider = Provider{}
+
+// Name returns the PowerVS provider name.
+func (p Provider) Name() string {
+	return powervstypes.Name
+}
+
+// PreProvision creates the PowerVS objects required prior to running capv.
+func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) error {
+	return nil
+}


### PR DESCRIPTION
Adds the initial, empty provider for the PowerVS CAPI install process. This should allow basic running of the CAPI provider and a foundation for building the rest of the supporting infrastructure provisioning.