### PR TITLE
MULTIARCH-4111: Update the CI image with virt-install

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -25,7 +25,8 @@ RUN yum update -y && \
     libvirt-client \
     libvirt-libs \
     nss_wrapper \
-    openssh-clients && \
+    openssh-clients \
+    virt-install && \
     yum clean all && rm -rf /var/cache/yum/*
 
 ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64


### PR DESCRIPTION
Multiarch CI jobs in 4.16 and onward are moving to a UPI deployment strategy.  `virt-install` is needed in the CI image to allow us to stand up the libvirt VMs for the cluster nodes.