### PR TITLE
OCPBUGS-27965: escape '%' in proxy settings

### DIFF
--- a/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -1,10 +1,10 @@
 {{if .Proxy -}}
 [Manager]
 {{if .Proxy.HTTPProxy -}}
-DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+DefaultEnvironment=HTTP_PROXY="{{replace .Proxy.HTTPProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.HTTPSProxy -}}
-DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+DefaultEnvironment=HTTPS_PROXY="{{replace .Proxy.HTTPSProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.NoProxy -}}
 DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -518,6 +518,11 @@ func AddSystemdUnits(config *igntypes.Config, uri string, templateData interface
 	return nil
 }
 
+// replace is an utilitary function to do string replacement in templates.
+func replace(input, from, to string) string {
+	return strings.ReplaceAll(input, from, to)
+}
+
 // Read data from the string reader, and, if the name ends with
 // '.template', strip that extension from the name and render the
 // template.
@@ -529,7 +534,7 @@ func readFile(name string, reader io.Reader, templateData interface{}) (finalNam
 
 	if filepath.Ext(name) == ".template" {
 		name = strings.TrimSuffix(name, ".template")
-		tmpl := template.New(name)
+		tmpl := template.New(name).Funcs(template.FuncMap{"replace": replace})
 		tmpl, err := tmpl.Parse(string(data))
 		if err != nil {
 			return name, data, err


### PR DESCRIPTION
The 'DefaultEnvironment' config from systemd accepts some % specifiers for expansion [1]. Because of that, proxy configurations that make use of that character need to be escaped with another '%'. However, during proxy validation, the Installer parses the URI and fails when it encounters a "%%" with an `invalid URL escape` error.

To mitigate the problem, we introduce a new `replace` function to the templating system and use it to substitute "%" with "%%" causing the following config:

```
proxy:
    httpProxy: http://user%40test:redhat@10.0.0.1:3128
    httpsProxy: http://user%40test:redhat@10.0.0.1:3128
```

to become the `10-default-env.conf`:

```
[Manager]
DefaultEnvironment=HTTP_PROXY="http://user%%40test:redhat@10.0.0.1:3128"
DefaultEnvironment=HTTPS_PROXY="http://user%%40test:redhat@10.0.0.1:3128"
```

[1] https://man7.org/linux/man-pages/man5/systemd-system.conf.5.html