### PR TITLE
OKD-213: Reference stream-coreos instead of centos-stream-coreos-9

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
@@ -23,7 +23,7 @@ if [ ! -f /opt/openshift/.pivot-done ]; then
 {{if .IsFCOS -}}
   MACHINE_OS_IMAGE=$(image_for fedora-coreos)
 {{else if .IsSCOS -}}
-  MACHINE_OS_IMAGE=$(image_for centos-stream-coreos-9)
+  MACHINE_OS_IMAGE=$(image_for stream-coreos)
 {{end -}}
   echo "Pulling ${MACHINE_OS_IMAGE}..."
   while true


### PR DESCRIPTION
Align with the version-less-ness of `rhel-coreos` and `fedora-coreos` and shorten the overall tag.

Both tags are currently aliases, `centos-stream-coreos-9` will be removed in the future.