### PR TITLE
OCPBUGS-32947: Changed vsphere CPMS to not include fields controlled by failure domains.

### DIFF
--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -148,7 +148,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 
 	// when multiple zones are defined, network and workspace are derived from the topology
 	origProv := vsphereMachineProvider.DeepCopy()
-	if len(failureDomains) > 1 {
+	if len(failureDomains) >= 1 {
 		vsphereMachineProvider.Network = machineapi.NetworkSpec{}
 		vsphereMachineProvider.Workspace = &machineapi.Workspace{}
 		vsphereMachineProvider.Template = ""


### PR DESCRIPTION
OCPBUGS-32947

### Changes
- Modified vSphere logic when generating the control plane machine set (CPMS) to not include the following if FailureDomain count >= 1
  - Network
  - Template
  - Workspace