### PR TITLE
OCPBUGS-33430: Fix CAPI installation typo

### DIFF
--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -205,7 +205,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		}
 	}
 	timer.StopTimer(infrastructureStage)
-	logrus.Info("Netork infrastructure is ready")
+	logrus.Info("Network infrastructure is ready")
 
 	if p, ok := i.impl.(InfraReadyProvider); ok {
 		infraReadyInput := InfraReadyInput{


### PR DESCRIPTION
This is just a minor typo, but since its in an Info message that will appear on every installation, it should be fixed.