### PR TITLE
AGENT-864: cleanup dnf cache after installing node-joiner reqs

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -18,7 +18,8 @@ RUN dnf upgrade -y && \
 
 # node-joiner requirements
 COPY --from=builder /go/src/github.com/openshift/installer/bin/node-joiner /bin/node-joiner
-RUN dnf install -y nmstate openshift-clients
+RUN dnf install -y nmstate openshift-clients && \
+    dnf clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
Fix to avoid including the cache in the final image