### PR TITLE
OCPBUGS-31733: remove generation of cpms manifest for vSphere

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -465,7 +465,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
 		machines = data.Machines
-		controlPlaneMachineSet = data.ControlPlaneMachineSet
 		ipClaims = data.IPClaims
 		ipAddrs = data.IPAddresses
 

--- a/pkg/asset/machines/vsphere/machines_test.go
+++ b/pkg/asset/machines/vsphere/machines_test.go
@@ -439,14 +439,6 @@ func TestConfigMasters(t *testing.T) {
 						t.Errorf("machine workspace was enountered too few times[min: %d]", tc.minAllowedWorkspaceMatches)
 					}
 				}
-
-				if data.ControlPlaneMachineSet != nil {
-					// Make sure FDs equal same quantity as config
-					fds := data.ControlPlaneMachineSet.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains
-					if len(fds.VSphere) != len(tc.workspaces) {
-						t.Errorf("machine workspace count %d does not equal number of failure domains [count: %d] in CPMS", len(tc.workspaces), len(fds.VSphere))
-					}
-				}
 			}
 		})
 	}


### PR DESCRIPTION
UPI and ABI installations are failing due to missing machines.  The CPMSO expects there to be a machine per node.  Since machines are removed in UPI and ABI installs, this results in the CPMS becoming degraded.  This PR will defer creation of the CPMS to the CPMSO.