### PR TITLE
AGENT-903: Change $@ to "$*" to fix shellcheck

### DIFF
--- a/docs/user/agent/add-node/node-joiner-monitor.sh
+++ b/docs/user/agent/add-node/node-joiner-monitor.sh
@@ -7,7 +7,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-ipAddresses=$@
+ipAddresses="$*"
 
 # Setup a cleanup function to ensure to remove the temporary
 # file when the script will be completed.


### PR DESCRIPTION
ipAddresses should be a string containing a space delimited list of IP addresses to be monitored.