### PR TITLE
OCPBUGS-30058: GCP: The CAPG bootstrap machine IP should be set according to the publish strategy

### DIFF
--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -64,6 +64,9 @@ func GenerateBootstrapMachines(name string, installConfig *installconfig.Install
 	// Identify this as a bootstrap machine
 	bootstrapGCPMachine.Labels["install.openshift.io/bootstrap"] = ""
 
+	bootstrapMachineIsPublic := installConfig.Config.Publish == types.ExternalPublishingStrategy
+	bootstrapGCPMachine.Spec.PublicIP = ptr.To(bootstrapMachineIsPublic)
+
 	result = append(result, &asset.RuntimeFile{
 		File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapGCPMachine.Name)},
 		Object: bootstrapGCPMachine,


### PR DESCRIPTION
** The default bootstrap machine IP is set to private. When the publish strategy is set to external this value should be True to indicate a public ip address.