### PR TITLE
OCPBUGS-31013: Fix vsi image missing

### DIFF
--- a/data/data/powervs/cluster/dns/dns.tf
+++ b/data/data/powervs/cluster/dns/dns.tf
@@ -147,11 +147,15 @@ resource "ibm_is_security_group_rule" "dns_vm_sg_squid_all" {
   }
 }
 
-data "ibm_is_image" "dns_vm_image" {
-  count = local.proxy_count
-  name  = var.dns_vm_image_name
+data "ibm_is_images" "images" {
+  count  = local.proxy_count
+  status = "available"
 }
 
+data "ibm_is_image" "dns_vm_image" {
+  count = local.proxy_count
+  name  = [for image in data.ibm_is_images.images[0].images : image if startswith(image.os, var.dns_vm_image_os)][0].name
+}
 
 locals {
   dns_zone    = var.publish_strategy == "Internal" ? data.ibm_dns_zones.dns_zones[0].dns_zones[index(data.ibm_dns_zones.dns_zones[0].dns_zones.*.name, var.base_domain)] : null

--- a/data/data/powervs/cluster/dns/variables.tf
+++ b/data/data/powervs/cluster/dns/variables.tf
@@ -58,10 +58,10 @@ variable "vpc_permitted" {
   description = "Specifies whether an existing VPC is already a Permitted Network for DNS Instance, for Private clusters."
 }
 
-variable "dns_vm_image_name" {
+variable "dns_vm_image_os" {
   type        = string
-  description = "The image name for the DNS VM."
-  default     = "ibm-centos-7-9-minimal-amd64-6"
+  description = "The image OS for the DNS VM."
+  default     = "centos-stream-9"
 }
 
 variable "ssh_key" {


### PR DESCRIPTION
The image we used for booting proxy VMs has been updated and has changed it's name. We need to choose our images in a smarter fashion so this doesn't happen again.