### PR TITLE
no-jira: pkg/asset/machines: remove static ip log lines

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -700,14 +700,12 @@ func (m *Master) Load(f asset.FileFetcher) (found bool, err error) {
 	if err != nil {
 		return true, err
 	}
-	logrus.Infof("Loaded %v ip claims.", len(fileList))
 	m.IPClaimFiles = fileList
 
 	fileList, err = f.FetchByPattern(filepath.Join(directory, masterIPAddressFileNamePattern))
 	if err != nil {
 		return true, err
 	}
-	logrus.Infof("Loaded %v ip addresses.", len(fileList))
 	m.IPAddrFiles = fileList
 
 	return true, nil


### PR DESCRIPTION
Removes log lines regarding loading static IPs from vsphere manifests. These are info level debug lines. We could downgrade them to debug level but I suspect they were originally included for debugging and it's better to just remove them.

```shell
# ./openshift-install create ignition-configs --dir c
INFO Loaded 0 ip claims.                          
INFO Loaded 0 ip addresses.                       
WARNING Found override for release image (registry.ci.openshift.org/ocp/release:4.16.0-0.ci-2024-03-18-142209). Please be warned, this is not advised 
INFO Consuming Worker Machines from target directory 
...
```