### PR TITLE
CORS-3524, CORS-3523: aws: terraform: add spot instance support for masters

### DIFF
--- a/cmd/openshift-install/features.go
+++ b/cmd/openshift-install/features.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	outputJSON     = false
+	hiddenFeatures = []string{
+		"terraform-spot-masters",
+	}
+)
+
+func newListFeaturesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "list-hidden-features",
+		Short:  "List supported hidden features",
+		Long:   "",
+		Hidden: true,
+		Args:   cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			var out string
+			if outputJSON {
+				outb, err := json.Marshal(hiddenFeatures)
+				if err != nil {
+					logrus.Fatalf("failed to marshal output: %s", err.Error())
+				}
+				out = string(outb)
+			} else {
+				out = strings.Join(hiddenFeatures, "\n")
+			}
+			fmt.Println(out)
+		},
+	}
+	cmd.PersistentFlags().BoolVar(&outputJSON, "json", false, "print output in json format")
+	return cmd
+}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -55,6 +55,7 @@ func installerMain() {
 		newCompletionCmd(),
 		newExplainCmd(),
 		newAgentCmd(ctx),
+		newListFeaturesCmd(),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -163,6 +163,16 @@ resource "aws_instance" "bootstrap" {
   vpc_security_group_ids      = [var.master_sg_id, aws_security_group.bootstrap.id]
   associate_public_ip_address = local.public_endpoints && var.aws_public_ipv4_pool == ""
 
+  dynamic "instance_market_options" {
+    for_each = var.aws_master_use_spot_instance ? [1] : []
+    content {
+      market_type = "spot"
+      spot_options {
+        spot_instance_type = "one-time"
+      }
+    }
+  }
+
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This
     # avoids accidental deletion of nodes whenever a new OS release comes out.

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -55,6 +55,7 @@ module "masters" {
   user_data_ign                    = var.ignition_master
   publish_strategy                 = var.aws_publish_strategy
   iam_role_name                    = var.aws_master_iam_role_name
+  use_spot_instance                = var.aws_master_use_spot_instance
 }
 
 module "iam" {

--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -146,6 +146,16 @@ resource "aws_instance" "master" {
     device_index         = 0
   }
 
+  dynamic "instance_market_options" {
+    for_each = var.use_spot_instance ? [1] : []
+    content {
+      market_type = "spot"
+      spot_options {
+        spot_instance_type = "one-time"
+      }
+    }
+  }
+
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This
     # avoids accidental deletion of nodes whenever a new CoreOS Release comes

--- a/data/data/aws/cluster/master/variables.tf
+++ b/data/data/aws/cluster/master/variables.tf
@@ -101,3 +101,8 @@ variable "iam_role_name" {
   type = string
   description = "The name of the existing role to use for the instance profile"
 }
+
+variable "use_spot_instance" {
+  type = bool
+  description = "Whether to use Spot instances for masters"
+}

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -239,3 +239,9 @@ EOF
 
   default = ""
 }
+
+variable "aws_master_use_spot_instance" {
+  type = bool
+  description = "(optional) Whether to use instances from the Spot market for masters"
+  default = false
+}


### PR DESCRIPTION
Spot instances can result on savings for short-lived clusters. If the control plane machine manifests have been edited with spot instance information, enable the use of spot instances in the terraform config. Notice that max price information is ignored, since it's not advised for it to be set.