### PR TITLE
OCPBUGS-33410: attach tag to folder,fix folder destroy

### DIFF
--- a/pkg/destroy/vsphere/client.go
+++ b/pkg/destroy/vsphere/client.go
@@ -185,6 +185,7 @@ func (c *Client) DeleteFolder(ctx context.Context, f mo.Folder) error {
 	defer cancel()
 
 	folder := object.NewFolder(c.client, f.Reference())
+
 	task, err := folder.Destroy(ctx)
 	if err == nil {
 		err = task.Wait(ctx)

--- a/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
@@ -53,6 +53,12 @@ func initializeFoldersAndTemplates(ctx context.Context, cachedImage string, fail
 		return fmt.Errorf("unable to create folder: %w", err)
 	}
 
+	// attach tag to folder
+	err = session.TagManager.AttachTag(ctx, tagID, folderMo.Reference())
+	if err != nil {
+		return fmt.Errorf("unable to attach tag to folder: %w", err)
+	}
+
 	// if the template is empty, the ova must be imported
 	if len(failureDomain.Topology.Template) == 0 {
 		if err = importRhcosOva(ctx, session, folderMo,


### PR DESCRIPTION
We missed tagging a folder while creating the
vsphere infrastucture in the capv/capi flow.

This PR adds the attachment.