### PR TITLE
OCPBUGS-25462: Validate control plane replicas

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/validations/compact_invalid_controlPlane_replicas.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/compact_invalid_controlPlane_replicas.txt
@@ -1,0 +1,42 @@
+! exec openshift-install agent create image --dir $WORK
+
+stderr 'ControlPlane.Replicas can only be set to 3 or 1. Found 2'
+
+! exists $WORK/agent.x86_64.iso
+! exists $WORK/auth/kubeconfig
+! exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 2
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  external:
+    platformName: oci
+    cloudControllerManager: External
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -89,6 +89,10 @@ func (a *OptionalInstallConfig) validateInstallConfig(installConfig *types.Insta
 	numMasters, numWorkers := GetReplicaCount(installConfig)
 	logrus.Infof(fmt.Sprintf("Configuration has %d master replicas and %d worker replicas", numMasters, numWorkers))
 
+	if err := a.validateControlPlaneConfiguration(installConfig); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	if err := a.validateSNOConfiguration(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
 	}
@@ -156,6 +160,19 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 		}
 	}
 
+	return allErrs
+}
+
+func (a *OptionalInstallConfig) validateControlPlaneConfiguration(installConfig *types.InstallConfig) field.ErrorList {
+	var allErrs field.ErrorList
+	var fieldPath *field.Path
+
+	if installConfig.ControlPlane != nil {
+		if *installConfig.ControlPlane.Replicas != 1 && *installConfig.ControlPlane.Replicas != 3 {
+			fieldPath = field.NewPath("ControlPlane", "Replicas")
+			allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.ControlPlane.Replicas, fmt.Sprintf("ControlPlane.Replicas can only be set to 3 or 1. Found %v", *installConfig.ControlPlane.Replicas)))
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -270,6 +270,30 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Total number of Compute.Replicas must be 0 when ControlPlane.Replicas is 1 for platform none or external. Found 3",
 		},
 		{
+			name: "incorrect compute.replicas set",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 2
+platform:
+  external:
+    platformName: oci
+    cloudControllerManager: External
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: ControlPlane.Replicas: Invalid value: 2: ControlPlane.Replicas can only be set to 3 or 1. Found 2",
+		},
+		{
 			name: "invalid platform for SNO cluster",
 			data: `
 apiVersion: v1


### PR DESCRIPTION
The number of control plane replicas defined in install-config.yaml (or agent-cluster-install.yaml) are validated to check if they are set to 3, or 1 in the case of SNO. If set to another value the "create image"(and other similar ) command fails.