### PR TITLE
OCPBUGS-33240: avoid FAT32 error messages when generating the agent ISO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.33.0
 	github.com/openshift/api v0.0.0-20240429104249-ac9356ba1784
-	github.com/openshift/assisted-image-service v0.0.0-20240408153851-f822399afa8a
+	github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0
 	github.com/openshift/assisted-service/models v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -1973,8 +1973,8 @@ github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/openshift/api v0.0.0-20240429104249-ac9356ba1784 h1:SmOZFMxuAH4d1Cj7dOftVyo4Wg/mEC4pwz6QIJJsAkc=
 github.com/openshift/api v0.0.0-20240429104249-ac9356ba1784/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
-github.com/openshift/assisted-image-service v0.0.0-20240408153851-f822399afa8a h1:xWlqkUnY9N6aiKFgzHG27fc3kyjoxeanVdwVUUzgTs0=
-github.com/openshift/assisted-image-service v0.0.0-20240408153851-f822399afa8a/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
+github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17 h1:rsTD5h6S3dCgAClbwWi/6AIo2twckeJEf+j4EZYkwII=
+github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8 h1:+fZLKbycDo4JeLwPGVSAgf2XPaJGLM341l9ZfrrlxG0=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8/go.mod h1:PmMnbVno5ocinfELDdKOaatvT5ucJLrau+fjHQNeCiY=
 github.com/openshift/assisted-service/client v0.0.0-20230831114549-1922eda29cf8 h1:9NpCGby6O44BlWqWCbd8wcN4QwBebR8McQGrjTwhlzQ=

--- a/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/isoutil.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/isoutil.go
@@ -22,7 +22,7 @@ func Extract(isoPath string, workDir string) error {
 		return err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
 		return 0, 0, err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -312,7 +312,7 @@ func GetFileFromISO(isoPath, filePath string) (filesystem.File, error) {
 		return nil, err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return nil, err
 	}
@@ -336,4 +336,9 @@ func ReadFileFromISO(isoPath, filePath string) ([]byte, error) {
 		return nil, err
 	}
 	return ret, nil
+}
+
+// Gets directly the ISO 9660 filesystem (equivalent to GetFileSystem(0)).
+func GetISO9660FileSystem(d *disk.Disk) (filesystem.FileSystem, error) {
+	return iso9660.Read(d.File, d.Size, 0, 0)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -993,7 +993,7 @@ github.com/openshift/api/machineconfiguration/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operator/v1alpha1
 github.com/openshift/api/route/v1
-# github.com/openshift/assisted-image-service v0.0.0-20240408153851-f822399afa8a
+# github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17
 ## explicit; go 1.21
 github.com/openshift/assisted-image-service/pkg/isoeditor
 github.com/openshift/assisted-image-service/pkg/overlay


### PR DESCRIPTION
This patch bumps the `assisted-image-service` dependency to version [v0.0.0-20240506123319-82517255ca17](https://github.com/openshift/assisted-image-service/commit/82517255ca171cd7351fec9da7107b4c2cdcac07), since it contains the required bug fix.

Requires https://github.com/openshift/assisted-image-service/pull/201