### PR TITLE
AGENT-851: use additionalTrustBundle from config file

### DIFF
--- a/pkg/asset/agent/joiner/addnodesconfig.go
+++ b/pkg/asset/agent/joiner/addnodesconfig.go
@@ -35,7 +35,8 @@ type Config struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Hosts []agent.Host `json:"hosts,omitempty"`
+	Hosts                 []agent.Host `json:"hosts,omitempty"`
+	AdditionalTrustBundle string       `json:"additionalTrustBundle,omitempty"`
 }
 
 // Params is used to store the command line parameters.

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -36,7 +36,7 @@ type ClusterInfo struct {
 	APIDNSName                    string
 	PullSecret                    string
 	Namespace                     string
-	UserCaBundle                  string
+	AdditionalTrustBundle         string
 	Proxy                         *types.Proxy
 	Architecture                  string
 	ImageDigestSources            []types.ImageDigestSource
@@ -90,10 +90,6 @@ func (ci *ClusterInfo) Generate(dependencies asset.Parents) error {
 	if err != nil {
 		return err
 	}
-	err = ci.retrieveUserTrustBundle()
-	if err != nil {
-		return err
-	}
 	err = ci.retrieveArchitecture()
 	if err != nil {
 		return err
@@ -108,6 +104,7 @@ func (ci *ClusterInfo) Generate(dependencies asset.Parents) error {
 	}
 
 	ci.Namespace = "cluster0"
+	ci.AdditionalTrustBundle = addNodesConfig.Config.AdditionalTrustBundle
 
 	return nil
 }
@@ -175,19 +172,6 @@ func (ci *ClusterInfo) retrievePullSecret() error {
 		return err
 	}
 	ci.PullSecret = string(pullSecret.Data[".dockerconfigjson"])
-
-	return nil
-}
-
-func (ci *ClusterInfo) retrieveUserTrustBundle() error {
-	userCaBundle, err := ci.Client.CoreV1().ConfigMaps("openshift-config").Get(context.Background(), "user-ca-bundle", metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	ci.UserCaBundle = userCaBundle.Data["ca-bundle.crt"]
 
 	return nil
 }

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -25,6 +25,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 	cases := []struct {
 		name                string
 		workflow            workflow.AgentWorkflowType
+		assets              []asset.Asset
 		objects             []runtime.Object
 		openshiftObjects    []runtime.Object
 		expectedClusterInfo ClusterInfo
@@ -32,11 +33,19 @@ func TestClusterInfo_Generate(t *testing.T) {
 		{
 			name:                "skip if not add-nodes workflow",
 			workflow:            workflow.AgentWorkflowTypeInstall,
+			assets:              []asset.Asset{&AddNodesConfig{}},
 			expectedClusterInfo: ClusterInfo{},
 		},
 		{
 			name:     "default",
 			workflow: workflow.AgentWorkflowTypeAddNodes,
+			assets: []asset.Asset{
+				&AddNodesConfig{
+					Config: Config{
+						AdditionalTrustBundle: "--- bundle ---",
+					},
+				},
+			},
 			openshiftObjects: []runtime.Object{
 				&configv1.ClusterVersion{
 					ObjectMeta: v1.ObjectMeta{
@@ -75,15 +84,6 @@ func TestClusterInfo_Generate(t *testing.T) {
 						".dockerconfigjson": []byte("c3VwZXJzZWNyZXQK"),
 					},
 				},
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "user-ca-bundle",
-						Namespace: "openshift-config",
-					},
-					Data: map[string]string{
-						"ca-bundle.crt": "--- bundle ---",
-					},
-				},
 				&corev1.Node{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
@@ -116,15 +116,15 @@ func TestClusterInfo_Generate(t *testing.T) {
 				},
 			},
 			expectedClusterInfo: ClusterInfo{
-				ClusterID:    "1b5ba46b-7e56-47b1-a326-a9eebddfb38c",
-				ClusterName:  "ostest",
-				ReleaseImage: "registry.ci.openshift.org/ocp/release@sha256:65d9b652d0d23084bc45cb66001c22e796d43f5e9e005c2bc2702f94397d596e",
-				Version:      "4.15.0",
-				APIDNSName:   "api.ostest.test.metalkube.org",
-				Namespace:    "cluster0",
-				PullSecret:   "c3VwZXJzZWNyZXQK",
-				UserCaBundle: "--- bundle ---",
-				Architecture: "amd64",
+				ClusterID:             "1b5ba46b-7e56-47b1-a326-a9eebddfb38c",
+				ClusterName:           "ostest",
+				ReleaseImage:          "registry.ci.openshift.org/ocp/release@sha256:65d9b652d0d23084bc45cb66001c22e796d43f5e9e005c2bc2702f94397d596e",
+				Version:               "4.15.0",
+				APIDNSName:            "api.ostest.test.metalkube.org",
+				Namespace:             "cluster0",
+				PullSecret:            "c3VwZXJzZWNyZXQK",
+				AdditionalTrustBundle: "--- bundle ---",
+				Architecture:          "amd64",
 				Proxy: &types.Proxy{
 					HTTPProxy:  "http://proxy",
 					HTTPSProxy: "https://proxy",
@@ -148,10 +148,9 @@ func TestClusterInfo_Generate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			agentWorkflow := &workflow.AgentWorkflow{Workflow: tc.workflow}
-			addNodesConfig := &AddNodesConfig{}
 			parents := asset.Parents{}
 			parents.Add(agentWorkflow)
-			parents.Add(addNodesConfig)
+			parents.Add(tc.assets...)
 
 			fakeClient := fake.NewSimpleClientset(tc.objects...)
 			fakeOCClient := fakeclientconfig.NewSimpleClientset(tc.openshiftObjects...)
@@ -170,7 +169,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 			assert.Equal(t, tc.expectedClusterInfo.APIDNSName, clusterInfo.APIDNSName)
 			assert.Equal(t, tc.expectedClusterInfo.PullSecret, clusterInfo.PullSecret)
 			assert.Equal(t, tc.expectedClusterInfo.Namespace, clusterInfo.Namespace)
-			assert.Equal(t, tc.expectedClusterInfo.UserCaBundle, clusterInfo.UserCaBundle)
+			assert.Equal(t, tc.expectedClusterInfo.AdditionalTrustBundle, clusterInfo.AdditionalTrustBundle)
 			assert.Equal(t, tc.expectedClusterInfo.Proxy, clusterInfo.Proxy)
 			assert.Equal(t, tc.expectedClusterInfo.Architecture, clusterInfo.Architecture)
 			assert.Equal(t, tc.expectedClusterInfo.ImageDigestSources, clusterInfo.ImageDigestSources)

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -72,7 +72,7 @@ func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 		}
 
 	case workflow.AgentWorkflowTypeAddNodes:
-		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.UserCaBundle, clusterInfo.Proxy, clusterInfo.Architecture)
+		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.AdditionalTrustBundle, clusterInfo.Proxy, clusterInfo.Architecture)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -161,9 +161,9 @@ func TestInfraEnv_Generate(t *testing.T) {
 			dependencies: []asset.Asset{
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeAddNodes},
 				&joiner.ClusterInfo{
-					ClusterName:  "agent-cluster",
-					Namespace:    "agent-ns",
-					UserCaBundle: "user-ca-bundle",
+					ClusterName:           "agent-cluster",
+					Namespace:             "agent-ns",
+					AdditionalTrustBundle: "user-ca-bundle",
 					Proxy: &types.Proxy{
 						HTTPProxy: "proxy",
 					},

--- a/pkg/asset/agent/mirror/cabundle.go
+++ b/pkg/asset/agent/mirror/cabundle.go
@@ -58,7 +58,7 @@ func (i *CaBundle) Generate(dependencies asset.Parents) error {
 		additionalTrustBundle = installConfig.Config.AdditionalTrustBundle
 
 	case workflow.AgentWorkflowTypeAddNodes:
-		additionalTrustBundle = clusterInfo.UserCaBundle
+		additionalTrustBundle = clusterInfo.AdditionalTrustBundle
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)

--- a/pkg/asset/agent/mirror/cabundle_test.go
+++ b/pkg/asset/agent/mirror/cabundle_test.go
@@ -138,7 +138,7 @@ OIUk31HnM/Fj
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeAddNodes},
 				&joiner.ClusterInfo{
 					Namespace: "cluster-0",
-					UserCaBundle: `-----BEGIN CERTIFICATE-----
+					AdditionalTrustBundle: `-----BEGIN CERTIFICATE-----
 MIIDZTCCAk2gAwIBAgIURbA8lR+5xlJZUoOXK66AHFWd3uswDQYJKoZIhvcNAQEL
 BQAwQjELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
 CgwTRGVmYXVsdCBDb21wYW55IEx0ZDAeFw0yMjA3MDgxOTUzMTVaFw0yMjA4MDcx


### PR DESCRIPTION
This patch adds the `additionalTrustBundle` field to the `nodes-config.yaml` file. The usage of this field fixes also the previous problem of retrieving the bundle from the cluster, which cause a subsequent size issue.