### PR TITLE
OCPBUGS-27848: If host is offline or disconnected don't check ver

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -260,9 +260,13 @@ func validateESXiVersion(validationCtx *validationContext, clusterPath string, v
 	for _, h := range hosts {
 		var esxiHostVersion *version.Version
 		var mh mo.HostSystem
-		err := h.Properties(context.TODO(), h.Reference(), []string{"config.product"}, &mh)
+		err := h.Properties(context.TODO(), h.Reference(), []string{"config.product", "runtime"}, &mh)
 		if err != nil {
 			return append(allErrs, field.InternalError(vSphereFldPath, err))
+		}
+
+		if mh.Runtime.InMaintenanceMode || mh.Runtime.ConnectionState == vim25types.HostSystemConnectionStateDisconnected || mh.Runtime.ConnectionState == vim25types.HostSystemConnectionStateNotResponding {
+			continue
 		}
 
 		if mh.Config != nil {


### PR DESCRIPTION
If a ESXi host is either in maintenancemode,
disconnected or not responding to vCenter
do not check the ESXi version as it may
not be available.