### PR TITLE
AGENT-863: fix oc dependency in installer images 

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -8,8 +8,6 @@ COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build-node-joiner.sh
 
-FROM registry.ci.openshift.org/ocp/4.16:cli-artifacts AS tools
-
 FROM registry.ci.openshift.org/ocp/4.16:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 
@@ -20,8 +18,7 @@ RUN dnf upgrade -y && \
 
 # node-joiner requirements
 COPY --from=builder /go/src/github.com/openshift/installer/bin/node-joiner /bin/node-joiner
-COPY --from=tools /usr/bin/oc /bin/oc
-RUN dnf install -y nmstate
+RUN dnf install -y nmstate openshift-clients
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -13,14 +13,9 @@ COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terr
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 
-FROM registry.ci.openshift.org/ocp/4.16:cli-artifacts AS tools
-
 FROM registry.ci.openshift.org/ocp/4.16:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
-# Required to run agent-based installer from the container
-COPY --from=tools /usr/bin/oc /bin/oc
-RUN dnf install -y nmstate
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
This patch removes the explicit `cli-artifacts` dependency from the images to avoid introducing further complications in the build pipeline (see https://github.com/openshift-eng/ocp-build-data/pull/4751), and switches the approach to directly install `openshift-clients` package just in the `baremetal-installer` image for retrieving the `oc` cli tool, required by [ node-joiner](https://github.com/openshift/installer/blob/c2fa2bfec3b1c0cbeeaa5d6c3486775c8f04d515/docs/user/agent/add-node/node-joiner.sh#L112).
