### PR TITLE
OCPBUGS-33610: fix API detection, azure bootstrap disk size, and use get to verify endpoint

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -215,7 +215,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
     name                   = "${var.cluster_id}-bootstrap_OSDisk" # os disk name needs to match cluster-api convention
     caching                = "ReadWrite"
     storage_account_type   = var.azure_master_root_volume_type
-    disk_size_gb           = 100
+    disk_size_gb           = 1000
     disk_encryption_set_id = var.azure_master_disk_encryption_set_id
 
     security_encryption_type         = var.azure_master_security_encryption_type

--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -31,6 +31,19 @@ function validate_url() {
         return 1
     fi
 }
+#
+# This functions expects 2 arguments:
+# 1. name of the URL
+# 2. URL to validate
+function validate_get_url() {
+    if [[ $(curl -k --get --silent --fail --write-out "%{http_code}\\n" "${2}" -o /dev/null) == 200 ]]; then
+        echo "Success while trying to reach ${1}'s https endpoint at ${2}"
+        return 0
+    else
+        echo "Unable to reach ${1}'s https endpoint at ${2}"
+        return 1
+    fi
+}
 
 function resolve_url() {
     if [[ -z "${1}" ]] || [[ -z "${2}" ]]; then
@@ -92,7 +105,7 @@ function check_url() {
     CURL_URL="https://${2}:6443/version"
 
     record_service_stage_start ${URL_STAGE_NAME}
-    if validate_url "$URL_TYPE" "$CURL_URL"; then
+    if validate_get_url "$URL_TYPE" "$CURL_URL"; then
         record_service_stage_success
         # Return the value from the validate_url- even on success
         return 0


### PR DESCRIPTION
In some instances we see bootkube.sh completing and writing the bootstrap complete configmap when the script has failed to detect the API servers. There is a separate case where the API up detection can timeout, but the error handling is bypassed.

```
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: Unable to reach API_URL's https endpoint at https://api.kwilczynski-dev2.catchall.azure.devcluster.openshift.com:6443/version
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: Unable to validate. https://api.kwilczynski-dev2.catchall.azure.devcluster.openshift.com:6443/version is currently unreachable.
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: Checking if api-int.kwilczynski-dev2.catchall.azure.devcluster.openshift.com of type API_INT_URL reachable
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: Unable to reach API_INT_URL's https endpoint at https://api-int.kwilczynski-dev2.catchall.azure.devcluster.openshift.com:6443/version
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: Unable to validate. https://api-int.kwilczynski-dev2.catchall.azure.devcluster.openshift.com:6443/version is currently unreachable.
May 08 15:59:54 kwilczynski-dev2-bgvpw-bootstrap bootkube.sh[2748]: bootkube.service complete
```