### PR TITLE
OCPBUGS-33649: add quota support to ca-west-1

### DIFF
--- a/pkg/quota/aws/limits.go
+++ b/pkg/quota/aws/limits.go
@@ -24,6 +24,7 @@ var SupportedRegions = sets.NewString(
 	"ap-southeast-2",
 	"ap-northeast-1",
 	"ca-central-1",
+	"ca-west-1",
 	"eu-central-1",
 	"eu-west-1",
 	"eu-west-2",


### PR DESCRIPTION
We missed this when support to ca-west-1 region was added.