### PR TITLE
CORS-3431: CAPI: Add firewall rule for worker nodes

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -137,6 +137,12 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 		return fmt.Errorf("failed to create internal load balancer address: %w", err)
 	}
 
+	// The firewall for masters, aka control-plane, is created by CAPG
+	// Create the ones needed for worker to master communication
+	if err = createFirewallRules(ctx, in, *gcpCluster.Status.Network.SelfLink); err != nil {
+		return fmt.Errorf("failed to add firewall rules: %w", err)
+	}
+
 	if in.InstallConfig.Config.GCP.UserProvisionedDNS != gcptypes.UserProvisionedDNSEnabled {
 		// Get the network from the GCP Cluster. The network is used to create the private managed zone.
 		if gcpCluster.Status.Network.SelfLink == nil {

--- a/pkg/infrastructure/gcp/clusterapi/firewallrules.go
+++ b/pkg/infrastructure/gcp/clusterapi/firewallrules.go
@@ -1,0 +1,191 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/api/compute/v1"
+
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+)
+
+func getControlPlanePorts() []*compute.FirewallAllowed {
+	return []*compute.FirewallAllowed{
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"22623", // Ignition
+			},
+		},
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"10257", // Kube manager
+			},
+		},
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"10259", // Kube scheduler
+			},
+		},
+	}
+}
+
+func getInternalClusterPorts() []*compute.FirewallAllowed {
+	return []*compute.FirewallAllowed{
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"30000-32767", // k8s NodePorts
+			},
+		},
+		{
+			IPProtocol: "udp",
+			Ports: []string{
+				"30000-32767", // k8s NodePorts
+			},
+		},
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"9000-9999", // host-level services
+			},
+		},
+		{
+			IPProtocol: "udp",
+			Ports: []string{
+				"9000-9999", // host-level services
+			},
+		},
+		{
+			IPProtocol: "udp",
+			Ports: []string{
+				"4789", "6081", // VXLAN and GENEVE
+			},
+		},
+		{
+			IPProtocol: "udp",
+			Ports: []string{
+				"500", "4500", // IKE and IKE(NAT-T)
+			},
+		},
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"10250", // kubelet secure
+			},
+		},
+		{
+			IPProtocol: "esp",
+		},
+	}
+}
+
+func getAPIPorts() []*compute.FirewallAllowed {
+	return []*compute.FirewallAllowed{
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"6443", // kube-apiserver
+			},
+		},
+	}
+}
+
+func getInternalNetworkPorts() []*compute.FirewallAllowed {
+	return []*compute.FirewallAllowed{
+		{
+			IPProtocol: "tcp",
+			Ports: []string{
+				"22", // SSH
+			},
+		},
+		{
+			IPProtocol: "icmp",
+		},
+	}
+}
+
+// addFirewallRule creates the firewall rule and adds it the compute's firewalls.
+func addFirewallRule(ctx context.Context, name, network, projectID string, ports []*compute.FirewallAllowed, srcTags, targetTags, srcRanges []string) error {
+	service, err := NewComputeService()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*3)
+	defer cancel()
+
+	firewallRule := &compute.Firewall{
+		Name:        name,
+		Description: resourceDescription,
+		Direction:   "INGRESS",
+		Network:     network,
+		Allowed:     ports,
+		SourceTags:  srcTags,
+		TargetTags:  targetTags,
+	}
+	if len(srcTags) > 0 {
+		firewallRule.SourceTags = srcTags
+	}
+	if len(srcRanges) > 0 {
+		firewallRule.SourceRanges = srcRanges
+	}
+
+	op, err := service.Firewalls.Insert(projectID, firewallRule).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to create %s firewall rule: %w", name, err)
+	}
+
+	if err := WaitForOperationGlobal(ctx, projectID, op); err != nil {
+		return fmt.Errorf("failed to wait for inserting %s firewall rule: %w", name, err)
+	}
+
+	return nil
+}
+
+// createFirewallRules creates the rules needed between tthe worker and master nodes.
+func createFirewallRules(ctx context.Context, in clusterapi.InfraReadyInput, network string) error {
+	projectID := in.InstallConfig.Config.Platform.GCP.ProjectID
+	workerTag := fmt.Sprintf("%s-worker", in.InfraID)
+	masterTag := fmt.Sprintf("%s-control-plane", in.InfraID)
+
+	// control-plane rules are needed for worker<->master communication for worker provisioning
+	firewallName := fmt.Sprintf("%s-control-plane", in.InfraID)
+	srcTags := []string{workerTag, masterTag}
+	targetTags := []string{masterTag}
+	srcRanges := []string{}
+	if err := addFirewallRule(ctx, firewallName, network, projectID, getControlPlanePorts(), srcTags, targetTags, srcRanges); err != nil {
+		return err
+	}
+
+	// internal-cluster rules are needed for worker<->master communication for k8s nodes
+	firewallName = fmt.Sprintf("%s-internal-cluster", in.InfraID)
+	srcTags = []string{workerTag, masterTag}
+	targetTags = []string{workerTag, masterTag}
+	srcRanges = []string{}
+	if err := addFirewallRule(ctx, firewallName, network, projectID, getInternalClusterPorts(), srcTags, targetTags, srcRanges); err != nil {
+		return err
+	}
+
+	// api rules are needed to access the kube-apiserver on master nodes
+	firewallName = fmt.Sprintf("%s-api", in.InfraID)
+	srcTags = []string{}
+	targetTags = []string{masterTag}
+	srcRanges = []string{}
+	if err := addFirewallRule(ctx, firewallName, network, projectID, getAPIPorts(), srcTags, targetTags, srcRanges); err != nil {
+		return err
+	}
+
+	// internal-network rules are used to access ssh and icmp over the machine network
+	firewallName = fmt.Sprintf("%s-internal-network", in.InfraID)
+	srcTags = []string{}
+	targetTags = []string{workerTag, masterTag}
+	machineCIDR := in.InstallConfig.Config.Networking.MachineNetwork[0].CIDR.String()
+	srcRanges = []string{machineCIDR}
+	err := addFirewallRule(ctx, firewallName, network, projectID, getInternalNetworkPorts(), srcTags, targetTags, srcRanges)
+
+	return err
+}


### PR DESCRIPTION
Worker firewall rules are created to communication between the master and worker nodes including allowing the worker nodes to pull ignition. These match the worker firewall rules that were created by Terraform.

Note that this does not affect the permissive rule created by CAPG to allow traffic between the bootstrap and master nodes.