### PR TITLE
OCPBUGS-30860: bootstrap: hit readyz when checking LB status

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -102,7 +102,7 @@ function check_url() {
         local URL_STAGE_NAME="check-api-int-url"
     fi
 
-    CURL_URL="https://${2}:6443/version"
+    CURL_URL="https://${2}:6443/readyz"
 
     record_service_stage_start ${URL_STAGE_NAME}
     if validate_get_url "$URL_TYPE" "$CURL_URL"; then


### PR DESCRIPTION
Improve API server readiness before leaving bootstrap