### PR TITLE
no-jira: AzureMachines: set disk caching to ReadWrite

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -83,6 +83,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 		ManagedDisk: &capz.ManagedDiskParameters{
 			StorageAccountType: mpool.DiskType,
 		},
+		CachingType: "ReadWrite",
 	}
 	ultrassd := mpool.UltraSSDCapability == "Enabled"
 	additionalCapabilities := &capz.AdditionalCapabilities{


### PR DESCRIPTION
CAPZ equivalent for #8380 

Change Azure Masters to use ReadWrite cache.

The write is then lazily written to the disk when the cache is flushed periodically. Customers can additionally force a flush by issuing an f/sync or fua command.

etcd should be ok with this change since etcd does fsyncs when needed.

https://learn.microsoft.com/en-us/azure/virtual-machines/disks-performance

/cc @rphillips @jhixson74 @rna-afk 