### PR TITLE
CORS-2895: aws/capi: setting zones to when creating cluster

### DIFF
--- a/pkg/asset/manifests/aws/zones.go
+++ b/pkg/asset/manifests/aws/zones.go
@@ -1,0 +1,271 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/installconfig/aws"
+	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	utilscidr "github.com/openshift/installer/pkg/asset/manifests/capiutils/cidr"
+	"github.com/openshift/installer/pkg/types"
+)
+
+type subnetsInput struct {
+	vpc            string
+	privateSubnets aws.Subnets
+	publicSubnets  aws.Subnets
+}
+
+type zonesInput struct {
+	InstallConfig *installconfig.InstallConfig
+	Cluster       *capa.AWSCluster
+	ClusterID     *installconfig.ClusterID
+	ZonesInRegion []string
+	Subnets       *subnetsInput
+}
+
+// GatherZonesFromMetadata retrieves zones from AWS API to be used
+// when building the subnets to CAPA.
+func (zin *zonesInput) GatherZonesFromMetadata(ctx context.Context) (err error) {
+	zin.ZonesInRegion, err = zin.InstallConfig.AWS.AvailabilityZones(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get availability zones: %w", err)
+	}
+	return nil
+}
+
+// GatherSubnetsFromMetadata retrieves subnets from AWS API to be used
+// when building the subnets to CAPA.
+func (zin *zonesInput) GatherSubnetsFromMetadata(ctx context.Context) (err error) {
+	zin.Subnets = &subnetsInput{}
+	if zin.Subnets.privateSubnets, err = zin.InstallConfig.AWS.PrivateSubnets(ctx); err != nil {
+		return fmt.Errorf("failed to get private subnets: %w", err)
+	}
+	if zin.Subnets.publicSubnets, err = zin.InstallConfig.AWS.PublicSubnets(ctx); err != nil {
+		return fmt.Errorf("failed to get public subnets: %w", err)
+	}
+	if zin.Subnets.vpc, err = zin.InstallConfig.AWS.VPC(ctx); err != nil {
+		return fmt.Errorf("failed to get VPC: %w", err)
+	}
+	return nil
+}
+
+type zonesCAPI struct {
+	controlPlaneZones sets.Set[string]
+	computeZones      sets.Set[string]
+}
+
+// AvailabilityZones returns a sorted union of Availability Zones defined
+// in the zone attribute in the pools for control plane and compute zones.
+func (zo *zonesCAPI) AvailabilityZones() []string {
+	return sets.List(zo.controlPlaneZones.Union(zo.computeZones))
+}
+
+// SetAvailabilityZones insert the zone to the given compute pool, and to
+// the regular zone (zone type availability-zone) list.
+func (zo *zonesCAPI) SetAvailabilityZones(pool string, zones []string) {
+	switch pool {
+	case types.MachinePoolControlPlaneRoleName:
+		zo.controlPlaneZones.Insert(zones...)
+
+	case types.MachinePoolComputeRoleName:
+		zo.computeZones.Insert(zones...)
+	}
+}
+
+// SetDefaultConfigZones evaluates if machine pools (control plane and workers) have been
+// set the zones from install-config.yaml, if not sets the default from platform, when exists,
+// otherwise set the default from the region discovered from AWS API.
+func (zo *zonesCAPI) SetDefaultConfigZones(pool string, defConfig []string, defRegion []string) {
+	zones := []string{}
+	switch pool {
+	case types.MachinePoolControlPlaneRoleName:
+		if len(zo.controlPlaneZones) == 0 && len(defConfig) > 0 {
+			zones = defConfig
+		} else if len(zo.controlPlaneZones) == 0 {
+			zones = defRegion
+		}
+		zo.controlPlaneZones.Insert(zones...)
+
+	case types.MachinePoolComputeRoleName:
+		if len(zo.computeZones) == 0 && len(defConfig) > 0 {
+			zones = defConfig
+		} else if len(zo.computeZones) == 0 {
+			zones = defRegion
+		}
+		zo.computeZones.Insert(zones...)
+	}
+}
+
+// setSubnets is the entrypoint to create the CAPI NetworkSpec structures
+// for managed or BYO VPC deployments from install-config.yaml.
+// The NetworkSpec.Subnets will be populated with the desired zones.
+func setSubnets(ctx context.Context, in *zonesInput) error {
+	if in.InstallConfig == nil {
+		return fmt.Errorf("failed to get installConfig")
+	}
+	if in.InstallConfig.AWS == nil {
+		return fmt.Errorf("failed to get AWS metadata")
+	}
+	if in.InstallConfig.Config == nil {
+		return fmt.Errorf("unable to get Config")
+	}
+	if in.Cluster == nil {
+		return fmt.Errorf("failed to get AWSCluster config")
+	}
+	if len(in.InstallConfig.Config.AWS.Subnets) > 0 {
+		if err := in.GatherSubnetsFromMetadata(ctx); err != nil {
+			return fmt.Errorf("failed to get subnets from metadata: %w", err)
+		}
+		return setSubnetsBYOVPC(in)
+	}
+
+	if err := in.GatherZonesFromMetadata(ctx); err != nil {
+		return fmt.Errorf("failed to get availability zones from metadata: %w", err)
+	}
+	return setSubnetsManagedVPC(in)
+}
+
+// setSubnetsBYOVPC creates the CAPI NetworkSpec.Subnets setting the
+// desired subnets from install-config.yaml in the BYO VPC deployment.
+// This function does not have support for unit test to mock for AWS API,
+// so all API calls must be done prior this execution.
+// TODO: create support to mock AWS API calls in the unit tests, so we can merge
+// the methods GatherSubnetsFromMetadata() into this.
+func setSubnetsBYOVPC(in *zonesInput) error {
+	in.Cluster.Spec.NetworkSpec.VPC = capa.VPCSpec{
+		ID: in.Subnets.vpc,
+	}
+	for _, subnet := range in.Subnets.privateSubnets {
+		in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+			ID:               subnet.ID,
+			CidrBlock:        subnet.CIDR,
+			AvailabilityZone: subnet.Zone.Name,
+			IsPublic:         subnet.Public,
+		})
+	}
+
+	for _, subnet := range in.Subnets.publicSubnets {
+		in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+			ID:               subnet.ID,
+			CidrBlock:        subnet.CIDR,
+			AvailabilityZone: subnet.Zone.Name,
+			IsPublic:         subnet.Public,
+		})
+	}
+
+	return nil
+}
+
+// setSubnetsManagedVPC creates the CAPI NetworkSpec.VPC and the NetworkSpec.Subnets,
+// setting the desired zones from install-config.yaml in the managed
+// VPC deployment, when specified, otherwise default zones are set from
+// the previously discovered from AWS API.
+// This function does not have mock for AWS API, so all API calls must be done prior
+// this execution.
+// TODO: create support to mock AWS API calls in the unit tests, so we can merge
+// the methods GatherZonesFromMetadata() into this.
+// The CIDR blocks are calculated leaving free blocks to allow future expansions,
+// in Day-2, when desired.
+func setSubnetsManagedVPC(in *zonesInput) error {
+	out, err := extractZonesFromInstallConfig(in)
+	if err != nil {
+		return fmt.Errorf("failed to get availability zones: %w", err)
+	}
+
+	allZones := out.AvailabilityZones()
+	isPublishingExternal := in.InstallConfig.Config.Publish == types.ExternalPublishingStrategy
+	mainCIDR := capiutils.CIDRFromInstallConfig(in.InstallConfig)
+	in.Cluster.Spec.NetworkSpec.VPC = capa.VPCSpec{
+		CidrBlock: mainCIDR.String(),
+	}
+
+	// Base subnets considering only private zones, leaving one free block to allow
+	// future subnet expansions in Day-2.
+	numSubnets := len(allZones) + 1
+
+	// Public subnets consumes one range from base blocks.
+	if isPublishingExternal {
+		numSubnets++
+	}
+
+	privateCIDRs, err := utilscidr.SplitIntoSubnetsIPv4(mainCIDR.String(), numSubnets)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve CIDR blocks for all private subnets: %w", err)
+	}
+
+	var publicCIDRs []*net.IPNet
+	if isPublishingExternal {
+		// The last num(zones) blocks are dedicated to the public subnets.
+		publicCIDRs, err = utilscidr.SplitIntoSubnetsIPv4(privateCIDRs[len(allZones)].String(), len(allZones))
+		if err != nil {
+			return fmt.Errorf("unable to retrieve CIDR blocks for all public subnets: %w", err)
+		}
+	}
+
+	// Create subnets from zone pool with type availability-zone
+	if len(privateCIDRs) < len(allZones) {
+		return fmt.Errorf("unable to define CIDR blocks to all zones for private subnets")
+	}
+	if isPublishingExternal && len(publicCIDRs) < len(allZones) {
+		return fmt.Errorf("unable to define CIDR blocks to all zones for public subnets")
+	}
+
+	for idxCIDR, zone := range allZones {
+		in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+			AvailabilityZone: zone,
+			CidrBlock:        privateCIDRs[idxCIDR].String(),
+			ID:               fmt.Sprintf("%s-subnet-private-%s", in.ClusterID.InfraID, zone),
+			IsPublic:         false,
+		})
+		if isPublishingExternal {
+			in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+				AvailabilityZone: zone,
+				CidrBlock:        publicCIDRs[idxCIDR].String(),
+				ID:               fmt.Sprintf("%s-subnet-public-%s", in.ClusterID.InfraID, zone),
+				IsPublic:         true,
+			})
+		}
+	}
+	return nil
+}
+
+// extractZonesFromInstallConfig extracts zones defined in the install-config.
+func extractZonesFromInstallConfig(in *zonesInput) (*zonesCAPI, error) {
+	out := zonesCAPI{
+		controlPlaneZones: sets.New[string](),
+		computeZones:      sets.New[string](),
+	}
+
+	cfg := in.InstallConfig.Config
+	defaultZones := []string{}
+	if cfg.AWS != nil && cfg.AWS.DefaultMachinePlatform != nil && len(cfg.AWS.DefaultMachinePlatform.Zones) > 0 {
+		defaultZones = cfg.AWS.DefaultMachinePlatform.Zones
+	}
+
+	if cfg.ControlPlane != nil && cfg.ControlPlane.Platform.AWS != nil {
+		out.SetAvailabilityZones(types.MachinePoolControlPlaneRoleName, cfg.ControlPlane.Platform.AWS.Zones)
+	}
+	out.SetDefaultConfigZones(types.MachinePoolControlPlaneRoleName, defaultZones, in.ZonesInRegion)
+
+	for _, pool := range cfg.Compute {
+		if pool.Platform.AWS == nil {
+			continue
+		}
+		if len(pool.Platform.AWS.Zones) > 0 {
+			out.SetAvailabilityZones(pool.Name, pool.Platform.AWS.Zones)
+		}
+		// Ignoring as edge pool is not yet supported by CAPA.
+		// See https://github.com/openshift/installer/pull/8173
+		if pool.Name == types.MachinePoolEdgeRoleName {
+			continue
+		}
+		out.SetDefaultConfigZones(types.MachinePoolComputeRoleName, defaultZones, in.ZonesInRegion)
+	}
+	return &out, nil
+}

--- a/pkg/asset/manifests/aws/zones_test.go
+++ b/pkg/asset/manifests/aws/zones_test.go
@@ -1,0 +1,834 @@
+package aws
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/installconfig/aws"
+	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+)
+
+var (
+	stubDefaultCIDR = "10.0.0.0/16"
+)
+
+func stubClusterID() *installconfig.ClusterID {
+	return &installconfig.ClusterID{
+		InfraID: "infra-id",
+	}
+}
+
+func stubInstallConfig() *installconfig.InstallConfig {
+	ic := &installconfig.InstallConfig{}
+	return ic
+}
+
+func stubInstallConfigType() *types.InstallConfig {
+	return &types.InstallConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: types.InstallConfigVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		Publish: types.ExternalPublishingStrategy,
+		Networking: &types.Networking{
+			MachineNetwork: []types.MachineNetworkEntry{
+				{
+					CIDR: *ipnet.MustParseCIDR(stubDefaultCIDR),
+				},
+			},
+		},
+	}
+}
+
+func stubInstallCOnfigPoolCompute() []types.MachinePool {
+	return []types.MachinePool{
+		{
+			Name: "worker",
+			Platform: types.MachinePoolPlatform{
+				AWS: &awstypes.MachinePool{
+					Zones: []string{"b", "c"},
+				},
+			},
+		},
+	}
+}
+
+func stubInstallConfigPoolControl() *types.MachinePool {
+	return &types.MachinePool{
+		Name: "master",
+		Platform: types.MachinePoolPlatform{
+			AWS: &awstypes.MachinePool{
+				Zones: []string{"a", "b"},
+			},
+		},
+	}
+}
+
+var stubAwsCluster = &capa.AWSCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "infraId",
+		Namespace: capiutils.Namespace,
+	},
+	Spec: capa.AWSClusterSpec{},
+}
+
+func tSortCapaSubnetsByID(in capa.Subnets) capa.Subnets {
+	subnetIds := []string{}
+	subnetsMap := make(map[string]capa.SubnetSpec, len(in))
+	for _, subnet := range in {
+		subnetsMap[subnet.ID] = subnet
+		subnetIds = append(subnetIds, subnet.ID)
+	}
+	sort.Strings(subnetIds)
+	out := capa.Subnets{}
+	for _, sid := range subnetIds {
+		out = append(out, subnetsMap[sid])
+	}
+	return out
+}
+
+func Test_extractZonesFromInstallConfig(t *testing.T) {
+	type args struct {
+		in *zonesInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *zonesCAPI
+		wantErr bool
+	}{
+		{
+			name: "default zones",
+			args: args{
+				in: &zonesInput{
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = stubInstallConfigType()
+						return ic
+					}(),
+				},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "custom zones control plane pool",
+			args: args{
+				in: &zonesInput{
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							ControlPlane: stubInstallConfigPoolControl(),
+							Compute:      nil,
+						}
+						return ic
+					}(),
+				},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("a", "b"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "custom zones compute pool",
+			args: args{
+				in: &zonesInput{
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							ControlPlane: nil,
+							Compute:      stubInstallCOnfigPoolCompute(),
+						}
+						return ic
+					}(),
+				},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b", "c"),
+			},
+		},
+		{
+			name: "custom zones control plane and compute pools",
+			args: args{
+				in: &zonesInput{
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							ControlPlane: stubInstallConfigPoolControl(),
+							Compute:      stubInstallCOnfigPoolCompute(),
+						}
+						return ic
+					}(),
+				},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("a", "b"),
+				computeZones:      sets.New("b", "c"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractZonesFromInstallConfig(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractZonesFromInstallConfig() error: %v, wantErr: %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractZonesFromInstallConfig() err=%v\ngot : %#v,\nwant: %#v\n", err, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_setSubnetsManagedVPC(t *testing.T) {
+	type args struct {
+		in *zonesInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    *capa.NetworkSpec
+	}{
+		{
+			name: "regular zones from config",
+			args: args{
+				in: &zonesInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR(stubDefaultCIDR),
+									},
+								},
+							},
+						}
+						return ic
+					}(),
+					Cluster:       stubAwsCluster,
+					ZonesInRegion: []string{"a", "b", "c"},
+				},
+			},
+			want: func() *capa.NetworkSpec {
+				c := capa.AWSCluster{}
+				c.Spec.NetworkSpec.VPC = capa.VPCSpec{CidrBlock: stubDefaultCIDR}
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-private-a",
+					AvailabilityZone: "a",
+					IsPublic:         false,
+					CidrBlock:        "10.0.0.0/19",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-private-b",
+					AvailabilityZone: "b",
+					IsPublic:         false,
+					CidrBlock:        "10.0.32.0/19",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-private-c",
+					AvailabilityZone: "c",
+					IsPublic:         false,
+					CidrBlock:        "10.0.64.0/19",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-public-a",
+					AvailabilityZone: "a",
+					IsPublic:         true,
+					CidrBlock:        "10.0.96.0/21",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-public-b",
+					AvailabilityZone: "b",
+					IsPublic:         true,
+					CidrBlock:        "10.0.104.0/21",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "infra-id-subnet-public-c",
+					AvailabilityZone: "c",
+					IsPublic:         true,
+					CidrBlock:        "10.0.112.0/21",
+				})
+				return &c.Spec.NetworkSpec
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := setSubnetsManagedVPC(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setSubnetsManagedVPC() #1 error: %+v,\nwantErr %+v\n", err, tt.wantErr)
+			}
+			var got *capa.NetworkSpec
+			if tt.args.in != nil && tt.args.in.Cluster != nil {
+				got = &tt.args.in.Cluster.Spec.NetworkSpec
+			} else {
+				if !tt.wantErr {
+					t.Errorf("setSubnetsManagedVPC() #2 error: %v, wantErr: %v", err, tt.wantErr)
+				}
+				return
+			}
+			if len(got.Subnets) == 0 {
+				if !tt.wantErr {
+					t.Errorf("setSubnetsManagedVPC() #2 error: %v, wantErr: %v", err, tt.wantErr)
+				}
+				return
+			}
+			got.Subnets = tSortCapaSubnetsByID(got.Subnets)
+			if tt.want != nil {
+				assert.EqualValuesf(t, tt.want, got, "%v failed.\nWant: %+v\nGot: %+v", tt.name)
+			}
+		})
+	}
+}
+
+func Test_setSubnetsBYOVPC(t *testing.T) {
+	type args struct {
+		in *zonesInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *capa.NetworkSpec
+		wantErr bool
+	}{
+		{
+			name: "default byo vpc",
+			args: args{
+				in: &zonesInput{
+					Cluster: &capa.AWSCluster{},
+					Subnets: &subnetsInput{
+						vpc: "vpc-name",
+						privateSubnets: aws.Subnets{
+							"subnetId-a-private": aws.Subnet{
+								ID:   "subnetId-a-private",
+								CIDR: "10.0.1.0/24",
+								Zone: &aws.Zone{
+									Name: "a",
+								},
+								Public: false,
+							},
+							"subnetId-b-private": aws.Subnet{
+								ID:   "subnetId-b-private",
+								CIDR: "10.0.2.0/24",
+								Zone: &aws.Zone{
+									Name: "b",
+								},
+								Public: false,
+							},
+							"subnetId-c-private": aws.Subnet{
+								ID:   "subnetId-c-private",
+								CIDR: "10.0.3.0/24",
+								Zone: &aws.Zone{
+									Name: "c",
+								},
+								Public: false,
+							},
+						},
+						publicSubnets: aws.Subnets{
+							"subnetId-a-public": aws.Subnet{
+								ID:   "subnetId-a-public",
+								CIDR: "10.0.4.0/24",
+								Zone: &aws.Zone{
+									Name: "a",
+								},
+								Public: true,
+							},
+							"subnetId-b-public": aws.Subnet{
+								ID:   "subnetId-b-public",
+								CIDR: "10.0.5.0/24",
+								Zone: &aws.Zone{
+									Name: "b",
+								},
+								Public: true,
+							},
+							"subnetId-c-public": aws.Subnet{
+								ID:   "subnetId-c-public",
+								CIDR: "10.0.6.0/24",
+								Zone: &aws.Zone{
+									Name: "c",
+								},
+								Public: true,
+							},
+						},
+					},
+				},
+			},
+			want: func() *capa.NetworkSpec {
+				c := capa.AWSCluster{}
+				c.Spec.NetworkSpec.VPC = capa.VPCSpec{
+					ID: "vpc-name",
+				}
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-a-private",
+					AvailabilityZone: "a",
+					IsPublic:         false,
+					CidrBlock:        "10.0.1.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-a-public",
+					AvailabilityZone: "a",
+					IsPublic:         true,
+					CidrBlock:        "10.0.4.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-b-private",
+					AvailabilityZone: "b",
+					IsPublic:         false,
+					CidrBlock:        "10.0.2.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-b-public",
+					AvailabilityZone: "b",
+					IsPublic:         true,
+					CidrBlock:        "10.0.5.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-c-private",
+					AvailabilityZone: "c",
+					IsPublic:         false,
+					CidrBlock:        "10.0.3.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-c-public",
+					AvailabilityZone: "c",
+					IsPublic:         true,
+					CidrBlock:        "10.0.6.0/24",
+				})
+				return &c.Spec.NetworkSpec
+			}(),
+		},
+		{
+			name: "byo vpc only private subnets",
+			args: args{
+				in: &zonesInput{
+					Cluster: &capa.AWSCluster{},
+					Subnets: &subnetsInput{
+						vpc: "vpc-name",
+						privateSubnets: aws.Subnets{
+							"subnetId-a-private": aws.Subnet{
+								ID:   "subnetId-a-private",
+								CIDR: "10.0.1.0/24",
+								Zone: &aws.Zone{
+									Name: "a",
+								},
+								Public: false,
+							},
+							"subnetId-b-private": aws.Subnet{
+								ID:   "subnetId-b-private",
+								CIDR: "10.0.2.0/24",
+								Zone: &aws.Zone{
+									Name: "b",
+								},
+								Public: false,
+							},
+							"subnetId-c-private": aws.Subnet{
+								ID:   "subnetId-c-private",
+								CIDR: "10.0.3.0/24",
+								Zone: &aws.Zone{
+									Name: "c",
+								},
+								Public: false,
+							},
+						},
+					},
+				},
+			},
+			want: func() *capa.NetworkSpec {
+				c := capa.AWSCluster{
+					Spec: capa.AWSClusterSpec{
+						NetworkSpec: capa.NetworkSpec{
+							VPC: capa.VPCSpec{
+								ID: "vpc-name",
+							},
+						},
+					},
+				}
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-a-private",
+					AvailabilityZone: "a",
+					IsPublic:         false,
+					CidrBlock:        "10.0.1.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-b-private",
+					AvailabilityZone: "b",
+					IsPublic:         false,
+					CidrBlock:        "10.0.2.0/24",
+				})
+				c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+					ID:               "subnetId-c-private",
+					AvailabilityZone: "c",
+					IsPublic:         false,
+					CidrBlock:        "10.0.3.0/24",
+				})
+				return &c.Spec.NetworkSpec
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := setSubnetsBYOVPC(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setSubnetsBYOVPC() #1 error: %v, wantErr: %v", err, tt.wantErr)
+				return
+			}
+			var got *capa.NetworkSpec
+			if tt.args.in != nil && tt.args.in.Cluster != nil {
+				got = &tt.args.in.Cluster.Spec.NetworkSpec
+			} else {
+				if !tt.wantErr {
+					t.Errorf("setSubnetsBYOVPC() #2 error: %v, wantErr: %v", err, tt.wantErr)
+				}
+				return
+			}
+			if len(got.Subnets) == 0 {
+				if !tt.wantErr {
+					t.Errorf("setSubnetsBYOVPC() #2 error: %v, wantErr: %v", err, tt.wantErr)
+				}
+				return
+			}
+			got.Subnets = tSortCapaSubnetsByID(got.Subnets)
+			if tt.want != nil {
+				assert.EqualValuesf(t, tt.want, got, "%v failed.\nWant: %+v\nGot: %+v", tt.name)
+			}
+		})
+	}
+}
+
+func Test_zonesCAPI_SetAvailabilityZones(t *testing.T) {
+	type fields struct {
+		controlPlaneZones sets.Set[string]
+		computeZones      sets.Set[string]
+	}
+	type args struct {
+		pool  string
+		zones []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *zonesCAPI
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:  types.MachinePoolControlPlaneRoleName,
+				zones: []string{},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "set zones for control plane pool",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:  types.MachinePoolControlPlaneRoleName,
+				zones: []string{"a", "b"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("a", "b"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "set zones for compute pool",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:  types.MachinePoolComputeRoleName,
+				zones: []string{"b", "c"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b", "c"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zo := &zonesCAPI{
+				controlPlaneZones: tt.fields.controlPlaneZones,
+				computeZones:      tt.fields.computeZones,
+			}
+			zo.SetAvailabilityZones(tt.args.pool, tt.args.zones)
+			if tt.want != nil {
+				assert.EqualValuesf(t, tt.want, zo, "%v failed", tt.name)
+			}
+		})
+	}
+}
+
+func Test_zonesCAPI_SetDefaultConfigZones(t *testing.T) {
+	type fields struct {
+		AvailabilityZones sets.Set[string]
+		controlPlaneZones sets.Set[string]
+		computeZones      sets.Set[string]
+	}
+	type args struct {
+		pool      string
+		defConfig []string
+		defRegion []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *zonesCAPI
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolControlPlaneRoleName,
+				defConfig: []string{},
+				defRegion: []string{},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "platform defaults when control plane pool exists",
+			fields: fields{
+				controlPlaneZones: sets.New("a"),
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolControlPlaneRoleName,
+				defConfig: []string{"d"},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("a"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "platform defaults when control plane pool not exists",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolControlPlaneRoleName,
+				defConfig: []string{"d"},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("d"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "region defaults when control plane pool exists",
+			fields: fields{
+				controlPlaneZones: sets.New("a"),
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolControlPlaneRoleName,
+				defConfig: []string{},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("a"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "region defaults when control plane pool not exists",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolControlPlaneRoleName,
+				defConfig: []string{},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.New("f"),
+				computeZones:      sets.Set[string]{},
+			},
+		},
+		{
+			name: "platform defaults when compute pool exists",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b"),
+			},
+			args: args{
+				pool:      types.MachinePoolComputeRoleName,
+				defConfig: []string{"d"},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b"),
+			},
+		},
+		{
+			name: "platform defaults when compute pool not exists",
+			fields: fields{
+				AvailabilityZones: sets.Set[string]{},
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolComputeRoleName,
+				defConfig: []string{"d"},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("d"),
+			},
+		},
+		{
+			name: "region defaults when compute pool exists",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b"),
+			},
+			args: args{
+				pool:      types.MachinePoolComputeRoleName,
+				defConfig: []string{},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("b"),
+			},
+		},
+		{
+			name: "region defaults when compute pool not exists",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			args: args{
+				pool:      types.MachinePoolComputeRoleName,
+				defConfig: []string{},
+				defRegion: []string{"f"},
+			},
+			want: &zonesCAPI{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("f"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zo := &zonesCAPI{
+				controlPlaneZones: tt.fields.controlPlaneZones,
+				computeZones:      tt.fields.computeZones,
+			}
+			zo.SetDefaultConfigZones(tt.args.pool, tt.args.defConfig, tt.args.defRegion)
+			if tt.want != nil {
+				assert.EqualValuesf(t, tt.want, zo, "%v failed", tt.name)
+			}
+		})
+	}
+}
+
+func Test_zonesCAPI_AvailabilityZones(t *testing.T) {
+	type fields struct {
+		controlPlaneZones sets.Set[string]
+		computeZones      sets.Set[string]
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		// TODO: Add test cases.
+		{
+			name: "empty",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.Set[string]{},
+			},
+			want: []string{},
+		},
+		{
+			name: "sorted",
+			fields: fields{
+				controlPlaneZones: sets.New("a", "b"),
+				computeZones:      sets.New("b", "c"),
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "unsorted",
+			fields: fields{
+				controlPlaneZones: sets.New("x", "a"),
+				computeZones:      sets.New("b", "a"),
+			},
+			want: []string{"a", "b", "x"},
+		},
+		{
+			name: "control planes only",
+			fields: fields{
+				controlPlaneZones: sets.New("x", "a"),
+				computeZones:      sets.Set[string]{},
+			},
+			want: []string{"a", "x"},
+		},
+		{
+			name: "compute only",
+			fields: fields{
+				controlPlaneZones: sets.Set[string]{},
+				computeZones:      sets.New("x", "a"),
+			},
+			want: []string{"a", "x"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zo := &zonesCAPI{
+				controlPlaneZones: tt.fields.controlPlaneZones,
+				computeZones:      tt.fields.computeZones,
+			}
+			if got := zo.AvailabilityZones(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("zonesCAPI.AvailabilityZones() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[CORS-2895](https://issues.redhat.com//browse/CORS-2895)

### Summary

This PR create parity support in CAPA of subnet discover based in zones defined in Install Config, setting up CAPA manifests to create subnets into those zones.

### Scenarios based in terraform version in `us-east-1`:

The following scenarios are install-config variants to implement/validate parity in CAPA version:

> The region prefix has been removed from the zone name. Eg `a` represents the zone `us-east-1a`

| Scen# | CP[1] | WK[2] | Plat. Def[3] | Machines rendered in zones: | 
| -- | -- | -- | -- | -- |
| 1 | -- | -- | -- | a, b, c, d, f (All zones, except zone "e") |
| 2 | a | -- | -- | a, b, c, d, f (All zones, except zone "e") |
| 3 | --  | b | -- | a, b, c |
| 4 | a | b | -- | a, b |
| 5 | -- | -- | c | c |
| 6 | a | b | c | a, b |
| 7 | a | -- | c | a, c |
| 8 | -- | b | c | b, c |

[1] Value for install config option `controlPlane.platform.aws.zones`
[2] Value for install config option `compute[?.name=="worker"].platform.aws.zones`
[3] Value for install config option `platform.aws.defaultMachinePlatform.zones`

### Test/validation: CAPA implementation parity:

- [ ] Scenario 1
- [ ] Scenario 2
- [ ] Scenario 3
- [ ] Scenario 4
- [ ] Scenario 5
- [ ] Scenario 6
- [ ] Scenario 7
- [ ] Scenario 8

Log for test scenarios
```
TBD
```
