### PR TITLE
CORS-2902: capi/aws: add ext-LB as CAPA secondary LB

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -151,13 +151,22 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 				PresignedURLDuration: &metav1.Duration{Duration: 1 * time.Hour},
 			},
 			ControlPlaneLoadBalancer: &capa.AWSLoadBalancerSpec{
-				Name:             ptr.To(clusterID.InfraID + "-ext"),
+				Name:             ptr.To(clusterID.InfraID + "-int"),
 				LoadBalancerType: capa.LoadBalancerTypeNLB,
-				Scheme:           &capa.ELBSchemeInternetFacing,
+				Scheme:           &capa.ELBSchemeInternal,
 				AdditionalListeners: []capa.AdditionalListenerSpec{
 					{
 						Port:     22623,
 						Protocol: capa.ELBProtocolTCP,
+					},
+				},
+				IngressRules: []capa.IngressRule{
+					{
+						Description: "Machine Config Server internal traffic from cluster",
+						Protocol:    capa.SecurityGroupProtocolTCP,
+						FromPort:    22623,
+						ToPort:      22623,
+						CidrBlocks:  []string{mainCIDR.String()},
 					},
 				},
 			},

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -175,6 +175,23 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	}
 
 	if installConfig.Config.Publish == types.ExternalPublishingStrategy {
+		// FIXME: CAPA bug. Remove when fixed upstream
+		// The primary and secondary load balancers in CAPA share the same
+		// security group. However, specifying an ingress rule only in the
+		// second LB does not seem to take effect, forcing us to add it to the
+		// primary LB instead.
+		// https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4865
+		awsCluster.Spec.ControlPlaneLoadBalancer.IngressRules = append(
+			awsCluster.Spec.ControlPlaneLoadBalancer.IngressRules,
+			capa.IngressRule{
+				Description: "Kubernetes API Server traffic for public access",
+				Protocol:    capa.SecurityGroupProtocolTCP,
+				FromPort:    6443,
+				ToPort:      6443,
+				CidrBlocks:  []string{"0.0.0.0/0"},
+			},
+		)
+
 		awsCluster.Spec.SecondaryControlPlaneLoadBalancer = &capa.AWSLoadBalancerSpec{
 			Name:                   ptr.To(clusterID.InfraID + "-ext"),
 			LoadBalancerType:       capa.LoadBalancerTypeNLB,

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -152,9 +152,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 				PresignedURLDuration: &metav1.Duration{Duration: 1 * time.Hour},
 			},
 			ControlPlaneLoadBalancer: &capa.AWSLoadBalancerSpec{
-				Name:             ptr.To(clusterID.InfraID + "-int"),
-				LoadBalancerType: capa.LoadBalancerTypeNLB,
-				Scheme:           &capa.ELBSchemeInternal,
+				Name:                   ptr.To(clusterID.InfraID + "-int"),
+				LoadBalancerType:       capa.LoadBalancerTypeNLB,
+				Scheme:                 &capa.ELBSchemeInternal,
+				CrossZoneLoadBalancing: true,
 				AdditionalListeners: []capa.AdditionalListenerSpec{
 					{
 						Port:     22623,


### PR DESCRIPTION
This PR makes the internal LB be the primary CAPA load balancer and then adds the external LB as a secondary one when using public endpoints.