### PR TITLE
OCPBUGS-33502: capi/aws: fix setting IMDSv2 value

### DIFF
--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -43,6 +43,11 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 		total = *in.Pool.Replicas
 	}
 
+	imds := capa.HTTPTokensStateOptional
+	if mpool.EC2Metadata.Authentication == "Required" {
+		imds = capa.HTTPTokensStateRequired
+	}
+
 	var result []*asset.RuntimeFile
 
 	for idx := int64(0); idx < total; idx++ {
@@ -97,7 +102,7 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 					EncryptionKey: mpool.KMSKeyARN,
 				},
 				InstanceMetadataOptions: &capa.InstanceMetadataOptions{
-					HTTPTokens:   capa.HTTPTokensState(mpool.EC2Metadata.Authentication),
+					HTTPTokens:   imds,
 					HTTPEndpoint: capa.InstanceMetadataEndpointStateEnabled,
 				},
 			},

--- a/pkg/asset/machines/aws/awsmachines_test.go
+++ b/pkg/asset/machines/aws/awsmachines_test.go
@@ -98,6 +98,7 @@ func TestGenerateMachines(t *testing.T) {
 						Spec: capa.AWSMachineSpec{
 							InstanceMetadataOptions: &capa.InstanceMetadataOptions{
 								HTTPEndpoint: capa.InstanceMetadataEndpointStateEnabled,
+								HTTPTokens:   capa.HTTPTokensStateOptional,
 							},
 							AMI: capa.AMIReference{
 								ID: ptr.To(""),
@@ -153,6 +154,7 @@ func TestGenerateMachines(t *testing.T) {
 						Spec: capa.AWSMachineSpec{
 							InstanceMetadataOptions: &capa.InstanceMetadataOptions{
 								HTTPEndpoint: capa.InstanceMetadataEndpointStateEnabled,
+								HTTPTokens:   capa.HTTPTokensStateOptional,
 							},
 							AMI: capa.AMIReference{
 								ID: ptr.To(""),


### PR DESCRIPTION
Convert from Installer type to CAPA type instead of relying on the string value, otherwise we'll fail with:

```
INFO Creating Route53 records for control plane load balancer
ERROR failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to create control-plane manifest: AWSMachine.infrastructure.cluster.x-k8s.io "yunjiang-cap4-fp88c-bootstrap" is invalid: spec.instanceMetadataOptions.httpTokens: Unsupported value: "Required": supported values: "optional", "required"
```