### PR TITLE
OCPBUGS-30547,OCPBUGS-29437: Run kubelet directly

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
@@ -3,8 +3,7 @@
 # shellcheck disable=SC1091  # using path on bootstrap machine
 . /usr/local/bin/bootstrap-service-record.sh
 
-/usr/bin/hyperkube \
-  kubelet \
+ /usr/bin/kubelet \
     --anonymous-auth=false \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout="${KUBELET_RUNTIME_REQUEST_TIMEOUT}" \

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -350,8 +350,7 @@ For example:
               EnvironmentFile=-/etc/kubernetes/kubelet-workaround
               EnvironmentFile=-/etc/kubernetes/kubelet-env
 
-              ExecStart=/usr/bin/hyperkube \
-                  kubelet \
+              ExecStart=/usr/bin/kubelet \
                     --config=/etc/kubernetes/kubelet.conf \
                     --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
                     --rotate-certificates \


### PR DESCRIPTION
In https://github.com/openshift/os/pull/1449 we removed hyperkube from RHCOS which was just a shell script that called kubelet. Chase that change in bootstrap assets. For some reason only s390x appears to have been broken by the removal where they're seeing bootstrap failing, maybe they do some special automation to ensure that the bootstrap node is running the latest RHCOS? I suspect without this change the next boot image bump will fail.