### PR TITLE
no-jira: PowerVS: Fix COS region and VPC subnets

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -257,16 +257,18 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 
 		if len(vpcSubnets) == 0 {
 			if capiutils.IsEnabled(installConfig) {
+				vpcZones, err := powervstypes.AvailableVPCZones(installConfig.Config.PowerVS.Region)
+				if err != nil {
+					return err
+				}
+
 				// The PowerVS CAPI provider generates three subnets.  One for
 				// each of the endpoint.
 				// @TODO the provider should export a function which gives us
 				// an array
-				for i := 1; i <= 3; i++ {
+				for _, zone := range vpcZones {
 					vpcSubnets = append(vpcSubnets,
-						fmt.Sprintf("%s-vpcsubnet-%s-%d",
-							clusterID.InfraID,
-							vpcRegion,
-							i))
+						fmt.Sprintf("%s-vpcsubnet-%s", clusterID.InfraID, zone))
 				}
 			} else {
 				vpcSubnets = append(vpcSubnets, fmt.Sprintf("vpc-subnet-%s", clusterID.InfraID))

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -25,6 +25,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		vpcRegion          string
 		transitGatewayName string
 		cosName            string
+		cosRegion          string
 		imageName          string
 		bucketName         string
 		err                error
@@ -40,6 +41,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		logrus.Debugf("GenerateClusterAssets: vpcRegion = %v", vpcRegion)
 		logrus.Debugf("GenerateClusterAssets: transitGatewayName = %v", transitGatewayName)
 		logrus.Debugf("GenerateClusterAssets: cosName = %v", cosName)
+		logrus.Debugf("GenerateClusterAssets: cosRegion = %v", cosRegion)
 		logrus.Debugf("GenerateClusterAssets: imageName = %v", imageName)
 		logrus.Debugf("GenerateClusterAssets: bucketName = %v", bucketName)
 		logrus.Debugf("GenerateClusterAssets: powerVSCluster.Spec.ControlPlaneEndpoint.Host = %v", powerVSCluster.Spec.ControlPlaneEndpoint.Host)
@@ -76,6 +78,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	transitGatewayName = fmt.Sprintf("%s-tg", clusterID.InfraID)
 
 	cosName = fmt.Sprintf("%s-cos", clusterID.InfraID)
+
+	if cosRegion, err = powervstypes.COSRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
+		return nil, fmt.Errorf("unable to derive cosRegion from region: %s %w", installConfig.Config.PowerVS.Region, err)
+	}
 
 	imageName = fmt.Sprintf("rhcos-%s", clusterID.InfraID)
 
@@ -140,7 +146,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			CosInstance: &capibm.CosInstance{
 				Name:         cosName,
 				BucketName:   bucketName,
-				BucketRegion: vpcRegion,
+				BucketRegion: cosRegion,
 			},
 			Ignition: &capibm.Ignition{
 				Version: "3.4",
@@ -181,7 +187,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			ServiceInstance: &service,
 			Bucket:          &bucket,
 			Object:          &object,
-			Region:          &vpcRegion,
+			Region:          &cosRegion,
 		},
 	}
 

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -17,6 +17,7 @@ type Region struct {
 	COSRegion   string
 	Zones       []string
 	SysTypes    []string
+	VPCZones    []string
 }
 
 // Regions holds the regions for IBM Power VS, and descriptions used during the survey.
@@ -27,6 +28,7 @@ var Regions = map[string]Region{
 		COSRegion:   "us-south",
 		Zones:       []string{"dal10", "dal12"},
 		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"eu-de": {
 		Description: "Frankfurt, Germany",
@@ -34,6 +36,7 @@ var Regions = map[string]Region{
 		COSRegion:   "eu-de",
 		Zones:       []string{"eu-de-1", "eu-de-2"},
 		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"eu-de-2", "eu-de-3"},
 	},
 	"mad": {
 		Description: "Madrid, Spain",
@@ -41,6 +44,7 @@ var Regions = map[string]Region{
 		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones:       []string{"mad02", "mad04"},
 		SysTypes:    []string{"s1022"},
+		VPCZones:    []string{"eu-es-1", "eu-es-2"},
 	},
 	"sao": {
 		Description: "São Paulo, Brazil",
@@ -48,6 +52,7 @@ var Regions = map[string]Region{
 		COSRegion:   "br-sao",
 		Zones:       []string{"sao04"},
 		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"br-sao-1", "br-sao-2"},
 	},
 	"wdc": {
 		Description: "Washington DC, USA",
@@ -55,6 +60,7 @@ var Regions = map[string]Region{
 		COSRegion:   "us-east",
 		Zones:       []string{"wdc06", "wdc07"},
 		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
 	},
 }
 
@@ -141,6 +147,15 @@ func AllKnownSysTypes() sets.Set[string] {
 		sysTypes.Insert(region.SysTypes...)
 	}
 	return sysTypes
+}
+
+// AvailableVPCZones returns the known VPC zones for a specified region.
+func AvailableVPCZones(region string) ([]string, error) {
+	knownRegion, ok := Regions[region]
+	if !ok {
+		return nil, fmt.Errorf("unknown region name provided")
+	}
+	return knownRegion.VPCZones, nil
 }
 
 // COSRegionForVPCRegion returns the corresponding COS region for the given VPC region.


### PR DESCRIPTION
1) We should be passing in a translated VPC region for the COS bucket.
2) The cluster-api-provider-ibmcloud uses a fixed set of subnets per VPC.  So, until we can ask the provider what it is, bring that data in so we can use it.
