### PR TITLE
OCPBUGS-33493: Revert "baremetal: pause provisioning"

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -25,12 +25,6 @@ while systemctl is-active metal3-baremetal-operator.service; do
     sleep 10
 done
 
-echo "Unpause provisioning"
-while ! oc annotate --overwrite provisioning provisioning-configuration "provisioning.metal3.io/paused-" ; do
-    sleep 5
-    echo "Unpause failed, retrying"
-done
-
 echo "Unpause all baremetal hosts"
 while ! oc annotate --overwrite -n openshift-machine-api baremetalhosts --all "baremetalhost.metal3.io/paused-" ; do
     sleep 5

--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -2,10 +2,6 @@ apiVersion: metal3.io/v1alpha1
 kind: Provisioning
 metadata:
   name: provisioning-configuration
-  annotations:
-    # We want to pause the metal3 provisioning services until we can be sure
-    # that all control plane nodes are ready.
-    provisioning.metal3.io/paused: "true"
 spec:
   provisioningInterface: "{{.Baremetal.ProvisioningNetworkInterface}}"
   provisioningIP: "{{.Baremetal.ClusterProvisioningIP}}"


### PR DESCRIPTION
This reverts commit e2dd7e596e6945017d4a2a904555d1d2e9577970.

This change is blocking agent installs.  Reverting while we work on a different solution. 

cc: https://github.com/openshift/cluster-baremetal-operator/pull/416