### PR TITLE
OCPBUGS-30882: GCP capg distribute instances across zones

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -305,6 +305,13 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		mpool := defaultGCPMachinePoolPlatform(pool.Architecture)
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
+		if len(mpool.Zones) == 0 {
+			azs, err := gcp.ZonesForInstanceType(ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region, mpool.InstanceType)
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch availability zones")
+			}
+			mpool.Zones = azs
+		}
 		pool.Platform.GCP = &mpool
 
 		gcpMachines, err := gcp.GenerateMachines(

--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -45,6 +45,13 @@ func GenerateMachines(installConfig *installconfig.InstallConfig, infraID string
 		dataSecret := fmt.Sprintf("%s-%s", infraID, masterRole)
 		capiMachine := createCAPIMachine(gcpMachine.Name, dataSecret, infraID)
 
+		if len(mpool.Zones) > 0 {
+			// When there are fewer zones than the number of control plane instances,
+			// cycle through the zones where the instances will reside.
+			zone := mpool.Zones[int(idx)%len(mpool.Zones)]
+			capiMachine.Spec.FailureDomain = ptr.To(zone)
+		}
+
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", capiMachine.Name)},
 			Object: capiMachine,


### PR DESCRIPTION
** CAPG machines were only being created in a single zone. The instances should be spread across multiple zones based on the availability zones.