### PR TITLE
OSASINFRA-3421: OpenStack: Customizable clientOpts for CheckNetworkEx…

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -333,6 +333,7 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
 			ic.Platform.OpenStack.Cloud,
 			"trunk",
+			nil,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check for trunk support: %w", err)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -313,6 +313,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
 			ic.Platform.OpenStack.Cloud,
 			"trunk",
+			nil,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to check for trunk support: %w", err)

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -375,8 +376,13 @@ func failureDomainsFromSpec(mpool openstack.MachinePool) []machinev1.OpenStackFa
 
 // CheckNetworkExtensionAvailability interrogates the OpenStack API to validate
 // the availability of a given Neutron extension.
-func CheckNetworkExtensionAvailability(cloud, alias string) (bool, error) {
-	opts := openstackdefaults.DefaultClientOpts(cloud)
+// The `opts` parameter is provided for external consumers needing to configure
+// the client e.g. with custom certs. If unspecified (nil), a default client is
+// built based on the specified `cloud`.
+func CheckNetworkExtensionAvailability(cloud, alias string, opts *clientconfig.ClientOpts) (bool, error) {
+	if opts == nil {
+		opts = openstackdefaults.DefaultClientOpts(cloud)
+	}
 	conn, err := openstackdefaults.NewServiceClient("network", opts)
 	if err != nil {
 		return false, err

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -587,6 +587,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
 				ic.Platform.OpenStack.Cloud,
 				"trunk",
+				nil,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to check for trunk support: %w", err)


### PR DESCRIPTION
…tensionAvailability

External consumers of `MachineSets()`, such as
[hive](https://github.com/openshift/hive/), need to be able to customize the client that queries the OpenStack cloud for trunk support.

A prior commit (#8187 / b99470c9), eliminating what looked like tech debt, removed that enablement, which was most recently added via #4638 / 3c4235c3, which was *itself* a revert of a previous commit (#4426 / 05453ef0) that had removed it similarly.

Here we reinstate the customizability, and include a docstring explanation to hopefully prevent it being removed again.

[OSASINFRA-3421](https://issues.redhat.com//browse/OSASINFRA-3421)