### PR TITLE
OCPBUGS-32519: Fix appliance CI jobs

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -105,6 +105,12 @@ function gather_database_data() {
 	( >&2 echo " Done")
 }
 
+function gather_systemd_units() {
+	( >&2 echo  -n "Gathering systemd data" )
+	mkdir -p "${ARTIFACTS_DIR}/etc/systemd"
+	cp -a /etc/systemd/system "${ARTIFACTS_DIR}/etc/systemd/"
+}
+
 function Help()
 {
 	echo "Gathers the necessary data for troubleshooting OpenShift's agent based installation"
@@ -147,6 +153,7 @@ gather_network_data
 gather_storage_data
 gather_container_status
 gather_database_data
+gather_systemd_units
 
 # Set permissions so regular users can delete the extracted content
 find "$ARTIFACTS_DIR" -type d -exec chmod a+rwx "{}" \;

--- a/data/data/agent/files/usr/local/bin/load-config-iso.sh
+++ b/data/data/agent/files/usr/local/bin/load-config-iso.sh
@@ -82,7 +82,7 @@ copy_archive_contents() {
        is_enabled=$(systemctl is-enabled "$service")
        if [[ "${is_enabled}" == "disabled" ]]; then
           echo "Service ${service} is disabled, enabling it"
-          systemctl enable "${service}"
+          systemctl --no-block --now enable "${service}"
        fi
     done
 

--- a/data/data/agent/systemd/units/agent-add-node.service
+++ b/data/data/agent/systemd/units/agent-add-node.service
@@ -2,9 +2,11 @@
 Description=Adds the current node to an already existing cluster
 Wants=network-online.target
 Requires=apply-host-config.service
+Conflicts=start-cluster-installation.service
 PartOf=assisted-service-pod.service
 After=network-online.target apply-host-config.service
 ConditionPathExists=/etc/assisted/node0
+ConditionPathExists=/etc/assisted/add-nodes.env
 
 [Service]
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env

--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -1,9 +1,11 @@
 [Unit]
 Description=Imports an already existing cluster
 Wants=network-online.target assisted-service.service
+Conflicts=agent-register-cluster.service
 PartOf=assisted-service-pod.service
 After=network-online.target assisted-service.service
 ConditionPathExists=/etc/assisted/node0
+ConditionPathExists=/etc/assisted/add-nodes.env
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -25,4 +25,4 @@ RestartSec=30
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=agent-add-node.service

--- a/data/data/agent/systemd/units/agent-register-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-register-cluster.service.template
@@ -1,9 +1,11 @@
 [Unit]
 Description=Service that registers the cluster
 Wants=network-online.target assisted-service.service
+Conflicts=agent-import-cluster.service
 PartOf=assisted-service-pod.service
 After=network-online.target assisted-service.service
 ConditionPathExists=/etc/assisted/node0
+ConditionPathExists=!/etc/assisted/add-nodes.env
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/data/data/agent/systemd/units/agent-register-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-register-cluster.service.template
@@ -24,4 +24,4 @@ RestartSec=30
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=start-cluster-installation.service

--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -2,7 +2,7 @@
 Description=Service that registers the infraenv
 Wants=network-online.target assisted-service.service
 PartOf=assisted-service-pod.service
-After=network-online.target assisted-service.service {{ if eq .WorkflowType "install" }}agent-register-cluster.service{{ end }}{{ if eq .WorkflowType "addnodes" }}agent-import-cluster.service{{ end }}
+After=network-online.target assisted-service.service agent-register-cluster.service agent-import-cluster.service
 ConditionPathExists=/etc/assisted/node0
 
 [Service]

--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -23,4 +23,4 @@ RestartSec=30
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=start-cluster-installation.service agent-add-node.service

--- a/data/data/agent/systemd/units/apply-host-config.service
+++ b/data/data/agent/systemd/units/apply-host-config.service
@@ -23,4 +23,4 @@ Type=oneshot
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=start-cluster-installation.service agent-add-node.service

--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -2,9 +2,11 @@
 Description=Service that starts cluster installation
 Wants=network-online.target
 Requires=apply-host-config.service
+Conflicts=agent-add-node.service
 PartOf=assisted-service-pod.service
 After=network-online.target apply-host-config.service
 ConditionPathExists=/etc/assisted/node0
+ConditionPathExists=!/etc/assisted/add-nodes.env
 
 [Service]
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -166,7 +166,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		numMasters = agentManifests.AgentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents
 		numWorkers = agentManifests.AgentClusterInstall.Spec.ProvisionRequirements.WorkerAgents
 		// Enable specific install services
-		enabledServices = append(enabledServices, "agent-register-cluster.service", "start-cluster-installation.service")
+		enabledServices = append(enabledServices, "start-cluster-installation.service")
 		// Version is retrieved from the embedded data
 		openshiftVersion, err = version.Version()
 		if err != nil {
@@ -185,7 +185,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		numMasters = 0
 		numWorkers = len(addNodesConfig.Config.Hosts)
 		// Enable add-nodes specific services
-		enabledServices = append(enabledServices, "agent-import-cluster.service", "agent-add-node.service")
+		enabledServices = append(enabledServices, "agent-add-node.service")
 		// Generate add-nodes.env file
 		addNodesEnvFile := ignition.FileFromString(addNodesEnvPath, "root", 0644, getAddNodesEnv(*clusterInfo))
 		config.Storage.Files = append(config.Storage.Files, addNodesEnvFile)
@@ -327,6 +327,8 @@ func getDefaultEnabledServices() []string {
 	return []string{
 		"agent-interactive-console.service",
 		"agent-interactive-console-serial@.service",
+		"agent-register-cluster.service",
+		"agent-import-cluster.service",
 		"agent-register-infraenv.service",
 		"agent.service",
 		"assisted-service-db.service",

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -74,7 +74,6 @@ type agentTemplateData struct {
 	ImageTypeISO              string
 	PublicKeyPEM              string
 	PrivateKeyPEM             string
-	WorkflowType              workflow.AgentWorkflowType
 	CaBundleMount             string
 }
 
@@ -256,7 +255,6 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		imageTypeISO,
 		keyPairAsset.PrivateKey,
 		keyPairAsset.PublicKey,
-		agentWorkflow.Workflow,
 		caBundleMount)
 
 	err = bootstrap.AddStorageFiles(&config, "/", "agent/files", agentTemplateData)
@@ -374,7 +372,6 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 	proxy *v1beta1.Proxy,
 	imageTypeISO,
 	privateKey, publicKey string,
-	workflow workflow.AgentWorkflowType,
 	caBundleMount string) *agentTemplateData {
 	return &agentTemplateData{
 		ServiceProtocol:           "http",
@@ -393,7 +390,6 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 		ImageTypeISO:              imageTypeISO,
 		PrivateKeyPEM:             privateKey,
 		PublicKeyPEM:              publicKey,
-		WorkflowType:              workflow,
 		CaBundleMount:             caBundleMount,
 	}
 }

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -92,7 +92,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	privateKey := "-----BEGIN EC PUBLIC KEY-----\nMFkwEwYHKoAiDHV4tg==\n-----END EC PUBLIC KEY-----\n"
 	publicKey := "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PRIVATE KEY-----\n"
 
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", privateKey, publicKey, workflow.AgentWorkflowTypeInstall, "")
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", privateKey, publicKey, "")
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)


### PR DESCRIPTION
The `agent-register-cluster` systemd service is disabled in the unconfigured ignition since #8093, which broke the appliance CI jobs.