### PR TITLE
NO-JIRA: OWNERS: pkg/infrastructure/openstack

### DIFF
--- a/pkg/infrastructure/openstack/OWNERS
+++ b/pkg/infrastructure/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers


### PR DESCRIPTION
Transfer ownership of OpenStack-specific CAPI code to the ShiftStack team.