### PR TITLE
no-jira: images: delete Dockerfile.upi.ci.rhel8

### DIFF
--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -1,1 +1,0 @@
-Dockerfile.upi.ci


### PR DESCRIPTION
This is now just a symlink to `Dockerfile.upi.ci` and it was first created during the transition from rhel7 to rhel9. All our images are now rhel9 based.

All the 4.16+ references to this symlink have been removed by https://github.com/openshift/release/pull/50359.