### PR TITLE
CORS-2840: Always build CAPI providers

### DIFF
--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-# Check if the OPENSHIFT_INSTALL_CLUSTER_API is not empty.
-if [ -z "${OPENSHIFT_INSTALL_CLUSTER_API}" ]; then
-  return
-fi
-
 TARGET_OS_ARCH=$(go env GOOS)_$(go env GOARCH)
 CLUSTER_API_BIN_DIR="${PWD}/cluster-api/bin/${TARGET_OS_ARCH}"
 CLUSTER_API_MIRROR_DIR="${PWD}/pkg/clusterapi/mirror/"
@@ -20,7 +15,9 @@ copy_cluster_api_to_mirror() {
   # Clean the mirror, but preserve the README file.
   rm -rf "${CLUSTER_API_MIRROR_DIR:?}/*.zip"
 
-  sync_envtest
+  if [ -n "${OPENSHIFT_INSTALL_CLUSTER_API}" ]; then
+    sync_envtest
+  fi
 
   # Zip every binary in the folder into a single zip file.
   zip -j1 "${CLUSTER_API_MIRROR_DIR}/cluster-api.zip" "${CLUSTER_API_BIN_DIR}"/*

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -80,10 +80,9 @@ then
 fi
 
 # build cluster-api binaries
-if [ -n "${OPENSHIFT_INSTALL_CLUSTER_API}" ]; then
-  make -C cluster-api all
-  copy_cluster_api_to_mirror
-fi
+make -C cluster-api all
+copy_cluster_api_to_mirror
+
 
 GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
 GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"


### PR DESCRIPTION
In 4.16 we may be including a mix of CAPI and Terraform, so let's test what that does to the builds.