### PR TITLE
CORS-2905: capi-aws delete bootstrap ssh rule

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -17,6 +17,11 @@ import (
 	"github.com/openshift/installer/pkg/types"
 )
 
+// BootstrapSSHDescription is the description for the
+// ingress rule that provides SSH access to the bootstrap node
+// & identifies the rule for removal during bootstrap destroy.
+const BootstrapSSHDescription = "Bootstrap SSH Access"
+
 // GenerateClusterAssets generates the manifests for the cluster-api.
 func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installconfig.ClusterID) (*capiutils.GenerateClusterAssetsOutput, error) {
 	manifests := []*asset.RuntimeFile{}
@@ -133,7 +138,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 						SourceSecurityGroupRoles: []capa.SecurityGroupRole{"controlplane", "node"},
 					},
 					{
-						Description: "SSH everyone",
+						Description: BootstrapSSHDescription,
 						Protocol:    capa.SecurityGroupProtocolTCP,
 						FromPort:    22,
 						ToPort:      22,

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -378,6 +378,17 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 		}
 	}
 
+	if p, ok := i.impl.(BootstrapDestroyer); ok {
+		bootstrapDestoryInput := BootstrapDestroyInput{
+			Client:   sys.Client(),
+			Metadata: *metadata,
+		}
+
+		if err = p.DestroyBootstrap(ctx, bootstrapDestoryInput); err != nil {
+			return fmt.Errorf("failed during the destroy bootstrap hook: %w", err)
+		}
+	}
+
 	machineName := capiutils.GenerateBoostrapMachineName(metadata.InfraID)
 	machineNamespace := capiutils.Namespace
 	if err := sys.Client().Delete(ctx, &clusterv1.Machine{

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	"github.com/openshift/installer/pkg/types"
 )
 
 // Provider is the base interface that cloud platforms
@@ -86,4 +87,16 @@ type PostProvisionInput struct {
 	Client        client.Client
 	InstallConfig *installconfig.InstallConfig
 	InfraID       string
+}
+
+// BootstrapDestroyer allows platform-specific behavior when
+// destroying bootstrap resources.
+type BootstrapDestroyer interface {
+	DestroyBootstrap(ctx context.Context, in BootstrapDestroyInput) error
+}
+
+// BootstrapDestroyInput collects args passed to the DestroyBootstrap hook.
+type BootstrapDestroyInput struct {
+	Client   client.Client
+	Metadata types.ClusterMetadata
 }


### PR DESCRIPTION
Extends the capi provider interface with a boostrap destroy hook and implements logic for aws to delete the bootstrap ssh rule by updating the ingress rules on the awscluster. 

Depends on #8350 which pipes the context into the bootstrap destroy logic

Tested locally and this works fine. I removed the debug logging, so there is not much to point to in ci logs.