### PR TITLE
OSASINFRA-3365: clusterapi: Add worker asset to PreProvision

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -70,6 +70,7 @@ func (c *Cluster) Dependencies() []asset.Asset {
 		&kubeconfig.AdminClient{},
 		&bootstrap.Bootstrap{},
 		&machine.Master{},
+		&machines.Worker{},
 		&machines.ClusterAPI{},
 		new(rhcos.Image),
 		&manifests.Manifests{},

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -58,6 +58,7 @@ func InitializeProvider(platform Provider) infrastructure.Provider {
 //nolint:gocyclo
 func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.File, error) {
 	manifestsAsset := &manifests.Manifests{}
+	workersAsset := &machines.Worker{}
 	capiManifestsAsset := &capimanifests.Cluster{}
 	capiMachinesAsset := &machines.ClusterAPI{}
 	clusterKubeconfigAsset := &kubeconfig.AdminClient{}
@@ -68,6 +69,7 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 	masterIgnAsset := &machine.Master{}
 	parents.Get(
 		manifestsAsset,
+		workersAsset,
 		capiManifestsAsset,
 		clusterKubeconfigAsset,
 		clusterID,
@@ -110,6 +112,7 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 			RhcosImage:       rhcosImage,
 			ManifestsAsset:   manifestsAsset,
 			MachineManifests: machineManifests,
+			WorkersAsset:     workersAsset,
 		}
 
 		if err := p.PreProvision(ctx, preProvisionInput); err != nil {

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 )
@@ -33,6 +34,7 @@ type PreProvisionInput struct {
 	RhcosImage       *rhcos.Image
 	ManifestsAsset   *manifests.Manifests
 	MachineManifests []client.Object
+	WorkersAsset     *machines.Worker
 }
 
 // IgnitionProvider handles preconditions for bootstrap ignition and


### PR DESCRIPTION
This is needed by OpenStack to provision the server group for workers in the CAPI flow, based on the manifests potentially modified by the user.