### PR TITLE
METAL-871: baremetal: bootstrap: rename master label

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -15,7 +15,7 @@ while [ "$(oc get bmh -n openshift-machine-api -o name | wc -l)" -lt 1  ]; do
     sleep 20
 done
 
-while [ "$(oc get bmh -n openshift-machine-api -l installer.openshift.io/role=master -o json | jq '.items[].status.provisioning.state' | grep -v provisioned -c)" -gt 0  ]; do
+while [ "$(oc get bmh -n openshift-machine-api -l installer.openshift.io/role=control-plane -o json | jq '.items[].status.provisioning.state' | grep -v provisioned -c)" -gt 0  ]; do
     echo "Waiting for masters to become provisioned"
     oc get bmh -A
     sleep 20

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -144,7 +144,7 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 			}
 
 			newHost.ObjectMeta.Labels = map[string]string{
-				"installer.openshift.io/role": "master",
+				"installer.openshift.io/role": "control-plane",
 			}
 
 			// Link the new host to the currently available machine

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -61,7 +61,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy()).build(),
+				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy()).build(),
 		},
 		{
 			Scenario: "default-norole",
@@ -70,7 +70,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy()).build(),
+				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy()).build(),
 		},
 		{
 			Scenario: "network-config",
@@ -85,7 +85,7 @@ routes:
 				networkConfigSecrets(secret("master-0-network-config-secret").nmstate(nmstate)).
 				hosts(
 					host("master-0").
-						label("installer.openshift.io/role", "master").
+						label("installer.openshift.io/role", "control-plane").
 						consumerRef("machine-0").
 						userDataRef("user-data-secret").
 						preprovisioningNetworkDataName("master-0-network-config-secret").
@@ -108,9 +108,9 @@ routes:
 					secret("master-1-bmc-secret").creds("usr1", "pwd1"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines",
@@ -131,9 +131,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("usr3", "pwd3")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", ""),
 				).build(),
 		},
@@ -156,9 +156,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", ""),
 				).build(),
 		},
@@ -183,9 +183,9 @@ routes:
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0"),
 					secret("worker-1-bmc-secret").creds("wrk1", "pwd1")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", ""),
 					host("worker-1").annotation("baremetalhost.metal3.io/paused", ""),
 				).build(),
@@ -211,11 +211,11 @@ routes:
 					secret("master-0-bmc-secret").creds("usr0", "pwd0"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", ""),
 					host("worker-1").annotation("baremetalhost.metal3.io/paused", ""),
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-master",
@@ -237,9 +237,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", ""),
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy()).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-worker",
@@ -260,9 +260,9 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
-					host("master-1").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
-					host("master-2").label("installer.openshift.io/role", "master").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy(),
+					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy(),
 					host("worker-0").annotation("baremetalhost.metal3.io/paused", "")).build(),
 		},
 	}


### PR DESCRIPTION
Let's use the new k8s upstream name.

This is a follow-up to #7649 