### PR TITLE
CORS-2905: capi/aws: destroy CAPA resources

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -20,11 +20,11 @@ import (
 func Metadata(clusterID, infraID string, config *types.InstallConfig) *awstypes.Metadata {
 	return &awstypes.Metadata{
 		Region: config.Platform.AWS.Region,
-		Identifier: []map[string]string{{
-			fmt.Sprintf("kubernetes.io/cluster/%s", infraID): "owned",
-		}, {
-			"openshiftClusterID": clusterID,
-		}},
+		Identifier: []map[string]string{
+			{fmt.Sprintf("kubernetes.io/cluster/%s", infraID): "owned"},
+			{"openshiftClusterID": clusterID},
+			{fmt.Sprintf("sigs.k8s.io/cluster-api-provider-aws/cluster/%s", infraID): "owned"},
+		},
 		ServiceEndpoints: config.AWS.ServiceEndpoints,
 		ClusterDomain:    config.ClusterDomain(),
 		HostedZoneRole:   config.AWS.HostedZoneRole,


### PR DESCRIPTION
Because of how the CCM selects a Load Balancer security group by using the "kubernetes.io/cluster/<infraID>: owned" tag, CAPA removes that tag from all the other security groups [1].

That means that when the Installer is looking for resources to delete with that tag, it will never find those security groups and they'll stay behind. To avoid that, let's also search for resources with the "sigs.k8s.io/cluster-api-provider-aws/cluster/<infraID>: owned" tag during cluster destroy.

[1] https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4571

EDIT: updated with more accurate description.