### PR TITLE
OCPBUGS-32133: GCP: Fixing GCP Bootstraping

### DIFF
--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -175,3 +175,8 @@ variable "gcp_ignition_shim" {
   description = "Ignition stub containing the signed url that points to the bucket containing the ignition data."
   default = ""
 }
+
+variable "gcp_signed_url" {
+  type = string
+  description = "Presigned url for bootstrap ignition link to the bucket where the ignition shim is stored."
+}

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -519,22 +519,12 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
 		defer cancel()
 
-		bucketName := gcpbootstrap.GetBootstrapStorageName(clusterID.InfraID)
-		bucketHandle, err := gcpbootstrap.CreateBucketHandle(ctx, bucketName)
-		if err != nil {
-			return fmt.Errorf("failed to create bucket handle %s: %w", bucketName, err)
-		}
-
-		bootstrapIgnURL, err := gcpbootstrap.ProvisionBootstrapStorage(ctx, installConfig, bucketHandle, clusterID.InfraID)
+		url, err := gcpbootstrap.CreateSignedURL(clusterID.InfraID)
 		if err != nil {
 			return fmt.Errorf("failed to provision gcp bootstrap storage resources: %w", err)
 		}
 
-		if err := gcpbootstrap.FillBucket(ctx, bucketHandle, bootstrapIgn); err != nil {
-			return fmt.Errorf("failed to fill bootstrap ignition bucket: %w", err)
-		}
-
-		shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(bootstrapIgnURL, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
+		shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(url, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
 		if err != nil {
 			return fmt.Errorf("failed to create gcp ignition shim: %w", err)
 		}
@@ -576,6 +566,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				UserProvisionedDNS:  installConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
 				UserTags:            tags,
 				IgnitionShim:        string(shim),
+				PresignedURL:        url,
 			},
 		)
 		if err != nil {

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/metadata"
+	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -67,6 +68,7 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 	rhcosImage := new(rhcos.Image)
 	bootstrapIgnAsset := &bootstrap.Bootstrap{}
 	masterIgnAsset := &machine.Master{}
+	tfvarsAsset := &tfvars.TerraformVariables{}
 	parents.Get(
 		manifestsAsset,
 		workersAsset,
@@ -78,6 +80,7 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 		bootstrapIgnAsset,
 		masterIgnAsset,
 		capiMachinesAsset,
+		tfvarsAsset,
 	)
 
 	fileList := []*asset.File{}
@@ -217,6 +220,7 @@ func (i *InfraProvider) Provision(dir string, parents asset.Parents) ([]*asset.F
 			BootstrapIgnData: bootstrapIgnData,
 			InfraID:          clusterID.InfraID,
 			InstallConfig:    installConfig,
+			TFVarsAsset:      tfvarsAsset,
 		}
 
 		if bootstrapIgnData, err = p.Ignition(ctx, ignInput); err != nil {

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -5,6 +5,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
@@ -51,6 +52,7 @@ type IgnitionInput struct {
 	BootstrapIgnData []byte
 	InfraID          string
 	InstallConfig    *installconfig.InstallConfig
+	TFVarsAsset      *tfvars.TerraformVariables
 }
 
 // InfraReadyProvider defines the InfraReady hook, which is

--- a/pkg/terraform/stages/gcp/stages.go
+++ b/pkg/terraform/stages/gcp/stages.go
@@ -1,10 +1,9 @@
 package gcp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"time"
+	"os"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
-	gcpbootstrap "github.com/openshift/installer/pkg/asset/ignition/bootstrap/gcp"
 	"github.com/openshift/installer/pkg/asset/lbconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/providers"
@@ -120,21 +118,20 @@ func extractGCPLBConfig(s stages.SplitStage, directory string, terraformDir stri
 		return "", err
 	}
 
-	clusterID, ok := tfvarData["cluster_id"]
-	if !ok {
-		return "", fmt.Errorf("failed to read cluster id from tfvars")
-	}
+	// Update the ignition bootstrap variable to include the lbconfig.
+	tfvarData["ignition_bootstrap"] = string(ignitionOutput)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
-	defer cancel()
-
-	bucketName := gcpbootstrap.GetBootstrapStorageName(clusterID.(string))
-	bucketHandle, err := gcpbootstrap.CreateBucketHandle(ctx, bucketName)
+	// Convert the bootstrap data and write the data back to a file. This will overwrite the original tfvars file.
+	jsonBootstrap, err := json.Marshal(tfvarData)
 	if err != nil {
-		return "", fmt.Errorf("failed to create bucket handle %s: %w", bucketName, err)
+		return "", fmt.Errorf("failed to convert bootstrap ignition to bytes: %w", err)
 	}
-	if err := gcpbootstrap.FillBucket(context.Background(), bucketHandle, string(ignitionOutput)); err != nil {
-		return "", fmt.Errorf("failed to fill gcp bucket with updated boostrap ignition contents: %w", err)
+	tfvarsFile.Data = jsonBootstrap
+
+	// update the value on disk to match
+	if err := os.WriteFile(fmt.Sprintf("%s/%s", directory, tfvarsFile.Filename), jsonBootstrap, 0o600); err != nil {
+		return "", fmt.Errorf("failed to rewrite %s: %w", tfvarsFile.Filename, err)
 	}
+
 	return "", nil
 }

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -50,6 +50,7 @@ type config struct {
 	UserProvisionedDNS        bool              `json:"gcp_user_provisioned_dns,omitempty"`
 	ExtraTags                 map[string]string `json:"gcp_extra_tags,omitempty"`
 	IgnitionShim              string            `json:"gcp_ignition_shim,omitempty"`
+	PresignedURL              string            `json:"gcp_signed_url"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -66,6 +67,7 @@ type TFVarsSources struct {
 	UserProvisionedDNS  bool
 	UserTags            map[string]string
 	IgnitionShim        string
+	PresignedURL        string
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
@@ -109,6 +111,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		UserProvisionedDNS:        sources.UserProvisionedDNS,
 		ExtraTags:                 sources.UserTags,
 		IgnitionShim:              sources.IgnitionShim,
+		PresignedURL:              sources.PresignedURL,
 	}
 
 	if masterConfig.Disks[0].EncryptionKey != nil {


### PR DESCRIPTION
** Adjusting the use of a presigned url. Passing to terraform. 
** Adding the bucket and bucket object back to terraform 
** Presigned url is created for both capg and terraform installs. 
** CAPG will create and destroy the bucket and bucket object for bootstrap.