### PR TITLE
no-jira: capi: replace deprecated `--metrics-bind-addr` arg

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -110,7 +110,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 			Components: []string{c.componentDir + "/core-components.yaml"},
 			Args: []string{
 				"-v=2",
-				"--metrics-bind-addr=0",
+				"--diagnostics-address=0",
 				"--health-addr={{suggestHealthHostPort}}",
 				"--webhook-port={{.WebhookPort}}",
 				"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -127,7 +127,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&AWS,
 				[]string{
 					"-v=4",
-					"--metrics-bind-addr=0",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -147,7 +147,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&Azure,
 				[]string{
 					"-v=2",
-					"--metrics-bind-addr=0",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -196,7 +196,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&GCP,
 				[]string{
 					"-v=2",
-					"--metrics-bind-addr=0",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -214,7 +214,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&OpenStack,
 				[]string{
 					"-v=2",
-					"--metrics-bind-addr=0",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -230,7 +230,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&VSphere,
 				[]string{
 					"-v=2",
-					"--metrics-bind-addr=0",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",


### PR DESCRIPTION
As the controllers' logs say, the arg has been replaced by `--diagnostics-address`:
```
Flag --metrics-bind-addr has been deprecated, Please use --diagnostics-address instead. To continue to servemetrics via http and without authentication/authorization set --insecure-diagnostics as well.
```