### PR TITLE
OCPBUGS-32174: save correct bootstrap public IP

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -161,7 +161,7 @@ resource "aws_instance" "bootstrap" {
   subnet_id                   = var.aws_publish_strategy == "External" ? var.public_subnet_ids[0] : var.private_subnet_ids[0]
   user_data                   = var.aws_bootstrap_stub_ignition
   vpc_security_group_ids      = [var.master_sg_id, aws_security_group.bootstrap.id]
-  associate_public_ip_address = local.public_endpoints
+  associate_public_ip_address = local.public_endpoints && var.aws_public_ipv4_pool == ""
 
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This
@@ -251,9 +251,10 @@ resource "aws_security_group_rule" "bootstrap_journald_gateway" {
 }
 
 resource "aws_eip" "bootstrap" {
+  count            = var.aws_public_ipv4_pool == "" ? 0 : 1
   domain           = "vpc"
   instance         = aws_instance.bootstrap.id
-  public_ipv4_pool = var.aws_public_ipv4_pool == "" ? null : var.aws_public_ipv4_pool
+  public_ipv4_pool = var.aws_public_ipv4_pool
 
   depends_on = [aws_instance.bootstrap]
 }

--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -256,5 +256,12 @@ resource "aws_eip" "bootstrap" {
   instance         = aws_instance.bootstrap.id
   public_ipv4_pool = var.aws_public_ipv4_pool
 
+  tags = merge(
+    {
+      "Name" = "${var.cluster_id}-bootstrap-eip"
+    },
+    local.tags,
+  )
+
   depends_on = [aws_instance.bootstrap]
 }

--- a/data/data/aws/bootstrap/outputs.tf
+++ b/data/data/aws/bootstrap/outputs.tf
@@ -1,3 +1,3 @@
 output "bootstrap_ip" {
-  value = local.public_endpoints ? aws_instance.bootstrap.public_ip : aws_instance.bootstrap.private_ip
+  value = var.aws_public_ipv4_pool != "" ? aws_eip.bootstrap[0].public_ip : local.public_endpoints ? aws_instance.bootstrap.public_ip : aws_instance.bootstrap.private_ip
 }


### PR DESCRIPTION
When the BYOIPv4 feature was introduced to the terraform provisioning in 50c0a9d8221, a new EIP resource was created unconditionally. The bootstrap VM was first getting a public IP from the `associate_public_ip_address` config in the instance and that IP was then discarded when the EIP was created and associated with the instance.

However, a "race" could happen in which, at the end of the bootstrap stage, we saved the first (and now dead) IP Address:
```
DEBUG Outputs:
DEBUG
DEBUG bootstrap_ip = "18.222.119.149"
DEBUG [INFO] running Terraform command: /c/terraform/bin/terraform output -no-color -json
DEBUG {
DEBUG   "bootstrap_ip": {
DEBUG     "sensitive": false,
DEBUG     "type": "string",
DEBUG     "value": "18.222.119.149"
DEBUG   }
DEBUG }
```
In case of bootstrap failure, the `gather bootstrap` would use the stale IP address and fail to connect:
```
time="2024-04-12T15:08:49Z" level=info msg="Failed to gather bootstrap logs: failed to connect to the bootstrap machine: dial tcp 18.222.119.149:22: connect: connection timed out"
```
instead of using the actual EIP address "18.225.29.102".

This changes proposes the following fixes:

1. Only create an EIP if a public IPv4 pool has been specified.
2. Only `associate_public_ip_address` to the bootstrap instance if public IPv4 pools have *not* been specified.
3. At the end of the bootstrap stage, save the correct IP address by considering whether the bootstrap EIP was created or not.
4. Tag the EIP, when created, so it can be properly deleted even when bootstrap fails.