### PR TITLE
CORS-3420: Remove libvirt platform from openshift-baremetal-install

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -113,7 +113,7 @@ then
 	GOOS='' GOARCH='' go generate ./data
 fi
 
-if (echo "${TAGS}" | grep -q 'libvirt')
+if (echo "${TAGS}" | grep -q '\bfipscapable\b')
 then
 	export CGO_ENABLED=1
 fi

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -2,7 +2,7 @@
 # It builds an image containing openshift-install.
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
-ARG TAGS="libvirt baremetal fipscapable"
+ARG TAGS="baremetal fipscapable"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -2,7 +2,7 @@
 # It builds an image containing openshift-install.
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
-ARG TAGS="libvirt baremetal"
+ARG TAGS="libvirt baremetal fipscapable"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -3,7 +3,7 @@
 # oc for getting assets from an existing cluster to spin up multi-architecture compute clusters on libvirt.
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
-ARG TAGS="libvirt"
+ARG TAGS="libvirt fipscapable"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh

--- a/pkg/hostcrypt/dynamic.go
+++ b/pkg/hostcrypt/dynamic.go
@@ -1,5 +1,5 @@
-//go:build libvirt
-// +build libvirt
+//go:build fipscapable
+// +build fipscapable
 
 package hostcrypt
 

--- a/pkg/hostcrypt/static.go
+++ b/pkg/hostcrypt/static.go
@@ -1,5 +1,5 @@
-//go:build !libvirt
-// +build !libvirt
+//go:build !fipscapable
+// +build !fipscapable
 
 package hostcrypt
 


### PR DESCRIPTION
Libvirt IPI was never supported, so remove it from the payload build.