### PR TITLE
OCPBUGS-32091: Add Top-level Context for Create Commands

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/installer/cmd/openshift-install/agent"
@@ -14,7 +16,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/password"
 )
 
-func newAgentCmd() *cobra.Command {
+func newAgentCmd(ctx context.Context) *cobra.Command {
 	agentCmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Commands for supporting cluster installation using agent installer",
@@ -23,7 +25,7 @@ func newAgentCmd() *cobra.Command {
 		},
 	}
 
-	agentCmd.AddCommand(newAgentCreateCmd())
+	agentCmd.AddCommand(newAgentCreateCmd(ctx))
 	agentCmd.AddCommand(agent.NewWaitForCmd())
 	agentCmd.AddCommand(newAgentGraphCmd())
 	return agentCmd
@@ -115,8 +117,7 @@ var (
 	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget, agentConfigImageTarget, agentUnconfiguredIgnitionTarget}
 )
 
-func newAgentCreateCmd() *cobra.Command {
-
+func newAgentCreateCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Commands for generating agent installation artifacts",
@@ -127,7 +128,7 @@ func newAgentCreateCmd() *cobra.Command {
 
 	for _, t := range agentTargets {
 		t.command.Args = cobra.ExactArgs(0)
-		t.command.Run = runTargetCmd(t.assets...)
+		t.command.Run = runTargetCmd(ctx, t.assets...)
 		cmd.AddCommand(t.command)
 	}
 

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -68,6 +68,7 @@ const (
 	exitCodeBootstrapFailed
 	exitCodeInstallFailed
 	exitCodeOperatorStabilityFailed
+	exitCodeInterrupt
 
 	// coStabilityThreshold is how long a cluster operator must have Progressing=False
 	// in order to be considered stable. Measured in seconds.

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -34,7 +34,7 @@ import (
 	_ "github.com/openshift/installer/pkg/gather/gcp"
 )
 
-func newGatherCmd() *cobra.Command {
+func newGatherCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gather",
 		Short: "Gather debugging data for a given installation failure",
@@ -47,7 +47,7 @@ to debug the installation failures`,
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newGatherBootstrapCmd())
+	cmd.AddCommand(newGatherBootstrapCmd(ctx))
 	return cmd
 }
 
@@ -58,7 +58,7 @@ var gatherBootstrapOpts struct {
 	skipAnalysis bool
 }
 
-func newGatherBootstrapCmd() *cobra.Command {
+func newGatherBootstrapCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Gather debugging data for a failing-to-bootstrap control plane",
@@ -66,7 +66,7 @@ func newGatherBootstrapCmd() *cobra.Command {
 		Run: func(_ *cobra.Command, _ []string) {
 			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
-			bundlePath, err := runGatherBootstrapCmd(command.RootOpts.Dir)
+			bundlePath, err := runGatherBootstrapCmd(ctx, command.RootOpts.Dir)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -87,14 +87,14 @@ func newGatherBootstrapCmd() *cobra.Command {
 	return cmd
 }
 
-func runGatherBootstrapCmd(directory string) (string, error) {
+func runGatherBootstrapCmd(ctx context.Context, directory string) (string, error) {
 	assetStore, err := assetstore.NewStore(directory)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create asset store")
 	}
 	// add the default bootstrap key pair to the sshKeys list
 	bootstrapSSHKeyPair := &tls.BootstrapSSHKeyPair{}
-	if err := assetStore.Fetch(bootstrapSSHKeyPair); err != nil {
+	if err := assetStore.Fetch(ctx, bootstrapSSHKeyPair); err != nil {
 		return "", errors.Wrapf(err, "failed to fetch %s", bootstrapSSHKeyPair.Name())
 	}
 	tmpfile, err := os.CreateTemp("", "bootstrap-ssh")
@@ -118,7 +118,7 @@ func runGatherBootstrapCmd(directory string) (string, error) {
 
 	if ha.Bootstrap == "" && len(ha.Masters) == 0 {
 		config := &installconfig.InstallConfig{}
-		if err := assetStore.Fetch(config); err != nil {
+		if err := assetStore.Fetch(ctx, config); err != nil {
 			return "", errors.Wrapf(err, "failed to fetch %s", config.Name())
 		}
 

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -44,17 +44,17 @@ func installerMain() {
 	logrus.RegisterExitHandler(shutdown)
 
 	for _, subCmd := range []*cobra.Command{
-		newCreateCmd(),
+		newCreateCmd(ctx),
 		newDestroyCmd(),
 		newWaitForCmd(),
-		newGatherCmd(),
+		newGatherCmd(ctx),
 		newAnalyzeCmd(),
 		newVersionCmd(),
 		newGraphCmd(),
 		newCoreOSCmd(),
 		newCompletionCmd(),
 		newExplainCmd(),
-		newAgentCmd(),
+		newAgentCmd(ctx),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io"
 	"os"
@@ -12,8 +13,10 @@ import (
 	terminal "golang.org/x/term"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
+	"github.com/openshift/installer/pkg/clusterapi"
 )
 
 func main() {
@@ -35,6 +38,10 @@ func main() {
 
 func installerMain() {
 	rootCmd := newRootCmd()
+
+	// Perform a graceful shutdown upon interrupt or at exit.
+	ctx := handleInterrupt(signals.SetupSignalHandler())
+	logrus.RegisterExitHandler(shutdown)
 
 	for _, subCmd := range []*cobra.Command{
 		newCreateCmd(),
@@ -95,4 +102,27 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.Fatal(errors.Wrap(err, "invalid log-level"))
 	}
+}
+
+// handleInterrupt executes a graceful shutdown then exits in
+// the case of a user interrupt. It returns a new context that
+// will be cancelled upon interrupt.
+func handleInterrupt(signalCtx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// If the context from the signal handler is done,
+	// an interrupt has been received, so shutdown & exit.
+	go func() {
+		<-signalCtx.Done()
+		logrus.Warn("Received interrupt signal")
+		shutdown()
+		cancel()
+		logrus.Exit(exitCodeInterrupt)
+	}()
+
+	return ctx
+}
+
+func shutdown() {
+	clusterapi.System().Teardown()
 }

--- a/pkg/asset/generator.go
+++ b/pkg/asset/generator.go
@@ -1,0 +1,31 @@
+package asset
+
+import (
+	"context"
+)
+
+// Generator is used to generate assets.
+type Generator interface {
+	// Generate generates this asset given
+	// the states of its parent assets.
+	GenerateWithContext(context.Context, Parents) error
+}
+
+// generatorAdapter wraps an asset to provide the
+// Generate with context function.
+type generatorAdapter struct {
+	a Asset
+}
+
+// NewDefaultGenerator creates a new adapter to generate
+// an asset with a context.
+func NewDefaultGenerator(a Asset) Generator {
+	return &generatorAdapter{a: a}
+}
+
+// Generate calls Generate on an asset, dropping the context
+// to maintain compatibility with assets that do not implement
+// generate with context.
+func (a *generatorAdapter) GenerateWithContext(_ context.Context, p Parents) error {
+	return a.a.Generate(p)
+}

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -1,11 +1,15 @@
 package asset
 
+import (
+	"context"
+)
+
 // Store is a store for the states of assets.
 type Store interface {
 	// Fetch retrieves the state of the given asset, generating it and its
 	// dependencies if necessary. When purging consumed assets, none of the
 	// assets in assetsToPreserve will be purged.
-	Fetch(assetToFetch Asset, assetsToPreserve ...WritableAsset) error
+	Fetch(ctx context.Context, assetToFetch Asset, assetsToPreserve ...WritableAsset) error
 
 	// Destroy removes the asset from all its internal state and also from
 	// disk if possible.

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -100,7 +101,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			}
 
 			for _, a := range tc.targets {
-				if err := assetStore.Fetch(a, tc.targets...); err != nil {
+				if err := assetStore.Fetch(context.TODO(), a, tc.targets...); err != nil {
 					t.Fatalf("failed to fetch %q: %v", a.Name(), err)
 				}
 
@@ -125,7 +126,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			for _, a := range tc.targets {
 				name := a.Name()
 				newAsset := reflect.New(reflect.TypeOf(a).Elem()).Interface().(asset.WritableAsset)
-				if err := newAssetStore.Fetch(newAsset, tc.targets...); err != nil {
+				if err := newAssetStore.Fetch(context.TODO(), newAsset, tc.targets...); err != nil {
 					t.Fatalf("failed to fetch %q in new store: %v", a.Name(), err)
 				}
 				assetState := newAssetStore.assets[reflect.TypeOf(a)]

--- a/pkg/asset/store/assetsfetcher.go
+++ b/pkg/asset/store/assetsfetcher.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -12,7 +13,7 @@ import (
 // AssetsFetcher it's used to retrieve and resolve a specified set of assets.
 type AssetsFetcher interface {
 	// Fetchs and persists all the writable assets from the configured assets store.
-	FetchAndPersist(assets []asset.WritableAsset) error
+	FetchAndPersist(context.Context, []asset.WritableAsset) error
 }
 
 type fetcher struct {
@@ -36,14 +37,14 @@ func asFileWriter(a asset.WritableAsset) asset.FileWriter {
 }
 
 // Fetchs all the writable assets from the configured assets store.
-func (f *fetcher) FetchAndPersist(assets []asset.WritableAsset) error {
+func (f *fetcher) FetchAndPersist(ctx context.Context, assets []asset.WritableAsset) error {
 	assetStore, err := NewStore(f.storeDir)
 	if err != nil {
 		return fmt.Errorf("failed to create asset store: %w", err)
 	}
 
 	for _, a := range assets {
-		err := assetStore.Fetch(a, assets...)
+		err := assetStore.Fetch(ctx, a, assets...)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 		}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -72,8 +73,8 @@ func newStore(dir string) (*storeImpl, error) {
 // Fetch retrieves the state of the given asset, generating it and its
 // dependencies if necessary. When purging consumed assets, none of the
 // assets in preserved will be purged.
-func (s *storeImpl) Fetch(a asset.Asset, preserved ...asset.WritableAsset) error {
-	if err := s.fetch(a, ""); err != nil {
+func (s *storeImpl) Fetch(ctx context.Context, a asset.Asset, preserved ...asset.WritableAsset) error {
+	if err := s.fetch(ctx, a, ""); err != nil {
 		return err
 	}
 	if err := s.saveStateFile(); err != nil {
@@ -192,7 +193,7 @@ func (s *storeImpl) saveStateFile() error {
 // fetch populates the given asset, generating it and its dependencies if
 // necessary, and returns whether or not the asset had to be regenerated and
 // any errors.
-func (s *storeImpl) fetch(a asset.Asset, indent string) error {
+func (s *storeImpl) fetch(ctx context.Context, a asset.Asset, indent string) error {
 	logrus.Debugf("%sFetching %s...", indent, a.Name())
 
 	assetState, ok := s.assets[reflect.TypeOf(a)]
@@ -217,13 +218,13 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 	dependencies := a.Dependencies()
 	parents := make(asset.Parents, len(dependencies))
 	for _, d := range dependencies {
-		if err := s.fetch(d, increaseIndent(indent)); err != nil {
+		if err := s.fetch(ctx, d, increaseIndent(indent)); err != nil {
 			return errors.Wrapf(err, "failed to fetch dependency of %q", a.Name())
 		}
 		parents.Add(d)
 	}
 	logrus.Debugf("%sGenerating %s...", indent, a.Name())
-	if err := a.Generate(parents); err != nil {
+	if err := asAssetGenerator(a).GenerateWithContext(ctx, parents); err != nil {
 		return errors.Wrapf(err, "failed to generate asset %q", a.Name())
 	}
 	assetState.asset = a
@@ -370,4 +371,15 @@ func (s *storeImpl) Load(a asset.Asset) (asset.Asset, error) {
 	}
 
 	return s.assets[reflect.TypeOf(a)].asset, nil
+}
+
+// asAssetGenerator determines if an asset implements the
+// Generate with context function, or if it needs an adapter.
+func asAssetGenerator(a asset.Asset) asset.Generator {
+	switch v := a.(type) {
+	case asset.Generator:
+		return v
+	default:
+		return asset.NewDefaultGenerator(a)
+	}
 }

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -281,7 +282,7 @@ func TestStoreFetch(t *testing.T) {
 					source: generatedSource,
 				}
 			}
-			err := store.Fetch(assets[tc.target])
+			err := store.Fetch(context.TODO(), assets[tc.target])
 			assert.NoError(t, err, "error fetching asset")
 			assert.EqualValues(t, tc.expectedGenerationLog, generationLog)
 		})
@@ -375,7 +376,7 @@ func TestStoreFetchOnDiskAssets(t *testing.T) {
 			for _, name := range tc.onDiskAssets {
 				onDiskAssets[reflect.TypeOf(assets[name])] = true
 			}
-			err := store.fetch(assets[tc.target], "")
+			err := store.fetch(context.TODO(), assets[tc.target], "")
 			assert.NoError(t, err, "unexpected error")
 			assert.EqualValues(t, tc.expectedGenerationLog, generationLog)
 			assert.Equal(t, tc.expectedDirty, store.assets[reflect.TypeOf(assets[tc.target])].anyParentsDirty)
@@ -395,7 +396,7 @@ func TestStoreFetchIdempotency(t *testing.T) {
 		}
 		assets := []asset.WritableAsset{&testStoreAssetA{}, &testStoreAssetB{}}
 		for _, a := range assets {
-			err = store.Fetch(a, assets...)
+			err = store.Fetch(context.TODO(), a, assets...)
 			if !assert.NoError(t, err, "(loop %d) unexpected error fetching asset %q", a.Name()) {
 				t.Fatal()
 			}

--- a/pkg/infrastructure/aws/sdk/aws.go
+++ b/pkg/infrastructure/aws/sdk/aws.go
@@ -61,7 +61,7 @@ type output struct {
 }
 
 // Provision creates cluster infrastructure using AWS SDK calls.
-func (a InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
+func (a InfraProvider) Provision(ctx context.Context, dir string, parents asset.Parents) ([]*asset.File, error) {
 	terraformVariables := &tfvarsAsset.TerraformVariables{}
 	parents.Get(terraformVariables)
 	// Unmarshall input from tf variables, so we can use it along with
@@ -109,7 +109,7 @@ func (a InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.Fi
 	usePublicEndpoints := clusterAWSConfig.PublishStrategy == "External"
 
 	logger := logrus.StandardLogger()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	ec2Client := ec2.New(awsSession)

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -17,7 +17,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/metadata"
@@ -95,15 +94,6 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	for _, m := range capiMachinesAsset.RuntimeFiles() {
 		machineManifests = append(machineManifests, m.Object)
 	}
-
-	// TODO(vincepri): The context should be passed down from the caller,
-	// although today the Asset interface doesn't allow it, refactor once it does.
-	ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
-	go func() {
-		<-ctx.Done()
-		cancel()
-		clusterapi.System().Teardown()
-	}()
 
 	if p, ok := i.impl.(PreProvider); ok {
 		preProvisionInput := PreProvisionInput{

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -307,6 +307,14 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	}
 
 	logrus.Infof("Cluster API resources have been created. Waiting for cluster to become ready...")
+
+	// If we're skipping bootstrap destroy, shutdown the local control plane.
+	// Otherwise, we will shut it down after bootstrap destroy.
+	if oi, ok := os.LookupEnv("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP"); ok && oi != "" {
+		logrus.Warn("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set, shutting down local control plane.")
+		clusterapi.System().Teardown()
+	}
+
 	return fileList, nil
 }
 

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -56,7 +56,7 @@ func InitializeProvider(platform Provider) infrastructure.Provider {
 // Provision creates cluster resources by applying CAPI manifests to a locally running control plane.
 //
 //nolint:gocyclo
-func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
+func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset.Parents) ([]*asset.File, error) {
 	manifestsAsset := &manifests.Manifests{}
 	workersAsset := &machines.Worker{}
 	capiManifestsAsset := &capimanifests.Cluster{}

--- a/pkg/infrastructure/provider.go
+++ b/pkg/infrastructure/provider.go
@@ -1,6 +1,8 @@
 package infrastructure
 
 import (
+	"context"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -9,10 +11,11 @@ import (
 // and working with cloud infrastructure.
 type Provider interface {
 	// Provision creates the infrastructure resources for the stage.
+	// ctx: parent context
 	// dir: the path of the install dir
 	// parents: the parent assets, which can be used to obtain any cluser asset dependencies
 	// returns a slice of File assets, which will be appended to the cluster asset file list.
-	Provision(dir string, parents asset.Parents) ([]*asset.File, error)
+	Provision(ctx context.Context, dir string, parents asset.Parents) ([]*asset.File, error)
 
 	// DestroyBootstrap destroys the temporary bootstrap resources.
 	DestroyBootstrap(dir string) error

--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -1,6 +1,8 @@
 package nodejoiner
 
 import (
+	"context"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/image"
 	"github.com/openshift/installer/pkg/asset/agent/joiner"
@@ -20,8 +22,10 @@ func NewAddNodesCommand(directory string, kubeConfig string) error {
 		return err
 	}
 
+	ctx := context.Background()
+
 	fetcher := store.NewAssetsFetcher(directory)
-	return fetcher.FetchAndPersist([]asset.WritableAsset{
+	return fetcher.FetchAndPersist(ctx, []asset.WritableAsset{
 		&workflow.AgentWorkflowAddNodes{},
 		&image.AgentImage{},
 		// To be completed

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -1,6 +1,8 @@
 package nodejoiner
 
 import (
+	"context"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/store"
 )
@@ -8,5 +10,5 @@ import (
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory string) error {
 	fetcher := store.NewAssetsFetcher(directory)
-	return fetcher.FetchAndPersist([]asset.WritableAsset{})
+	return fetcher.FetchAndPersist(context.Background(), []asset.WritableAsset{})
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -36,7 +36,7 @@ func InitializeProvider(stages []Stage) infrastructure.Provider {
 
 // Provision implements pkg/infrastructure/provider.Provision. Provision iterates
 // through each of the stages and applies the Terraform config for the stage.
-func (p *Provider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
+func (p *Provider) Provision(_ context.Context, dir string, parents asset.Parents) ([]*asset.File, error) {
 	tfVars := &tfvars.TerraformVariables{}
 	parents.Get(tfVars)
 	vars := tfVars.Files()


### PR DESCRIPTION
Adds a top-level context when running create commands. The context is passed through the asset store and then to any PostRun functions. The main motivation is for a clean shutdown of CAPI controllers, but there are a wide variety of potential use cases.

This PR uses the pattern introduced in #6009 to enable the introduction of a `GenerateWithContext` function for assets and an adapter to drop the context and call the original `Generate` function. Currently only the Cluster asset implements `GenerateWithContext`. 

Currently the PR achieves the primary goal of shutting down capi controllers on interrupt. There are some remaining issues I would like to clear up:

- [x] on interrupt, the error message simply says context cancelled. Would be better for the error message to indicate a user interrupt
- [x] Need to test that the logrus exit handler is properly shutting down the controllers on error (not just interrupt)
- [x] the interrupt signal handler is being short circuited by [the call to logrus.Exit](https://github.com/openshift/installer/blob/master/cmd/openshift-install/create.go#L313-L323), this means the controllers are not "gracefully shutting down", but on the other hand the processes are being properly killed. It's unclear to me whether we need any special handling now that we have the top-level context.