### PR TITLE
OSASINFRA-3420: openstack: Decouple OpenStack API calls from Machine generation

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -377,6 +377,13 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		pool.Platform.OpenStack = &mpool
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
+		trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
+			ic.Platform.OpenStack.Cloud,
+			"trunk",
+		)
+		if err != nil {
+			return fmt.Errorf("failed to check for trunk support: %w", err)
+		}
 
 		for _, role := range []string{"master", "bootstrap"} {
 			openStackMachines, err := openstack.GenerateMachines(
@@ -385,6 +392,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 				&pool,
 				imageName,
 				role,
+				trunkSupport,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create machine objects: %w", err)

--- a/pkg/asset/machines/openstack/openstackmachines.go
+++ b/pkg/asset/machines/openstack/openstackmachines.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GenerateMachines returns manifests and runtime objects to provision the control plane (including bootstrap, if applicable) nodes using CAPI.
-func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role string) ([]*asset.RuntimeFile, error) {
+func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role string, trunkSupport bool) ([]*asset.RuntimeFile, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -27,10 +27,6 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 	}
 
 	mpool := pool.Platform.OpenStack
-	trunkSupport, err := checkNetworkExtensionAvailability(config.Platform.OpenStack.Cloud, "trunk", nil)
-	if err != nil {
-		return nil, err
-	}
 
 	total := int64(1)
 	if role == "master" && pool.Replicas != nil {


### PR DESCRIPTION
To make unit tests possible (and separate responsibilities), remove OSP API calls from the functions that generate Machines and MachineSets.