### PR TITLE
OCPBUGS-32591: GCP Destroy target pools fix misleading log

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -60,7 +60,7 @@ func (o *ClusterUninstaller) listCloudControllerTargetPools(ctx context.Context,
 				}
 
 				if !foundClusterResource {
-					o.Logger.Debugf("Invalid instance %s in target pool %s, target pool will not be destroyed", name, pool.Name)
+					o.Logger.Debugf("Skipping target pool instance %s because it is not a cluster resource", pool.Name)
 					return false
 				}
 			}


### PR DESCRIPTION
** Alter the log when destroying target pools. When the target pool is found but is not part of the cluster it was logging as an issue. It was a bit misleading, so the log is changed to explain that the resource wont be deleted because it is not part of the cluster.