### PR TITLE
azure: Add securityProfile to control plane machines

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -131,6 +131,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				AdditionalCapabilities: additionalCapabilities,
 				AllocatePublicIP:       false,
 				EnableIPForwarding:     false,
+				SecurityProfile:        securityProfile,
 			},
 		}
 		azureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))


### PR DESCRIPTION
Adding the option to encrypt control plane disks for Azure CAPI.