### PR TITLE
OCPBUGS-30836: Power VS: Fix wait_for_workspace

### DIFF
--- a/data/data/powervs/cluster/iaas/iaas.tf
+++ b/data/data/powervs/cluster/iaas/iaas.tf
@@ -24,6 +24,7 @@ resource "ibm_resource_instance" "created_service_instance" {
     delete = "10m"
   }
 }
+
 resource "time_sleep" "wait_for_workspace" {
   count           = var.service_instance_name == "" ? 1 : 0
   depends_on      = [ibm_resource_instance.created_service_instance]

--- a/data/data/powervs/cluster/iaas/outputs.tf
+++ b/data/data/powervs/cluster/iaas/outputs.tf
@@ -1,11 +1,14 @@
 output "si_name" {
-  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].name) : one(data.ibm_resource_instance.existing_service_instance[*].name)
+  depends_on = [resource.time_sleep.wait_for_workspace]
+  value      = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].name) : one(data.ibm_resource_instance.existing_service_instance[*].name)
 }
 
 output "si_guid" {
-  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].guid) : one(data.ibm_resource_instance.existing_service_instance[*].guid)
+  depends_on = [resource.time_sleep.wait_for_workspace]
+  value      = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].guid) : one(data.ibm_resource_instance.existing_service_instance[*].guid)
 }
 
 output "si_crn" {
-  value = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].crn) : one(data.ibm_resource_instance.existing_service_instance[*].crn)
+  depends_on = [resource.time_sleep.wait_for_workspace]
+  value      = var.service_instance_name == "" ? one(resource.ibm_resource_instance.created_service_instance[*].crn) : one(data.ibm_resource_instance.existing_service_instance[*].crn)
 }

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -48,7 +48,7 @@ variable "powervs_service_instance_name" {
 variable "powervs_wait_for_workspace" {
   type        = string
   description = "The seconds wait for the Power VS Workspace after creation, default is 60s"
-  default     = "60s"
+  default     = "3m"
 }
 
 ################################################################


### PR DESCRIPTION
The terraform used for waiting after a workspace is created was not preventing the DHCP service from getting created. This was the intention of the sleep and should be fixed.