### PR TITLE
OCPBUGS-31017: aws: add missing permission for IPv4 pools

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -263,6 +263,8 @@ var permissions = map[PermissionGroup][]string{
 		"kms:ListGrants",
 	},
 	PermissionPublicIpv4Pool: {
+		// Needed to check the IP pools during install-config validation
+		"ec2:DescribePublicIpv4Pools",
 		// Needed by terraform because of bootstrap EIP created
 		"ec2:DisassociateAddress",
 	},


### PR DESCRIPTION
We need to retrieve the IPv4 pools to validate them before the install, so we need the `ec2:DescribePublicIpv4Pools` permission when the feature is enabled.