### PR TITLE
DNM: aws: disable perms check

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -308,6 +308,10 @@ var permissions = map[PermissionGroup][]string{
 // as either capable of creating new credentials for components that interact with the cloud or
 // being able to be passed through as-is to the components that need cloud credentials
 func ValidateCreds(ssn *session.Session, groups []PermissionGroup, region string) error {
+	if true {
+		return nil
+	}
+
 	requiredPermissions, err := PermissionsList(groups)
 	if err != nil {
 		return err


### PR DESCRIPTION
To use for testing which perms are actually required by capi/capa.