### PR TITLE
OCPBUGS-31711: AWS update explain docs

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2271,12 +2271,13 @@ spec:
                     type: string
                   lbType:
                     description: "LBType is an optional field to specify a load balancer
-                      type. \n When this field is specified, the default ingresscontroller
-                      will be created using the specified load-balancer type. \n Following
-                      are the accepted values: \n * \"Classic\": A Classic Load Balancer
-                      that makes routing decisions at either the transport layer (TCP/SSL)
-                      or the application layer (HTTP/HTTPS). See the following for
-                      additional details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+                      type. When this field is specified, all ingresscontrollers (including
+                      the default ingresscontroller) will be created using the specified
+                      load-balancer type by default. \n Following are the accepted
+                      values: \n * \"Classic\": A Classic Load Balancer that makes
+                      routing decisions at either the transport layer (TCP/SSL) or
+                      the application layer (HTTP/HTTPS). See the following for additional
+                      details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
                       \n * \"NLB\": A Network Load Balancer that makes routing decisions
                       at the transport layer (TCP/SSL). See the following for additional
                       details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -166,8 +166,7 @@ func Test_PrintFields(t *testing.T) {
       HostedZoneRole is the ARN of an IAM role to be assumed when performing operations on the provided HostedZone. HostedZoneRole can be used in a shared VPC scenario when the private hosted zone belongs to a different account than the rest of the cluster resources. If HostedZoneRole is set, HostedZone must also be set.
 
     lbType <string>
-      LBType is an optional field to specify a load balancer type. 
- When this field is specified, the default ingresscontroller will be created using the specified load-balancer type. 
+      LBType is an optional field to specify a load balancer type. When this field is specified, all ingresscontrollers (including the default ingresscontroller) will be created using the specified load-balancer type by default. 
  Following are the accepted values: 
  * "Classic": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb 
  * "NLB": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb 

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -81,9 +81,9 @@ type Platform struct {
 	PropagateUserTag bool `json:"propagateUserTags,omitempty"`
 
 	// LBType is an optional field to specify a load balancer type.
-	//
-	// When this field is specified, the default ingresscontroller will be
-	// created using the specified load-balancer type.
+	// When this field is specified, all ingresscontrollers (including the
+	// default ingresscontroller) will be created using the specified load-balancer
+	// type by default.
 	//
 	// Following are the accepted values:
 	//


### PR DESCRIPTION
** The go docs in the install-config's platform.aws.lbType is misleading as well as on the ingress object (oc explain ingresses.config.openshift.io.spec.loadBalancer.platform.aws.type). Update the docs to further explain the ingress controller info.