### PR TITLE
MULTIARCH-4616: Power VS: Add ServiceEndpoints for endpoint overrides

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4247,6 +4247,34 @@ spec:
                     description: Region specifies the IBM Cloud colo region where
                       the cluster will be created.
                     type: string
+                  serviceEndpoints:
+                    description: ServiceEndpoints is a list which contains custom
+                      endpoints to override default service endpoints of IBM Cloud
+                      Services. There must only be one ServiceEndpoint for a service
+                      (no duplicates).
+                    items:
+                      description: PowervsServiceEndpoint stores the configuration
+                        of a custom url to override existing defaults of PowerVS Services.
+                      properties:
+                        name:
+                          description: name is the name of the Power VS service. Few
+                            of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                            ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                            Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                          pattern: ^[a-z0-9-]+$
+                          type: string
+                        url:
+                          description: url is fully qualified URI with scheme https,
+                            that overrides the default generated endpoint for a client.
+                            This must be provided and cannot be empty.
+                          format: uri
+                          pattern: ^https://
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
                   serviceInstanceGUID:
                     description: ServiceInstanceGUID is the GUID of the Power IAAS
                       instance created from the IBM Cloud Catalog before the cluster

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -295,11 +295,12 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			return errors.New("unknown publishing strategy")
 		}
 		config.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{
-			Region:         installConfig.Config.Platform.PowerVS.Region,
-			Zone:           installConfig.Config.Platform.PowerVS.Zone,
-			ResourceGroup:  installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
-			CISInstanceCRN: cisInstanceCRN,
-			DNSInstanceCRN: dnsInstanceCRN,
+			Region:           installConfig.Config.Platform.PowerVS.Region,
+			Zone:             installConfig.Config.Platform.PowerVS.Zone,
+			ResourceGroup:    installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
+			CISInstanceCRN:   cisInstanceCRN,
+			DNSInstanceCRN:   dnsInstanceCRN,
+			ServiceEndpoints: installConfig.Config.Platform.PowerVS.ServiceEndpoints,
 		}
 	case nutanix.Name:
 		config.Spec.PlatformSpec.Type = configv1.NutanixPlatformType

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -1,5 +1,9 @@
 package powervs
 
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
@@ -52,4 +56,10 @@ type Platform struct {
 	// instance during cluster creation.
 	// +optional
 	ServiceInstanceGUID string `json:"serviceInstanceGUID,omitempty"`
+
+	// ServiceEndpoints is a list which contains custom endpoints to override default
+	// service endpoints of IBM Cloud Services.
+	// There must only be one ServiceEndpoint for a service (no duplicates).
+	// +optional
+	ServiceEndpoints []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
 }

--- a/pkg/types/powervs/validation/platform.go
+++ b/pkg/types/powervs/validation/platform.go
@@ -1,9 +1,15 @@
 package validation
 
 import (
+	"fmt"
+	"net/url"
+	"regexp"
+
 	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/powervs"
 )
 
@@ -44,6 +50,68 @@ func ValidatePlatform(p *powervs.Platform, fldPath *field.Path) field.ErrorList 
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("ServiceInstanceGUID"), p.ServiceInstanceGUID, "ServiceInstanceGUID must be a valid UUID"))
 		}
 	}
+	if p.ServiceEndpoints != nil {
+		allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
+	}
 
 	return allErrs
+}
+
+// validateServiceEndpoints checks that the specified ServiceEndpoints are valid.
+func validateServiceEndpoints(endpoints []configv1.PowerVSServiceEndpoint, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	knownEndpoints := sets.New[string]()
+	for index, endpoint := range endpoints {
+		fldp := fldPath.Index(index)
+		if knownEndpoints.Has(endpoint.Name) {
+			allErrs = append(allErrs, field.Duplicate(fldp.Child("name"), endpoint.Name))
+		}
+		knownEndpoints.Insert(endpoint.Name)
+
+		if err := validateServiceURL(endpoint.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("url"), endpoint.URL, err.Error()))
+		}
+	}
+	return allErrs
+}
+
+// schemeRE is used to check whether a string starts with a scheme (URI format).
+var schemeRE = regexp.MustCompile("^([^:]+)://")
+
+// versionPath is the regexp for a trailing API version in URL path ('/v1', '/v22/', etc.)
+var versionPath = regexp.MustCompile(`(/v\d+[/]{0,1})$`)
+
+// validateServiceURL checks that a string meets certain URI expectations.
+func validateServiceURL(uri string) error {
+	endpoint := uri
+	httpsScheme := "https"
+
+	// determine if the endpoint (uri) starts with an URI scheme
+	// add 'https' scheme if not
+	if !schemeRE.MatchString(endpoint) {
+		endpoint = fmt.Sprintf("%s://%s", httpsScheme, endpoint)
+	}
+
+	// verify the endpoint meets the following criteria
+	// 1. contains a hostname
+	// 2. uses 'https' scheme
+	// 3. contains no path or request parameters, except API version paths ('/v1')
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("empty hostname provided, it cannot be empty")
+	}
+	// check the scheme in case one was provided and is not 'https' (we didn't set it above)
+	if s := u.Scheme; s != httpsScheme {
+		return fmt.Errorf("invalid scheme %s, only https is allowed", s)
+	}
+	// check that the path is empty ('/'), or only contains an API version ('/v1'), by using regexp to replace the API version and should result in empty string
+	if r := u.RequestURI(); r != "/" && versionPath.ReplaceAllString(r, "") != "" {
+		return fmt.Errorf("no path or request parameters can be provided, %q was provided", r)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Some cluster operators will read the platformStatus for endpoint overrides. Read them from the install config and pass them along through the infrastructure manifest.