### PR TITLE
CORS-3434: azure: Skip image upload if env var is set

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -628,12 +629,46 @@ func ValidateForProvisioning(client API, ic *types.InstallConfig) error {
 	allErrs = append(allErrs, validateResourceGroup(client, field.NewPath("platform").Child("azure"), ic.Azure)...)
 	allErrs = append(allErrs, ValidateDiskEncryptionSet(client, ic)...)
 	allErrs = append(allErrs, ValidateSecurityProfileDiskEncryptionSet(client, ic)...)
+	allErrs = append(allErrs, validateSkipImageUpload(field.NewPath("image"), ic)...)
 	if ic.Azure.CloudName == aztypes.StackCloud {
 		allErrs = append(allErrs, checkAzureStackClusterOSImageSet(ic.Azure.ClusterOSImage, field.NewPath("platform").Child("azure"))...)
 	}
 	return allErrs.ToAggregate()
 }
 
+func validateSkipImageUpload(fieldPath *field.Path, ic *types.InstallConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+	defaultOSImage := aztypes.OSImage{}
+	if ic.Azure.DefaultMachinePlatform != nil {
+		defaultOSImage = aztypes.OSImage{
+			Plan:      ic.Azure.DefaultMachinePlatform.OSImage.Plan,
+			Publisher: ic.Azure.DefaultMachinePlatform.OSImage.Publisher,
+			SKU:       ic.Azure.DefaultMachinePlatform.OSImage.SKU,
+			Version:   ic.Azure.DefaultMachinePlatform.OSImage.Version,
+			Offer:     ic.Azure.DefaultMachinePlatform.OSImage.Offer,
+		}
+	}
+	controlPlaneOSImage := defaultOSImage
+	if ic.ControlPlane.Platform.Azure != nil {
+		controlPlaneOSImage = ic.ControlPlane.Platform.Azure.OSImage
+	}
+	allErrs = append(allErrs, validateOSImage(fieldPath.Child("controlplane"), controlPlaneOSImage)...)
+	computeOSImage := defaultOSImage
+	if len(ic.Compute) > 0 && ic.Compute[0].Platform.Azure != nil {
+		computeOSImage = ic.Compute[0].Platform.Azure.OSImage
+	}
+	allErrs = append(allErrs, validateOSImage(fieldPath.Child("compute"), computeOSImage)...)
+	return allErrs
+}
+func validateOSImage(fieldPath *field.Path, osImage aztypes.OSImage) field.ErrorList {
+	if _, ok := os.LookupEnv("OPENSHIFT_INSTALL_SKIP_IMAGE_UPLOAD"); ok {
+		if len(osImage.SKU) > 0 {
+			return nil
+		}
+		return field.ErrorList{field.Invalid(fieldPath, "image", "cannot skip image upload without marketplace image specified")}
+	}
+	return nil
+}
 func validateResourceGroup(client API, fieldPath *field.Path, platform *aztypes.Platform) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(platform.ResourceGroupName) == 0 {

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -58,7 +58,8 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 					Offer:     osImage.Offer,
 					SKU:       osImage.SKU,
 				},
-				Version: osImage.Version,
+				Version:         osImage.Version,
+				ThirdPartyImage: osImage.Plan != azure.ImageNoPurchasePlan,
 			},
 		}
 	case useImageGallery:

--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -173,7 +173,6 @@ func (c *system) Run(ctx context.Context) error {
 				&Azure,
 				[]string{
 					"-v=2",
-					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",


### PR DESCRIPTION
Adding option to skip the image upload from the installer if an environment variable is set since it takes a lot of time and the marketplace images can be used to skip this step.