### PR TITLE
CORS-3270: azure: tag installer-created LB resources

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -335,6 +335,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 		subscriptionID: session.Credentials.SubscriptionID,
 		lbClient:       lbClient,
 		pipClient:      networkClientFactory.NewPublicIPAddressesClient(),
+		tags:           p.Tags,
 	}
 
 	intLoadBalancer, err := updateInternalLoadBalancer(ctx, lbInput)

--- a/pkg/infrastructure/azure/loadbalancer.go
+++ b/pkg/infrastructure/azure/loadbalancer.go
@@ -17,6 +17,7 @@ type lbInput struct {
 	subscriptionID string
 	pipClient      *armnetwork.PublicIPAddressesClient
 	lbClient       *armnetwork.LoadBalancersClient
+	tags           map[string]*string
 }
 
 type vmInput struct {
@@ -49,6 +50,7 @@ func createPublicIP(ctx context.Context, in *lbInput) (*armnetwork.PublicIPAddre
 					DomainNameLabel: to.Ptr(in.infraID),
 				},
 			},
+			Tags: in.tags,
 		},
 		nil,
 	)
@@ -129,6 +131,7 @@ func createExternalLoadBalancer(ctx context.Context, pip *armnetwork.PublicIPAdd
 					},
 				},
 			},
+			Tags: in.tags,
 		}, nil)
 
 	if err != nil {


### PR DESCRIPTION
Adds tags to the load balancer and public IP created in hooks. Forgot these in #8115