### PR TITLE
no-jira: capi/aws: bump controller log level to debug

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -125,7 +125,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 			c.getInfrastructureController(
 				&AWS,
 				[]string{
-					"-v=2",
+					"-v=4",
 					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",


### PR DESCRIPTION
According to [1] v=4 is debug level.

[1] https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/logger/logger.go#L30