### PR TITLE
OCPBUGS-30641: Enable deploy by Service ID on PowerVS

### DIFF
--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -595,6 +595,7 @@ func (c *Client) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error
 // ListResourceGroups returns a list of resource groups.
 func (c *Client) ListResourceGroups(ctx context.Context) (*resourcemanagerv2.ResourceGroupList, error) {
 	listResourceGroupsOptions := c.managementAPI.NewListResourceGroupsOptions()
+	listResourceGroupsOptions.AccountID = &c.BXCli.User.Account
 
 	resourceGroups, _, err := c.managementAPI.ListResourceGroups(listResourceGroupsOptions)
 	if err != nil {
@@ -624,6 +625,7 @@ func (c *Client) ListServiceInstances(ctx context.Context) ([]string, error) {
 
 	// If the user passes in a human readable group id, then we need to convert it to a UUID
 	listGroupOptions := c.managementAPI.NewListResourceGroupsOptions()
+	listGroupOptions.AccountID = &c.BXCli.User.Account
 	groups, _, err := c.managementAPI.ListResourceGroupsWithContext(ctx, listGroupOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resource groups: %w", err)
@@ -699,6 +701,7 @@ func (c *Client) ServiceInstanceGUIDToName(ctx context.Context, id string) (stri
 
 	// If the user passes in a human readable group id, then we need to convert it to a UUID
 	listGroupOptions := c.managementAPI.NewListResourceGroupsOptions()
+	listGroupOptions.AccountID = &c.BXCli.User.Account
 	groups, _, err := c.managementAPI.ListResourceGroupsWithContext(ctx, listGroupOptions)
 	if err != nil {
 		return "", fmt.Errorf("failed to list resource groups: %w", err)

--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -56,12 +56,10 @@ func (m *Metadata) AccountID(ctx context.Context) (string, error) {
 	}
 
 	if m.accountID == "" {
-		apiKeyDetails, err := m.client.GetAuthenticatorAPIKeyDetails(ctx)
-		if err != nil {
-			return "", err
+		if m.client.BXCli.User == nil || m.client.BXCli.User.Account == "" {
+			return "", fmt.Errorf("failed to get find account ID: %+v", m.client.BXCli.User)
 		}
-
-		m.accountID = *apiKeyDetails.AccountID
+		m.accountID = m.client.BXCli.User.Account
 	}
 
 	return m.accountID, nil


### PR DESCRIPTION
With #8025 merged, enabling deploy/destroy by a Service ID turns out to be rather simple by just addressing the below error;
```
FATAL failed to fetch Terraform Variables: failed to fetch dependency of "Terraform Variables": failed to generate asset "Platform Provisioning Check": failed to list resourceGroups: Can not get resource groups without account id in parameter by service id token.
```

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>