### PR TITLE
OCPBUGS-33470: use read/write cache on azure masters

### DIFF
--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -114,7 +114,7 @@ resource "azurerm_linux_virtual_machine" "master" {
 
   os_disk {
     name                   = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
-    caching                = "ReadOnly"
+    caching                = "ReadWrite"
     storage_account_type   = var.os_volume_type
     disk_size_gb           = var.os_volume_size
     disk_encryption_set_id = var.disk_encryption_set_id


### PR DESCRIPTION
Change Azure Masters to use ReadWrite cache.

```The write is then lazily written to the disk when the cache is flushed periodically. Customers can additionally force a flush by issuing an f/sync or fua command.```

etcd should be ok with this change since etcd does fsyncs when needed.

https://learn.microsoft.com/en-us/azure/virtual-machines/disks-performance