### PR TITLE
CORS-3303: GCP: Add me-central2 (Dammam, Saudi Arabia, Middle East) region to the survey as supported region

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -41,6 +41,7 @@ var (
 		"europe-west12":           "Turin, Italy",
 		"europe-southwest1":       "Madrid, Spain",
 		"me-central1":             "Doha, Qatar, Middle East",
+		"me-central2":             "Dammam, Saudi Arabia, Middle East",
 		"me-west1":                "Tel Aviv, Israel",
 		"northamerica-northeast1": "Montréal, Québec, Canada",
 		"northamerica-northeast2": "Toronto, Ontario, Canada",


### PR DESCRIPTION
Add the me-central2 GCP region that was not previously listed as a supported region for the installer to use.
