### PR TITLE
[4.15] OCPBUGS-30944: Don't run libvirt validations in agent installer

### DIFF
--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -491,6 +491,8 @@ func ValidateProvisioning(p *baremetal.Platform, n *types.Networking, fldPath *f
 
 	allErrs = append(allErrs, ValidateProvisioningNetworking(p, n, fldPath)...)
 
+	allErrs = append(allErrs, validateProvisioningBootstrapNetworking(p, fldPath)...)
+
 	return allErrs
 }
 
@@ -585,6 +587,13 @@ func ValidateProvisioningNetworking(p *baremetal.Platform, n *types.Networking, 
 	}
 
 	allErrs = append(allErrs, validateHostsBMCOnly(p.Hosts, fldPath)...)
+
+	return allErrs
+}
+
+// validateProvisioningBootstrapNetworking checks that provisioning network requirements specified is valid for the bootstrap VM.
+func validateProvisioningBootstrapNetworking(p *baremetal.Platform, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
 
 	for _, validator := range dynamicProvisioningValidators {
 		allErrs = append(allErrs, validator(p, fldPath)...)


### PR DESCRIPTION
For builds with baremetal support (until now only the openshift-baremetal-installer), the agent installer was attempting to validate the bootstrap provisioning network using libvirt. This is not required because the agent installer does not make use of a bootstrap VM.