### PR TITLE
WIP: GCP: Add a metadata startup-script to update a VM's dns resolver

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -25,7 +25,7 @@ done
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in crio kubelet machine-config-daemon-host machine-config-daemon-firstboot openshift-azure-routes openshift-gcp-routes pivot sssd
+for service in crio kubelet machine-config-daemon-host machine-config-daemon-firstboot openshift-azure-routes openshift-gcp-routes pivot sssd google-startup-scripts
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -38,6 +38,8 @@ module "master" {
   gcp_extra_tags       = var.gcp_extra_tags
 
   tags = var.gcp_control_plane_tags
+
+  user_provisioned_dns = var.gcp_user_provisioned_dns
 }
 
 module "iam" {

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -85,6 +85,7 @@ resource "google_compute_instance" "master" {
   metadata = {
     user-data = var.ignition
   }
+  metadata_startup_script = var.gcp_user_provisioned_dns ? "echo \"Custom-DNS Test\"; echo \"Added by OpenShift\" >> /tmp/temp.conf; echo \"nameserver $(ip route get 8.8.8.8 | grep -oP 'src \\K[^ ]+')\" >> /tmp/temp.conf; cat /etc/resolv.conf >> /tmp/temp.conf; cat /tmp/temp.conf; sudo cp /tmp/temp.conf /etc/resolv.conf" : ""
 
   tags = concat(
     ["${var.cluster_id}-master"],

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -83,9 +83,9 @@ resource "google_compute_instance" "master" {
   }
 
   metadata = {
-    user-data = var.ignition
+    user-data      = var.ignition
+    startup-script = var.user_provisioned_dns ? "echo \"Custom-DNS Test\"; echo \"#Added by OpenShift\" >> /tmp/temp.conf; echo \"nameserver $(ip -o route get 8.8.8.8 | head -1 | cut -d' ' -f7\" >> /tmp/temp.conf; cat /etc/resolv.conf >> /tmp/temp.conf; cat /tmp/temp.conf; sudo cp /tmp/temp.conf /etc/resolv.conf" : ""
   }
-  metadata_startup_script = var.user_provisioned_dns ? "echo \"Custom-DNS Test\"; echo \"Added by OpenShift\" >> /tmp/temp.conf; echo \"nameserver $(ip route get 8.8.8.8 | grep -oP 'src \\K[^ ]+')\" >> /tmp/temp.conf; cat /etc/resolv.conf >> /tmp/temp.conf; cat /tmp/temp.conf; sudo cp /tmp/temp.conf /etc/resolv.conf" : ""
 
   tags = concat(
     ["${var.cluster_id}-master"],

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -85,7 +85,7 @@ resource "google_compute_instance" "master" {
   metadata = {
     user-data = var.ignition
   }
-  metadata_startup_script = var.gcp_user_provisioned_dns ? "echo \"Custom-DNS Test\"; echo \"Added by OpenShift\" >> /tmp/temp.conf; echo \"nameserver $(ip route get 8.8.8.8 | grep -oP 'src \\K[^ ]+')\" >> /tmp/temp.conf; cat /etc/resolv.conf >> /tmp/temp.conf; cat /tmp/temp.conf; sudo cp /tmp/temp.conf /etc/resolv.conf" : ""
+  metadata_startup_script = var.user_provisioned_dns ? "echo \"Custom-DNS Test\"; echo \"Added by OpenShift\" >> /tmp/temp.conf; echo \"nameserver $(ip route get 8.8.8.8 | grep -oP 'src \\K[^ ]+')\" >> /tmp/temp.conf; cat /etc/resolv.conf >> /tmp/temp.conf; cat /tmp/temp.conf; sudo cp /tmp/temp.conf /etc/resolv.conf" : ""
 
   tags = concat(
     ["${var.cluster_id}-master"],

--- a/data/data/gcp/cluster/master/variables.tf
+++ b/data/data/gcp/cluster/master/variables.tf
@@ -94,3 +94,11 @@ Example: `{ "tagKeys/123" = "tagValues/456", "tagKeys/456" = "tagValues/789" }`
 EOF
   default = {}
 }
+
+variable "user_provisioned_dns" {
+  type = bool
+  default = false
+  description = <<EOF
+When true the user has selected to configure their own dns solution, and no dns records will be created.
+EOF
+}


### PR DESCRIPTION
There might be a way to use the terraform module https://github.com/terraform-google-modules/terraform-google-startup-scripts.  Choosing this approach now for its simplicity.