### PR TITLE
OPNET-476: GA Load balancer feature for Nutanix

### DIFF
--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -73,13 +73,6 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 		allErrs = append(allErrs, field.Required(fldPath.Child("subnet"), "must specify the subnet"))
 	}
 
-	// Platform fields only allowed in TechPreviewNoUpgrade
-	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
-		if c.Nutanix.LoadBalancer != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("loadBalancer"), "load balancer is not supported in this feature set"))
-		}
-	}
-
 	if c.Nutanix.LoadBalancer != nil {
 		if !validateLoadBalancer(c.Nutanix.LoadBalancer.Type) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancer", "type"), c.Nutanix.LoadBalancer.Type, "invalid load balancer type"))

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -47,22 +47,6 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.prismCentral\.endpoint\.address: Required value: must specify the Prism Central endpoint address$`,
 		},
 		{
-			name:     "forbidden load balancer field",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				Platform: types.Platform{
-					Nutanix: func() *nutanix.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.NutanixPlatformLoadBalancer{
-							Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
-						}
-						return p
-					}(),
-				},
-			},
-			expectedError: `^test-path\.loadBalancer: Forbidden: load balancer is not supported in this feature set`,
-		},
-		{
 			name:     "allowed load balancer field with OpenShift managed default",
 			platform: validPlatform(),
 			config: &types.InstallConfig{


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/OPNET-305 we are promoting External Load Balancer to GA. This requires installer to soften validations so that the feature is not any more limited only to TechPreview clusters.

Contributes-to: [OPNET-476](https://issues.redhat.com//browse/OPNET-476)