### PR TITLE
CORS-3446: Add instructions for obtaining correct binary

### DIFF
--- a/pkg/hostcrypt/dynamic.go
+++ b/pkg/hostcrypt/dynamic.go
@@ -1,0 +1,17 @@
+//go:build libvirt
+// +build libvirt
+
+package hostcrypt
+
+import "fmt"
+
+func allowFIPSCluster() error {
+	fipsEnabled, err := hostFIPSEnabled()
+	if err != nil {
+		return err
+	}
+	if fipsEnabled {
+		return nil
+	}
+	return fmt.Errorf("enable FIPS mode on the host")
+}

--- a/pkg/hostcrypt/hostcrypt.go
+++ b/pkg/hostcrypt/hostcrypt.go
@@ -18,23 +18,27 @@ func VerifyHostTargetState(fips bool) error {
 	if !fips {
 		return nil
 	}
+
+	if err := allowFIPSCluster(); err != nil {
+		return fmt.Errorf("target cluster is in FIPS mode, %w", err)
+	}
+	return nil
+}
+
+func hostFIPSEnabled() (bool, error) {
 	if runtime.GOOS != "linux" {
-		return fmt.Errorf("target cluster is in FIPS mode, operation requires a Linux client")
+		return false, fmt.Errorf("operation requires a Linux client")
 	}
 
 	hostFIPSData, err := os.ReadFile(fipsFile)
 	if err != nil {
-		return fmt.Errorf("target cluster is in FIPS mode, but failed to read client FIPS state %s: %w", fipsFile, err)
+		return false, fmt.Errorf("failed to read client FIPS state %s: %w", fipsFile, err)
 	}
 
 	hostFIPS, err := strconv.ParseBool(strings.TrimSuffix(string(hostFIPSData), "\n"))
 	if err != nil {
-		return fmt.Errorf("target cluster is in FIPS mode, but failed to parse client FIPS state %s: %w", fipsFile, err)
+		return false, fmt.Errorf("failed to parse client FIPS state %s: %w", fipsFile, err)
 	}
 
-	if !hostFIPS {
-		return fmt.Errorf("target cluster is in FIPS mode, operation requires a FIPS enabled client")
-	}
-
-	return nil
+	return hostFIPS, nil
 }

--- a/pkg/hostcrypt/static.go
+++ b/pkg/hostcrypt/static.go
@@ -1,0 +1,17 @@
+//go:build !libvirt
+// +build !libvirt
+
+package hostcrypt
+
+import "fmt"
+
+const binaryInstructions = "To obtain a suitable binary, download the openshift-install-rhel8 archive from the client mirror, or extract the openshift-install-fips command from the release payload."
+
+func allowFIPSCluster() error {
+	hostMsg := ""
+	if fipsEnabled, err := hostFIPSEnabled(); err != nil || !fipsEnabled {
+		hostMsg = " on a host with FIPS enabled"
+	}
+	return fmt.Errorf("use the FIPS-capable installer binary for RHEL 8%s.\n%s",
+		hostMsg, binaryInstructions)
+}


### PR DESCRIPTION
Update the warning message from the hostcrypt check to give more specific instructions on how to obtain the correct binary and where to run it.