### PR TITLE
OCPBUGS-33709: GCP mixup when using the ignition shim vs the signed url

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -118,7 +118,7 @@ resource "google_compute_instance" "bootstrap" {
   }
 
   metadata = {
-    user-data = data.ignition_config.redirect.rendered
+    user-data = var.gcp_ignition_shim
   }
 
   tags = ["${var.cluster_id}-master", "${var.cluster_id}-bootstrap"]


### PR DESCRIPTION
** Ignition was being given the signed url, but the url does not point to ignition data that contains the proxy information. The ignition shim contains the url and should be supplied as metadata to the bootstrap node. The shim will contain the url as well as proxy data, and the url will point to the bucket that contains the actual ignition bootstrap data.