### PR TITLE
CORS-3516: hack: do not execute cross-compiled binaries 

### DIFF
--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -23,6 +23,10 @@ copy_cluster_api_to_mirror() {
 
 sync_envtest() {
   if [ -f "${CLUSTER_API_BIN_DIR}/kube-apiserver" ]; then
+    if [ "$(go env GOOS)" != "$(go env GOHOSTOS)" ] || [ "$(go env GOARCH)" != "$(go env GOHOSTARCH)" ]; then
+      echo "Found cross-compiled artifact: skipping envtest binaries version check"
+      return
+    fi
     version=$("${CLUSTER_API_BIN_DIR}/kube-apiserver" --version | sed 's/Kubernetes //' || echo "v0.0.0")
     echo "Found envtest binaries with version: ${version}"
     if printf '%s\n%s' v${ENVTEST_K8S_VERSION} "${version}" | sort -V -C; then

--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -27,7 +27,7 @@ sync_envtest() {
       echo "Found cross-compiled artifact: skipping envtest binaries version check"
       return
     fi
-    version=$("${CLUSTER_API_BIN_DIR}/kube-apiserver" --version | sed 's/Kubernetes //' || echo "v0.0.0")
+    version=$( ("${CLUSTER_API_BIN_DIR}/kube-apiserver" --version || echo "v0.0.0") | sed 's/Kubernetes //' )
     echo "Found envtest binaries with version: ${version}"
     if printf '%s\n%s' v${ENVTEST_K8S_VERSION} "${version}" | sort -V -C; then
       return


### PR DESCRIPTION
We cannot execute cross-compiled binaries, otherwise we get an error saying:
```
hack/build-cluster-api.sh: line 26: /go/src/github.com/openshift/installer/cluster-api/bin/darwin_amd64/kube-apiserver: cannot execute binary file: Exec format error
```
The check should be skipped in those cases.