### PR TITLE
CORS-3250: images/altinfra: add etcd/kas binaries from containers

### DIFF
--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -28,9 +28,9 @@ copy_cluster_api_to_mirror() {
 
 sync_envtest() {
   if [ -f "${CLUSTER_API_BIN_DIR}/kube-apiserver" ]; then
-    version=$("${CLUSTER_API_BIN_DIR}/kube-apiserver" --version || echo "Kubernetes v0.0.0")
+    version=$("${CLUSTER_API_BIN_DIR}/kube-apiserver" --version | sed 's/Kubernetes //' || echo "v0.0.0")
     echo "Found envtest binaries with version: ${version}"
-    if [ "${version}" = "Kubernetes v${ENVTEST_K8S_VERSION}" ]; then
+    if printf '%s\n%s' v${ENVTEST_K8S_VERSION} "${version}" | sort -V -C; then
       return
     fi
   fi

--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -7,18 +7,25 @@
 # solutions. Once all providers have alternate implementations, this image will
 # not be needed. 
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/4.16:etcd AS etcd
+FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 # FIPS support is offered via the baremetal-installer image
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS="altinfra"
 ARG OPENSHIFT_INSTALL_CLUSTER_API=""
 WORKDIR /go/src/github.com/openshift/installer
+COPY --from=etcd /usr/bin/etcd /usr/bin/etcd
+COPY --from=kas /usr/bin/kube-apiserver /usr/bin/kube-apiserver
 COPY . .
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv /usr/bin/etcd /usr/bin/kube-apiserver -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
 RUN mkdir /output && chown 1000:1000 /output


### PR DESCRIPTION
When building the altinfra image for inclusion in the release payload, we cannot download any binaries as it is currently done for etcd/kas. Instead let's copy those binaries from their existing container images.