### PR TITLE
OCPBUGS-33840: Warn before trimming cluster name

### DIFF
--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -70,6 +71,7 @@ func generateInfraID(base string, maxLen int) string {
 
 	// truncate to maxBaseLen
 	if len(base) > maxBaseLen {
+		logrus.Warnf("Length of cluster name %q is %d which is greater than the max %d allowed. The name will be truncated to %q", base, len(base), maxBaseLen, strings.TrimRight(base[:maxBaseLen], "-"))
 		base = base[:maxBaseLen]
 	}
 	base = strings.TrimRight(base, "-")


### PR DESCRIPTION
Long cluster names get trimmed by the installer if they're greater than `maxBaseLen`. The user needs to be warned about this behavior so that they don't create say, two clusters with similar names distinguished only towards the ending such as `verylongclustername1` and `verylongclustername2`. Although these two clusters won't create conflicting resources as they're suffixed by alphanumeric characters, this can still lead to the user getting confused.