### PR TITLE
MULTIARCH-4111: Updating CI image to include qemu-kvm

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -27,7 +27,8 @@ RUN yum update -y && \
     libvirt-libs \
     nss_wrapper \
     openssh-clients \
-    virt-install && \
+    virt-install \
+    qemu-kvm && \
     yum clean all && rm -rf /var/cache/yum/*
 
 COPY --from=yq3 /yq /bin/yq-go


### PR DESCRIPTION
In an effort to convert the libvirt IPI workflows to UPI, I will be using qemu-img to increase the size of a qemu used for cluster node creation.