### PR TITLE
no-jira: images: upi-installer image cleanup

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -72,17 +72,6 @@ RUN pip-3 install cryptography pyOpenSSL==23.2.0
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
 
-ENV TERRAFORM_VERSION=1.0.11
-RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
-ENV MATCHBOX_PROVIDER_VERSION=0.5.0
-RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/v${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip && \
-    unzip terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip -d /bin/ && \
-    mv /bin/terraform-provider-matchbox_v${MATCHBOX_PROVIDER_VERSION} /bin/terraform-provider-matchbox
-ENV IGNITION_PROVIDER_VERSION=v2.1.0
-RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    mv terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64/terraform-provider-ignition /bin/terraform-provider-ignition
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install -b /bin && \

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -60,11 +60,6 @@ RUN yum update -y && \
 COPY --from=yq3 /yq /bin/yq-go
 COPY --from=yq4 /usr/bin/yq /bin/yq-v4
 
-ARG ALIYUN_URI=https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz
-RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz && \
-  tar --directory=/bin/ -xvf /tmp/aliyun-cli-linux-latest-amd64.tgz && \
-  rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
-
 # Not packaged, but required by gcloud. See https://cloud.google.com/sdk/crypto
 # Pin version because of https://github.com/GoogleCloudPlatform/gsutil/issues/1753
 RUN pip-3 install cryptography pyOpenSSL==23.2.0


### PR DESCRIPTION
* remove terraform and terraform provider binaries: they are leftover from before the time we started building or own
 binaries.
* remove alibaba cli: the provider support has been removed.