### PR TITLE
CORS-3250: images: use pre-built KAS/etcd binaries

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,10 +1,18 @@
 # This Dockerfile is a used by CI to publish an installer image
 # It builds an image containing openshift-install.
 
+# The binaries in these images are dynamically linked
+FROM registry.ci.openshift.org/ocp/4.16:etcd AS etcd
+FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ARG TAGS="baremetal fipscapable"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=etcd /usr/bin/etcd /usr/bin/etcd
+COPY --from=kas /usr/bin/kube-apiserver /usr/bin/kube-apiserver
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv /usr/bin/etcd /usr/bin/kube-apiserver -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build-node-joiner.sh
 

--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -7,8 +7,9 @@
 # solutions. Once all providers have alternate implementations, this image will
 # not be needed. 
 
-FROM registry.ci.openshift.org/ocp/4.16:etcd AS etcd
-FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
+# We copy from the -artifacts images because they are statically linked
+FROM registry.ci.openshift.org/ocp/4.16:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.16:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -16,11 +17,11 @@ ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS="altinfra"
 ARG OPENSHIFT_INSTALL_CLUSTER_API=""
 WORKDIR /go/src/github.com/openshift/installer
-COPY --from=etcd /usr/bin/etcd /usr/bin/etcd
-COPY --from=kas /usr/bin/kube-apiserver /usr/bin/kube-apiserver
 COPY . .
+COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
+COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
 RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
-	mv /usr/bin/etcd /usr/bin/kube-apiserver -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
+	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -2,6 +2,9 @@
 # the installer layered on top of the cluster-native Linux installer image.
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers AS providers
+# We copy from the -artifacts images because they are statically linked
+FROM registry.ci.openshift.org/ocp/4.16:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.16:installer-etcd-artifacts AS etcd-artifacts
 
 # FIPS support is offered via the baremetal-installer image
 
@@ -11,6 +14,8 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_amd64 terraform/bin/darwin_amd64
+COPY --from=kas-artifacts /usr/share/openshift/darwin/amd64 cluster-api/bin/darwin_amd64
+COPY --from=etcd-artifacts /usr/share/openshift/darwin/amd64 cluster-api/bin/darwin_amd64
 RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macarmbuilder
@@ -19,6 +24,8 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_arm64 terraform/bin/darwin_arm64
+COPY --from=kas-artifacts /usr/share/openshift/darwin/arm64 cluster-api/bin/darwin_arm64
+COPY --from=etcd-artifacts /usr/share/openshift/darwin/arm64 cluster-api/bin/darwin_arm64
 RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxbuilder
@@ -27,6 +34,8 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_amd64 terraform/bin/linux_amd64
+COPY --from=kas-artifacts /usr/share/openshift/linux/amd64 cluster-api/bin/linux_amd64
+COPY --from=etcd-artifacts /usr/share/openshift/linux/amd64 cluster-api/bin/linux_amd64
 RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxarmbuilder
@@ -35,6 +44,8 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_arm64 terraform/bin/linux_arm64
+COPY --from=kas-artifacts /usr/share/openshift/linux/arm64 cluster-api/bin/linux_arm64
+COPY --from=etcd-artifacts /usr/share/openshift/linux/arm64 cluster-api/bin/linux_arm64
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -2,6 +2,9 @@
 # It builds an image containing only the openshift-install.
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers AS providers
+# We copy from the -artifacts images because they are statically linked
+FROM registry.ci.openshift.org/ocp/4.16:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.16:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -10,6 +13,10 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
+COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,6 +3,9 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers as providers
+# We copy from the -artifacts images because they are statically linked
+FROM registry.ci.openshift.org/ocp/4.16:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.16:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -11,6 +14,10 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
+COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.16:cli as cli

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -2,10 +2,18 @@
 # It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments and
 # oc for getting assets from an existing cluster to spin up multi-architecture compute clusters on libvirt.
 
+# The binaries in these images are dynamically linked
+FROM registry.ci.openshift.org/ocp/4.16:etcd AS etcd
+FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ARG TAGS="libvirt fipscapable"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
+COPY --from=etcd /usr/bin/etcd /usr/bin/etcd
+COPY --from=kas /usr/bin/kube-apiserver /usr/bin/kube-apiserver
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv /usr/bin/etcd /usr/bin/kube-apiserver -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.16:cli as cli

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,6 +1,9 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
 FROM registry.ci.openshift.org/ocp/4.16:installer-terraform-providers as providers
+# We copy from the -artifacts images because they are statically linked
+FROM registry.ci.openshift.org/ocp/4.16:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.16:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -9,6 +12,10 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
+COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
+COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
+RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
+	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.16:cli AS cli


### PR DESCRIPTION
We copy pre-built binaries from the `-artifacts` images when we want statically linked binaries and from the regular etcd/hyperkube images for dynamically linked binaries.

This is necessary to have capi and capi providers included in the installer images both for CI and for the release payload.