### PR TITLE
CORS-3076: azure: Add additional tags to AzureCluster

### DIFF
--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -48,6 +48,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			AzureClusterClassSpec: capz.AzureClusterClassSpec{
 				SubscriptionID:   session.Credentials.SubscriptionID,
 				Location:         installConfig.Config.Azure.Region,
+				AdditionalTags:   installConfig.Config.Platform.Azure.UserTags,
 				AzureEnvironment: string(installConfig.Azure.CloudName),
 				IdentityRef: &corev1.ObjectReference{
 					APIVersion: capz.GroupVersion.String(),


### PR DESCRIPTION
Adding the field AdditionalTags to AzureCluster with the user tags from the install config.