### PR TITLE
WIP:OCPBUGS-24412: azure: Generate Ignition shim with proxy for bootstrap

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -70,7 +70,9 @@ resource "azurerm_storage_blob" "ignition" {
 
 data "ignition_config" "redirect" {
   replace {
-    source = "${azurerm_storage_blob.ignition.url}${data.azurerm_storage_account_sas.ignition.sas}"
+    source = replace(var.azure_bootstrap_ignition_stub,
+      var.azure_bootstrap_ignition_url_placeholder,
+      "${azurerm_storage_blob.ignition.url}${data.azurerm_storage_account_sas.ignition.sas}")
   }
 }
 

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -381,17 +381,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 		preexistingnetwork := installConfig.Config.Azure.VirtualNetwork != ""
 
-		var bootstrapIgnStub, bootstrapIgnURLPlaceholder string
-		if installConfig.Azure.CloudName == azure.StackCloud {
-			// Due to the SAS created in Terraform to limit access to bootstrap ignition, we cannot know the URL in advance.
-			// Instead, we will pass a placeholder string in the ignition to be replaced in TF once the value is known.
-			bootstrapIgnURLPlaceholder = "BOOTSTRAP_IGNITION_URL_PLACEHOLDER"
-			shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(bootstrapIgnURLPlaceholder, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
-			if err != nil {
-				return errors.Wrap(err, "failed to create stub Ignition config for bootstrap")
-			}
-			bootstrapIgnStub = string(shim)
+		// Due to the SAS created in Terraform to limit access to bootstrap ignition, we cannot know the URL in advance.
+		// Instead, we will pass a placeholder string in the ignition to be replaced in TF once the value is known.
+		bootstrapIgnURLPlaceholder := "BOOTSTRAP_IGNITION_URL_PLACEHOLDER"
+		shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(bootstrapIgnURLPlaceholder, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
+		if err != nil {
+			return errors.Wrap(err, "failed to create stub Ignition config for bootstrap")
 		}
+		bootstrapIgnStub := string(shim)
 
 		managedKeys := azure.CustomerManagedKey{}
 		if installConfig.Config.Azure.CustomerManagedKey != nil {


### PR DESCRIPTION
Creating the ignition shim with the proxy information for the bootstrap to get the resources that might be behind a private network.