### PR TITLE
OCPBUGS-30057: Don't auto create subnets for CAPG

### DIFF
--- a/pkg/asset/manifests/gcp/cluster.go
+++ b/pkg/asset/manifests/gcp/cluster.go
@@ -88,6 +88,8 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	}
 
 	subnets := []capg.SubnetSpec{master, worker}
+	// Subnets should never be auto created, even in shared VPC installs
+	autoCreateSubnets := false
 
 	labels := map[string]string{}
 	labels[fmt.Sprintf("kubernetes-io-cluster-%s", clusterID.InfraID)] = "owned"
@@ -107,8 +109,9 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			Network: capg.NetworkSpec{
 				// TODO: Need a network project for installs where the network resources will exist in another
 				// project such as shared vpc installs
-				Name:    ptr.To(networkName),
-				Subnets: subnets,
+				Name:                  ptr.To(networkName),
+				Subnets:               subnets,
+				AutoCreateSubnetworks: ptr.To(autoCreateSubnets),
 			},
 			AdditionalLabels: labels,
 			FailureDomains:   findFailureDomains(installConfig),


### PR DESCRIPTION
Set the AutoCreateSubnetworks to `false` always (default is `true`) as we don't want to auto create these subnets even when doing a shared VPC install.