### PR TITLE
CORS-3142: capi: write manifests to disk during create manifests

### DIFF
--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -54,10 +54,6 @@ func GenerateMachines(clusterID string, region string, subnets map[string]string
 		}
 
 		awsMachine := &capa.AWSMachine{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
-				Kind:       "AWSMachine",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
 				Labels: map[string]string{
@@ -82,6 +78,7 @@ func GenerateMachines(clusterID string, region string, subnets map[string]string
 				},
 			},
 		}
+		awsMachine.SetGroupVersionKind(capa.GroupVersion.WithKind("AWSMachine"))
 
 		// Handle additional security groups.
 		for _, sg := range mpool.AdditionalSecurityGroupIDs {
@@ -115,6 +112,7 @@ func GenerateMachines(clusterID string, region string, subnets map[string]string
 				},
 			},
 		}
+		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},

--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -106,7 +106,7 @@ func GenerateMachines(clusterID string, region string, subnets map[string]string
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIVersion: capa.GroupVersion.String(),
 					Kind:       "AWSMachine",
 					Name:       awsMachine.Name,
 				},

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -109,10 +109,6 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 	for idx := int64(0); idx < total; idx++ {
 		zone := mpool.Zones[int(idx)%len(mpool.Zones)]
 		azureMachine := &capz.AzureMachine{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-				Kind:       "AzureMachine",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
 				Labels: map[string]string{
@@ -131,6 +127,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				SecurityProfile:        securityProfile,
 			},
 		}
+		azureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", azureMachine.Name)},
 			Object: azureMachine,
@@ -155,6 +152,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				},
 			},
 		}
+		controlPlaneMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", azureMachine.Name)},
@@ -163,10 +161,6 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 	}
 
 	bootstrapAzureMachine := &capz.AzureMachine{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-			Kind:       "AzureMachine",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: capiutils.GenerateBoostrapMachineName(clusterID),
 			Labels: map[string]string{
@@ -186,6 +180,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 			SecurityProfile:        securityProfile,
 		},
 	}
+	bootstrapAzureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))
 
 	result = append(result, &asset.RuntimeFile{
 		File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapAzureMachine.Name)},
@@ -211,6 +206,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 			},
 		},
 	}
+	bootstrapMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 	result = append(result, &asset.RuntimeFile{
 		File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapMachine.Name)},

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -146,7 +146,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIVersion: capz.GroupVersion.String(),
 					Kind:       "AzureMachine",
 					Name:       azureMachine.Name,
 				},
@@ -200,7 +200,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, "bootstrap")),
 			},
 			InfrastructureRef: v1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+				APIVersion: capz.GroupVersion.String(),
 				Kind:       "AzureMachine",
 				Name:       bootstrapAzureMachine.Name,
 			},

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -193,6 +193,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 				},
 			},
 		}
+		bootstrapAWSMachine.SetGroupVersionKind(capa.GroupVersion.WithKind("AWSMachine"))
 
 		// Handle additional security groups.
 		for _, sg := range mpool.AdditionalSecurityGroupIDs {
@@ -226,6 +227,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 				},
 			},
 		}
+		bootstrapMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 		c.FileList = append(c.FileList, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapMachine.Name)},

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -44,6 +44,8 @@ import (
 
 var _ asset.WritableRuntimeAsset = (*ClusterAPI)(nil)
 
+var machineManifestDir = filepath.Join(capiutils.ManifestDir, "machines")
+
 // ClusterAPI is the asset for CAPI control-plane manifests.
 type ClusterAPI struct {
 	FileList []*asset.RuntimeFile
@@ -78,7 +80,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(capiutils.ManifestDir), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(machineManifestDir), 0755); err != nil {
 		return err
 	}
 
@@ -421,10 +423,10 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		m.Data = objData
 
 		// If the filename is already a path, do not append the manifest dir.
-		if filepath.Dir(m.Filename) == capiutils.ManifestDir {
+		if filepath.Dir(m.Filename) == machineManifestDir {
 			continue
 		}
-		m.Filename = filepath.Join(capiutils.ManifestDir, m.Filename)
+		m.Filename = filepath.Join(machineManifestDir, m.Filename)
 	}
 	asset.SortManifestFiles(c.FileList)
 	return nil
@@ -446,15 +448,15 @@ func (c *ClusterAPI) RuntimeFiles() []*asset.RuntimeFile {
 
 // Load returns the openshift asset from disk.
 func (c *ClusterAPI) Load(f asset.FileFetcher) (bool, error) {
-	yamlFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.yaml"))
+	yamlFileList, err := f.FetchByPattern(filepath.Join(machineManifestDir, "*.yaml"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.yaml files")
 	}
-	ymlFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.yml"))
+	ymlFileList, err := f.FetchByPattern(filepath.Join(machineManifestDir, "*.yml"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.yml files")
 	}
-	jsonFileList, err := f.FetchByPattern(filepath.Join(capiutils.ManifestDir, "*.json"))
+	jsonFileList, err := f.FetchByPattern(filepath.Join(machineManifestDir, "*.json"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load *.json files")
 	}

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -3,7 +3,6 @@ package machines
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -78,10 +77,6 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 	// If the feature gate is not enabled, do not generate any manifests.
 	if !capiutils.IsEnabled(installConfig) {
 		return nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(machineManifestDir), 0755); err != nil {
-		return err
 	}
 
 	c.FileList = []*asset.RuntimeFile{}

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -221,7 +221,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID.InfraID, "bootstrap")),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIVersion: capa.GroupVersion.String(),
 					Kind:       "AWSMachine",
 					Name:       bootstrapAWSMachine.Name,
 				},

--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -104,10 +104,6 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 	}
 
 	gcpMachine := &capg.GCPMachine{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-			Kind:       "GCPMachine",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
@@ -123,6 +119,7 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 			RootDeviceSize:   mpool.OSDisk.DiskSizeGB,
 		},
 	}
+	gcpMachine.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPMachine"))
 	// Set optional values from machinepool
 	if mpool.OnHostMaintenance != "" {
 		gcpMachine.Spec.OnHostMaintenance = ptr.To(capg.HostMaintenancePolicy(mpool.OnHostMaintenance))
@@ -180,6 +177,7 @@ func createCAPIMachine(name string, dataSecret string, infraID string) *capi.Mac
 			},
 		},
 	}
+	machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 	return machine
 }

--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -171,7 +171,7 @@ func createCAPIMachine(name string, dataSecret string, infraID string) *capi.Mac
 				DataSecretName: ptr.To(dataSecret),
 			},
 			InfrastructureRef: v1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: capg.GroupVersion.String(),
 				Kind:       "GCPMachine",
 				Name:       name,
 			},

--- a/pkg/asset/machines/gcp/gcpmachines_test.go
+++ b/pkg/asset/machines/gcp/gcpmachines_test.go
@@ -153,10 +153,6 @@ func getBaseGCPMachine() *capg.GCPMachine {
 	image := "rhcos-415-92-202311241643-0-gcp-x86-64"
 	diskType := "pd-ssd"
 	gcpMachine := &capg.GCPMachine{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-			Kind:       "GCPMachine",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "012345678-master-0",
 			Labels: map[string]string{
@@ -178,6 +174,7 @@ func getBaseGCPMachine() *capg.GCPMachine {
 			},
 		},
 	}
+	gcpMachine.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPMachine"))
 	return gcpMachine
 }
 
@@ -233,5 +230,6 @@ func getBaseCapiMachine() *capi.Machine {
 			},
 		},
 	}
+	capiMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 	return capiMachine
 }

--- a/pkg/asset/machines/gcp/gcpmachines_test.go
+++ b/pkg/asset/machines/gcp/gcpmachines_test.go
@@ -224,7 +224,7 @@ func getBaseCapiMachine() *capi.Machine {
 				DataSecretName: ptr.To(dataSecret),
 			},
 			InfrastructureRef: v1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: capg.GroupVersion.String(),
 				Kind:       "GCPMachine",
 				Name:       "012345678-master-0",
 			},

--- a/pkg/asset/machines/openstack/openstackmachines.go
+++ b/pkg/asset/machines/openstack/openstackmachines.go
@@ -96,7 +96,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha7",
+					APIVersion: capo.GroupVersion.String(),
 					Kind:       "OpenStackMachine",
 					Name:       openStackMachine.Name,
 				},

--- a/pkg/asset/machines/powervs/powervsmachines.go
+++ b/pkg/asset/machines/powervs/powervsmachines.go
@@ -74,7 +74,7 @@ func GenerateMachines(clusterID string, pool *types.MachinePool, role string) ([
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					APIVersion: capibm.GroupVersion.String(),
 					Kind:       "IBMPowerVSMachine",
 					Name:       powervsMachine.Name,
 				},

--- a/pkg/asset/machines/powervs/powervsmachines.go
+++ b/pkg/asset/machines/powervs/powervsmachines.go
@@ -37,10 +37,6 @@ func GenerateMachines(clusterID string, pool *types.MachinePool, role string) ([
 
 	for idx := int64(0); idx < total; idx++ {
 		powervsMachine := &capibm.IBMPowerVSMachine{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: capibm.GroupVersion.String(),
-				Kind:       "IBMPowerVSMachine",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
 				Labels: map[string]string{
@@ -58,6 +54,7 @@ func GenerateMachines(clusterID string, pool *types.MachinePool, role string) ([
 				MemoryGiB:     mpool.MemoryGiB,
 			},
 		}
+		powervsMachine.SetGroupVersionKind(capibm.GroupVersion.WithKind("IBMPowerVSMachine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", powervsMachine.Name)},
@@ -65,10 +62,6 @@ func GenerateMachines(clusterID string, pool *types.MachinePool, role string) ([
 		})
 
 		machine := &capi.Machine{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Machine",
-				APIVersion: capi.GroupVersion.String(),
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: powervsMachine.Name,
 				Labels: map[string]string{
@@ -87,6 +80,7 @@ func GenerateMachines(clusterID string, pool *types.MachinePool, role string) ([
 				},
 			},
 		}
+		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},

--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -159,7 +159,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					APIVersion: capv.GroupVersion.String(),
 					Kind:       "VSphereMachine",
 					Name:       vsphereMachine.Name,
 				},
@@ -217,7 +217,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 					DataSecretName: ptr.To(fmt.Sprintf("%s-bootstrap", clusterID)),
 				},
 				InfrastructureRef: v1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					APIVersion: capv.GroupVersion.String(),
 					Kind:       "VSphereMachine",
 					Name:       bootstrapVSphereMachine.Name,
 				},

--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -111,10 +111,6 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 		}
 
 		vsphereMachine := &capv.VSphereMachine{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-				Kind:       "VSphereMachine",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: capiutils.Namespace,
 				Name:      machine.Name,
@@ -141,6 +137,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 				},
 			},
 		}
+		vsphereMachine.SetGroupVersionKind(capv.GroupVersion.WithKind("VSphereMachine"))
 		capvMachines = append(capvMachines, vsphereMachine)
 
 		result = append(result, &asset.RuntimeFile{
@@ -168,6 +165,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 				},
 			},
 		}
+		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},
@@ -199,6 +197,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			},
 			Spec: bootstrapSpec,
 		}
+		bootstrapVSphereMachine.SetGroupVersionKind(capv.GroupVersion.WithKind("VSphereMachine"))
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapVSphereMachine.Name)},
@@ -224,6 +223,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 				},
 			},
 		}
+		bootstrapMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapVSphereMachine.Name)},
 			Object: bootstrapMachine,

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -170,6 +170,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			AdditionalTags: tags,
 		},
 	}
+	awsCluster.SetGroupVersionKind(capa.GroupVersion.WithKind("AWSCluster"))
 
 	// If the install config has subnets, use them.
 	if len(installConfig.AWS.Subnets) > 0 {
@@ -224,6 +225,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			},
 		},
 	}
+	id.SetGroupVersionKind(capa.GroupVersion.WithKind("AWSClusterControllerIdentity"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: id,
 		File:   asset.File{Filename: "01_aws-cluster-controller-identity-default.yaml"},

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -234,7 +234,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+			APIVersion: capa.GroupVersion.String(),
 			Kind:       "AWSCluster",
 			Name:       awsCluster.Name,
 			Namespace:  awsCluster.Namespace,

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -49,7 +49,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 				Location:         installConfig.Config.Azure.Region,
 				AzureEnvironment: string(installConfig.Azure.CloudName),
 				IdentityRef: &corev1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					APIVersion: capz.GroupVersion.String(),
 					Kind:       "AzureClusterIdentity",
 					Name:       clusterID.InfraID,
 				},
@@ -132,7 +132,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: capz.GroupVersion.String(),
 			Kind:       "AzureCluster",
 			Name:       azureCluster.Name,
 			Namespace:  azureCluster.Namespace,

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -31,6 +31,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 
 	// CAPZ expects the capz-system to be created.
 	azureNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "capz-system"}}
+	azureNamespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: azureNamespace,
 		File:   asset.File{Filename: "00_azure-namespace.yaml"},
@@ -85,6 +86,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			},
 		},
 	}
+	azureCluster.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureCluster"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: azureCluster,
 		File:   asset.File{Filename: "02_azure-cluster.yaml"},
@@ -99,6 +101,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			"clientSecret": session.Credentials.ClientSecret,
 		},
 	}
+	azureClientSecret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: azureClientSecret,
 		File:   asset.File{Filename: "01_azure-client-secret.yaml"},
@@ -120,6 +123,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			TenantID: session.Credentials.TenantID,
 		},
 	}
+	id.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureClusterIdentity"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: id,
 		File:   asset.File{Filename: "01_aws-cluster-controller-identity-default.yaml"},

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -2,7 +2,6 @@ package clusterapi
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -69,10 +68,6 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 	// If the feature gate is not enabled, do not generate any manifests.
 	if !capiutils.IsEnabled(installConfig) {
 		return nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(capiutils.ManifestDir), 0755); err != nil {
-		return err
 	}
 
 	c.FileList = []*asset.RuntimeFile{}

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -82,6 +82,7 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 			Name: capiutils.Namespace,
 		},
 	}
+	namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
 	c.FileList = append(c.FileList, &asset.RuntimeFile{Object: namespace, File: asset.File{Filename: "000_capi-namespace.yaml"}})
 
 	cluster := &clusterv1.Cluster{
@@ -91,6 +92,7 @@ func (c *Cluster) Generate(dependencies asset.Parents) error {
 		},
 		Spec: clusterv1.ClusterSpec{},
 	}
+	cluster.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("Cluster"))
 	c.FileList = append(c.FileList, &asset.RuntimeFile{Object: cluster, File: asset.File{Filename: "01_capi-cluster.yaml"}})
 
 	var out *capiutils.GenerateClusterAssetsOutput

--- a/pkg/asset/manifests/gcp/cluster.go
+++ b/pkg/asset/manifests/gcp/cluster.go
@@ -117,6 +117,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			FailureDomains:   findFailureDomains(installConfig),
 		},
 	}
+	gcpCluster.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPCluster"))
 
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: gcpCluster,

--- a/pkg/asset/manifests/gcp/cluster.go
+++ b/pkg/asset/manifests/gcp/cluster.go
@@ -127,7 +127,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: capg.GroupVersion.String(),
 			Kind:       "GCPCluster",
 			Name:       gcpCluster.Name,
 			Namespace:  gcpCluster.Namespace,

--- a/pkg/asset/manifests/openstack/cluster.go
+++ b/pkg/asset/manifests/openstack/cluster.go
@@ -92,7 +92,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha7",
+			APIVersion: capo.GroupVersion.String(),
 			Kind:       "OpenStackCluster",
 			Name:       openStackCluster.Name,
 			Namespace:  openStackCluster.Namespace,

--- a/pkg/asset/manifests/vsphere/cluster.go
+++ b/pkg/asset/manifests/vsphere/cluster.go
@@ -25,6 +25,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		},
 		Data: make(map[string][]byte),
 	}
+	vsphereCreds.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
 
 	vsphereCreds.Data["username"] = []byte(vcenter.Username)
 	vsphereCreds.Data["password"] = []byte(vcenter.Password)
@@ -51,6 +52,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			},
 		},
 	}
+	vsphereCluster.SetGroupVersionKind(capv.GroupVersion.WithKind("VSphereCluster"))
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: vsphereCluster,
 		File:   asset.File{Filename: "01_vsphere-cluster.yaml"},

--- a/pkg/asset/manifests/vsphere/cluster.go
+++ b/pkg/asset/manifests/vsphere/cluster.go
@@ -61,7 +61,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: capv.GroupVersion.String(),
 			Kind:       "VSphereCluster",
 			Name:       clusterID.InfraID,
 			Namespace:  capiutils.Namespace,

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -115,10 +115,12 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			}
 
 			emptyAssets := map[string]bool{
-				"Master Machines":    true, // no files for the 'none' platform
-				"Worker Machines":    true, // no files for the 'none' platform
-				"Metadata":           true, // read-only
-				"Kubeadmin Password": true, // read-only
+				"Master Machines":               true, // no files for the 'none' platform
+				"Worker Machines":               true, // no files for the 'none' platform
+				"Cluster API Manifests":         true, // no files for the 'none' platform and ClusterAPIInstall feature gate not set
+				"Cluster API Machine Manifests": true, // no files for the 'none' platform and ClusterAPIInstall feature gate not set
+				"Metadata":                      true, // read-only
+				"Kubeadmin Password":            true, // read-only
 			}
 			for _, a := range tc.targets {
 				name := a.Name()

--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
+	"github.com/openshift/installer/pkg/asset/manifests/clusterapi"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/templates/content/bootkube"
 	"github.com/openshift/installer/pkg/asset/templates/content/openshift"
@@ -26,8 +27,10 @@ var (
 	Manifests = []asset.WritableAsset{
 		&machines.Master{},
 		&machines.Worker{},
+		&machines.ClusterAPI{},
 		&manifests.Manifests{},
 		&manifests.Openshift{},
+		&clusterapi.Cluster{},
 	}
 
 	// ManifestTemplates are the manifest-templates targeted assets.

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -372,7 +372,7 @@ func (i *InfraProvider) ExtractHostAddresses(dir string, config *types.InstallCo
 // IgnitionSecret provides the basic formatting for creating the
 // ignition secret.
 func IgnitionSecret(ign []byte, infraID, role string) *corev1.Secret {
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", infraID, role),
 			Namespace: capiutils.Namespace,
@@ -385,4 +385,6 @@ func IgnitionSecret(ign []byte, infraID, role string) *corev1.Secret {
 			"value":  ign,
 		},
 	}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	return secret
 }


### PR DESCRIPTION
This PR:
* Changes the location where the capi machine manifests are written
* Adds TypeMeta information to all CAPI manifests
* Uses `.GroupVersion.String()` to retrieve `APIVersion` from the respective libs.
* Adds capi manifests to the output of `create manifests`