### PR TITLE
SPLAT-1596: Created new function to workaround issue with Set-HardDisk.

### DIFF
--- a/upi/vsphere/powercli/upi.ps1
+++ b/upi/vsphere/powercli/upi.ps1
@@ -211,7 +211,8 @@ foreach ($fd in $fds)
 
             New-TagAssignment -Entity $template -Tag $tag
             Set-VM -VM $template -MemoryGB 16 -NumCpu 4 -CoresPerSocket 4 -Confirm:$false > $null
-            Get-HardDisk -VM $template | Select-Object -First 1 | Set-HardDisk -CapacityGB 120 -Confirm:$false > $null
+            #Get-HardDisk -VM $template | Select-Object -First 1 | Set-HardDisk -CapacityGB 120 -Confirm:$false > $null
+            updateDisk -VM $template -CapacityGB 120
             New-AdvancedSetting -Entity $template -name "disk.EnableUUID" -value 'TRUE' -confirm:$false -Force > $null
             New-AdvancedSetting -Entity $template -name "guestinfo.ignition.config.data.encoding" -value "base64" -confirm:$false -Force > $null
             #$snapshot = New-Snapshot -VM $template -Name "linked-clone" -Description "linked-clone" -Memory -Quiesce


### PR DESCRIPTION
[SPLAT-1596]([SPLAT-1596](https://issues.redhat.com//browse/SPLAT-1596))

Attempting to fix an issue where in vSphere 8.0, the Set-HardDisk is causing vCenter to crash.

### Changes
- Created new updateDisk function

### Notes
It seems that the Set-HardDisk function of vSphere's powercli works fine in our vSphere 7.x instances, but for devqe (which is 8.x), it seems the Set-HardDisk function causes the vCenter instance to stop running.  To workaround this due to time, we quickly created this method to manually attempt to set the disk size using back channels.