### PR TITLE
CORS-3471: standalone destroy bootstrap support with capi

### DIFF
--- a/pkg/clusterapi/localcontrolplane.go
+++ b/pkg/clusterapi/localcontrolplane.go
@@ -76,6 +76,11 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 		BinaryAssetsDirectory:    c.BinDir,
 		ControlPlaneStartTimeout: 10 * time.Second,
 		ControlPlaneStopTimeout:  10 * time.Second,
+		ControlPlane: envtest.ControlPlane{
+			Etcd: &envtest.Etcd{
+				DataDir: c.BinDir,
+			},
+		},
 	}
 	var err error
 	c.Cfg, err = c.Env.Start()

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -84,7 +84,7 @@ func Destroy(ctx context.Context, dir string) (err error) {
 		return fmt.Errorf("error getting infrastructure provider: %w", err)
 	}
 
-	if err := provider.DestroyBootstrap(dir); err != nil {
+	if err := provider.DestroyBootstrap(ctx, dir); err != nil {
 		return fmt.Errorf("error destroying bootstrap resources %w", err)
 	}
 

--- a/pkg/infrastructure/aws/sdk/aws.go
+++ b/pkg/infrastructure/aws/sdk/aws.go
@@ -303,7 +303,7 @@ func (a InfraProvider) Provision(ctx context.Context, dir string, parents asset.
 }
 
 // DestroyBootstrap destroys the temporary bootstrap resources.
-func (a InfraProvider) DestroyBootstrap(dir string) error {
+func (a InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error {
 	// Unmarshall input from tf variables, so we can use it along with
 	// installConfig and other assets as the contractual input regardless of
 	// the implementation.
@@ -341,7 +341,7 @@ func (a InfraProvider) DestroyBootstrap(dir string) error {
 		Fn:   request.MakeAddToUserAgentHandler("OpenShift/4.x Destroyer", version.Raw),
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	logger := logrus.StandardLogger()

--- a/pkg/infrastructure/baremetal/baremetal.go
+++ b/pkg/infrastructure/baremetal/baremetal.go
@@ -33,7 +33,7 @@ func (a Provider) Provision(ctx context.Context, dir string, parents asset.Paren
 }
 
 // DestroyBootstrap destroys the temporary bootstrap resources.
-func (a Provider) DestroyBootstrap(dir string) error {
+func (a Provider) DestroyBootstrap(ctx context.Context, dir string) error {
 	config, err := getConfig(dir)
 	if err != nil {
 		return fmt.Errorf("failed to get baremetal platform config: %w", err)

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -132,7 +132,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	// Run the CAPI system.
 	timer.StartTimer(infrastructureStage)
 	capiSystem := clusterapi.System()
-	if err := capiSystem.Run(ctx, installConfig); err != nil {
+	if err := capiSystem.Run(ctx); err != nil {
 		return fileList, fmt.Errorf("failed to run cluster api system: %w", err)
 	}
 

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -362,7 +362,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 }
 
 // DestroyBootstrap destroys the temporary bootstrap resources.
-func (i *InfraProvider) DestroyBootstrap(dir string) error {
+func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error {
 	metadata, err := metadata.Load(dir)
 	if err != nil {
 		return err

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -368,42 +368,47 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 		return err
 	}
 
-	// TODO(padillon): start system if not running
-	if sys := clusterapi.System(); sys.State() == clusterapi.SystemStateRunning {
-		machineName := capiutils.GenerateBoostrapMachineName(metadata.InfraID)
-		machineNamespace := capiutils.Namespace
-		if err := sys.Client().Delete(context.TODO(), &clusterv1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineName,
-				Namespace: machineNamespace,
-			},
-		}); err != nil {
-			return fmt.Errorf("failed to delete bootstrap machine: %w", err)
-		}
-
-		machineDeletionTimeout := 2 * time.Minute
-		logrus.Infof("Waiting up to %v for bootstrap machine deletion %s/%s...", machineDeletionTimeout, machineNamespace, machineName)
-		machineContext, cancel := context.WithTimeout(context.TODO(), machineDeletionTimeout)
-		wait.Until(func() {
-			err := sys.Client().Get(context.TODO(), client.ObjectKey{
-				Name:      machineName,
-				Namespace: machineNamespace,
-			}, &clusterv1.Machine{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					logrus.Debugf("Machine deleted: %s", machineName)
-					cancel()
-				} else {
-					logrus.Debugf("Error when deleting bootstrap machine: %s", err)
-				}
-			}
-		}, 2*time.Second, machineContext.Done())
-
-		err = machineContext.Err()
-		if err != nil && !errors.Is(err, context.Canceled) {
-			logrus.Infof("Timeout deleting bootstrap machine: %s", err)
+	sys := clusterapi.System()
+	if sys.State() != clusterapi.SystemStateRunning {
+		if err := sys.Run(ctx); err != nil {
+			return fmt.Errorf("failed to run capi system: %w", err)
 		}
 	}
+
+	machineName := capiutils.GenerateBoostrapMachineName(metadata.InfraID)
+	machineNamespace := capiutils.Namespace
+	if err := sys.Client().Delete(ctx, &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: machineNamespace,
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to delete bootstrap machine: %w", err)
+	}
+
+	machineDeletionTimeout := 2 * time.Minute
+	logrus.Infof("Waiting up to %v for bootstrap machine deletion %s/%s...", machineDeletionTimeout, machineNamespace, machineName)
+	ctx, cancel := context.WithTimeout(ctx, machineDeletionTimeout)
+	wait.UntilWithContext(ctx, func(context.Context) {
+		err := sys.Client().Get(ctx, client.ObjectKey{
+			Name:      machineName,
+			Namespace: machineNamespace,
+		}, &clusterv1.Machine{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Debugf("Machine deleted: %s", machineName)
+				cancel()
+			} else {
+				logrus.Debugf("Error when deleting bootstrap machine: %s", err)
+			}
+		}
+	}, 2*time.Second)
+
+	err = ctx.Err()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Infof("Timeout deleting bootstrap machine: %s", err)
+	}
+
 	logrus.Infof("Finished destroying bootstrap resources")
 	clusterapi.System().Teardown()
 

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -386,7 +386,7 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 		return fmt.Errorf("failed to delete bootstrap machine: %w", err)
 	}
 
-	machineDeletionTimeout := 2 * time.Minute
+	machineDeletionTimeout := 5 * time.Minute
 	logrus.Infof("Waiting up to %v for bootstrap machine deletion %s/%s...", machineDeletionTimeout, machineNamespace, machineName)
 	ctx, cancel := context.WithTimeout(ctx, machineDeletionTimeout)
 	wait.UntilWithContext(ctx, func(context.Context) {
@@ -406,10 +406,10 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 
 	err = ctx.Err()
 	if err != nil && !errors.Is(err, context.Canceled) {
-		logrus.Infof("Timeout deleting bootstrap machine: %s", err)
+		logrus.Warnf("Timeout deleting bootstrap machine: %s", err)
+	} else {
+		logrus.Infof("Finished destroying bootstrap resources")
 	}
-
-	logrus.Infof("Finished destroying bootstrap resources")
 	clusterapi.System().Teardown()
 
 	return nil

--- a/pkg/infrastructure/provider.go
+++ b/pkg/infrastructure/provider.go
@@ -18,7 +18,7 @@ type Provider interface {
 	Provision(ctx context.Context, dir string, parents asset.Parents) ([]*asset.File, error)
 
 	// DestroyBootstrap destroys the temporary bootstrap resources.
-	DestroyBootstrap(dir string) error
+	DestroyBootstrap(ctx context.Context, dir string) error
 
 	// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
 	ExtractHostAddresses(dir string, config *types.InstallConfig, ha *HostAddresses) error

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -81,7 +81,7 @@ func (p *Provider) Provision(_ context.Context, dir string, parents asset.Parent
 // DestroyBootstrap implements pkg/infrastructure/provider.DestroyBootstrap.
 // DestroyBootstrap iterates through each stage, and will run the destroy
 // command when defined on a stage.
-func (p *Provider) DestroyBootstrap(dir string) error {
+func (p *Provider) DestroyBootstrap(ctx context.Context, dir string) error {
 	varFiles := []string{tfVarsFileName, tfPlatformVarsFileName}
 	for _, stage := range p.stages {
 		varFiles = append(varFiles, stage.OutputsFilename())


### PR DESCRIPTION
Sets the etcd data dir in envtest so that etcd state is written to disk, allowing the local CAPI control plane to be restarted, particularly for the support of the `openshift install destroy bootstrap` command.

Tested locally by starting an installation:

```shell
[root@41b49ed47ee7 /]# ./openshift-install create cluster --dir c
INFO Credentials loaded from the "default" profile in file "/root/.aws/credentials" 
WARNING Found override for release image (quay.io/openshift-release-dev/ocp-release:4.16.0-ec.6-x86_64). Please be warned, this is not advised 
INFO Consuming Install Config from target directory 
WARNING FeatureSet "CustomNoUpgrade" is enabled. This FeatureSet does not allow upgrades and may affect the supportability of the cluster. 
INFO Creating infrastructure resources...         
INFO Creating IAM roles for control-plane and compute nodes 
INFO Started local control plane with envtest     
INFO Stored kubeconfig for envtest in: /c/auth/envtest.kubeconfig 
INFO Running process: Cluster API with args [-v=2 --diagnostics-address=0 --health-addr=127.0.0.1:40669 --webhook-port=46243 --webhook-cert-dir=/tmp/envtest-serving-certs-3134224372] 
INFO Running process: aws infrastructure provider with args [-v=4 --diagnostics-address=0 --health-addr=127.0.0.1:33985 --webhook-port=33369 --webhook-cert-dir=/tmp/envtest-serving-certs-4260070358 --feature-gates=BootstrapFormatIgnition=true,ExternalResourceGC=true] 
INFO Created manifest *v1.Namespace, namespace= name=openshift-cluster-api-guests 
INFO Created manifest *v1beta2.AWSClusterControllerIdentity, namespace= name=default 
INFO Created manifest *v1beta1.Cluster, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb 
INFO Created manifest *v1beta2.AWSCluster, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb 
INFO Waiting up to 15m0s (until 10:55PM UTC) for network infrastructure to become ready... 
INFO Netork infrastructure is ready               
INFO Creating private Hosted Zone                 
INFO Creating Route53 records for control plane load balancer 
INFO Created manifest *v1beta2.AWSMachine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-bootstrap 
INFO Created manifest *v1beta2.AWSMachine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-0 
INFO Created manifest *v1beta2.AWSMachine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-1 
INFO Created manifest *v1beta2.AWSMachine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-2 
INFO Created manifest *v1beta1.Machine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-bootstrap 
INFO Created manifest *v1beta1.Machine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-0 
INFO Created manifest *v1beta1.Machine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-1 
INFO Created manifest *v1beta1.Machine, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master-2 
INFO Created manifest *v1.Secret, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-bootstrap 
INFO Created manifest *v1.Secret, namespace=openshift-cluster-api-guests name=padillon-05051836-zw5pb-master 
INFO Waiting up to 15m0s (until 11:01PM UTC) for machines to provision... 
INFO Control-plane machines are ready             
INFO Cluster API resources have been created. Waiting for cluster to become ready... 
INFO Waiting up to 20m0s (until 11:07PM UTC) for the Kubernetes API at https://api.padillon-05051836.devcluster.openshift.com:6443... 
INFO API v1.29.4+d9d4530 up                       
INFO Waiting up to 30m0s (until 11:19PM UTC) for bootstrapping to complete... 
^CWARNING Received interrupt signal                    
INFO Shutting down local Cluster API control plane... 
INFO Stopped controller: Cluster API              
WARNING process cluster-api-provider-aws exited with error: signal: killed 
INFO Stopped controller: aws infrastructure provider 
INFO Local Cluster API system has completed operations 
```
Then interrupting while waiting for bootstrap to complete. Then running `openshift install destroy bootstrap`
```
[root@41b49ed47ee7 /]# ./openshift-install destroy bootstrap --dir c
INFO Started local control plane with envtest     
INFO Stored kubeconfig for envtest in: /c/auth/envtest.kubeconfig 
INFO Running process: Cluster API with args [-v=2 --diagnostics-address=0 --health-addr=127.0.0.1:45765 --webhook-port=40653 --webhook-cert-dir=/tmp/envtest-serving-certs-1606154849] 
INFO Running process: aws infrastructure provider with args [-v=4 --diagnostics-address=0 --health-addr=127.0.0.1:33695 --webhook-port=33941 --webhook-cert-dir=/tmp/envtest-serving-certs-173331836 --feature-gates=BootstrapFormatIgnition=true,ExternalResourceGC=true] 
INFO Waiting up to 5m0s for bootstrap machine deletion openshift-cluster-api-guests/padillon-05051836-zw5pb-bootstrap... 
INFO Finished destroying bootstrap resources      
INFO Shutting down local Cluster API control plane... 
INFO Stopped controller: Cluster API              
INFO Stopped controller: aws infrastructure provider 
INFO Local Cluster API system has completed operations 
INFO Time elapsed: 3m15s 
``` 

A previous testing run, which interrupted earlier in the machine provisioning process, took less than 2m. This took a reasonable 3:15. This PR bumps up the bootstrap destroy timeout which was too short at an ambitious 2 minutes.