### PR TITLE
AGENT-903: monitor-add-nodes should only show CSRs matching node

### DIFF
--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -34,7 +34,22 @@ func main() {
 		Use:   "monitor-add-nodes",
 		Short: "Monitors the configured nodes while they are joining an existing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nodejoiner.NewMonitorAddNodesCommand("")
+			wd, err := os.Getwd()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			kubeConfig, err := cmd.Flags().GetString("kubeconfig")
+			if err != nil {
+				return err
+			}
+
+			ips := args
+			logrus.Infof("Monitoring IPs: %v", ips)
+			if len(ips) == 0 {
+				logrus.Fatal("At least one IP address must be specified")
+			}
+			return nodejoiner.NewMonitorAddNodesCommand(wd, kubeConfig, ips)
 		},
 	}
 
@@ -74,8 +89,9 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		// Overriding it here allows the same check to be done, but against the
 		// hook's output instead of the logger's output.
 		ForceColors:            terminal.IsTerminal(int(os.Stderr.Fd())),
-		DisableTimestamp:       true,
 		DisableLevelTruncation: true,
+		DisableTimestamp:       false,
+		FullTimestamp:          true,
 		DisableQuote:           true,
 	}))
 

--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -34,9 +34,9 @@ func main() {
 		Use:   "monitor-add-nodes",
 		Short: "Monitors the configured nodes while they are joining an existing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			wd, err := os.Getwd()
+			dir, err := cmd.Flags().GetString("dir")
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			kubeConfig, err := cmd.Flags().GetString("kubeconfig")
@@ -49,7 +49,7 @@ func main() {
 			if len(ips) == 0 {
 				logrus.Fatal("At least one IP address must be specified")
 			}
-			return nodejoiner.NewMonitorAddNodesCommand(wd, kubeConfig, ips)
+			return nodejoiner.NewMonitorAddNodesCommand(dir, kubeConfig, ips)
 		},
 	}
 

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -62,8 +63,15 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
+			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			if err != nil {
+				logrus.Exit(exitCodeBootstrapFailed)
+			}
+
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir)
+			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}
@@ -90,8 +98,15 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
+			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			if err != nil {
+				logrus.Exit(exitCodeBootstrapFailed)
+			}
+
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir)
+			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -64,15 +63,8 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
-			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
-
-			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
-			if err != nil {
-				logrus.Exit(exitCodeBootstrapFailed)
-			}
-
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey, workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetDir, "", "", workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}
@@ -99,15 +91,8 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
-			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
-
-			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
-			if err != nil {
-				logrus.Exit(exitCodeBootstrapFailed)
-			}
-
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey, workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetDir, "", "", workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	agentpkg "github.com/openshift/installer/pkg/agent"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
 
 const (
@@ -71,7 +72,7 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 			}
 
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey)
+			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}
@@ -106,7 +107,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 			}
 
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey)
+			cluster, err := agentpkg.NewCluster(ctx, kubeconfigPath, rendezvousIP, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -63,8 +64,15 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
+			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir, "", "", workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetDir, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}
@@ -91,8 +99,15 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				logrus.Fatal("No cluster installation directory found")
 			}
 
+			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir, "", "", workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetDir, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(exitCodeBootstrapFailed)
 			}

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -497,21 +497,9 @@ func (czero *Cluster) humanFriendlyClusterInstallStatus(status string) string {
 		models.ClusterStatusPreparingForInstallation:    "Preparing cluster for installation",
 		models.ClusterStatusReady:                       "Cluster is ready for install",
 	}
-	hostStoppedInstallingStates := map[string]string{
-		models.ClusterStatusAddingHosts:                 "Cluster is adding host",
-		models.ClusterStatusCancelled:                   "Host installation cancelled",
-		models.ClusterStatusError:                       "Host has error(s)",
-		models.ClusterStatusFinalizing:                  "Finalizing host installation",
-		models.ClusterStatusInstalling:                  "Host installation in progress",
-		models.ClusterStatusInstallingPendingUserAction: "Host installation started but now requires user input",
-		models.ClusterStatusInsufficient:                "Host is not ready for install. Check validations",
-		models.ClusterStatusPendingForInput:             "User input is required to continue host installation",
-		models.ClusterStatusPreparingForInstallation:    "Preparing host for installation",
-		models.ClusterStatusReady:                       "Host is ready for install",
-	}
 	switch czero.workflow {
 	case workflow.AgentWorkflowTypeAddNodes:
-		return fmt.Sprintf("Node %s: %s", czero.API.Rest.NodeZeroIP, hostStoppedInstallingStates[status])
+		return fmt.Sprintf("Node %s: %s", czero.API.Rest.NodeZeroIP, clusterStoppedInstallingStates[status])
 	default:
 		return clusterStoppedInstallingStates[status]
 	}

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/gather/ssh"
 )
 
@@ -27,6 +29,7 @@ type Cluster struct {
 	clusterID              *strfmt.UUID
 	clusterInfraEnvID      *strfmt.UUID
 	installHistory         *clusterInstallStatusHistory
+	workflow               workflow.AgentWorkflowType
 }
 
 type clientSet struct {
@@ -63,7 +66,7 @@ type clusterInstallStatusHistory struct {
 }
 
 // NewCluster initializes a Cluster object
-func NewCluster(ctx context.Context, kubeconfigPath, rendezvousIP, sshKey string) (*Cluster, error) {
+func NewCluster(ctx context.Context, kubeconfigPath, rendezvousIP, sshKey string, workflowType workflow.AgentWorkflowType) (*Cluster, error) {
 
 	czero := &Cluster{}
 	capi := &clientSet{}
@@ -108,6 +111,7 @@ func NewCluster(ctx context.Context, kubeconfigPath, rendezvousIP, sshKey string
 
 	czero.Ctx = ctx
 	czero.API = capi
+	czero.workflow = workflowType
 	czero.clusterID = nil
 	czero.clusterInfraEnvID = nil
 	czero.assetDir = kubeconfigPath
@@ -167,7 +171,6 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 		if configmap {
 			logrus.Info("Bootstrap configMap status is complete")
 			czero.installHistory.ClusterBootstrapComplete = true
-			return true, false, nil
 		}
 		if err != nil {
 			logrus.Debug(err)
@@ -176,104 +179,121 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 
 	// Agent Rest API is available
 	if agentRestAPILive {
-
-		// First time we see the agent Rest API
-		if !czero.installHistory.RestAPISeen {
-			logrus.Debug("Agent Rest API Initialized")
-			czero.installHistory.RestAPISeen = true
-			czero.installHistory.NotReadyTime = time.Now()
-		}
-
-		// Lazy loading of the clusterID and clusterInfraEnvID
-		if czero.clusterID == nil {
-			clusterID, err := czero.API.Rest.getClusterID()
-			if err != nil {
-				return false, false, errors.Wrap(err, "Unable to retrieve clusterID from Agent Rest API")
-			}
-			czero.clusterID = clusterID
-		}
-
-		if czero.clusterInfraEnvID == nil {
-			clusterInfraEnvID, err := czero.API.Rest.getClusterInfraEnvID()
-			if err != nil {
-				return false, false, errors.Wrap(err, "Unable to retrieve clusterInfraEnvID from Agent Rest API")
-			}
-			czero.clusterInfraEnvID = clusterInfraEnvID
-		}
-
-		// Getting cluster metadata from Agent Rest API
-		clusterMetadata, err := czero.GetClusterRestAPIMetadata()
+		isBootstrapComplete, exitOnErr, err := czero.LogAssistedServiceStatus()
 		if err != nil {
-			return false, false, errors.Wrap(err, "Unable to retrieve cluster metadata from Agent Rest API")
+			return isBootstrapComplete, exitOnErr, err
 		}
+	}
 
-		if clusterMetadata == nil {
-			return false, false, errors.New("cluster metadata returned nil from Agent Rest API")
+	// cluster bootstrap is not complete
+	return false, false, nil
+}
+
+func (czero *Cluster) LogAssistedServiceStatus() (bool, bool, error) {
+	resource := "cluster"
+	logPrefix := ""
+	if czero.workflow == workflow.AgentWorkflowTypeAddNodes {
+		resource = "host"
+		logPrefix = fmt.Sprintf("Node %s: ", czero.API.Rest.NodeZeroIP)
+	}
+
+	// First time we see the agent Rest API
+	if !czero.installHistory.RestAPISeen {
+		logrus.Debugf("%sAgent Rest API Initialized", logPrefix)
+		czero.installHistory.RestAPISeen = true
+		czero.installHistory.NotReadyTime = time.Now()
+	}
+
+	// Lazy loading of the clusterID and clusterInfraEnvID
+	if czero.clusterID == nil {
+		clusterID, err := czero.API.Rest.getClusterID()
+		if err != nil {
+			return false, false, errors.Wrap(err, "Unable to retrieve clusterID from Agent Rest API")
 		}
+		czero.clusterID = clusterID
+	}
 
-		czero.PrintInstallStatus(clusterMetadata)
+	if czero.clusterInfraEnvID == nil {
+		clusterInfraEnvID, err := czero.API.Rest.getClusterInfraEnvID()
+		if err != nil {
+			return false, false, errors.Wrap(err, "Unable to retrieve clusterInfraEnvID from Agent Rest API")
+		}
+		czero.clusterInfraEnvID = clusterInfraEnvID
+	}
 
-		// If status indicates pending action, log host info to help pinpoint what is missing
-		if (*clusterMetadata.Status != czero.installHistory.RestAPIPreviousClusterStatus) &&
-			(*clusterMetadata.Status == models.ClusterStatusInstallingPendingUserAction) {
-			for _, host := range clusterMetadata.Hosts {
-				if *host.Status == models.ClusterStatusInstallingPendingUserAction {
+	// Getting cluster metadata from Agent Rest API
+	clusterMetadata, err := czero.GetClusterRestAPIMetadata()
+	if err != nil {
+		return false, false, errors.Wrap(err, "Unable to retrieve cluster metadata from Agent Rest API")
+	}
+
+	if clusterMetadata == nil {
+		return false, false, errors.New("cluster metadata returned nil from Agent Rest API")
+	}
+
+	czero.PrintInstallStatus(clusterMetadata)
+
+	// If status indicates pending action, log host info to help pinpoint what is missing
+	if (*clusterMetadata.Status != czero.installHistory.RestAPIPreviousClusterStatus) &&
+		(*clusterMetadata.Status == models.ClusterStatusInstallingPendingUserAction) {
+		for _, host := range clusterMetadata.Hosts {
+			if *host.Status == models.ClusterStatusInstallingPendingUserAction {
+				if logPrefix != "" {
+					logrus.Warningf("%s%s %s", logPrefix, host.RequestedHostname, *host.StatusInfo)
+				} else {
 					logrus.Warningf("Host %s %s", host.RequestedHostname, *host.StatusInfo)
 				}
 			}
 		}
+	}
 
-		if *clusterMetadata.Status == models.ClusterStatusReady {
-			stuck, err := czero.IsClusterStuckInReady()
-			if err != nil {
-				return false, stuck, err
-			}
-		} else {
-			czero.installHistory.NotReadyTime = time.Now()
-		}
-
-		czero.installHistory.RestAPIPreviousClusterStatus = *clusterMetadata.Status
-
-		installing, _ := czero.IsInstalling(*clusterMetadata.Status)
-		if !installing {
-			errored, _ := czero.HasErrored(*clusterMetadata.Status)
-			if errored {
-				return false, false, errors.New("cluster has stopped installing... working to recover installation")
-			} else if *clusterMetadata.Status == models.ClusterStatusCancelled {
-				return false, true, errors.New("cluster installation was cancelled")
-			}
-		}
-
-		validationsErr := checkValidations(clusterMetadata, czero.installHistory.ValidationResults, logrus.StandardLogger())
-		if validationsErr != nil {
-			return false, false, errors.Wrap(validationsErr, "cluster host validations failed")
-
-		}
-
-		// Print most recent event associated with the clusterInfraEnvID
-		eventList, err := czero.API.Rest.GetInfraEnvEvents(czero.clusterInfraEnvID)
+	if *clusterMetadata.Status == models.ClusterStatusReady {
+		stuck, err := czero.IsClusterStuckInReady()
 		if err != nil {
-			return false, false, errors.Wrap(err, "Unable to retrieve events about the cluster from the Agent Rest API")
+			return false, stuck, err
 		}
-		if len(eventList) == 0 {
-			// No cluster events detected from the Agent Rest API
-		} else {
-			mostRecentEvent := eventList[len(eventList)-1]
-			// Don't print the same status message back to back
-			if *mostRecentEvent.Message != czero.installHistory.RestAPIPreviousEventMessage {
-				if *mostRecentEvent.Severity == models.EventSeverityInfo {
-					logrus.Info(*mostRecentEvent.Message)
-				} else {
-					logrus.Warn(*mostRecentEvent.Message)
-				}
-			}
-			czero.installHistory.RestAPIPreviousEventMessage = *mostRecentEvent.Message
-			czero.installHistory.RestAPIInfraEnvEventList = eventList
+	} else {
+		czero.installHistory.NotReadyTime = time.Now()
+	}
+
+	czero.installHistory.RestAPIPreviousClusterStatus = *clusterMetadata.Status
+
+	installing, _ := czero.IsInstalling(*clusterMetadata.Status)
+	if !installing {
+		errored, _ := czero.HasErrored(*clusterMetadata.Status)
+		if errored {
+			return false, false, errors.New(fmt.Sprintf("%s has stopped installing... working to recover installation", resource))
+		} else if *clusterMetadata.Status == models.ClusterStatusCancelled {
+			return false, true, errors.New(fmt.Sprintf("%s installation was cancelled", resource))
 		}
+	}
+
+	validationsErr := checkValidations(clusterMetadata, czero.installHistory.ValidationResults, logrus.StandardLogger(), logPrefix)
+	if validationsErr != nil {
+		return false, false, errors.Wrap(validationsErr, "host validations failed")
 
 	}
 
-	// cluster bootstrap is not complete
+	// Print most recent event associated with the clusterInfraEnvID
+	eventList, err := czero.API.Rest.GetInfraEnvEvents(czero.clusterInfraEnvID)
+	if err != nil {
+		return false, false, errors.Wrap(err, fmt.Sprintf("Unable to retrieve events about the %s from the Agent Rest API", resource))
+	}
+	if len(eventList) == 0 {
+		// No cluster events detected from the Agent Rest API
+	} else {
+		mostRecentEvent := eventList[len(eventList)-1]
+		// Don't print the same status message back to back
+		if *mostRecentEvent.Message != czero.installHistory.RestAPIPreviousEventMessage {
+			if *mostRecentEvent.Severity == models.EventSeverityInfo {
+				logrus.Infof("%s%s", logPrefix, *mostRecentEvent.Message)
+			} else {
+				logrus.Warnf("%s%s", logPrefix, *mostRecentEvent.Message)
+			}
+		}
+		czero.installHistory.RestAPIPreviousEventMessage = *mostRecentEvent.Message
+		czero.installHistory.RestAPIInfraEnvEventList = eventList
+	}
 	return false, false, nil
 }
 
@@ -431,7 +451,7 @@ func (czero *Cluster) PrintInstallationComplete() error {
 // PrintInstallStatus Print a human friendly message using the models from the Agent Rest API.
 func (czero *Cluster) PrintInstallStatus(cluster *models.Cluster) error {
 
-	friendlyStatus := humanFriendlyClusterInstallStatus(*cluster.Status)
+	friendlyStatus := czero.humanFriendlyClusterInstallStatus(*cluster.Status)
 	// Don't print the same status message back to back
 	if *cluster.Status != czero.installHistory.RestAPIPreviousClusterStatus {
 		logrus.Info(friendlyStatus)
@@ -453,7 +473,7 @@ func (czero *Cluster) CanSSHToNodeZero() bool {
 }
 
 // Human friendly install status strings mapped to the Agent Rest API cluster statuses
-func humanFriendlyClusterInstallStatus(status string) string {
+func (czero *Cluster) humanFriendlyClusterInstallStatus(status string) string {
 	clusterStoppedInstallingStates := map[string]string{
 		models.ClusterStatusAddingHosts:                 "Cluster is adding hosts",
 		models.ClusterStatusCancelled:                   "Cluster installation cancelled",
@@ -466,6 +486,22 @@ func humanFriendlyClusterInstallStatus(status string) string {
 		models.ClusterStatusPreparingForInstallation:    "Preparing cluster for installation",
 		models.ClusterStatusReady:                       "Cluster is ready for install",
 	}
-	return clusterStoppedInstallingStates[status]
-
+	hostStoppedInstallingStates := map[string]string{
+		models.ClusterStatusAddingHosts:                 "Cluster is adding host",
+		models.ClusterStatusCancelled:                   "Host installation cancelled",
+		models.ClusterStatusError:                       "Host has error(s)",
+		models.ClusterStatusFinalizing:                  "Finalizing host installation",
+		models.ClusterStatusInstalling:                  "Host installation in progress",
+		models.ClusterStatusInstallingPendingUserAction: "Host installation started but now requires user input",
+		models.ClusterStatusInsufficient:                "Host is not ready for install. Check validations",
+		models.ClusterStatusPendingForInput:             "User input is required to continue host installation",
+		models.ClusterStatusPreparingForInstallation:    "Preparing host for installation",
+		models.ClusterStatusReady:                       "Host is ready for install",
+	}
+	switch czero.workflow {
+	case workflow.AgentWorkflowTypeAddNodes:
+		return fmt.Sprintf("Node %s: %s", czero.API.Rest.NodeZeroIP, hostStoppedInstallingStates[status])
+	default:
+		return clusterStoppedInstallingStates[status]
+	}
 }

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -63,21 +63,21 @@ type clusterInstallStatusHistory struct {
 }
 
 // NewCluster initializes a Cluster object
-func NewCluster(ctx context.Context, assetDir string) (*Cluster, error) {
+func NewCluster(ctx context.Context, kubeconfigPath, rendezvousIP, sshKey string) (*Cluster, error) {
 
 	czero := &Cluster{}
 	capi := &clientSet{}
 
-	restclient, err := NewNodeZeroRestClient(ctx, assetDir)
+	restclient, err := NewNodeZeroRestClient(ctx, rendezvousIP, sshKey)
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	kubeclient, err := NewClusterKubeAPIClient(ctx, assetDir)
+	kubeclient, err := NewClusterKubeAPIClient(ctx, kubeconfigPath)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
-	ocpclient, err := NewClusterOpenShiftAPIClient(ctx, assetDir)
+	ocpclient, err := NewClusterOpenShiftAPIClient(ctx, kubeconfigPath)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func NewCluster(ctx context.Context, assetDir string) (*Cluster, error) {
 	czero.API = capi
 	czero.clusterID = nil
 	czero.clusterInfraEnvID = nil
-	czero.assetDir = assetDir
+	czero.assetDir = kubeconfigPath
 	czero.clusterConsoleRouteURL = ""
 	czero.installHistory = cinstallstatushistory
 	czero.installHistory.ValidationResults = cvalidationresults

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -201,6 +201,8 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 	return false, false, nil
 }
 
+// LogAssistedServiceStatus logs validations and events from
+// Assisted Service.
 func (czero *Cluster) LogAssistedServiceStatus() (bool, bool, error) {
 	resource := "cluster"
 	logPrefix := ""
@@ -274,9 +276,9 @@ func (czero *Cluster) LogAssistedServiceStatus() (bool, bool, error) {
 	if !installing {
 		errored, _ := czero.HasErrored(*clusterMetadata.Status)
 		if errored {
-			return false, false, errors.New(fmt.Sprintf("%s has stopped installing... working to recover installation", resource))
+			return false, false, fmt.Errorf("%s has stopped installing... working to recover installation", resource)
 		} else if *clusterMetadata.Status == models.ClusterStatusCancelled {
-			return false, true, errors.New(fmt.Sprintf("%s installation was cancelled", resource))
+			return false, true, fmt.Errorf("%s installation was cancelled", resource)
 		}
 	}
 
@@ -461,15 +463,12 @@ func (czero *Cluster) PrintInstallationComplete() error {
 }
 
 // PrintInstallStatus Print a human friendly message using the models from the Agent Rest API.
-func (czero *Cluster) PrintInstallStatus(cluster *models.Cluster) error {
-
+func (czero *Cluster) PrintInstallStatus(cluster *models.Cluster) {
 	friendlyStatus := czero.humanFriendlyClusterInstallStatus(*cluster.Status)
 	// Don't print the same status message back to back
 	if *cluster.Status != czero.installHistory.RestAPIPreviousClusterStatus {
 		logrus.Info(friendlyStatus)
 	}
-
-	return nil
 }
 
 // CanSSHToNodeZero Checks if ssh to NodeZero succeeds.

--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -8,7 +8,6 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	certificatesClient "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	"k8s.io/client-go/rest"
@@ -68,7 +67,7 @@ func (kube *ClusterKubeAPIClient) DoesKubeConfigExist() (bool, error) {
 // IsBootstrapConfigMapComplete Detemine if the cluster's bootstrap configmap has the status complete.
 func (kube *ClusterKubeAPIClient) IsBootstrapConfigMapComplete() (bool, error) {
 	// Get latest version of bootstrap configmap
-	bootstrap, err := kube.Client.CoreV1().ConfigMaps("kube-system").Get(kube.ctx, "bootstrap", v1.GetOptions{})
+	bootstrap, err := kube.Client.CoreV1().ConfigMaps("kube-system").Get(kube.ctx, "bootstrap", metav1.GetOptions{})
 
 	if err != nil {
 		// bootstrap configmap not found

--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -21,11 +20,10 @@ type ClusterKubeAPIClient struct {
 }
 
 // NewClusterKubeAPIClient Create a new kube client to interact with the cluster under install.
-func NewClusterKubeAPIClient(ctx context.Context, assetDir string) (*ClusterKubeAPIClient, error) {
+func NewClusterKubeAPIClient(ctx context.Context, kubeconfigPath string) (*ClusterKubeAPIClient, error) {
 	kubeClient := &ClusterKubeAPIClient{}
 
-	kubeconfigpath := filepath.Join(assetDir, "auth", "kubeconfig")
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigpath)
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading kubeconfig from assets")
 	}
@@ -38,7 +36,7 @@ func NewClusterKubeAPIClient(ctx context.Context, assetDir string) (*ClusterKube
 	kubeClient.Client = kubeclient
 	kubeClient.ctx = ctx
 	kubeClient.config = kubeconfig
-	kubeClient.configPath = kubeconfigpath
+	kubeClient.configPath = kubeconfigPath
 
 	return kubeClient, nil
 }

--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -104,21 +104,3 @@ func (kube *ClusterKubeAPIClient) ListCSRs() (*certificatesv1.CertificateSigning
 	}
 	return csrs, nil
 }
-
-func (kube *ClusterKubeAPIClient) getCSRsPendingApproval(signerName string) []certificatesv1.CertificateSigningRequest {
-	csrs, err := kube.ListCSRs()
-	if err != nil {
-		logrus.Debugf("error calling listCSRs(): %v ", err)
-	}
-
-	var matchedCSRs []certificatesv1.CertificateSigningRequest
-	for _, csr := range csrs.Items {
-		if len(csr.Status.Conditions) == 0 {
-			// CSR is Pending and awaiting approval
-			if csr.Spec.SignerName == signerName {
-				matchedCSRs = append(matchedCSRs, csr)
-			}
-		}
-	}
-	return matchedCSRs
-}

--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -104,3 +104,21 @@ func (kube *ClusterKubeAPIClient) ListCSRs() (*certificatesv1.CertificateSigning
 	}
 	return csrs, nil
 }
+
+func (kube *ClusterKubeAPIClient) getCSRsPendingApproval(signerName string) []certificatesv1.CertificateSigningRequest {
+	csrs, err := kube.ListCSRs()
+	if err != nil {
+		logrus.Debugf("error calling listCSRs(): %v ", err)
+	}
+
+	var matchedCSRs []certificatesv1.CertificateSigningRequest
+	for _, csr := range csrs.Items {
+		if len(csr.Status.Conditions) == 0 {
+			// CSR is Pending and awaiting approval
+			if csr.Spec.SignerName == signerName {
+				matchedCSRs = append(matchedCSRs, csr)
+			}
+		}
+	}
+	return matchedCSRs
+}

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -2,19 +2,16 @@ package agent
 
 import (
 	"context"
-	"io"
+	"fmt"
 	"net"
-	"strconv"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	gatherssh "github.com/openshift/installer/pkg/gather/ssh"
 )
 
 type addNodeState int
@@ -22,25 +19,8 @@ type addNodeState int
 // The node states that we observe and report.
 const (
 	InitialState addNodeState = iota
-	WaitingForInitialBoot
-	NodeBootedAndSSHIsUp
-	WaitingForAssistedService
 	AssistedServiceIsUp
-	AssistedServiceFailedToStart // terminal state
-	ClusterIsImported
-	ClusterImportedFailed // terminal state
-	InfraenvIsRegistered
-	InfraenvRegisterFailed // terminal state
-	HostConfigsApplied
-	HostConfigsApplyFailed // terminal state
-	WaitingForHostToBeReady
-	HostHasErrors // terminal state, host does not pass validation or has some other error
-	HostInstallationStarted
-	CoreosInstallerWritingToDisk
-	HostPreparingForFirstReboot
-	AfterFirstReboot
-	AfterSecondReboot
-	AfterSecondRebootKubeletIsUp
+	KubeletIsRunningOnNode
 	FirstCSRPendingApproval
 	SecondCSRPendingApproval
 	NodeJoinedClusterStatusNotReady
@@ -49,27 +29,10 @@ const (
 
 var stateNameMap = map[int]string{
 	int(InitialState):                    "Initial State",
-	int(WaitingForInitialBoot):           "Waiting for node to boot",
-	int(NodeBootedAndSSHIsUp):            "Node booted and SSH is up",
-	int(WaitingForAssistedService):       "Waiting for Assisted Service to start",
 	int(AssistedServiceIsUp):             "Assisted Service API is available",
-	int(AssistedServiceFailedToStart):    "Assisted Service API failed to start",
-	int(ClusterIsImported):               "Cluster imported into Assisted Service",
-	int(ClusterImportedFailed):           "Cluster import failed, check agent-import-cluster.service",
-	int(InfraenvIsRegistered):            "InfraEnv registered into Assisted Service",
-	int(InfraenvRegisterFailed):          "Failed to register InfraEnv into Assisted Service",
-	int(HostConfigsApplied):              "Host configurations (if any) applied",
-	int(HostConfigsApplyFailed):          "Failed to apply host configurations",
-	int(WaitingForHostToBeReady):         "Waiting for host validations to complete",
-	int(HostHasErrors):                   "Host has errors, node cannot be added until errors are corrected",
-	int(HostInstallationStarted):         "Host installation started",
-	int(CoreosInstallerWritingToDisk):    "Installer is initializing disk",
-	int(HostPreparingForFirstReboot):     "Host preparing to reboot",
-	int(AfterFirstReboot):                "Node completed reboot 1 of 2",
-	int(AfterSecondReboot):               "Node completed reboot 2 of 2",
-	int(AfterSecondRebootKubeletIsUp):    "Kubelet is running",
-	int(FirstCSRPendingApproval):         "1st CSR Pending approval",
-	int(SecondCSRPendingApproval):        "2nd CSR Pending approval",
+	int(KubeletIsRunningOnNode):          "Kubelet is running",
+	int(FirstCSRPendingApproval):         "First CSR Pending approval",
+	int(SecondCSRPendingApproval):        "Second CSR Pending approval",
 	int(NodeJoinedClusterStatusNotReady): "Node joined cluster and status is NotReady",
 	int(Finish):                          "Node is Ready",
 }
@@ -79,165 +42,46 @@ type checkFunction func(nodeMonitor *addNodeMonitor)
 type checkFunctions map[int]checkFunction
 
 var defaultChecks = checkFunctions{
-	int(WaitingForInitialBoot): func(mon *addNodeMonitor) {
-		if mon.in(InitialState) &&
-			!mon.canSSHToNode() {
-			mon.setState(WaitingForInitialBoot)
-		}
-	},
-	int(NodeBootedAndSSHIsUp): func(mon *addNodeMonitor) {
-		if mon.before(NodeBootedAndSSHIsUp) &&
-			mon.canSSHToNode() {
-			mon.setState(NodeBootedAndSSHIsUp)
-		}
-	},
-	int(WaitingForAssistedService): func(mon *addNodeMonitor) {
-		if mon.before(WaitingForAssistedService) &&
-			mon.nodeCommandOutputContains("ls -l /etc/systemd/system/assisted-service.service", "assisted-service.service") {
-			mon.setState(WaitingForAssistedService)
-		}
-	},
 	int(AssistedServiceIsUp): func(mon *addNodeMonitor) {
-		if mon.in(WaitingForAssistedService) &&
-			mon.nodeCommandOutputContains("sudo podman ps -a", "assisted-service") {
+		if mon.in(InitialState) &&
+			mon.cluster.API.Rest.IsRestAPILive() {
 			mon.setState(AssistedServiceIsUp)
 		}
 	},
-	int(AssistedServiceFailedToStart): func(mon *addNodeMonitor) {
-		if mon.in(WaitingForAssistedService) &&
-			mon.nodeCommandOutputContains("systemctl status assisted-service", "FAILURE") {
-			mon.setState(AssistedServiceFailedToStart)
-		}
-	},
-	int(ClusterIsImported): func(mon *addNodeMonitor) {
-		if mon.in(AssistedServiceIsUp) &&
-			mon.nodeCommandOutputContains("systemctl status agent-import-cluster", "Imported cluster with id:") {
-			mon.setState(ClusterIsImported)
-		}
-	},
-	int(ClusterImportedFailed): func(mon *addNodeMonitor) {
-		// Can simulate this by attempting to add a node using version 4.15 where
-		// the ABI CLI does not have the importcluster subcommand
-		if mon.in(AssistedServiceIsUp) &&
-			mon.nodeCommandOutputContains("systemctl status agent-import-cluster", "FAILURE") {
-			mon.setState(ClusterImportedFailed)
-		}
-	},
-	int(InfraenvIsRegistered): func(mon *addNodeMonitor) {
-		if mon.in(ClusterIsImported) &&
-			mon.nodeCommandOutputContains("systemctl status agent-register-infraenv", "Registered infraenv with id:") {
-			mon.setState(InfraenvIsRegistered)
-		}
-	},
-	int(InfraenvRegisterFailed): func(mon *addNodeMonitor) {
-		if mon.in(ClusterIsImported) &&
-			mon.nodeCommandOutputContains("systemctl status agent-register-infraenv", "FAILURE") {
-			mon.setState(InfraenvRegisterFailed)
-		}
-	},
-	int(HostConfigsApplied): func(mon *addNodeMonitor) {
-		if mon.in(InfraenvIsRegistered) &&
-			mon.nodeCommandOutputContains("systemctl status apply-host-config", "Finished Service") {
-			mon.setState(HostConfigsApplied)
-		}
-	},
-	int(HostConfigsApplyFailed): func(mon *addNodeMonitor) {
-		if mon.in(InfraenvIsRegistered) &&
-			mon.nodeCommandOutputContains("systemctl status apply-host-config", "FAILURE") {
-			mon.setState(HostConfigsApplyFailed)
-		}
-	},
-	int(WaitingForHostToBeReady): func(mon *addNodeMonitor) {
-		if mon.in(HostConfigsApplied) &&
-			mon.nodeCommandOutputContains("sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status from hosts'", "insufficient") {
-			mon.setState(WaitingForHostToBeReady)
-		}
-	},
-	int(HostHasErrors): func(mon *addNodeMonitor) {
-		if mon.in(WaitingForHostToBeReady) &&
-			mon.nodeCommandOutputContains("systemctl status agent-add-node", "FAILURE") {
-			mon.setState(HostHasErrors)
-		}
-	},
-	int(HostInstallationStarted): func(mon *addNodeMonitor) {
-		if mon.in(WaitingForHostToBeReady) &&
-			// Or
-			// sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status from hosts'
-			// and status will show "installing"
-			mon.nodeCommandOutputContains("systemctl status agent-add-node", "Host installation started") {
-			mon.setState(HostInstallationStarted)
-		}
-	},
-	int(CoreosInstallerWritingToDisk): func(mon *addNodeMonitor) {
-		if mon.in(HostInstallationStarted) &&
-			mon.nodeCommandOutputContains("ps -ef | grep coreos-installer", "coreos-installer") {
-			mon.setState(CoreosInstallerWritingToDisk)
-		}
-	},
-	int(HostPreparingForFirstReboot): func(mon *addNodeMonitor) {
-		if mon.in(CoreosInstallerWritingToDisk) &&
-			!mon.cluster.CanSSHToNodeZero() {
-			mon.setState(HostPreparingForFirstReboot)
-		}
-	},
-	int(AfterFirstReboot): func(mon *addNodeMonitor) {
-		if mon.before(AfterFirstReboot) &&
-			mon.nodeCommandOutputContains("ps -ef", "ostree") {
-			mon.setState(AfterFirstReboot)
-		}
-	},
-	int(AfterSecondReboot): func(mon *addNodeMonitor) {
-		if mon.before(AfterSecondRebootKubeletIsUp) &&
-			mon.nodeCommandOutputContains("ps -ef", "coredns") {
-			mon.setState(AfterSecondReboot)
-		}
-	},
-	int(AfterSecondRebootKubeletIsUp): func(mon *addNodeMonitor) {
-		if mon.onOrAfter(AfterSecondReboot) &&
-			mon.before(FirstCSRPendingApproval) &&
-			mon.nodeCommandOutputContains("ps -ef", "kubelet") {
-			mon.setState(AfterSecondRebootKubeletIsUp)
+	int(KubeletIsRunningOnNode): func(mon *addNodeMonitor) {
+		if mon.onOrBefore(KubeletIsRunningOnNode) &&
+			mon.isKubeletRunningOnNode() {
+			mon.setState(KubeletIsRunningOnNode)
 		}
 	},
 	int(FirstCSRPendingApproval): func(mon *addNodeMonitor) {
-		if mon.onOrAfter(AfterSecondReboot) &&
-			mon.onOrBefore(FirstCSRPendingApproval) &&
-			mon.nodeCommandOutputContains("sudo KUBECONFIG=/etc/kubernetes/kubeconfig oc get csr | grep Pending", "node-bootstrapper") {
+		if mon.onOrAfter(KubeletIsRunningOnNode) &&
+			mon.clusterHasFirstCSRPending() {
 			mon.setState(FirstCSRPendingApproval)
-			mon.logCSRsPendingApproval()
 		}
 	},
 	int(SecondCSRPendingApproval): func(mon *addNodeMonitor) {
-		if mon.onOrAfter(AfterSecondReboot) &&
-			mon.onOrBefore(SecondCSRPendingApproval) &&
-			mon.nodeCommandOutputContains("sudo KUBECONFIG=/etc/kubernetes/kubeconfig oc get csr | grep Pending", "system:node") {
+		if mon.onOrAfter(KubeletIsRunningOnNode) &&
+			mon.clusterHasSecondCSRPending() {
 			mon.setState(SecondCSRPendingApproval)
-			mon.logCSRsPendingApproval()
 		}
 	},
 	int(NodeJoinedClusterStatusNotReady): func(mon *addNodeMonitor) {
-		if mon.in(AfterSecondRebootKubeletIsUp) ||
-			mon.in(SecondCSRPendingApproval) {
-			hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
-			if err != nil {
-				logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
-			}
-			if hasJoined && !isReady {
-				mon.setState(NodeJoinedClusterStatusNotReady)
-			}
+		hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
+		if err != nil {
+			logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
+		}
+		if hasJoined && !isReady {
+			mon.setState(NodeJoinedClusterStatusNotReady)
 		}
 	},
 	int(Finish): func(mon *addNodeMonitor) {
-		if mon.in(AfterSecondRebootKubeletIsUp) ||
-			mon.in(SecondCSRPendingApproval) ||
-			mon.in(NodeJoinedClusterStatusNotReady) {
-			hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
-			if err != nil {
-				logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
-			}
-			if hasJoined && isReady {
-				mon.setState(Finish)
-			}
+		hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
+		if err != nil {
+			logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
+		}
+		if hasJoined && isReady {
+			mon.setState(Finish)
 		}
 	},
 }
@@ -245,6 +89,11 @@ var defaultChecks = checkFunctions{
 // MonitorAddNodes waits for the a node to be added to the cluster
 // and reports its status until it becomes Ready.
 func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
+	parsedIPAddress := net.ParseIP(nodeIPAddress)
+	if parsedIPAddress == nil {
+		return fmt.Errorf("%s is not valid IP Address", nodeIPAddress)
+	}
+
 	timeout := 90 * time.Minute
 	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
 	defer cancel()
@@ -252,8 +101,7 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 	mon := newAddNodeMonitor(nodeIPAddress, cluster)
 
 	wait.Until(func() {
-		if mon.onOrAfter(AssistedServiceIsUp) &&
-			mon.onOrBefore(HostInstallationStarted) {
+		if mon.cluster.API.Rest.IsRestAPILive() {
 			_, _, err := cluster.LogAssistedServiceStatus()
 			if err != nil {
 				logrus.Warnf("Node %s: %s", nodeIPAddress, err)
@@ -269,20 +117,19 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 			}
 		}
 
+		if mon.clusterHasFirstCSRPending() || mon.clusterHasSecondCSRPending() {
+			// TODO? The CSRs have no IP address to identify for which
+			// node it is for, so it is possible to log CSRs pending for
+			// other nodes.
+			mon.logCSRsPendingApproval()
+		}
+
 		if mon.in(Finish) {
 			// TODO: There appears to be a bug where the node becomes Ready
 			// before second CSR is approved. Log Pending CSRs for now, so users
 			// are aware there are still some waiting their approval even
 			// though the node status is Ready.
 			mon.logCSRsPendingApproval()
-			cancel()
-		}
-
-		if mon.in(AssistedServiceFailedToStart) ||
-			mon.in(ClusterImportedFailed) ||
-			mon.in(InfraenvRegisterFailed) ||
-			mon.in(HostConfigsApplyFailed) ||
-			mon.in(HostHasErrors) {
 			cancel()
 		}
 	}, 5*time.Second, waitContext.Done())
@@ -323,10 +170,6 @@ func (mon *addNodeMonitor) in(state addNodeState) bool {
 	return mon.currentState == state
 }
 
-func (mon *addNodeMonitor) before(state addNodeState) bool {
-	return mon.currentState < state
-}
-
 func (mon *addNodeMonitor) onOrBefore(state addNodeState) bool {
 	return mon.currentState <= state
 }
@@ -337,10 +180,6 @@ func (mon *addNodeMonitor) onOrAfter(state addNodeState) bool {
 
 func (mon *addNodeMonitor) currentStateName() string {
 	return stateNameMap[int(mon.currentState)]
-}
-
-func (mon *addNodeMonitor) canSSHToNode() bool {
-	return mon.cluster.CanSSHToNodeZero()
 }
 
 func (mon *addNodeMonitor) nodeHasJoinedClusterAndIsReady() (bool, bool, error) {
@@ -398,64 +237,36 @@ func (mon *addNodeMonitor) logCSRsPendingApproval() {
 	}
 }
 
-func (mon *addNodeMonitor) sshClient() (*ssh.Client, error) {
-	ip := mon.nodeIPAddress
-	port := 22
-
-	client, err := gatherssh.NewClient("core", net.JoinHostPort(ip, strconv.Itoa(port)), mon.cluster.API.Rest.NodeSSHKey)
-	if err != nil {
-		logrus.Debugf("Failed to create SSH client to %s: %s", ip, err)
-	}
-	return client, err
+func (mon *addNodeMonitor) clusterHasFirstCSRPending() bool {
+	return len(mon.cluster.API.Kube.getCSRsPendingApproval("kubernetes.io/kube-apiserver-client-kubelet")) > 0
 }
 
-func (mon *addNodeMonitor) nodeCommandOutputContains(command, stringToMatchInOutput string) bool {
-	sshClient, err := mon.sshClient()
+func (mon *addNodeMonitor) clusterHasSecondCSRPending() bool {
+	return len(mon.cluster.API.Kube.getCSRsPendingApproval("kubernetes.io/kubelet-serving")) > 0
+}
+
+// isKubeletRunningOnNode checks if kubelet responds
+// to http. Even if kubelet responds with error like
+// TLS errors, kubelet is considered running.
+func (mon *addNodeMonitor) isKubeletRunningOnNode() bool {
+	url := fmt.Sprintf("https://%s:10250/metrics", mon.nodeIPAddress)
+	// http get without authentication
+	resp, err := http.Get(url) //nolint mon.nodeIPAddress is prevalidated to be IP address
 	if err != nil {
-		logrus.Debugf("Failed to create SSH client to %s: %s", mon.nodeIPAddress, err)
-		return false
-	}
-
-	logrus.Debugf("sshCommandOutputContains command: %v ", command)
-
-	// Create an SSH session
-	session, err := sshClient.NewSession()
-	if err != nil {
-		logrus.Debugf("failed to create session: %s", err)
-		return false
-	}
-	defer session.Close()
-
-	// Run the command on the remote machine
-	stdout, err := session.StdoutPipe()
-	if err != nil {
-		logrus.Debugf("failed to get stdout: %s", err)
-		return false
-	}
-
-	if err := session.Start(command); err != nil {
-		logrus.Debugf("failed to start command: %s", err)
-		return false
-	}
-
-	output, err := io.ReadAll(stdout)
-	if err != nil {
-		logrus.Debugf("failed to read stdout: %s", err)
-		return false
-	}
-
-	if err := session.Wait(); err != nil {
-		if strings.Contains(err.Error(), "Process exited with status") {
-			// command finished with exit code other than 0
-			// which could happen in the case where "systemctl status"
-			// shows service is in failed state and exits with code 3.
-		} else {
-			logrus.Debugf("command failed: %s output: %v", err, string(output))
+		logrus.Debugf("kubelet http err: %v", err)
+		if strings.Contains(err.Error(), "remote error: tls: internal error") {
+			// nodes being added will return this error
+			return true
+		}
+		if strings.Contains(err.Error(), "tls: failed to verify certificate: x509: certificate signed by unknown authority") {
+			// existing control plane nodes returns this error
+			return true
+		}
+		if strings.Contains(err.Error(), "connect: no route to host") {
 			return false
 		}
+	} else {
+		logrus.Debugf("kubelet http status code: %v", resp.StatusCode)
 	}
-
-	logrus.Debugf("sshCommandOutputContains command: %v output: \n %v", command, string(output))
-
-	return strings.Contains(string(output), stringToMatchInOutput)
+	return false
 }

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -252,6 +252,12 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 	mon := newAddNodeMonitor(nodeIPAddress, cluster)
 
 	wait.Until(func() {
+
+		if mon.onOrAfter(AssistedServiceIsUp) &&
+			mon.onOrBefore(HostInstallationStarted) {
+			cluster.LogAssistedServiceStatus()
+		}
+
 		for _, checkFunc := range defaultChecks {
 			lastState := mon.currentState
 			checkFunc(mon)

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -102,7 +102,7 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 
 	wait.Until(func() {
 		if mon.cluster.API.Rest.IsRestAPILive() {
-			_, _, err := cluster.LogAssistedServiceStatus()
+			_, err := cluster.MonitorStatusFromAssistedService()
 			if err != nil {
 				logrus.Warnf("Node %s: %s", nodeIPAddress, err)
 			}

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -1,0 +1,426 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	gatherssh "github.com/openshift/installer/pkg/gather/ssh"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type addNodeState int
+
+// The node states that we observe and report.
+const (
+	InitialState addNodeState = iota
+	WaitingForInitialBoot
+	NodeBootedAndSSHIsUp
+	WaitingForAssistedService
+	AssistedServiceIsUp
+	AssistedServiceFailedToStart // terminal state
+	ClusterIsImported
+	ClusterImportedFailed // terminal state
+	InfraenvIsRegistered
+	InfraenvRegisterFailed // terminal state
+	HostConfigsApplied
+	HostConfigsApplyFailed // terminal state
+	WaitingForHostToBeReady
+	HostHasErrors // terminal state, host does not pass validation or has some other error
+	HostInstallationStarted
+	CoreosInstallerWritingToDisk
+	HostPreparingForFirstReboot
+	AfterFirstReboot
+	AfterSecondReboot
+	AfterSecondRebootKubeletIsUp
+	FirstCSRPendingApproval
+	SecondCSRPendingApproval
+	NodeJoinedClusterStatusNotReady
+	Finish // terminal state
+)
+
+var stateNameMap = map[int]string{
+	int(InitialState):                    "Initial State",
+	int(WaitingForInitialBoot):           "Waiting for node to boot",
+	int(NodeBootedAndSSHIsUp):            "Node booted and SSH is up",
+	int(WaitingForAssistedService):       "Waiting for Assisted Service to start",
+	int(AssistedServiceIsUp):             "Assisted Service API is available",
+	int(AssistedServiceFailedToStart):    "Assisted Service API failed to start",
+	int(ClusterIsImported):               "Cluster imported into Assisted Service",
+	int(ClusterImportedFailed):           "Cluster import failed, check agent-import-cluster.service",
+	int(InfraenvIsRegistered):            "InfraEnv registered into Assisted Service",
+	int(InfraenvRegisterFailed):          "Failed to register InfraEnv into Assisted Service",
+	int(HostConfigsApplied):              "Host configurations (if any) applied",
+	int(HostConfigsApplyFailed):          "Failed to apply host configurations",
+	int(WaitingForHostToBeReady):         "Waiting for host validations to complete",
+	int(HostHasErrors):                   "Host has errors, node cannot be added until errors are corrected",
+	int(HostInstallationStarted):         "Host installation started",
+	int(CoreosInstallerWritingToDisk):    "Installer is initializing disk",
+	int(HostPreparingForFirstReboot):     "Host preparing to reboot",
+	int(AfterFirstReboot):                "Node completed reboot 1 of 2",
+	int(AfterSecondReboot):               "Node completed reboot 2 of 2",
+	int(AfterSecondRebootKubeletIsUp):    "Kubelet is running",
+	int(FirstCSRPendingApproval):         "1st CSR Pending approval",
+	int(SecondCSRPendingApproval):        "2nd CSR Pending approval",
+	int(NodeJoinedClusterStatusNotReady): "Node joined cluster and status is NotReady",
+	int(Finish):                          "Node is Ready",
+}
+
+type addNodeMonitor struct {
+	nodeIP       string
+	cluster      *Cluster
+	currentState addNodeState
+}
+
+func newAddNodeMonitor(nodeIP string, cluster *Cluster) *addNodeMonitor {
+	mon := addNodeMonitor{
+		nodeIP:       nodeIP,
+		cluster:      cluster,
+		currentState: InitialState,
+	}
+	return &mon
+}
+
+type checkFunction func(nodeMonitor *addNodeMonitor)
+
+type checkFunctions map[int]checkFunction
+
+var defaultChecks = checkFunctions{
+	int(WaitingForInitialBoot): func(mon *addNodeMonitor) {
+		if mon.currentState == InitialState &&
+			!mon.cluster.CanSSHToNodeZero() {
+			mon.currentState = WaitingForInitialBoot
+		}
+	},
+	int(NodeBootedAndSSHIsUp): func(mon *addNodeMonitor) {
+		if mon.currentState < NodeBootedAndSSHIsUp &&
+			mon.cluster.CanSSHToNodeZero() {
+			mon.currentState = NodeBootedAndSSHIsUp
+		}
+	},
+	int(WaitingForAssistedService): func(mon *addNodeMonitor) {
+		if mon.currentState < WaitingForAssistedService &&
+			mon.cluster.sshCommandOutputContains("ls -l /etc/systemd/system/assisted-service.service", "assisted-service.service") {
+			mon.currentState = WaitingForAssistedService
+		}
+	},
+	int(AssistedServiceIsUp): func(mon *addNodeMonitor) {
+		if mon.currentState == WaitingForAssistedService &&
+			mon.cluster.sshCommandOutputContains("sudo podman ps -a", "assisted-service") {
+			mon.currentState = AssistedServiceIsUp
+		}
+	},
+	int(AssistedServiceFailedToStart): func(mon *addNodeMonitor) {
+		if mon.currentState == WaitingForAssistedService &&
+			mon.cluster.sshCommandOutputContains("systemctl status assisted-service", "FAILURE") {
+			mon.currentState = AssistedServiceFailedToStart
+		}
+	},
+	int(ClusterIsImported): func(mon *addNodeMonitor) {
+		if mon.currentState == AssistedServiceIsUp &&
+			mon.cluster.sshCommandOutputContains("systemctl status agent-import-cluster", "Imported cluster with id:") {
+			mon.currentState = ClusterIsImported
+		}
+	},
+	int(ClusterImportedFailed): func(mon *addNodeMonitor) {
+		// Can simulate this by attempting to add a node using version 4.15 where
+		// the ABI CLI does not have the importcluster subcommand
+		if mon.currentState == AssistedServiceIsUp &&
+			mon.cluster.sshCommandOutputContains("systemctl status agent-import-cluster", "FAILURE") {
+			mon.currentState = ClusterImportedFailed
+		}
+	},
+	int(InfraenvIsRegistered): func(mon *addNodeMonitor) {
+		if mon.currentState == ClusterIsImported &&
+			mon.cluster.sshCommandOutputContains("systemctl status agent-register-infraenv", "Registered infraenv with id:") {
+			mon.currentState = InfraenvIsRegistered
+		}
+	},
+	int(InfraenvRegisterFailed): func(mon *addNodeMonitor) {
+		if mon.currentState == ClusterIsImported &&
+			mon.cluster.sshCommandOutputContains("systemctl status agent-register-infraenv", "FAILURE") {
+			mon.currentState = InfraenvRegisterFailed
+		}
+	},
+	int(HostConfigsApplied): func(mon *addNodeMonitor) {
+		if mon.currentState == InfraenvIsRegistered &&
+			mon.cluster.sshCommandOutputContains("systemctl status apply-host-config", "Finished Service") {
+			mon.currentState = HostConfigsApplied
+		}
+	},
+	int(HostConfigsApplyFailed): func(mon *addNodeMonitor) {
+		if mon.currentState == InfraenvIsRegistered &&
+			mon.cluster.sshCommandOutputContains("systemctl status apply-host-config", "FAILURE") {
+			mon.currentState = HostConfigsApplyFailed
+		}
+	},
+	int(WaitingForHostToBeReady): func(mon *addNodeMonitor) {
+		if mon.currentState == HostConfigsApplied &&
+			mon.cluster.sshCommandOutputContains("sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status from hosts'", "insufficient") {
+			mon.currentState = WaitingForHostToBeReady
+		}
+	},
+	int(HostHasErrors): func(mon *addNodeMonitor) {
+		if mon.currentState == WaitingForHostToBeReady &&
+			mon.cluster.sshCommandOutputContains("systemctl status agent-add-node", "FAILURE") {
+			mon.currentState = HostHasErrors
+		}
+	},
+	int(HostInstallationStarted): func(mon *addNodeMonitor) {
+		if mon.currentState == WaitingForHostToBeReady &&
+			// Or
+			// sudo podman exec assisted-db psql -d installer -c 'select id, status_info, status from hosts'
+			// and status will show "installing"
+			mon.cluster.sshCommandOutputContains("systemctl status agent-add-node", "Host installation started") {
+			mon.currentState = HostInstallationStarted
+		}
+	},
+	int(CoreosInstallerWritingToDisk): func(mon *addNodeMonitor) {
+		if mon.currentState == HostInstallationStarted &&
+			mon.cluster.sshCommandOutputContains("ps -ef | grep coreos-installer", "coreos-installer") {
+			mon.currentState = CoreosInstallerWritingToDisk
+		}
+	},
+	int(HostPreparingForFirstReboot): func(mon *addNodeMonitor) {
+		if mon.currentState == CoreosInstallerWritingToDisk &&
+			!mon.cluster.CanSSHToNodeZero() {
+			mon.currentState = HostPreparingForFirstReboot
+		}
+	},
+	int(AfterFirstReboot): func(mon *addNodeMonitor) {
+		if mon.currentState < AfterFirstReboot &&
+			mon.cluster.sshCommandOutputContains("ps -ef", "ostree") {
+			mon.currentState = AfterFirstReboot
+		}
+	},
+	int(AfterSecondReboot): func(mon *addNodeMonitor) {
+		if mon.currentState < AfterSecondRebootKubeletIsUp &&
+			mon.cluster.sshCommandOutputContains("ps -ef", "coredns") {
+			mon.currentState = AfterSecondReboot
+		}
+	},
+	int(AfterSecondRebootKubeletIsUp): func(mon *addNodeMonitor) {
+		if mon.currentState >= AfterSecondReboot &&
+			mon.currentState < FirstCSRPendingApproval &&
+			mon.cluster.sshCommandOutputContains("ps -ef", "kubelet") {
+			mon.currentState = AfterSecondRebootKubeletIsUp
+		}
+	},
+	int(FirstCSRPendingApproval): func(mon *addNodeMonitor) {
+		if mon.currentState >= AfterSecondReboot &&
+			mon.currentState <= FirstCSRPendingApproval &&
+			mon.cluster.sshCommandOutputContains("sudo KUBECONFIG=/etc/kubernetes/kubeconfig oc get csr | grep Pending", "node-bootstrapper") {
+			mon.currentState = FirstCSRPendingApproval
+			mon.cluster.logCSRsPendingApproval()
+		}
+	},
+	int(SecondCSRPendingApproval): func(mon *addNodeMonitor) {
+		if mon.currentState >= AfterSecondReboot &&
+			mon.currentState <= SecondCSRPendingApproval &&
+			mon.cluster.sshCommandOutputContains("sudo KUBECONFIG=/etc/kubernetes/kubeconfig oc get csr | grep Pending", "system:node") {
+			mon.currentState = SecondCSRPendingApproval
+			mon.cluster.logCSRsPendingApproval()
+		}
+	},
+	int(NodeJoinedClusterStatusNotReady): func(mon *addNodeMonitor) {
+		if mon.currentState == AfterSecondRebootKubeletIsUp ||
+			mon.currentState == SecondCSRPendingApproval {
+			hasJoined, isReady, err := mon.cluster.hasNodeJoinedClusterAndIsReady(mon.nodeIP)
+			if err != nil {
+				logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
+			}
+			if hasJoined && !isReady {
+				mon.currentState = NodeJoinedClusterStatusNotReady
+			}
+		}
+	},
+	int(Finish): func(mon *addNodeMonitor) {
+		if mon.currentState == AfterSecondRebootKubeletIsUp ||
+			mon.currentState == SecondCSRPendingApproval ||
+			mon.currentState == NodeJoinedClusterStatusNotReady {
+			hasJoined, isReady, err := mon.cluster.hasNodeJoinedClusterAndIsReady(mon.nodeIP)
+			if err != nil {
+				logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
+			}
+			if hasJoined && isReady {
+				mon.currentState = Finish
+			}
+		}
+	},
+}
+
+// MonitorAddNodes waits for the a node to be added to the cluster
+// and reports its status until it becomes Ready.
+func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
+	timeout := 90 * time.Minute
+	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
+	defer cancel()
+
+	mon := newAddNodeMonitor(nodeIPAddress, cluster)
+
+	wait.Until(func() {
+		for _, checkFunc := range defaultChecks {
+			currentState := mon.currentState
+			checkFunc(mon)
+			if int(mon.currentState) != int(currentState) {
+				logrus.Infof("Node %s: %s", nodeIPAddress, stateNameMap[int(mon.currentState)])
+			}
+		}
+
+		if mon.currentState == Finish {
+			// TODO: There appears to be a bug where the node becomes Ready
+			// before second CSR is approved. Log Pending CSRs for now, so users
+			// are aware there are still some waiting their approval even
+			// though the node status is Ready.
+			mon.cluster.logCSRsPendingApproval()
+			cancel()
+		}
+
+		if mon.currentState == AssistedServiceFailedToStart ||
+			mon.currentState == ClusterImportedFailed ||
+			mon.currentState == InfraenvRegisterFailed ||
+			mon.currentState == HostConfigsApplyFailed ||
+			mon.currentState == HostHasErrors {
+			cancel()
+		}
+
+	}, 5*time.Second, waitContext.Done())
+
+	waitErr := waitContext.Err()
+	if waitErr != nil {
+		if errors.Is(waitErr, context.Canceled) {
+			cancel()
+		}
+		if errors.Is(waitErr, context.DeadlineExceeded) {
+			return errors.Wrap(waitErr, "monitor-add-nodes process timed out")
+		}
+	}
+
+	return nil
+}
+
+// hasNodeJoinedClusterAndIsReady checks if the node specified by nodeIPAddress
+// has joined the cluster and is in Ready state.
+func (c *Cluster) hasNodeJoinedClusterAndIsReady(nodeIPAddress string) (bool, bool, error) {
+	nodes, err := c.API.Kube.ListNodes()
+	if err != nil {
+		logrus.Debugf("error getting node list %v", err)
+		return false, false, nil
+	}
+
+	var joinedNode corev1.Node
+	hasJoined := false
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				if address.Address == nodeIPAddress {
+					joinedNode = node
+					hasJoined = true
+				}
+			}
+		}
+	}
+
+	isReady := false
+	if hasJoined {
+		logrus.Debugf("Node %v (%s) has joined cluster", nodeIPAddress, joinedNode.Name)
+		for _, cond := range joinedNode.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				isReady = true
+			}
+		}
+		if isReady {
+			logrus.Debugf("Node %s (%s) is Ready", nodeIPAddress, joinedNode.Name)
+		} else {
+			logrus.Debugf("Node %s (%s) is not Ready", nodeIPAddress, joinedNode.Name)
+		}
+	} else {
+		logrus.Debugf("Node %s has not joined cluster", nodeIPAddress)
+	}
+
+	return hasJoined, isReady, nil
+}
+
+func (c *Cluster) logCSRsPendingApproval() {
+	csrs, err := c.API.Kube.ListCSRs()
+	if err != nil {
+		logrus.Debugf("error calling listCSRs(): %v ", err)
+	}
+
+	for _, csr := range csrs.Items {
+		if len(csr.Status.Conditions) == 0 {
+			// CSR is Pending and awaiting approval
+			logrus.Infof("CSR %s with signerName %s and username %s is Pending and awaiting approval",
+				csr.Name, csr.Spec.SignerName, csr.Spec.Username)
+		}
+	}
+}
+
+func (c *Cluster) sshClient() (*ssh.Client, error) {
+	ip := c.API.Rest.NodeZeroIP
+	port := 22
+
+	client, err := gatherssh.NewClient("core", net.JoinHostPort(ip, strconv.Itoa(port)), c.API.Rest.NodeSSHKey)
+	if err != nil {
+		logrus.Debugf("Failed to create SSH client to %s: %s", ip, err)
+	}
+	return client, err
+}
+
+func (c *Cluster) sshCommandOutputContains(command, stringToMatchInOutput string) bool {
+	sshClient, err := c.sshClient()
+	if err != nil {
+		logrus.Debugf("Failed to create SSH client to %s: %s", c.API.Rest.NodeZeroIP, err)
+		return false
+	}
+
+	logrus.Debugf("sshCommandOutputContains command: %v ", command)
+
+	// Create an SSH session
+	session, err := sshClient.NewSession()
+	if err != nil {
+		logrus.Debugf("failed to create session: %s", err)
+		return false
+	}
+	defer session.Close()
+
+	// Run the command on the remote machine
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		logrus.Debugf("failed to get stdout: %s", err)
+		return false
+	}
+
+	if err := session.Start(command); err != nil {
+		logrus.Debugf("failed to start command: %s", err)
+		return false
+	}
+
+	output, err := io.ReadAll(stdout)
+	if err != nil {
+		logrus.Debugf("failed to read stdout: %s", err)
+		return false
+	}
+
+	if err := session.Wait(); err != nil {
+		if strings.Contains(err.Error(), "Process exited with status") {
+			// command finished with exit code other than 0
+			// which could happen in the case where "systemctl status"
+			// shows service is in failed state and exits with code 3.
+		} else {
+			logrus.Debugf("command failed: %s output: %v", err, string(output))
+			return false
+		}
+	}
+
+	logrus.Debugf("sshCommandOutputContains command: %v output: \n %v", command, string(output))
+
+	return strings.Contains(string(output), stringToMatchInOutput)
+}

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -252,10 +252,12 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 	mon := newAddNodeMonitor(nodeIPAddress, cluster)
 
 	wait.Until(func() {
-
 		if mon.onOrAfter(AssistedServiceIsUp) &&
 			mon.onOrBefore(HostInstallationStarted) {
-			cluster.LogAssistedServiceStatus()
+			_, _, err := cluster.LogAssistedServiceStatus()
+			if err != nil {
+				logrus.Warnf("Node %s: %s", nodeIPAddress, err)
+			}
 		}
 
 		for _, checkFunc := range defaultChecks {

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -14,76 +14,44 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-type addNodeState int
-
-// The node states that we observe and report.
 const (
-	InitialState addNodeState = iota
-	AssistedServiceIsUp
-	KubeletIsRunningOnNode
-	FirstCSRPendingApproval
-	SecondCSRPendingApproval
-	NodeJoinedClusterStatusNotReady
-	Finish // terminal state
+	firstCSRSignerName  = "kubernetes.io/kube-apiserver-client-kubelet"
+	secondCSRSignerName = "kubernetes.io/kubelet-serving"
 )
 
-var stateNameMap = map[int]string{
-	int(InitialState):                    "Initial State",
-	int(AssistedServiceIsUp):             "Assisted Service API is available",
-	int(KubeletIsRunningOnNode):          "Kubelet is running",
-	int(FirstCSRPendingApproval):         "First CSR Pending approval",
-	int(SecondCSRPendingApproval):        "Second CSR Pending approval",
-	int(NodeJoinedClusterStatusNotReady): "Node joined cluster and status is NotReady",
-	int(Finish):                          "Node is Ready",
+type addNodeStatusHistory struct {
+	RestAPISeen            bool
+	KubeletIsRunningOnNode bool
+	FirstCSRSeen           bool
+	SecondCSRSeen          bool
+	NodeJoinedCluster      bool
+	NodeIsReady            bool
 }
 
-type checkFunction func(nodeMonitor *addNodeMonitor)
+type addNodeMonitor struct {
+	nodeIPAddress string
+	cluster       *Cluster
+	status        addNodeStatusHistory
+}
 
-type checkFunctions map[int]checkFunction
+func newAddNodeMonitor(nodeIP string, cluster *Cluster) *addNodeMonitor {
+	mon := addNodeMonitor{
+		nodeIPAddress: nodeIP,
+		cluster:       cluster,
+		status: addNodeStatusHistory{
+			RestAPISeen:            false,
+			KubeletIsRunningOnNode: false,
+			FirstCSRSeen:           false,
+			SecondCSRSeen:          false,
+			NodeJoinedCluster:      false,
+			NodeIsReady:            false,
+		},
+	}
+	return &mon
+}
 
-var defaultChecks = checkFunctions{
-	int(AssistedServiceIsUp): func(mon *addNodeMonitor) {
-		if mon.in(InitialState) &&
-			mon.cluster.API.Rest.IsRestAPILive() {
-			mon.setState(AssistedServiceIsUp)
-		}
-	},
-	int(KubeletIsRunningOnNode): func(mon *addNodeMonitor) {
-		if mon.onOrBefore(KubeletIsRunningOnNode) &&
-			mon.isKubeletRunningOnNode() {
-			mon.setState(KubeletIsRunningOnNode)
-		}
-	},
-	int(FirstCSRPendingApproval): func(mon *addNodeMonitor) {
-		if mon.onOrAfter(KubeletIsRunningOnNode) &&
-			mon.clusterHasFirstCSRPending() {
-			mon.setState(FirstCSRPendingApproval)
-		}
-	},
-	int(SecondCSRPendingApproval): func(mon *addNodeMonitor) {
-		if mon.onOrAfter(KubeletIsRunningOnNode) &&
-			mon.clusterHasSecondCSRPending() {
-			mon.setState(SecondCSRPendingApproval)
-		}
-	},
-	int(NodeJoinedClusterStatusNotReady): func(mon *addNodeMonitor) {
-		hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
-		if err != nil {
-			logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
-		}
-		if hasJoined && !isReady {
-			mon.setState(NodeJoinedClusterStatusNotReady)
-		}
-	},
-	int(Finish): func(mon *addNodeMonitor) {
-		hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
-		if err != nil {
-			logrus.Debugf("HasNodeJoinedClusterAndIsReady returned err: %v", err)
-		}
-		if hasJoined && isReady {
-			mon.setState(Finish)
-		}
-	},
+func (mon *addNodeMonitor) logStatus(status string) {
+	logrus.Infof("Node %s: %s", mon.nodeIPAddress, status)
 }
 
 // MonitorAddNodes waits for the a node to be added to the cluster
@@ -101,36 +69,60 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 	mon := newAddNodeMonitor(nodeIPAddress, cluster)
 
 	wait.Until(func() {
-		if mon.cluster.API.Rest.IsRestAPILive() {
-			_, err := cluster.MonitorStatusFromAssistedService()
-			if err != nil {
-				logrus.Warnf("Node %s: %s", nodeIPAddress, err)
-			}
+		if !mon.status.RestAPISeen &&
+			mon.cluster.API.Rest.IsRestAPILive() {
+			mon.status.RestAPISeen = true
+			mon.logStatus("Assisted Service API is available")
 		}
 
-		for _, checkFunc := range defaultChecks {
-			lastState := mon.currentState
-			checkFunc(mon)
-			if !mon.in(lastState) {
-				// log state change
-				logrus.Infof("Node %s: %s", nodeIPAddress, mon.currentStateName())
-			}
+		if !mon.status.KubeletIsRunningOnNode &&
+			mon.isKubeletRunningOnNode() {
+			mon.status.KubeletIsRunningOnNode = true
+			mon.logStatus("Kubelet is running")
 		}
 
-		if mon.clusterHasFirstCSRPending() || mon.clusterHasSecondCSRPending() {
-			// TODO? The CSRs have no IP address to identify for which
-			// node it is for, so it is possible to log CSRs pending for
-			// other nodes.
-			mon.logCSRsPendingApproval()
+		if mon.status.KubeletIsRunningOnNode &&
+			!mon.status.FirstCSRSeen &&
+			mon.clusterHasFirstCSRPending() {
+			mon.status.FirstCSRSeen = true
+			mon.logStatus("First CSR Pending approval")
+			mon.logCSRsPendingApproval(firstCSRSignerName)
 		}
 
-		if mon.in(Finish) {
+		if mon.status.KubeletIsRunningOnNode &&
+			!mon.status.SecondCSRSeen &&
+			mon.clusterHasSecondCSRPending() {
+			mon.status.SecondCSRSeen = true
+			mon.logStatus("Second CSR Pending approval")
+			mon.logCSRsPendingApproval(secondCSRSignerName)
+		}
+
+		hasJoined, isReady, err := mon.nodeHasJoinedClusterAndIsReady()
+		if err != nil {
+			logrus.Debugf("nodeHasJoinedClusterAndIsReady returned err: %v", err)
+		}
+
+		if !mon.status.NodeJoinedCluster && hasJoined {
+			mon.status.NodeJoinedCluster = true
+			mon.logStatus("Node joined cluster")
+		}
+
+		if !mon.status.NodeIsReady && isReady {
+			mon.status.NodeIsReady = true
+			mon.logStatus("Node is Ready")
 			// TODO: There appears to be a bug where the node becomes Ready
 			// before second CSR is approved. Log Pending CSRs for now, so users
 			// are aware there are still some waiting their approval even
 			// though the node status is Ready.
-			mon.logCSRsPendingApproval()
+			mon.logCSRsPendingApproval(secondCSRSignerName)
 			cancel()
+		}
+
+		if mon.cluster.API.Rest.IsRestAPILive() {
+			_, err = cluster.MonitorStatusFromAssistedService()
+			if err != nil {
+				logrus.Warnf("Node %s: %s", nodeIPAddress, err)
+			}
 		}
 	}, 5*time.Second, waitContext.Done())
 
@@ -145,41 +137,6 @@ func MonitorAddNodes(cluster *Cluster, nodeIPAddress string) error {
 	}
 
 	return nil
-}
-
-type addNodeMonitor struct {
-	nodeIPAddress string
-	cluster       *Cluster
-	currentState  addNodeState
-}
-
-func newAddNodeMonitor(nodeIP string, cluster *Cluster) *addNodeMonitor {
-	mon := addNodeMonitor{
-		nodeIPAddress: nodeIP,
-		cluster:       cluster,
-		currentState:  InitialState,
-	}
-	return &mon
-}
-
-func (mon *addNodeMonitor) setState(state addNodeState) {
-	mon.currentState = state
-}
-
-func (mon *addNodeMonitor) in(state addNodeState) bool {
-	return mon.currentState == state
-}
-
-func (mon *addNodeMonitor) onOrBefore(state addNodeState) bool {
-	return mon.currentState <= state
-}
-
-func (mon *addNodeMonitor) onOrAfter(state addNodeState) bool {
-	return mon.currentState >= state
-}
-
-func (mon *addNodeMonitor) currentStateName() string {
-	return stateNameMap[int(mon.currentState)]
 }
 
 func (mon *addNodeMonitor) nodeHasJoinedClusterAndIsReady() (bool, bool, error) {
@@ -222,7 +179,10 @@ func (mon *addNodeMonitor) nodeHasJoinedClusterAndIsReady() (bool, bool, error) 
 	return hasJoined, isReady, nil
 }
 
-func (mon *addNodeMonitor) logCSRsPendingApproval() {
+func (mon *addNodeMonitor) logCSRsPendingApproval(signerName string) {
+	// TODO? The CSRs have no IP address to identify for which
+	// node it is for, so it is possible to log CSRs pending for
+	// other nodes.
 	csrs, err := mon.cluster.API.Kube.ListCSRs()
 	if err != nil {
 		logrus.Debugf("error calling listCSRs(): %v ", err)
@@ -231,6 +191,10 @@ func (mon *addNodeMonitor) logCSRsPendingApproval() {
 	for _, csr := range csrs.Items {
 		if len(csr.Status.Conditions) == 0 {
 			// CSR is Pending and awaiting approval
+			if signerName != "" && signerName != csr.Spec.SignerName {
+				continue
+			}
+
 			logrus.Infof("CSR %s with signerName %s and username %s is Pending and awaiting approval",
 				csr.Name, csr.Spec.SignerName, csr.Spec.Username)
 		}
@@ -238,11 +202,14 @@ func (mon *addNodeMonitor) logCSRsPendingApproval() {
 }
 
 func (mon *addNodeMonitor) clusterHasFirstCSRPending() bool {
-	return len(mon.cluster.API.Kube.getCSRsPendingApproval("kubernetes.io/kube-apiserver-client-kubelet")) > 0
+	return len(mon.cluster.API.Kube.getCSRsPendingApproval(firstCSRSignerName)) > 0
 }
 
 func (mon *addNodeMonitor) clusterHasSecondCSRPending() bool {
-	return len(mon.cluster.API.Kube.getCSRsPendingApproval("kubernetes.io/kubelet-serving")) > 0
+	// TODO: the csr.Spec.Username contains the node name
+	// can we use it as an additional filter to only show
+	// those matching mon.nodeIPAddress?
+	return len(mon.cluster.API.Kube.getCSRsPendingApproval(secondCSRSignerName)) > 0
 }
 
 // isKubeletRunningOnNode checks if kubelet responds

--- a/pkg/agent/monitoraddnodes_test.go
+++ b/pkg/agent/monitoraddnodes_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	certificatesv1 "k8s.io/api/certificates/v1"
+)
+
+func TestDecodedFirstCSRSubjectContainsHostname(t *testing.T) {
+	firstCSRRequestForExtraworker0 := "-----BEGIN CERTIFICATE REQUEST-----\nMIH3MIGdAgEAMDsxFTATBgNVBAoTDHN5c3RlbTpub2RlczEiMCAGA1UEAxMZc3lz\ndGVtOm5vZGU6ZXh0cmF3b3JrZXItMDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA\nBGaK3U+3X3lM6tdgjD2b/y7Kysws8xgFW1rNd/wvKEvXzP5+A1K1M38zJiAWqKXP\n5AL2IDklO4GaO7PcRDNPabigADAKBggqhkjOPQQDAgNJADBGAiEA7C33Nym0Go73\nCZY+XOmyqE/IhaBMSwign+fgbPX1ibkCIQDHIfF7QpZReF93IW0v864/yLoXKyXy\nTGygkuR4KtXTDw==\n-----END CERTIFICATE REQUEST-----\n"
+	tests := []struct {
+		name           string
+		hostnames      []string
+		request        string
+		expectedResult bool
+	}{
+		{
+			name:           "request contains hostname",
+			hostnames:      []string{"extraworker-0"},
+			request:        firstCSRRequestForExtraworker0,
+			expectedResult: true,
+		},
+		{
+			name:           "request contains hostname using FQDN",
+			hostnames:      []string{"extraworker-0.ostest.test.metalkube.org"},
+			request:        firstCSRRequestForExtraworker0,
+			expectedResult: true,
+		},
+		{
+			name:           "request contains hostname when multiple names are resolved",
+			hostnames:      []string{"somename", "extraworker-0.ostest.test.metalkube.org"},
+			request:        firstCSRRequestForExtraworker0,
+			expectedResult: true,
+		},
+		{
+			name:           "request does not contain hostname",
+			hostnames:      []string{"extraworker-1"},
+			request:        firstCSRRequestForExtraworker0,
+			expectedResult: false,
+		},
+		{
+			name:           "request is empty string",
+			hostnames:      []string{"hostname-not-specified"},
+			request:        "",
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containsHostname := containsHostname(decodedFirstCSRSubject([]byte(tt.request)), tt.hostnames)
+			assert.Equal(t, tt.expectedResult, containsHostname)
+		})
+	}
+}
+
+func TestFilterCSRsMatchingHostnames(t *testing.T) {
+	firstCSRRequestForExtraworker0 := "-----BEGIN CERTIFICATE REQUEST-----\nMIH3MIGdAgEAMDsxFTATBgNVBAoTDHN5c3RlbTpub2RlczEiMCAGA1UEAxMZc3lz\ndGVtOm5vZGU6ZXh0cmF3b3JrZXItMDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA\nBGaK3U+3X3lM6tdgjD2b/y7Kysws8xgFW1rNd/wvKEvXzP5+A1K1M38zJiAWqKXP\n5AL2IDklO4GaO7PcRDNPabigADAKBggqhkjOPQQDAgNJADBGAiEA7C33Nym0Go73\nCZY+XOmyqE/IhaBMSwign+fgbPX1ibkCIQDHIfF7QpZReF93IW0v864/yLoXKyXy\nTGygkuR4KtXTDw==\n-----END CERTIFICATE REQUEST-----\n"
+
+	tests := []struct {
+		name           string
+		csrs           *certificatesv1.CertificateSigningRequestList
+		hostnames      []string
+		signerName     string
+		expectedResult []certificatesv1.CertificateSigningRequest
+	}{
+		{
+			name: "first CSR filtering",
+			csrs: &certificatesv1.CertificateSigningRequestList{
+				Items: []certificatesv1.CertificateSigningRequest{
+					{
+						// should match only this one
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							SignerName: firstCSRSignerName,
+							Request:    []byte(firstCSRRequestForExtraworker0),
+						},
+					},
+					{
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							SignerName: "other-request",
+							Request:    []byte("other-request"),
+						},
+					},
+				},
+			},
+			hostnames:  []string{"extraworker-0.ostest.test.metalkube.org"},
+			signerName: "kubernetes.io/kube-apiserver-client-kubelet",
+			expectedResult: []certificatesv1.CertificateSigningRequest{
+				{
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						SignerName: "kubernetes.io/kube-apiserver-client-kubelet",
+						Request:    []byte(firstCSRRequestForExtraworker0),
+					},
+				},
+			},
+		},
+		{
+			name: "second CSR filtering",
+			csrs: &certificatesv1.CertificateSigningRequestList{
+				Items: []certificatesv1.CertificateSigningRequest{
+					{
+						// should match only this one
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							SignerName: secondCSRSignerName,
+							Username:   "system:node:extraworker-0",
+							Request:    []byte("something"),
+						},
+					},
+					{
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							SignerName: secondCSRSignerName,
+							Username:   "system:node:extraworker-1",
+							Request:    []byte("something"),
+						},
+					},
+					{
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							SignerName: "other-request",
+							Request:    []byte("other-request"),
+						},
+					},
+				},
+			},
+			hostnames:  []string{"extraworker-0.ostest.test.metalkube.org"},
+			signerName: secondCSRSignerName,
+			expectedResult: []certificatesv1.CertificateSigningRequest{
+				{
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						SignerName: "kubernetes.io/kubelet-serving",
+						Username:   "system:node:extraworker-0",
+						Request:    []byte("something"),
+					},
+				},
+			},
+		},
+		{
+			name: "no CSRs should not result in error",
+			csrs: &certificatesv1.CertificateSigningRequestList{
+				Items: []certificatesv1.CertificateSigningRequest{},
+			},
+			hostnames:      []string{"extraworker-0.ostest.test.metalkube.org"},
+			signerName:     secondCSRSignerName,
+			expectedResult: []certificatesv1.CertificateSigningRequest{},
+		},
+		{
+			name: "no hostnames should not result in error",
+			csrs: &certificatesv1.CertificateSigningRequestList{
+				Items: []certificatesv1.CertificateSigningRequest{},
+			},
+			hostnames:      []string{},
+			signerName:     secondCSRSignerName,
+			expectedResult: []certificatesv1.CertificateSigningRequest{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filteredCSRs := filterCSRsMatchingHostname(tt.signerName, tt.csrs, tt.hostnames)
+			assert.Equal(t, tt.expectedResult, filteredCSRs)
+		})
+	}
+}

--- a/pkg/agent/ocp.go
+++ b/pkg/agent/ocp.go
@@ -34,7 +34,6 @@ const (
 
 // NewClusterOpenShiftAPIClient Create a kube client with OCP understanding
 func NewClusterOpenShiftAPIClient(ctx context.Context, kubeconfigPath string) (*ClusterOpenShiftAPIClient, error) {
-
 	ocpClient := &ClusterOpenShiftAPIClient{}
 
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)

--- a/pkg/agent/ocp.go
+++ b/pkg/agent/ocp.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -34,12 +33,11 @@ const (
 )
 
 // NewClusterOpenShiftAPIClient Create a kube client with OCP understanding
-func NewClusterOpenShiftAPIClient(ctx context.Context, assetDir string) (*ClusterOpenShiftAPIClient, error) {
+func NewClusterOpenShiftAPIClient(ctx context.Context, kubeconfigPath string) (*ClusterOpenShiftAPIClient, error) {
 
 	ocpClient := &ClusterOpenShiftAPIClient{}
 
-	kubeconfigpath := filepath.Join(assetDir, "auth", "kubeconfig")
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigpath)
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating kubeconfig for ocp config client")
 	}
@@ -58,7 +56,7 @@ func NewClusterOpenShiftAPIClient(ctx context.Context, assetDir string) (*Cluste
 	ocpClient.RouteClient = routeClient
 	ocpClient.ctx = ctx
 	ocpClient.config = kubeconfig
-	ocpClient.configPath = kubeconfigpath
+	ocpClient.configPath = kubeconfigPath
 
 	return ocpClient, nil
 

--- a/pkg/agent/rest.go
+++ b/pkg/agent/rest.go
@@ -120,10 +120,7 @@ func (rest *NodeZeroRestClient) IsRestAPILive() bool {
 	// GET /v2/infraenvs
 	listInfraEnvsParams := installer.NewListInfraEnvsParams()
 	_, err := rest.Client.Installer.ListInfraEnvs(rest.ctx, listInfraEnvsParams)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 // GetRestAPIServiceBaseURL Return the url of the Agent Rest API on node zero

--- a/pkg/agent/validations.go
+++ b/pkg/agent/validations.go
@@ -34,7 +34,7 @@ type validationResultHistory struct {
 	previousMessage string
 }
 
-func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger) error {
+func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger, hostLogPrefix string) error {
 	clusterLogPrefix := "Cluster validation: "
 	updatedClusterValidationHistory, err := updateValidationResultHistory(clusterLogPrefix, cluster.ValidationsInfo, validationResults.ClusterValidationHistory, log)
 	if err != nil {
@@ -43,7 +43,9 @@ func checkValidations(cluster *models.Cluster, validationResults *validationResu
 	validationResults.ClusterValidationHistory = updatedClusterValidationHistory
 
 	for _, h := range cluster.Hosts {
-		hostLogPrefix := "Host " + h.RequestedHostname + " validation: "
+		if hostLogPrefix == "" {
+			hostLogPrefix = "Host " + h.RequestedHostname + " validation: "
+		}
 		if _, ok := validationResults.HostValidationHistory[h.RequestedHostname]; !ok {
 			validationResults.HostValidationHistory[h.RequestedHostname] = make(map[string]*validationResultHistory)
 		}

--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -18,12 +18,7 @@ const (
 
 // NewAddNodesCommand creates a new command for add nodes.
 func NewAddNodesCommand(directory string, kubeConfig string) error {
-	// Store the current parameters into the assets folder, so
-	// that they could be retrieved later by the assets
-	params := joiner.Params{
-		Kubeconfig: kubeConfig,
-	}
-	err := params.Save(directory)
+	err := saveParams(directory, kubeConfig)
 	if err != nil {
 		return err
 	}
@@ -44,4 +39,13 @@ func NewAddNodesCommand(directory string, kubeConfig string) error {
 	}
 
 	return err
+}
+
+func saveParams(directory, kubeConfig string) error {
+	// Store the current parameters into the assets folder, so
+	// that they could be retrieved later by the assets
+	params := joiner.Params{
+		Kubeconfig: kubeConfig,
+	}
+	return params.Save(directory)
 }

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -6,11 +6,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	agentpkg "github.com/openshift/installer/pkg/agent"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
-	cluster, err := agentpkg.NewCluster(context.Background(), kubeconfigPath, ips[0], "")
+	cluster, err := agentpkg.NewCluster(context.Background(), kubeconfigPath, ips[0], "", workflow.AgentWorkflowTypeAddNodes)
 	if err != nil {
 		// TODO exit code enumerate
 		logrus.Exit(1)

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -11,10 +11,19 @@ import (
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
+	err := saveParams(directory, kubeconfigPath)
+	if err != nil {
+		return err
+	}
+
 	cluster, err := agentpkg.NewCluster(context.Background(), "", ips[0], kubeconfigPath, "", workflow.AgentWorkflowTypeAddNodes)
 	if err != nil {
 		// TODO exit code enumerate
 		logrus.Exit(1)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	return agentpkg.MonitorAddNodes(cluster, ips[0])

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -11,7 +11,7 @@ import (
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
-	cluster, err := agentpkg.NewCluster(context.Background(), "", ips[0], kubeconfigPath, workflow.AgentWorkflowTypeAddNodes)
+	cluster, err := agentpkg.NewCluster(context.Background(), "", ips[0], kubeconfigPath, "", workflow.AgentWorkflowTypeAddNodes)
 	if err != nil {
 		// TODO exit code enumerate
 		logrus.Exit(1)

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -11,7 +11,7 @@ import (
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
-	cluster, err := agentpkg.NewCluster(context.Background(), kubeconfigPath, ips[0], "", workflow.AgentWorkflowTypeAddNodes)
+	cluster, err := agentpkg.NewCluster(context.Background(), "", ips[0], kubeconfigPath, workflow.AgentWorkflowTypeAddNodes)
 	if err != nil {
 		// TODO exit code enumerate
 		logrus.Exit(1)

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -3,12 +3,18 @@ package nodejoiner
 import (
 	"context"
 
-	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/store"
+	"github.com/sirupsen/logrus"
+
+	agentpkg "github.com/openshift/installer/pkg/agent"
 )
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
-func NewMonitorAddNodesCommand(directory string) error {
-	fetcher := store.NewAssetsFetcher(directory)
-	return fetcher.FetchAndPersist(context.Background(), []asset.WritableAsset{})
+func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
+	cluster, err := agentpkg.NewCluster(context.Background(), kubeconfigPath, ips[0], "")
+	if err != nil {
+		// TODO exit code enumerate
+		logrus.Exit(1)
+	}
+
+	return agentpkg.MonitorAddNodes(cluster, ips[0])
 }


### PR DESCRIPTION
The first and second CSRs pending approval have the node name (hostname) embedded in their specs. monitor-add-nodes should only show CSRs pending approval for a specific node. Currently it shows all CSRs pending approval for all nodes.
    
If the IP address of the node cannot be resolved to a hostname, we will not be able to determine if there are any CSRs pending approval for that node. The monitoring command will skip showing CSRs pending approval. In this case, users can still approve the CSRs, and the monitoring command will continue to check if the node has joined the cluster and has become Ready.