### PR TITLE
OCPBUGS-4466: Add check for compact-cluster install on GCP, AWS & Azure

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -272,6 +272,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		// Based on the number of workers, we could have the following outcomes:
+		// 1. workers > 0, masters not schedulable, valid cluster
+		// 2. workers = 0, masters schedulable, valid compact cluster but currently unsupported
+		// 3. workers = 0, masters not schedulable, invalid cluster
+		if len(workers) == 0 {
+			return errors.Errorf("compact clusters with 0 workers are not supported at this time")
+		}
 		workerConfigs := make([]*machinev1beta1.AWSMachineProviderConfig, len(workers))
 		for i, m := range workers {
 			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AWSMachineProviderConfig) //nolint:errcheck // legacy, pre-linter
@@ -369,6 +376,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
 			return err
+		}
+		// Based on the number of workers, we could have the following outcomes:
+		// 1. workers > 0, masters not schedulable, valid cluster
+		// 2. workers = 0, masters schedulable, valid compact cluster but currently unsupported
+		// 3. workers = 0, masters not schedulable, invalid cluster
+		if len(workers) == 0 {
+			return errors.Errorf("compact clusters with 0 workers are not supported at this time")
 		}
 		workerConfigs := make([]*machinev1beta1.AzureMachineProviderSpec, len(workers))
 		for i, w := range workers {
@@ -484,6 +498,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		workers, err := workersAsset.MachineSets()
 		if err != nil {
 			return err
+		}
+		// Based on the number of workers, we could have the following outcomes:
+		// 1. workers > 0, masters not schedulable, valid cluster
+		// 2. workers = 0, masters schedulable, valid compact cluster but currently unsupported
+		// 3. workers = 0, masters not schedulable, invalid cluster
+		if len(workers) == 0 {
+			return errors.Errorf("compact clusters with 0 workers are not supported at this time")
 		}
 		workerConfigs := make([]*machinev1beta1.GCPMachineProviderSpec, len(workers))
 		for i, w := range workers {


### PR DESCRIPTION
Add additional checks around detecting 0 worker machinesets when generating terraform.tfvars for compact clusters.

This bug was raised when https://issues.redhat.com/browse/CORS-2420 was tested. The associated feature https://issues.redhat.com/browse/OCPSTRAT-341 had epics for AWS, GCP, Azure and vSphere. Support for compact clusters was not implemented and hence this is a good way error out of the install with an informational message to the customer (instead of crashing).