### PR TITLE
OCPBUGS-32981: baremetal: use ControlPlane.Replicas

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -10,10 +10,9 @@ until oc get baremetalhosts -n openshift-machine-api; do
    sleep 20
 done
 
-N="{{ .PlatformData.BareMetal.MasterHostCount }}"
-echo "Waiting for $N masters to become provisioned"
-while [ "$(oc get bmh -n openshift-machine-api -l installer.openshift.io/role=control-plane -o json | jq '.items[].status.provisioning.state' | grep provisioned -c)" -lt "$N"  ]; do
-    echo "Waiting for $N masters to become provisioned"
+echo "Waiting for $CONTROL_PLANE_REPLICA_COUNT masters to become provisioned"
+while [ "$(oc get bmh -n openshift-machine-api -l installer.openshift.io/role=control-plane -o json | jq '.items[].status.provisioning.state' | grep provisioned -c)" -lt "$CONTROL_PLANE_REPLICA_COUNT"  ]; do
+    echo "Waiting for $CONTROL_PLANE_REPLICA_COUNT masters to become provisioned"
     oc get bmh -A || true
     sleep 20
 done

--- a/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service.template
+++ b/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service.template
@@ -6,6 +6,7 @@ Before=progress.service
 
 [Service]
 Type=oneshot
+Environment="CONTROL_PLANE_REPLICA_COUNT={{.PlatformData.BareMetal.ControlPlaneReplicas}}"
 ExecStart=/usr/local/bin/master-bmh-update.sh
 RemainAfterExit=true
 Restart=on-failure

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -59,7 +59,7 @@ type TemplateData struct {
 	Hosts []*baremetal.Host
 
 	// How many of the Hosts are control plane machines?
-	MasterHostCount int
+	ControlPlaneReplicas int64
 
 	// ProvisioningNetwork displays the type of provisioning network being used
 	ProvisioningNetwork string
@@ -98,16 +98,11 @@ func externalURLs(apiVIPs []string) (externalURLv4 string, externalURLv6 string)
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
-func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, ironicUsername, ironicPassword string) *TemplateData {
+func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, controlPlaneReplicaCount int64, ironicUsername, ironicPassword string) *TemplateData {
 	var templateData TemplateData
 
 	templateData.Hosts = config.Hosts
-
-	for _, host := range config.Hosts {
-		if host.IsMaster() {
-			templateData.MasterHostCount++
-		}
-	}
+	templateData.ControlPlaneReplicas = controlPlaneReplicaCount
 
 	templateData.ProvisioningIP = config.BootstrapProvisioningIP
 	templateData.ProvisioningNetwork = string(config.ProvisioningNetwork)

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -35,7 +35,7 @@ func TestTemplatingIPv4(t *testing.T) {
 		},
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100,24")
 	assert.Equal(t, result.ProvisioningCIDR, 24)
@@ -54,7 +54,7 @@ func TestTemplatingManagedIPv6(t *testing.T) {
 		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff,80")
 	assert.Equal(t, result.ProvisioningCIDR, 80)
@@ -71,7 +71,7 @@ func TestTemplatingUnmanagedIPv6(t *testing.T) {
 		ProvisioningNetwork:     baremetal.UnmanagedProvisioningNetwork,
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "")
 	assert.Equal(t, result.ProvisioningCIDR, 64)

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -283,7 +283,13 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 
 	switch installConfig.Config.Platform.Name() {
 	case baremetaltypes.Name:
-		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Config.Platform.BareMetal, installConfig.Config.MachineNetwork, ironicCreds.Username, ironicCreds.Password)
+		platformData.BareMetal = baremetal.GetTemplateData(
+			installConfig.Config.Platform.BareMetal,
+			installConfig.Config.MachineNetwork,
+			*installConfig.Config.ControlPlane.Replicas,
+			ironicCreds.Username,
+			ironicCreds.Password,
+		)
 	case vspheretypes.Name:
 		platformData.VSphere = vsphere.GetTemplateData(installConfig.Config.Platform.VSphere)
 	}


### PR DESCRIPTION
`*installConfig.ControlPlane.Replicas` is the canonical source of this information and we don't want to rely on the `IsMaster()` function.

We also change how that number gets to the master-bmh-update.sh script. We template the number into the systemd service instead of the shell script.  This gives us shellcheck.

This is a follow-up to #8316 