### PR TITLE
AGENT-858: Agent day2 ignition services

### DIFF
--- a/data/data/agent/files/usr/local/bin/add-node.sh
+++ b/data/data/agent/files/usr/local/bin/add-node.sh
@@ -38,11 +38,10 @@ printf '\nHost %s is ready for installation\n' "${HOST_ID}" 1>&2
 clear_issue "${status_issue}"
 
 # Add the current host to the cluster
-res=$(curl -X POST -s -S "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install")
-code=$(echo "$res" | jq -r '.code')
-message=$(echo "$res" | jq -r '.message')
-if [[ $res = "200" ]]; then 
-    printf "\nHost installation started\n" 1>&2
+res=$(curl -X POST -s -S -w "%{http_code}\\n" -o /dev/null "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install")
+if [[ $res = "202" ]]; then 
+    printf '\nHost installation started\n' 1>&2
 else
-    printf '\nHost installation failed: %s\n' "${message}" 1>&2
+    printf '\nHost installation failed\n' 1>&2
+    exit 1
 fi

--- a/data/data/agent/files/usr/local/bin/add-node.sh
+++ b/data/data/agent/files/usr/local/bin/add-node.sh
@@ -22,14 +22,14 @@ status_issue="90_add-node"
 
 # For some reason the initial role patching doesn't seem to work properly
 echo "Patching host..."
-export HOST_ID=$(curl -s ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts | jq -r '.[].id')
-curl -X PATCH -d '{"host_role":"worker"}' -H "Content-Type: application/json" ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}
+HOST_ID=$(curl -s "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts" | jq -r '.[].id')
+curl -X PATCH -d '{"host_role":"worker"}' -H "Content-Type: application/json" "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}"
 
 # Wait for the current host to be ready
 host_ready=false
-while [[ host_ready == false ]]
+while [[ $host_ready == false ]]
 do
-    host_status=$(curl -s -S "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}" | jq -r .[].status)
+    host_status=$(curl -s -S "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts" | jq -r ".[].status")
     if [[ "${host_status}" != "known" ]]; then
         printf '\\e{yellow}Waiting for the host to be ready' | set_issue "${status_issue}"
         sleep 10
@@ -43,5 +43,5 @@ clear_issue "${status_issue}"
 sleep 1m
 
 # Add the current host to the cluster
-curl -X POST -s -S ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install
+curl -X POST -s -S "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install"
 echo "Host installation started" 1>&2

--- a/data/data/agent/files/usr/local/bin/add-node.sh
+++ b/data/data/agent/files/usr/local/bin/add-node.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# shellcheck disable=SC1091
+source issue_status.sh
+
+BASE_URL="${SERVICE_BASE_URL}api/assisted-install/v2"
+
+cluster_id=""
+while [[ "${cluster_id}" = "" ]]
+do
+    # Get cluster id
+    cluster_id=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].id)
+    if [[ "${cluster_id}" = "" ]]; then
+        sleep 2
+    fi
+done
+
+printf '\nInfra env id is %s\n' "${INFRA_ENV_ID}" 1>&2
+
+status_issue="90_add-node"
+
+# For some reason the initial role patching doesn't seem to work properly
+echo "Patching host..."
+export HOST_ID=$(curl -s ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts | jq -r '.[].id')
+curl -X PATCH -d '{"host_role":"worker"}' -H "Content-Type: application/json" ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}
+
+# Wait for the current host to be ready
+host_ready=false
+while [[ host_ready == false ]]
+do
+    host_status=$(curl -s -S "${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}" | jq -r .[].status)
+    if [[ "${host_status}" != "known" ]]; then
+        printf '\\e{yellow}Waiting for the host to be ready' | set_issue "${status_issue}"
+        sleep 10
+    else
+        host_ready=true
+    fi
+done
+
+clear_issue "${status_issue}"
+
+sleep 1m
+
+# Add the current host to the cluster
+curl -X POST -s -S ${BASE_URL}/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install
+echo "Host installation started" 1>&2

--- a/data/data/agent/systemd/units/agent-add-node.service
+++ b/data/data/agent/systemd/units/agent-add-node.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Adds the current node to an already existing cluster
+Wants=network-online.target
+Requires=apply-host-config.service
+PartOf=assisted-service-pod.service
+After=network-online.target apply-host-config.service
+ConditionPathExists=/etc/assisted/node0
+
+[Service]
+EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
+EnvironmentFile=/usr/local/share/start-cluster/start-cluster.env
+EnvironmentFile=/etc/assisted/rendezvous-host.env
+ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
+ExecStart=/usr/local/bin/add-node.sh
+
+KillMode=none
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -1,0 +1,28 @@
+[Unit]
+Description=Imports an already existing cluster
+Wants=network-online.target assisted-service.service
+PartOf=assisted-service-pod.service
+After=network-online.target assisted-service.service
+ConditionPathExists=/etc/assisted/node0
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Environment=OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
+EnvironmentFile=/etc/assisted/rendezvous-host.env
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
+EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
+EnvironmentFile=/etc/assisted/add-nodes.env
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-import-cluster -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env CLUSTER_ID --env CLUSTER_NAME --env CLUSTER_API_VIP_DNS_NAME $SERVICE_IMAGE /usr/local/bin/agent-installer-client importCluster
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+
+KillMode=none
+Type=oneshot
+Restart=on-failure
+RestartSec=30
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -2,7 +2,7 @@
 Description=Service that registers the infraenv
 Wants=network-online.target assisted-service.service
 PartOf=assisted-service-pod.service
-After=network-online.target assisted-service.service agent-register-cluster.service
+After=network-online.target assisted-service.service {{ if eq .WorkflowType "install" }}agent-register-cluster.service{{ end }}{{ if eq .WorkflowType "addnodes" }}agent-import-cluster.service{{ end }}
 ConditionPathExists=/etc/assisted/node0
 
 [Service]

--- a/data/data/agent/systemd/units/apply-host-config.service
+++ b/data/data/agent/systemd/units/apply-host-config.service
@@ -14,7 +14,7 @@ EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID --env WORKFLOW_TYPE $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/hack/build-node-joiner.sh
+++ b/hack/build-node-joiner.sh
@@ -47,4 +47,4 @@ fi
 echo "building node-joiner"
 
 # shellcheck disable=SC2086
-echo go build ${GOFLAGS} -gcflags "${GCFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/node-joiner
+go build ${GOFLAGS} -gcflags "${GCFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/node-joiner

--- a/hack/build-node-joiner.sh
+++ b/hack/build-node-joiner.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -ex
+
+# shellcheck disable=SC2068
+version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
+
+minimum_go_version=1.21
+current_go_version=$(go version | cut -d " " -f 3)
+
+if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version")" ]; then
+     echo "Go version should be greater or equal to $minimum_go_version"
+     exit 1
+fi
+
+export CGO_ENABLED=0
+MODE="${MODE:-release}"
+
+GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
+GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"
+DEFAULT_ARCH="${DEFAULT_ARCH:-amd64}"
+GOFLAGS="${GOFLAGS:--mod=vendor}"
+GCFLAGS=""
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=${GIT_TAG} -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT} -X github.com/openshift/installer/pkg/version.defaultArch=${DEFAULT_ARCH}"
+TAGS="${TAGS:-}"
+OUTPUT="${OUTPUT:-bin/node-joiner}"
+
+case "${MODE}" in
+release)
+	LDFLAGS="${LDFLAGS} -s -w"
+	TAGS="${TAGS} release"
+	;;
+dev)
+    GCFLAGS="${GCFLAGS} all=-N -l"
+	;;
+*)
+	echo "unrecognized mode: ${MODE}" >&2
+	exit 1
+esac
+
+if test "${SKIP_GENERATION}" != y
+then
+	# this step has to be run natively, even when cross-compiling
+	GOOS='' GOARCH='' go generate ./data
+fi
+
+echo "building node-joiner"
+
+# shellcheck disable=SC2086
+echo go build ${GOFLAGS} -gcflags "${GCFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/node-joiner

--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -92,7 +92,7 @@ func (a *AgentArtifacts) Generate(dependencies asset.Parents) error {
 func (a *AgentArtifacts) fetchAgentTuiFiles(releaseImage string, pullSecret string, mirrorConfig []mirror.RegistriesConfig) ([]string, error) {
 	release := NewRelease(
 		Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay},
-		releaseImage, pullSecret, mirrorConfig)
+		releaseImage, pullSecret, mirrorConfig, nil)
 
 	agentTuiFilenames := []string{"/usr/bin/agent-tui", "/usr/lib64/libnmstate.so.*"}
 	files := []string{}

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	agentISOFilename    = "agent.%s.iso"
-	iso9660Level1ExtLen = 3
+	agentISOFilename         = "agent.%s.iso"
+	agentAddNodesISOFilename = "agent-addnodes.%s.iso"
+	iso9660Level1ExtLen      = 3
 )
 
 // AgentImage is an asset that generates the bootable image used to install clusters.
@@ -34,6 +35,7 @@ type AgentImage struct {
 	rootFSURL            string
 	bootArtifactsBaseURL string
 	platform             hiveext.PlatformType
+	isoFilename          string
 }
 
 var _ asset.WritableAsset = (*AgentImage)(nil)
@@ -61,9 +63,11 @@ func (a *AgentImage) Generate(dependencies asset.Parents) error {
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		a.platform = agentManifests.AgentClusterInstall.Spec.PlatformType
+		a.isoFilename = agentISOFilename
 
 	case workflow.AgentWorkflowTypeAddNodes:
 		a.platform = clusterInfo.PlatformType
+		a.isoFilename = agentAddNodesISOFilename
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
@@ -239,7 +243,7 @@ func (a *AgentImage) PersistToFile(directory string) error {
 		return errors.New("cannot generate ISO image due to configuration errors")
 	}
 
-	agentIsoFile := filepath.Join(directory, fmt.Sprintf(agentISOFilename, a.cpuArch))
+	agentIsoFile := filepath.Join(directory, fmt.Sprintf(a.isoFilename, a.cpuArch))
 
 	// Remove symlink if it exists
 	os.Remove(agentIsoFile)

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -31,13 +31,13 @@ type BaseIso struct {
 	ocRelease    Release
 }
 
+// CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
 type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
 
 var (
-	baseIsoFilename           = ""
-	DefaultCoreOSStreamGetter = func(ctx context.Context) (*stream.Stream, error) {
-		return rhcos.FetchCoreOSBuild(ctx)
-	}
+	baseIsoFilename = ""
+	// DefaultCoreOSStreamGetter uses the pinned metadata.
+	DefaultCoreOSStreamGetter = rhcos.FetchCoreOSBuild
 )
 
 var _ asset.WritableAsset = (*BaseIso)(nil)
@@ -143,7 +143,6 @@ func (i *BaseIso) checkReleasePayloadBaseISOVersion(r Release, archName string) 
 
 // Generate the baseIso
 func (i *BaseIso) Generate(dependencies asset.Parents) error {
-
 	var err error
 	var baseIsoFileName string
 

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
 	"github.com/openshift/installer/pkg/asset/agent/mirror"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/rhcos/cache"
 	"github.com/openshift/installer/pkg/types"
@@ -24,11 +26,18 @@ import (
 
 // BaseIso generates the base ISO file for the image
 type BaseIso struct {
-	File *asset.File
+	File         *asset.File
+	streamGetter CoreOSBuildFetcher
+	ocRelease    Release
 }
 
+type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
+
 var (
-	baseIsoFilename = ""
+	baseIsoFilename           = ""
+	DefaultCoreOSStreamGetter = func(ctx context.Context) (*stream.Stream, error) {
+		return rhcos.FetchCoreOSBuild(ctx)
+	}
 )
 
 var _ asset.WritableAsset = (*BaseIso)(nil)
@@ -38,26 +47,12 @@ func (i *BaseIso) Name() string {
 	return "BaseIso Image"
 }
 
-// getIsoFile is a pluggable function that gets the base ISO file
-type getIsoFile func(archName string) (string, error)
-
-type getIso struct {
-	getter getIsoFile
-}
-
-func newGetIso(getter getIsoFile) *getIso {
-	return &getIso{getter: getter}
-}
-
-// GetIsoPluggable defines the method to use get the baseIso file
-var GetIsoPluggable = downloadIso
-
-func getMetalArtifact(archName string) (stream.PlatformArtifacts, error) {
+func (i *BaseIso) getMetalArtifact(archName string) (stream.PlatformArtifacts, error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
 	// Get the ISO to use from rhcos.json
-	st, err := rhcos.FetchCoreOSBuild(ctx)
+	st, err := i.streamGetter(ctx)
 	if err != nil {
 		return stream.PlatformArtifacts{}, err
 	}
@@ -76,8 +71,8 @@ func getMetalArtifact(archName string) (stream.PlatformArtifacts, error) {
 }
 
 // Download the ISO using the URL in rhcos.json.
-func downloadIso(archName string) (string, error) {
-	metal, err := getMetalArtifact(archName)
+func (i *BaseIso) downloadIso(archName string) (string, error) {
+	metal, err := i.getMetalArtifact(archName)
 	if err != nil {
 		return "", err
 	}
@@ -99,7 +94,7 @@ func downloadIso(archName string) (string, error) {
 
 // Fetch RootFS URL using the rhcos.json.
 func (i *BaseIso) getRootFSURL(archName string) (string, error) {
-	metal, err := getMetalArtifact(archName)
+	metal, err := i.getMetalArtifact(archName)
 	if err != nil {
 		return "", err
 	}
@@ -115,6 +110,8 @@ func (i *BaseIso) getRootFSURL(archName string) (string, error) {
 // Dependencies returns dependencies used by the asset.
 func (i *BaseIso) Dependencies() []asset.Asset {
 	return []asset.Asset{
+		&workflow.AgentWorkflow{},
+		&joiner.ClusterInfo{},
 		&manifests.AgentManifests{},
 		&agent.OptionalInstallConfig{},
 		&mirror.RegistriesConf{},
@@ -132,7 +129,7 @@ func (i *BaseIso) checkReleasePayloadBaseISOVersion(r Release, archName string) 
 	}
 
 	// Get pinned version from installer
-	metal, err := getMetalArtifact(archName)
+	metal, err := i.getMetalArtifact(archName)
 	if err != nil {
 		logrus.Warnf("unable to determine base ISO version: %s", err.Error())
 		return
@@ -147,10 +144,6 @@ func (i *BaseIso) checkReleasePayloadBaseISOVersion(r Release, archName string) 
 // Generate the baseIso
 func (i *BaseIso) Generate(dependencies asset.Parents) error {
 
-	// TODO - if image registry location is defined in InstallConfig,
-	// ic := &agent.OptionalInstallConfig{}
-	// p.Get(ic)
-
 	var err error
 	var baseIsoFileName string
 
@@ -158,6 +151,7 @@ func (i *BaseIso) Generate(dependencies asset.Parents) error {
 		logrus.Warn("Found override for OS Image. Please be warned, this is not advised")
 		baseIsoFileName, err = cache.DownloadImageFile(urlOverride, cache.AgentApplicationName)
 	} else {
+		i.setStreamGetter(dependencies)
 		baseIsoFileName, err = i.retrieveBaseIso(dependencies)
 	}
 
@@ -171,12 +165,43 @@ func (i *BaseIso) Generate(dependencies asset.Parents) error {
 	return errors.Wrap(err, "failed to get base ISO image")
 }
 
+func (i *BaseIso) setStreamGetter(dependencies asset.Parents) {
+	if i.streamGetter != nil {
+		return
+	}
+
+	agentWorkflow := &workflow.AgentWorkflow{}
+	clusterInfo := &joiner.ClusterInfo{}
+	dependencies.Get(agentWorkflow, clusterInfo)
+
+	i.streamGetter = DefaultCoreOSStreamGetter
+	if agentWorkflow.Workflow == workflow.AgentWorkflowTypeAddNodes {
+		i.streamGetter = func(ctx context.Context) (*stream.Stream, error) {
+			return clusterInfo.OSImage, nil
+		}
+	}
+}
+
+func (i *BaseIso) getRelease(agentManifests *manifests.AgentManifests, registriesConf *mirror.RegistriesConf) Release {
+	if i.ocRelease != nil {
+		return i.ocRelease
+	}
+
+	releaseImage := agentManifests.ClusterImageSet.Spec.ReleaseImage
+	pullSecret := agentManifests.GetPullSecretData()
+
+	i.ocRelease = NewRelease(
+		Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay},
+		releaseImage, pullSecret, registriesConf.MirrorConfig, i.streamGetter)
+
+	return i.ocRelease
+}
+
 func (i *BaseIso) retrieveBaseIso(dependencies asset.Parents) (string, error) {
 	// use the GetIso function to get the BaseIso from the release payload
 	agentManifests := &manifests.AgentManifests{}
-	dependencies.Get(agentManifests)
-	var baseIsoFileName string
-	var err error
+	registriesConf := &mirror.RegistriesConf{}
+	dependencies.Get(agentManifests, registriesConf)
 
 	// Default iso archName to x86_64.
 	archName := arch.RpmArch(types.ArchitectureAMD64)
@@ -186,18 +211,11 @@ func (i *BaseIso) retrieveBaseIso(dependencies asset.Parents) (string, error) {
 		if agentManifests.InfraEnv.Spec.CpuArchitecture != "" {
 			archName = agentManifests.InfraEnv.Spec.CpuArchitecture
 		}
-		releaseImage := agentManifests.ClusterImageSet.Spec.ReleaseImage
-		pullSecret := agentManifests.GetPullSecretData()
-		registriesConf := &mirror.RegistriesConf{}
-		dependencies.Get(agentManifests, registriesConf)
 
 		// If we have the image registry location and 'oc' command is available then get from release payload
-		ocRelease := NewRelease(
-			Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay},
-			releaseImage, pullSecret, registriesConf.MirrorConfig)
-
+		ocRelease := i.getRelease(agentManifests, registriesConf)
 		logrus.Info("Extracting base ISO from release payload")
-		baseIsoFileName, err = ocRelease.GetBaseIso(archName)
+		baseIsoFileName, err := ocRelease.GetBaseIso(archName)
 		if err == nil {
 			i.checkReleasePayloadBaseISOVersion(ocRelease, archName)
 
@@ -216,8 +234,7 @@ func (i *BaseIso) retrieveBaseIso(dependencies asset.Parents) (string, error) {
 	}
 
 	logrus.Info("Downloading base ISO")
-	isoGetter := newGetIso(GetIsoPluggable)
-	return isoGetter.getter(archName)
+	return i.downloadIso(archName)
 }
 
 // Files returns the files generated by the asset.

--- a/pkg/asset/agent/image/baseiso_test.go
+++ b/pkg/asset/agent/image/baseiso_test.go
@@ -1,20 +1,196 @@
 package image
 
 import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
 	"testing"
 
+	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/assisted-service/api/v1beta1"
+	v1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/agent/mirror"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
 
-func TestInfraBaseIso_Generate(t *testing.T) {
+func setupEmbeddedResources(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	assert.NoError(t, err)
+	err = os.Chdir(path.Join(workingDirectory, "../../../../data"))
+	assert.NoError(t, err)
+}
 
-	GetIsoPluggable = func(archName string) (string, error) {
-		return "some-openshift-release.iso", nil
+func TestBaseIso_Generate(t *testing.T) {
+	setupEmbeddedResources(t)
+	ocReleaseImage := "416.94.202402130130-0"
+	ocBaseIsoFilename := "openshift-4.16"
+
+	cases := []struct {
+		name                       string
+		dependencies               []asset.Asset
+		envVarOsImageOverrideValue string
+		getIsoError                error
+		expectedBaseIsoFilename    string
+		expectedError              string
+	}{
+		{
+			name:                       "os image override",
+			envVarOsImageOverrideValue: "openshift-4.15",
+			expectedBaseIsoFilename:    "openshift-4.15",
+		},
+		{
+			name: "default",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.ClusterInfo{},
+				&manifests.AgentManifests{
+					InfraEnv: &v1beta1.InfraEnv{},
+					ClusterImageSet: &v1.ClusterImageSet{
+						Spec: v1.ClusterImageSetSpec{
+							ReleaseImage: ocReleaseImage,
+						},
+					},
+					PullSecret: &corev1.Secret{
+						StringData: map[string]string{
+							".dockerconfigjson": "supersecret",
+						},
+					},
+				},
+				&mirror.RegistriesConf{},
+			},
+			expectedBaseIsoFilename: ocBaseIsoFilename,
+		},
+		{
+			name: "direct download if oc is not available",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.ClusterInfo{},
+				&manifests.AgentManifests{
+					InfraEnv: &v1beta1.InfraEnv{},
+					ClusterImageSet: &v1.ClusterImageSet{
+						Spec: v1.ClusterImageSetSpec{
+							ReleaseImage: ocReleaseImage,
+						},
+					},
+					PullSecret: &corev1.Secret{
+						StringData: map[string]string{
+							".dockerconfigjson": "supersecret",
+						},
+					},
+				},
+				&mirror.RegistriesConf{},
+			},
+			getIsoError:             &exec.Error{"", exec.ErrNotFound},
+			expectedBaseIsoFilename: ocReleaseImage,
+		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dependencies := asset.Parents{}
+			dependencies.Add(tc.dependencies...)
+
+			// Setup a fake http server, to serve the future download request.
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Answer with a fixed size randomly filled buffer
+				buffer := make([]byte, 1024)
+				rand.Read(buffer)
+				w.Write(buffer)
+			}))
+			defer svr.Close()
+			// Creates a tmp folder to store the .cache downloaded images.
+			tmpPath, err := os.MkdirTemp("", "agent-baseiso-test")
+			assert.NoError(t, err)
+			previousXdgCacheHomeValue := os.Getenv("XDG_CACHE_HOME")
+			os.Setenv("XDG_CACHE_HOME", tmpPath)
+			// Set the image override if defined
+			previousOpenshiftInstallOsImageOverrideValue := os.Getenv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE")
+			if tc.envVarOsImageOverrideValue != "" {
+				newOsImageOverride := fmt.Sprintf("%s/%s", svr.URL, tc.envVarOsImageOverrideValue)
+				os.Setenv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE", newOsImageOverride)
+			}
+			// Cleanup on exit.
+			defer func() {
+				err := os.Setenv("XDG_CACHE_HOME", previousXdgCacheHomeValue)
+				assert.NoError(t, err)
+				err = os.Setenv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE", previousOpenshiftInstallOsImageOverrideValue)
+				assert.NoError(t, err)
+				err = os.RemoveAll(tmpPath)
+				assert.NoError(t, err)
+			}()
+
+			baseIso := &BaseIso{
+				ocRelease: &mockRelease{
+					isoBaseVersion:  ocReleaseImage,
+					baseIsoFileName: ocBaseIsoFilename,
+					baseIsoError:    tc.getIsoError,
+				},
+				streamGetter: func(ctx context.Context) (*stream.Stream, error) {
+					return &stream.Stream{
+						Architectures: map[string]stream.Arch{
+							"x86_64": {
+								Artifacts: map[string]stream.PlatformArtifacts{
+									"metal": {
+										Release: ocReleaseImage,
+										Formats: map[string]stream.ImageFormat{
+											"iso": stream.ImageFormat{
+												Disk: &stream.Artifact{
+													Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			}
+			err = baseIso.Generate(dependencies)
+
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Regexp(t, tc.expectedBaseIsoFilename, baseIso.File.Filename)
+			} else {
+				assert.Equal(t, tc.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+type mockRelease struct {
+	isoBaseVersion  string
+	baseIsoFileName string
+	baseIsoError    error
+}
+
+func (m *mockRelease) GetBaseIso(architecture string) (string, error) {
+	if m.baseIsoError != nil {
+		return "", m.baseIsoError
+	}
+	return m.baseIsoFileName, nil
+}
+
+func (m *mockRelease) GetBaseIsoVersion(architecture string) (string, error) {
+	return m.isoBaseVersion, nil
+}
+
+func (m *mockRelease) ExtractFile(image string, filename string, architecture string) ([]string, error) {
+	return []string{}, nil
+}
+
+func TestInfraBaseIso_GenerateOld(t *testing.T) {
 
 	parents := asset.Parents{}
 	manifests := &manifests.AgentManifests{}

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -262,7 +262,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	rendezvousHostFile := ignition.FileFromString(rendezvousHostEnvPath,
 		"root", 0644,
-		getRendezvousHostEnv(agentTemplateData.ServiceProtocol, a.RendezvousIP))
+		getRendezvousHostEnv(agentTemplateData.ServiceProtocol, a.RendezvousIP, agentWorkflow.Workflow))
 	config.Storage.Files = append(config.Storage.Files, rendezvousHostFile)
 
 	err = addBootstrapScripts(&config, agentManifests.ClusterImageSet.Spec.ReleaseImage)
@@ -390,7 +390,7 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 	}
 }
 
-func getRendezvousHostEnv(serviceProtocol, nodeZeroIP string) string {
+func getRendezvousHostEnv(serviceProtocol, nodeZeroIP string, workflowType workflow.AgentWorkflowType) string {
 	serviceBaseURL := url.URL{
 		Scheme: serviceProtocol,
 		Host:   net.JoinHostPort(nodeZeroIP, "8090"),
@@ -405,7 +405,8 @@ func getRendezvousHostEnv(serviceProtocol, nodeZeroIP string) string {
 	return fmt.Sprintf(`NODE_ZERO_IP=%s
 SERVICE_BASE_URL=%s
 IMAGE_SERVICE_BASE_URL=%s
-`, nodeZeroIP, serviceBaseURL.String(), imageServiceBaseURL.String())
+WORKFLOW_TYPE=%s
+`, nodeZeroIP, serviceBaseURL.String(), imageServiceBaseURL.String(), workflowType)
 }
 
 func getAddNodesEnv(clusterInfo joiner.ClusterInfo) string {

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -178,7 +178,9 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		a.RendezvousIP = "127.0.0.1"
 		// Reuse the existing cluster name.
 		clusterName = clusterInfo.ClusterName
-		// Fetch the required number of master and worker nodes.
+		// Fetch the required number of master and worker nodes. Currently only adding workers
+		// is supported, so forcing the expected number of masters to zero, and assuming implcitly
+		// that all the hosts defined are workers.
 		numMasters = 0
 		numWorkers = len(addNodesConfig.Config.Hosts)
 		// Enable add-nodes specific services
@@ -360,7 +362,7 @@ func addBootstrapScripts(config *igntypes.Config, releaseImage string) (err erro
 
 func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 	releaseImageMirror string, haveMirrorConfig bool, publicContainerRegistries string,
-	numMasters int, numWorkers int,
+	numMasters, numWorkers int,
 	infraEnvID string,
 	osImage *models.OsImage,
 	proxy *v1beta1.Proxy,

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -164,9 +164,9 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		// Fetch the required number of master and worker nodes.
 		numMasters = agentManifests.AgentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents
 		numWorkers = agentManifests.AgentClusterInstall.Spec.ProvisionRequirements.WorkerAgents
-		// Service
+		// Enable specific install services
 		enabledServices = append(enabledServices, "agent-register-cluster.service", "start-cluster-installation.service")
-		//Version
+		// Version is retrieved from the embedded data
 		openshiftVersion, err = version.Version()
 		if err != nil {
 			return err
@@ -181,12 +181,12 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		// Fetch the required number of master and worker nodes.
 		numMasters = 0
 		numWorkers = len(addNodesConfig.Config.Hosts)
-		// Service
+		// Enable add-nodes specific services
 		enabledServices = append(enabledServices, "agent-import-cluster.service", "agent-add-node.service")
 		// Generate add-nodes.env file
 		addNodesEnvFile := ignition.FileFromString(addNodesEnvPath, "root", 0644, getAddNodesEnv(*clusterInfo))
 		config.Storage.Files = append(config.Storage.Files, addNodesEnvFile)
-		// Version
+		// Version matches the source cluster one
 		openshiftVersion = clusterInfo.Version
 		streamGetter = func(ctx context.Context) (*stream.Stream, error) {
 			return clusterInfo.OSImage, nil

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -112,9 +112,9 @@ func TestIgnition_getTemplateData(t *testing.T) {
 
 func TestIgnition_getRendezvousHostEnv(t *testing.T) {
 	nodeZeroIP := "2001:db8::dead:beef"
-	rendezvousHostEnv := getRendezvousHostEnv("http", nodeZeroIP)
+	rendezvousHostEnv := getRendezvousHostEnv("http", nodeZeroIP, workflow.AgentWorkflowTypeInstall)
 	assert.Equal(t,
-		"NODE_ZERO_IP="+nodeZeroIP+"\nSERVICE_BASE_URL=http://["+nodeZeroIP+"]:8090/\nIMAGE_SERVICE_BASE_URL=http://["+nodeZeroIP+"]:8888/\n",
+		"NODE_ZERO_IP="+nodeZeroIP+"\nSERVICE_BASE_URL=http://["+nodeZeroIP+"]:8090/\nIMAGE_SERVICE_BASE_URL=http://["+nodeZeroIP+"]:8888/\nWORKFLOW_TYPE=install\n",
 		rendezvousHostEnv)
 }
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -92,7 +92,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	privateKey := "-----BEGIN EC PUBLIC KEY-----\nMFkwEwYHKoAiDHV4tg==\n-----END EC PUBLIC KEY-----\n"
 	publicKey := "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PRIVATE KEY-----\n"
 
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", privateKey, publicKey)
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", privateKey, publicKey, workflow.AgentWorkflowTypeInstall)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -390,6 +390,7 @@ func commonFiles() []string {
 		"/usr/local/bin/issue_status.sh",
 		"/usr/local/bin/load-config-iso.sh",
 		"/etc/udev/rules.d/80-agent-config-image.rules",
+		"/usr/local/bin/add-node.sh",
 	}
 }
 

--- a/pkg/asset/agent/image/releaseextract.go
+++ b/pkg/asset/agent/image/releaseextract.go
@@ -61,7 +61,7 @@ type release struct {
 	streamGetter CoreOSBuildFetcher
 }
 
-// NewRelease is used to set up the executor to run oc commands
+// NewRelease is used to set up the executor to run oc commands.
 func NewRelease(config Config, releaseImage string, pullSecret string, mirrorConfig []mirror.RegistriesConfig, streamGetter CoreOSBuildFetcher) Release {
 	return &release{
 		config:       config,
@@ -259,7 +259,7 @@ func (r *release) extractFileFromImage(image, file, cacheDir string, architectur
 	return matches, nil
 }
 
-// Get hash from rhcos.json
+// Get hash from rhcos.json.
 func (r *release) getHashFromInstaller(architecture string) (bool, string) {
 	// Get hash from metadata in the installer
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)

--- a/pkg/asset/agent/image/releaseextract.go
+++ b/pkg/asset/agent/image/releaseextract.go
@@ -26,7 +26,6 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/agent/mirror"
-	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/rhcos/cache"
 )
 
@@ -59,15 +58,17 @@ type release struct {
 	releaseImage string
 	pullSecret   string
 	mirrorConfig []mirror.RegistriesConfig
+	streamGetter CoreOSBuildFetcher
 }
 
-// NewRelease is used to set up the executor to run oc commands.
-func NewRelease(config Config, releaseImage string, pullSecret string, mirrorConfig []mirror.RegistriesConfig) Release {
+// NewRelease is used to set up the executor to run oc commands
+func NewRelease(config Config, releaseImage string, pullSecret string, mirrorConfig []mirror.RegistriesConfig, streamGetter CoreOSBuildFetcher) Release {
 	return &release{
 		config:       config,
 		releaseImage: releaseImage,
 		pullSecret:   pullSecret,
 		mirrorConfig: mirrorConfig,
+		streamGetter: streamGetter,
 	}
 }
 
@@ -258,13 +259,13 @@ func (r *release) extractFileFromImage(image, file, cacheDir string, architectur
 	return matches, nil
 }
 
-// Get hash from rhcos.json.
-func getHashFromInstaller(architecture string) (bool, string) {
+// Get hash from rhcos.json
+func (r *release) getHashFromInstaller(architecture string) (bool, string) {
 	// Get hash from metadata in the installer
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
-	st, err := rhcos.FetchCoreOSBuild(ctx)
+	st, err := r.streamGetter(ctx)
 	if err != nil {
 		return false, ""
 	}
@@ -307,7 +308,7 @@ func (r *release) verifyCacheFile(image, file, architecture string) (bool, error
 	fileSha := h.Sum(nil)
 
 	// Check if the hash of cached file matches hash in rhcos.json
-	found, rhcosSha := getHashFromInstaller(architecture)
+	found, rhcosSha := r.getHashFromInstaller(architecture)
 	if found && matchingHash(fileSha, rhcosSha) {
 		logrus.Debug("Found matching hash in installer metadata")
 		return true, nil

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/version"
 )
 
 const (
@@ -124,7 +125,11 @@ func (a *UnconfiguredIgnition) Generate(dependencies asset.Parents) error {
 	infraEnvID := uuid.New().String()
 	logrus.Debug("Generated random infra-env id ", infraEnvID)
 
-	osImage, err := getOSImagesInfo(archName)
+	openshiftVersion, err := version.Version()
+	if err != nil {
+		return err
+	}
+	osImage, err := getOSImagesInfo(archName, openshiftVersion, DefaultCoreOSStreamGetter)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/coreos/stream-metadata-go/arch"
+	"github.com/coreos/stream-metadata-go/stream"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -12,8 +14,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
-	"github.com/coreos/stream-metadata-go/arch"
-	"github.com/coreos/stream-metadata-go/stream"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -2,6 +2,7 @@ package joiner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -11,6 +12,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
+	"github.com/coreos/stream-metadata-go/arch"
+	"github.com/coreos/stream-metadata-go/stream"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
@@ -40,6 +43,8 @@ type ClusterInfo struct {
 	DeprecatedImageContentSources []types.ImageContentSource
 	PlatformType                  hiveext.PlatformType
 	SSHKey                        string
+	OSImage                       *stream.Stream
+	OSImageLocation               string
 }
 
 var _ asset.WritableAsset = (*ClusterInfo)(nil)
@@ -94,6 +99,10 @@ func (ci *ClusterInfo) Generate(dependencies asset.Parents) error {
 		return err
 	}
 	err = ci.retrieveInstallConfigData()
+	if err != nil {
+		return err
+	}
+	err = ci.retrieveOsImage()
 	if err != nil {
 		return err
 	}
@@ -219,6 +228,43 @@ func (ci *ClusterInfo) retrieveInstallConfigData() error {
 	ci.SSHKey = installConfig.SSHKey
 	ci.ClusterName = installConfig.ObjectMeta.Name
 	ci.APIDNSName = fmt.Sprintf("api.%s.%s", ci.ClusterName, installConfig.BaseDomain)
+
+	return nil
+}
+
+func (ci *ClusterInfo) retrieveOsImage() error {
+	clusterConfig, err := ci.Client.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.Background(), "coreos-bootimages", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	data, ok := clusterConfig.Data["stream"]
+	if !ok {
+		return fmt.Errorf("cannot find stream data")
+	}
+
+	var st stream.Stream
+	if err := json.Unmarshal([]byte(data), &st); err != nil {
+		return fmt.Errorf("failed to parse CoreOS stream metadata: %w", err)
+	}
+	ci.OSImage = &st
+
+	clusterArch := arch.RpmArch(ci.Architecture)
+	streamArch, err := st.GetArchitecture(clusterArch)
+	if err != nil {
+		return err
+	}
+	metal, ok := streamArch.Artifacts["metal"]
+	if !ok {
+		return fmt.Errorf("stream data not found for 'metal' artifact")
+	}
+	format, ok := metal.Formats["iso"]
+	if !ok {
+		return fmt.Errorf("no ISO found to download for %s", clusterArch)
+	}
+	ci.OSImageLocation = format.Disk.Location
 
 	return nil
 }

--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -27,10 +27,6 @@ func getProxy(proxy *types.Proxy) *aiv1beta1.Proxy {
 	}
 }
 
-func getNMStateConfigName(ic *agent.OptionalInstallConfig) string {
-	return ic.ClusterName()
-}
-
 func getNMStateConfigLabels(clusterName string) map[string]string {
 	return map[string]string{
 		"infraenvs.agent-install.openshift.io": clusterName,


### PR DESCRIPTION
This patch is based on PR #8080 (and also reuses service definitions from PR #8051 thanks @rwsu)

In this patch the Ignition asset is modified to enable the required services in case of add-node workflow
