### PR TITLE
CORS-3075: Allow for installation in existing resource group

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -247,7 +247,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		// useImageGallery := installConfig.Azure.CloudName != azuretypes.StackCloud
 		useImageGallery := false
 		masterUserDataSecretName := "master-user-data"
-		resourceGroupName := fmt.Sprintf("%s-rg", clusterID.InfraID)
+		resourceGroupName := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
 
 		azureMachines, err := azure.GenerateMachines(installConfig.Config.Platform.Azure, &pool, masterUserDataSecretName, clusterID.InfraID, "master", capabilities, useImageGallery, installConfig.Config.Platform.Azure.UserTags, hyperVGen, subnet, resourceGroupName, session.Credentials.SubscriptionID)
 		if err != nil {

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -37,13 +37,14 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		File:   asset.File{Filename: "00_azure-namespace.yaml"},
 	})
 
+	resourceGroup := installConfig.Config.Platform.Azure.ClusterResourceGroupName(clusterID.InfraID)
 	azureCluster := &capz.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterID.InfraID,
 			Namespace: capiutils.Namespace,
 		},
 		Spec: capz.AzureClusterSpec{
-			ResourceGroup: fmt.Sprintf("%s-rg", clusterID.InfraID),
+			ResourceGroup: resourceGroup,
 			AzureClusterClassSpec: capz.AzureClusterClassSpec{
 				SubscriptionID:   session.Credentials.SubscriptionID,
 				Location:         installConfig.Config.Azure.Region,

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -370,7 +370,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	p.StorageAccountKeys = storageAccountKeys
 	p.lbBackendAddressPool = lbBap
 
-	if err := createDNSEntries(ctx, in, extLBFQDN); err != nil {
+	if err := createDNSEntries(ctx, in, extLBFQDN, resourceGroupName); err != nil {
 		return fmt.Errorf("error creating DNS records: %w", err)
 	}
 

--- a/pkg/infrastructure/azure/dns.go
+++ b/pkg/infrastructure/azure/dns.go
@@ -37,14 +37,13 @@ type recordPrivateList struct {
 }
 
 // Create DNS entries for azure.
-func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBFQDN string) error {
+func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBFQDN string, resourceGroup string) error {
 	private := in.InstallConfig.Config.Publish == types.InternalPublishingStrategy
 	baseDomainResourceGroup := in.InstallConfig.Config.Azure.BaseDomainResourceGroupName
 	zone := in.InstallConfig.Config.BaseDomain
 	privatezone := in.InstallConfig.Config.ClusterDomain()
 	apiExternalName := fmt.Sprintf("api.%s", in.InstallConfig.Config.ObjectMeta.Name)
 
-	resourceGroup := fmt.Sprintf("%s-rg", in.InfraID)
 	if in.InstallConfig.Config.Azure.ResourceGroupName != "" {
 		resourceGroup = in.InstallConfig.Config.Azure.ResourceGroupName
 	}


### PR DESCRIPTION
Use the existing resource group if the user sets the value for CAPI installation.