### PR TITLE
[release-4.15] OCPBUGS-32383: sdk/aws: add ssh security group rule for compute

### DIFF
--- a/pkg/infrastructure/aws/securitygroup.go
+++ b/pkg/infrastructure/aws/securitygroup.go
@@ -273,6 +273,8 @@ func defaultWorkerSGIngressRules(workerSGID *string, masterSGID *string, cidrBlo
 	return []*ec2.IpPermission{
 		// worker icmp
 		createSGRule(workerSGID, "icmp", cidrBlocks, nil, -1, -1, false, nil),
+		// worker ssh
+		createSGRule(workerSGID, "tcp", cidrBlocks, nil, 22, 22, false, nil),
 		// worker vxlan
 		createSGRule(workerSGID, "udp", nil, nil, 4789, 4789, true, nil),
 		// worker geneve


### PR DESCRIPTION
Somehow this was missed when the rules were brought over from terraform.

Manual cherry-pick from https://github.com/openshift/installer/pull/8229