### PR TITLE
CORS-3281: IBMCloud: initial CAPI infrastructure

### DIFF
--- a/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
@@ -1,0 +1,24 @@
+package clusterapi
+
+import (
+	"context"
+
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
+)
+
+var _ clusterapi.PreProvider = (*Provider)(nil)
+var _ clusterapi.Provider = (*Provider)(nil)
+
+// Provider implements IBM Cloud CAPI installation.
+type Provider struct{}
+
+// Name returns the IBM Cloud provider name.
+func (p Provider) Name() string {
+	return ibmcloudtypes.Name
+}
+
+// PreProvision creates the IBM Cloud objects required prior to running capibmcloud.
+func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) error {
+	return nil
+}

--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -13,6 +13,7 @@ import (
 	azureinfra "github.com/openshift/installer/pkg/infrastructure/azure"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
+	ibmcloudcapi "github.com/openshift/installer/pkg/infrastructure/ibmcloud/clusterapi"
 	openstackcapi "github.com/openshift/installer/pkg/infrastructure/openstack/clusterapi"
 	powervscapi "github.com/openshift/installer/pkg/infrastructure/powervs/clusterapi"
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
@@ -70,6 +71,9 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 		}
 		return terraform.InitializeProvider(gcp.PlatformStages), nil
 	case ibmcloudtypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
+		}
 		return terraform.InitializeProvider(ibmcloud.PlatformStages), nil
 	case libvirttypes.Name:
 		return terraform.InitializeProvider(libvirt.PlatformStages), nil

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -13,6 +13,7 @@ import (
 	azurecapi "github.com/openshift/installer/pkg/infrastructure/azure"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	gcpcapi "github.com/openshift/installer/pkg/infrastructure/gcp/clusterapi"
+	ibmcloudcapi "github.com/openshift/installer/pkg/infrastructure/ibmcloud/clusterapi"
 	openstackcapi "github.com/openshift/installer/pkg/infrastructure/openstack/clusterapi"
 	powervscapi "github.com/openshift/installer/pkg/infrastructure/powervs/clusterapi"
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
@@ -20,6 +21,7 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/featuregates"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
@@ -41,6 +43,11 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 	case gcptypes.Name:
 		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
 			return clusterapi.InitializeProvider(gcpcapi.Provider{}), nil
+		}
+		return nil, nil
+	case ibmcloudtypes.Name:
+		if fg.Enabled(configv1.FeatureGateClusterAPIInstall) {
+			return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
 		}
 		return nil, nil
 	case vspheretypes.Name:


### PR DESCRIPTION
Adds the initial provider and infrastructure framework for the IBM Cloud CAPI install process.

Related: https://issues.redhat.com/browse/CORS-3281