### PR TITLE
OPNET-476: GA Load balancer feature for vSphere and Baremetal

### DIFF
--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -457,13 +457,6 @@ func ValidatePlatform(p *baremetal.Platform, agentBasedInstallation bool, n *typ
 		allErrs = append(allErrs, validateHostsName(p.Hosts, fldPath.Child("Hosts"))...)
 	}
 
-	// Platform fields only allowed in TechPreviewNoUpgrade
-	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
-		if c.BareMetal.LoadBalancer != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("loadBalancer"), "load balancer is not supported in this feature set"))
-		}
-	}
-
 	if c.BareMetal.LoadBalancer != nil {
 		if !validateLoadBalancer(c.BareMetal.LoadBalancer.Type) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancer", "type"), c.BareMetal.LoadBalancer.Type, "invalid load balancer type"))

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -182,13 +182,6 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "baremetal.hosts\\[0\\].Name: Required value: missing Name",
 		},
 		{
-			name: "forbidden_feature_loadbalancer",
-			config: installConfig().
-				BareMetalPlatform(
-					platform().LoadBalancerType("OpenShiftManagedDefault")).build(),
-			expected: "baremetal.loadBalancer: Forbidden: load balancer is not supported in this feature set",
-		},
-		{
 			name: "allowed_feature_loadbalancer_openshift_managed_default",
 			config: installConfig().
 				BareMetalPlatform(

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -72,13 +72,6 @@ func ValidatePlatform(p *vsphere.Platform, agentBasedInstallation bool, fldPath 
 		}
 	}
 
-	// Platform fields only allowed in TechPreviewNoUpgrade
-	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
-		if c.VSphere.LoadBalancer != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("loadBalancer"), "load balancer is not supported in this feature set"))
-		}
-	}
-
 	if c.VSphere.LoadBalancer != nil {
 		if !validateLoadBalancer(c.VSphere.LoadBalancer.Type) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancer", "type"), c.VSphere.LoadBalancer.Type, "invalid load balancer type"))

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -361,22 +361,6 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.failureDomains\.zone: Required value: must specify zone tag value`,
 		},
 		{
-			name:     "forbidden load balancer field",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				Platform: types.Platform{
-					VSphere: func() *vsphere.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.VSpherePlatformLoadBalancer{
-							Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
-						}
-						return p
-					}(),
-				},
-			},
-			expectedError: `^test-path\.loadBalancer: Forbidden: load balancer is not supported in this feature set`,
-		},
-		{
 			name:     "allowed load balancer field with OpenShift managed default",
 			platform: validPlatform(),
 			config: &types.InstallConfig{


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/OPNET-305 we are promoting External Load Balancer to GA. This requires installer to soften validations so that the feature is not any more limited only to TechPreview clusters.

Contributes-to: [OPNET-476](https://issues.redhat.com//browse/OPNET-476)