### PR TITLE
no-jira: Vendor api changes for tech preview with capg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.3-0.20240416171357-98239ba02cb2
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.33.0
-	github.com/openshift/api v0.0.0-20240510053056-88a8afea030c
+	github.com/openshift/api v0.0.0-20240514123321-944467d2cc3b
 	github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -1971,8 +1971,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1:YWuSjZCQAPM8UUBLkYUk1e+rZcvWHJmFb6i6rM44Xs8=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
-github.com/openshift/api v0.0.0-20240510053056-88a8afea030c h1:cRP/J9kbXFv3oe4LbR1XeHQuTU+/6S4DJ5vMnZTtvRM=
-github.com/openshift/api v0.0.0-20240510053056-88a8afea030c/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
+github.com/openshift/api v0.0.0-20240514123321-944467d2cc3b h1:aULqM8xdW5+Pz5Pod0CzFGKYlvKo5Jd7/Z2zzKc1ndU=
+github.com/openshift/api v0.0.0-20240514123321-944467d2cc3b/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17 h1:rsTD5h6S3dCgAClbwWi/6AIo2twckeJEf+j4EZYkwII=
 github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8 h1:+fZLKbycDo4JeLwPGVSAgf2XPaJGLM341l9ZfrrlxG0=

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -492,6 +492,7 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("bfournie").
 					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateClusterAPIInstallIBMCloud = newFeatureGate("ClusterAPIInstallIBMCloud").

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -980,7 +980,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.17
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift/api v0.0.0-20240510053056-88a8afea030c
+# github.com/openshift/api v0.0.0-20240514123321-944467d2cc3b
 ## explicit; go 1.21
 github.com/openshift/api/annotations
 github.com/openshift/api/config/v1


### PR DESCRIPTION
Vendoring openshift API changes to include tech preview feature set for gcp capi installs