### PR TITLE
CORS-3273: capi system: don't log env vars

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -463,7 +463,7 @@ func (c *system) runController(ctx context.Context, ct *controller) error {
 	}
 
 	// Run the controller and store its state.
-	logrus.Infof("Running process: %s with args %v and env %v", ct.Name, ct.Args, env)
+	logrus.Infof("Running process: %s with args %v", ct.Name, ct.Args)
 	if err := pr.Start(ctx, os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("failed to start controller %q: %w", ct.Name, err)
 	}


### PR DESCRIPTION
Only log process args.