### PR TITLE
no-jira:  machines/aws: fix subnet filter comment

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -261,8 +261,8 @@ func provider(in *machineProviderInput) (*machineapi.AWSMachineProviderConfig, e
 		{
 			Name: "tag:Name",
 			Values: []string{
-				fmt.Sprintf("%s-%s-%s", in.clusterID, visibility, in.zone),
-				fmt.Sprintf("%s-subnet-%s-%s", in.clusterID, visibility, in.zone), // legacy Terraform config, remove with Terraform
+				fmt.Sprintf("%s-%s-%s", in.clusterID, visibility, in.zone), // legacy Terraform config, remove with Terraform
+				fmt.Sprintf("%s-subnet-%s-%s", in.clusterID, visibility, in.zone),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes the comment to correctly identify that the legacy terraform subnet filter does NOT include the 'subnet' string.