### PR TITLE
CORS-3428,CORS-2901: pkg/types/aws: limit additionalSecurityGroups to 10

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -143,6 +143,7 @@ spec:
                             is presented in the format sg-xxxx.
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         amiID:
                           description: AMIID is the AMI that should be used to boot
@@ -1057,6 +1058,7 @@ spec:
                           in the format sg-xxxx.
                         items:
                           type: string
+                        maxItems: 10
                         type: array
                       amiID:
                         description: AMIID is the AMI that should be used to boot
@@ -2174,6 +2176,7 @@ spec:
                           in the format sg-xxxx.
                         items:
                           type: string
+                        maxItems: 10
                         type: array
                       amiID:
                         description: AMIID is the AMI that should be used to boot

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -38,6 +38,7 @@ type MachinePool struct {
 	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines, where each ID
 	// is presented in the format sg-xxxx.
 	//
+	// +kubebuilder:validation:MaxItems=10
 	// +optional
 	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 }

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -29,8 +29,10 @@ var (
 	validMetadataAuthValues = sets.NewString("Required", "Optional")
 )
 
+// AWS has a limit of 16 security groups. See:
 // https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html
-const maxSecurityGroupsCount = 16
+// We set a user limit of 10 and reserve 6 for use by OpenShift.
+const maxUserSecurityGroupsCount = 10
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
@@ -63,8 +65,8 @@ func validateSecurityGroups(platform *aws.Platform, p *aws.MachinePool, fldPath 
 	}
 
 	// The installer also creates a security group: `${var.cluster_id}-master-sg/${var.cluster_id}-worker-sg`
-	if count := len(p.AdditionalSecurityGroupIDs); count > maxSecurityGroupsCount-1 {
-		allErrs = append(allErrs, field.TooMany(fldPath, count, maxSecurityGroupsCount-1))
+	if count := len(p.AdditionalSecurityGroupIDs); count > maxUserSecurityGroupsCount {
+		allErrs = append(allErrs, field.TooMany(fldPath, count, maxUserSecurityGroupsCount))
 	}
 
 	return allErrs

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -142,9 +142,9 @@ func TestValidateMachinePool(t *testing.T) {
 }
 
 func Test_ValdidateSecurityGroups(t *testing.T) {
-	maxSecurityGroups := make([]string, 0, maxSecurityGroupsCount)
-	for i := 0; i < maxSecurityGroupsCount; i++ {
-		maxSecurityGroups = append(maxSecurityGroups, fmt.Sprintf("sg-valid-%d", i))
+	tooManySecurityGroups := make([]string, 0, maxUserSecurityGroupsCount+1)
+	for i := 0; i < maxUserSecurityGroupsCount+1; i++ {
+		tooManySecurityGroups = append(tooManySecurityGroups, fmt.Sprintf("sg-valid-%d", i))
 	}
 	cases := []struct {
 		name     string
@@ -177,9 +177,9 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 				Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
 			},
 			pool: &aws.MachinePool{
-				AdditionalSecurityGroupIDs: maxSecurityGroups,
+				AdditionalSecurityGroupIDs: tooManySecurityGroups,
 			},
-			err: "test-path: Too many: 16: must have at most 15 items",
+			err: "test-path: Too many: 11: must have at most 10 items",
 		},
 		{
 			name: "valid maximum security group config",
@@ -188,7 +188,7 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 				Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
 			},
 			pool: &aws.MachinePool{
-				AdditionalSecurityGroupIDs: maxSecurityGroups[:maxSecurityGroupsCount-1],
+				AdditionalSecurityGroupIDs: tooManySecurityGroups[:maxUserSecurityGroupsCount],
 			},
 		},
 	}


### PR DESCRIPTION
AWS has a limit of 16 security groups. This limits the users to supply 10 security groups and reserves the additional 6 for OpenShift, which leaves room for additional features such as using CAPI for installs.