### PR TITLE
no-jira: PowerVS: Open port 10258

### DIFF
--- a/data/data/powervs/cluster/loadbalancer/sg.tf
+++ b/data/data/powervs/cluster/loadbalancer/sg.tf
@@ -1,5 +1,5 @@
 locals {
-  tcp_ports = [22623, 6443, 22]
+  tcp_ports = [22623, 10258, 6443, 22]
 }
 
 resource "ibm_is_security_group" "ocp_security_group" {


### PR DESCRIPTION
The following testcase is failing:

```
[sig-arch] events should not repeat pathologically for ns/openshift-cloud-controller-manager

event happened 52 times, something is wrong: namespace/openshift-cloud-controller-manager node/p-wdc06-par-orig-416-fccsg-master-2 pod/powervs-cloud-controller-manager-67cdbc4ff-bv5cz hmsg/28f38e6c52 - reason/ProbeError Liveness probe error: Get "https://192.168.228.10:10258/healthz": dial tcp 192.168.228.10:10258: connect: connection refused result=reject
```

The cloud-provider-powervs provides that port, so open up access to it.