### PR TITLE
OCPBUGS-33542: images: do not force terraform-providers to be statically linked

### DIFF
--- a/images/infrastructure-providers/Dockerfile
+++ b/images/infrastructure-providers/Dockerfile
@@ -1,22 +1,22 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macbuilder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 make -C terraform
+RUN GOOS=darwin GOARCH=amd64 make -C terraform
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS macarmbuilder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 make -C terraform
+RUN GOOS=darwin GOARCH=arm64 make -C terraform
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxbuilder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make -C terraform
+RUN GOOS=linux GOARCH=amd64 make -C terraform
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS linuxarmbuilder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 make -C terraform
+RUN GOOS=linux GOARCH=arm64 make -C terraform
 
 FROM registry.ci.openshift.org/ocp/4.15:base
 WORKDIR /go/src/github.com/openshift/installer


### PR DESCRIPTION
They should be dynamically linked as the rest of the binaries for FIPS support.