### PR TITLE
no-jira: Revert "Merge pull request #8251 from r4f4/capi-metrics-arg-deprec"

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -113,7 +113,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 			Components: []string{c.componentDir + "/core-components.yaml"},
 			Args: []string{
 				"-v=2",
-				"--diagnostics-address=0",
+				"--metrics-bind-addr=0",
 				"--health-addr={{suggestHealthHostPort}}",
 				"--webhook-port={{.WebhookPort}}",
 				"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -130,7 +130,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&AWS,
 				[]string{
 					"-v=4",
-					"--diagnostics-address=0",
+					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -150,7 +150,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&Azure,
 				[]string{
 					"-v=2",
-					"--diagnostics-address=0",
+					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -199,7 +199,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&GCP,
 				[]string{
 					"-v=2",
-					"--diagnostics-address=0",
+					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -217,7 +217,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&OpenStack,
 				[]string{
 					"-v=2",
-					"--diagnostics-address=0",
+					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -233,7 +233,7 @@ func (c *system) Run(ctx context.Context, installConfig *installconfig.InstallCo
 				&VSphere,
 				[]string{
 					"-v=2",
-					"--diagnostics-address=0",
+					"--metrics-bind-addr=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",


### PR DESCRIPTION
This reverts commit 5578855cd93d99fb07ba5bf70d598e298b072bdf, reversing changes made to dd2830921834e6372dd1dfe7a5eaae5930762910.

Other platforms are using provider versions that still use the old argument name.