### PR TITLE
CORS-2893: capi-aws: implement preserveBootstrapIgnition

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -142,8 +142,9 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 				},
 			},
 			S3Bucket: &capa.S3Bucket{
-				Name:                 fmt.Sprintf("openshift-bootstrap-data-%s", clusterID.InfraID),
-				PresignedURLDuration: &metav1.Duration{Duration: 1 * time.Hour},
+				Name:                    fmt.Sprintf("openshift-bootstrap-data-%s", clusterID.InfraID),
+				PresignedURLDuration:    &metav1.Duration{Duration: 1 * time.Hour},
+				BestEffortDeleteObjects: ptr.To(ic.Config.AWS.PreserveBootstrapIgnition),
 			},
 			ControlPlaneLoadBalancer: &capa.AWSLoadBalancerSpec{
 				Name:                   ptr.To(clusterID.InfraID + "-int"),


### PR DESCRIPTION
This feature is needed for customers running installs under systems with policies that prevent S3 objects from being deleted.

The way this was implemented in CAPA, the provider will try to delete the objects but ignore the errors if `BestEffortDeleteObjects` is set in the `AWSCluster` bucket spec.