### PR TITLE
WIP: Allow setting of ManagedBy field

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -1,6 +1,14 @@
 package azure
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 )
@@ -12,3 +20,34 @@ type Provider struct{}
 
 // Name gives the name of the provider, Azure.
 func (*Provider) Name() string { return azuretypes.Name }
+
+func (*Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) {
+	if in.InstallConfig.Config.Azure.ResourceGroupName == "" {
+		createResourceGroup(ctx, in.InstallConfig, in.InfraID)
+	}
+}
+
+// createResourceGroup creates the resource group required for Azure installation.
+func createResourceGroup(ctx context.Context, ic *installconfig.InstallConfig, infraID string) error {
+	rgName := fmt.Sprintf("%s-rg", infraID)
+	managedBy := ic.Config.Azure.ManagedBy
+	session, err := ic.Azure.Session()
+	if err != nil {
+		return err
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return err
+	}
+	rgClient, err := armresources.NewResourceGroupsClient(session.Credentials.SubscriptionID, cred, nil)
+	if err != nil {
+		return err
+	}
+	param := armresources.ResourceGroup{
+		Location:  to.StringPtr(ic.Config.Azure.Region),
+		ManagedBy: &managedBy,
+	}
+
+	_, err = rgClient.CreateOrUpdate(ctx, rgName, param, nil)
+	return err
+}

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -100,6 +100,9 @@ type Platform struct {
 
 	// CustomerManagedKey has the keys needed to encrypt the storage account.
 	CustomerManagedKey *CustomerManagedKey `json:"customerManagedKey,omitempty"`
+
+	// ManagedBy sets the managedBy field in the azure resource group.
+	ManagedBy string `json:"managedBy,omitempty"`
 }
 
 // KeyVault defines an Azure Key Vault.


### PR DESCRIPTION
Adding a provision for the users to set the ManagedBy field in the resourceGroup
during azure CAPI installation. Also adding a step to create the resource group 
since CAPI does not have the option to set the ManagedBy field if it creates the
resource group.