### PR TITLE
OCPBUGS-33024: agent: escape '%' in proxy settings

### DIFF
--- a/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -1,10 +1,10 @@
 {{if .Proxy -}}
 [Manager]
 {{if .Proxy.HTTPProxy -}}
-DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+DefaultEnvironment=HTTP_PROXY="{{replace .Proxy.HTTPProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.HTTPSProxy -}}
-DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+DefaultEnvironment=HTTPS_PROXY="{{replace .Proxy.HTTPSProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.NoProxy -}}
 DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"


### PR DESCRIPTION
The 'DefaultEnvironment' config from systemd accepts some % specifiers for expansion [1]. Because of that, proxy configurations that make use of that character need to be escaped with another '%'.

[1] https://man7.org/linux/man-pages/man5/systemd-system.conf.5.html