### PR TITLE
Revert "SPLAT-1390: remove feature gate for vSphere control plane machinesets"

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -461,6 +461,10 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		ipClaims = data.IPClaims
 		ipAddrs = data.IPAddresses
 
+		if ic.FeatureSet != configv1.TechPreviewNoUpgrade {
+			controlPlaneMachineSet = nil
+		}
+
 		vsphere.ConfigMasters(machines, clusterID.InfraID)
 	case powervstypes.Name:
 		mpool := defaultPowerVSMachinePoolPlatform(ic)

--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -316,11 +316,11 @@ func provider(clusterID string, vcenter *vsphere.VCenter, failureDomain vsphere.
 	networkDeviceSpec := make([]machineapi.NetworkDeviceSpec, len(failureDomain.Topology.Networks))
 
 	// If failureDomain.Topology.Folder is empty this will be used
-	folder := path.Clean(fmt.Sprintf("/%s/vm/%s", failureDomain.Topology.Datacenter, clusterID))
+	folder := fmt.Sprintf("/%s/vm/%s", failureDomain.Topology.Datacenter, clusterID)
 
 	// If failureDomain.Topology.ResourcePool is empty this will be used
 	// computeCluster is required to be a path
-	resourcePool := path.Clean(fmt.Sprintf("%s/Resources", failureDomain.Topology.ComputeCluster))
+	resourcePool := fmt.Sprintf("%s/Resources", failureDomain.Topology.ComputeCluster)
 
 	if failureDomain.Topology.Folder != "" {
 		folder = failureDomain.Topology.Folder

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"fmt"
 	"net"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -165,7 +164,6 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path, isLegacyUp
 			if !strings.Contains(failureDomain.Topology.Datastore, failureDomain.Topology.Datacenter) {
 				return append(allErrs, field.Invalid(topologyFld.Child("datastore"), failureDomain.Topology.Datastore, "the datastore defined does not exist in the correct datacenter"))
 			}
-			p.FailureDomains[index].Topology.Datastore = filepath.Clean(p.FailureDomains[index].Topology.Datastore)
 		}
 
 		if len(failureDomain.Topology.TagIDs) > 10 {
@@ -217,7 +215,6 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path, isLegacyUp
 			if len(failureDomain.Topology.Datacenter) != 0 && datacenterName != failureDomain.Topology.Datacenter {
 				return append(allErrs, field.Invalid(topologyFld.Child("computeCluster"), computeCluster, fmt.Sprintf("compute cluster must be in datacenter %s", failureDomain.Topology.Datacenter)))
 			}
-			p.FailureDomains[index].Topology.ComputeCluster = filepath.Clean(p.FailureDomains[index].Topology.ComputeCluster)
 		}
 
 		if len(failureDomain.Topology.ResourcePool) != 0 {
@@ -235,12 +232,6 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path, isLegacyUp
 			if len(failureDomain.Topology.ComputeCluster) != 0 && !strings.Contains(failureDomain.Topology.ComputeCluster, clusterName) {
 				return append(allErrs, field.Invalid(topologyFld.Child("resourcePool"), resourcePool, fmt.Sprintf("resource pool must be in compute cluster %s", failureDomain.Topology.ComputeCluster)))
 			}
-
-			p.FailureDomains[index].Topology.ResourcePool = filepath.Clean(p.FailureDomains[index].Topology.ResourcePool)
-		}
-
-		if len(failureDomain.Topology.Template) > 0 {
-			p.FailureDomains[index].Topology.Template = filepath.Clean(p.FailureDomains[index].Topology.Template)
 		}
 	}
 


### PR DESCRIPTION
Reverts openshift/installer#7908

tracked by [SPLAT-1567](https://issues.redhat.com/browse/SPLAT-1567)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Slack discussion: https://redhat-internal.slack.com/archives/C015H2WDJRY/p1710879146769489?thread_ts=1709840245.522819&cid=C015H2WDJRY

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run the following and make sure installation succeeds

/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-vsphere-ovn-upi


CC: @rvanderp3