### PR TITLE
CORS-3297: Add GCP firewall rule to access bootstrap node via ssh

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -144,6 +144,10 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 		logrus.Debugf("publish strategy is set to external but api address is empty")
 	}
 
+	if err := createBootstrapFirewallRules(ctx, in, *gcpCluster.Status.Network.SelfLink); err != nil {
+		return fmt.Errorf("failed to add bootstrap firewall rule: %w", err)
+	}
+
 	client, err := icgcp.NewClient(context.TODO())
 	if err != nil {
 		return err
@@ -222,7 +226,6 @@ func (p Provider) DestroyBootstrap(dir string) error {
 	if err != nil {
 		return err
 	}
-
 	if err := gcp.DestroyStorage(context.Background(), metadata.ClusterID); err != nil {
 		return fmt.Errorf("failed to destroy storage")
 	}


### PR DESCRIPTION
Add a rule to ssh into the bootstrap node. Node that this rule will need to be deleted when the bootstrap is deleted. The deletion fix depends on https://github.com/openshift/installer/pull/8359 and will be made after that merges.