### PR TITLE
DNM: CAPG/MAPI Instance group compatibility workaround

### DIFF
--- a/cluster-api/providers/gcp/vendor/sigs.k8s.io/cluster-api-provider-gcp/cloud/scope/cluster.go
+++ b/cluster-api/providers/gcp/vendor/sigs.k8s.io/cluster-api-provider-gcp/cloud/scope/cluster.go
@@ -340,7 +340,7 @@ func (s *ClusterScope) HealthCheckSpec() *compute.HealthCheck {
 func (s *ClusterScope) InstanceGroupSpec(zone string) *compute.InstanceGroup {
 	port := ptr.Deref(s.GCPCluster.Spec.Network.LoadBalancerBackendPort, 6443)
 	return &compute.InstanceGroup{
-		Name: fmt.Sprintf("%s-%s-%s", s.Name(), infrav1.APIServerRoleTagValue, zone),
+		Name: fmt.Sprintf("%s-%s-%s", s.Name(), "master", zone),
 		NamedPorts: []*compute.NamedPort{
 			{
 				Name: "apiserver",

--- a/cluster-api/providers/gcp/vendor/sigs.k8s.io/cluster-api-provider-gcp/cloud/scope/machine.go
+++ b/cluster-api/providers/gcp/vendor/sigs.k8s.io/cluster-api-provider-gcp/cloud/scope/machine.go
@@ -128,7 +128,7 @@ func (m *MachineScope) Namespace() string {
 
 // ControlPlaneGroupName returns the control-plane instance group name.
 func (m *MachineScope) ControlPlaneGroupName() string {
-	return fmt.Sprintf("%s-%s-%s", m.ClusterGetter.Name(), infrav1.APIServerRoleTagValue, m.Zone())
+	return fmt.Sprintf("%s-%s-%s", m.ClusterGetter.Name(), "master", m.Zone())
 }
 
 // IsControlPlane returns true if the machine is a control plane.


### PR DESCRIPTION
DO NOT MERGE

Directly updates the in-repo vendored code as a PoC to demonstrate creating an instance group in CAPG which has the same naming conventions as MAPI. This can be used for testing or workarounding the issue until we can merge a fix upstream.