### PR TITLE
SPLAT-1437: CAPI/AWS/BYOIP: supporting Public IPv4 Pool

### DIFF
--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -23,12 +23,13 @@ import (
 
 // MachineInput defines the inputs needed to generate a machine asset.
 type MachineInput struct {
-	Role     string
-	Pool     *types.MachinePool
-	Subnets  map[string]string
-	Tags     capa.Tags
-	PublicIP bool
-	Ignition *capa.Ignition
+	Role           string
+	Pool           *types.MachinePool
+	Subnets        map[string]string
+	Tags           capa.Tags
+	PublicIP       bool
+	PublicIpv4Pool string
+	Ignition       *capa.Ignition
 }
 
 // GenerateMachines returns manifests and runtime objects to provision the control plane (including bootstrap, if applicable) nodes using CAPI.
@@ -112,6 +113,14 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 		if in.Role == "bootstrap" {
 			awsMachine.Name = capiutils.GenerateBoostrapMachineName(clusterID)
 			awsMachine.Labels["install.openshift.io/bootstrap"] = ""
+
+			// Enable BYO Public IPv4 Pool when defined on install-config.yaml.
+			if len(in.PublicIpv4Pool) > 0 {
+				awsMachine.Spec.ElasticIPPool = &capa.ElasticIPPool{
+					PublicIpv4Pool:              ptr.To(in.PublicIpv4Pool),
+					PublicIpv4PoolFallBackOrder: ptr.To(capa.PublicIpv4PoolFallbackOrderAmazonPool),
+				}
+			}
 		}
 
 		// Handle additional security groups.

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -196,12 +196,13 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		pool.Replicas = ptr.To[int64](1)
 		pool.Platform.AWS = &mpool
 		bootstrapAWSMachine, err := aws.GenerateMachines(clusterID.InfraID, &aws.MachineInput{
-			Role:     "bootstrap",
-			Subnets:  bootstrapSubnets,
-			Pool:     &pool,
-			Tags:     tags,
-			PublicIP: installConfig.Config.Publish == types.ExternalPublishingStrategy,
-			Ignition: ignition,
+			Role:           "bootstrap",
+			Subnets:        bootstrapSubnets,
+			Pool:           &pool,
+			Tags:           tags,
+			PublicIP:       installConfig.Config.Publish == types.ExternalPublishingStrategy,
+			PublicIpv4Pool: ic.Platform.AWS.PublicIpv4Pool,
+			Ignition:       ignition,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create bootstrap machine object: %w", err)

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -233,6 +233,14 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 		return nil, fmt.Errorf("failed to set cluster zones or subnets: %w", err)
 	}
 
+	// Enable BYO Public IPv4 when defined on install-config.yaml
+	if len(ic.Config.Platform.AWS.PublicIpv4Pool) > 0 {
+		awsCluster.Spec.NetworkSpec.VPC.ElasticIPPool = &capa.ElasticIPPool{
+			PublicIpv4Pool:              ptr.To(ic.Config.Platform.AWS.PublicIpv4Pool),
+			PublicIpv4PoolFallBackOrder: ptr.To(capa.PublicIpv4PoolFallbackOrderAmazonPool),
+		}
+	}
+
 	manifests = append(manifests, &asset.RuntimeFile{
 		Object: awsCluster,
 		File:   asset.File{Filename: "02_infra-cluster.yaml"},


### PR DESCRIPTION
[SPLAT-1437](https://issues.redhat.com/browse/SPLAT-1437)

This PR introduces the support of "BYO IPv4" on CAPA, where it intents to allocate Public IPv4 Address from a custom user-provided Pool for all infra resources created by installer: Nat Gateways, NLBs and Bootstrap node - when using the "External" deployment.

References:
- Terraform support on installer: https://github.com/openshift/installer/pull/7983
- Upstream/CAPA feature support: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4905
