### PR TITLE
MULTIARCH-4549: Logic for creating private DNS records for PowerVS CAPI

### DIFF
--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -68,17 +68,17 @@ func (mr *MockAPIMockRecorder) AddSecurityGroupRule(ctx, securityGroupID, rule i
 }
 
 // CreateDNSRecord mocks base method.
-func (m *MockAPI) CreateDNSRecord(ctx context.Context, crnstr, baseDomain, hostname, cname string) error {
+func (m *MockAPI) CreateDNSRecord(ctx context.Context, publish types.PublishingStrategy, crnstr, baseDomain, hostname, cname string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDNSRecord", ctx, crnstr, baseDomain, hostname, cname)
+	ret := m.ctrl.Call(m, "CreateDNSRecord", ctx, publish, crnstr, baseDomain, hostname, cname)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateDNSRecord indicates an expected call of CreateDNSRecord.
-func (mr *MockAPIMockRecorder) CreateDNSRecord(ctx, crnstr, baseDomain, hostname, cname interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateDNSRecord(ctx, publish, crnstr, baseDomain, hostname, cname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDNSRecord", reflect.TypeOf((*MockAPI)(nil).CreateDNSRecord), ctx, crnstr, baseDomain, hostname, cname)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDNSRecord", reflect.TypeOf((*MockAPI)(nil).CreateDNSRecord), ctx, publish, crnstr, baseDomain, hostname, cname)
 }
 
 // CreateSSHKey mocks base method.

--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -178,6 +178,7 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 			Steps:    math.MaxInt32}
 		err = wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
 			err2 := client.CreateDNSRecord(ctx,
+				in.InstallConfig.Config.Publish,
 				instanceCRN,
 				in.InstallConfig.PowerVS.BaseDomain,
 				hostname,


### PR DESCRIPTION
In order to support `Internal` publishing strategy with CAPI, code must be added to create necessary DNS entries on the private DNS instance.