### PR TITLE
OCPBUGS-33531: update RHCOS 4.16 bootimage metadata to 416.94.202405132047-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.16",
   "metadata": {
-    "last-modified": "2024-05-01T11:48:18Z",
+    "last-modified": "2024-05-14T17:50:56Z",
     "generator": "plume cosa2stream d0fc725"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-aws.aarch64.vmdk.gz",
-                "sha256": "91c593497a8e654e9238c5a5ce5c8fd24773c91110a09669606890f15369e75a",
-                "uncompressed-sha256": "c4e9648838e711a89388852e263427246e067019ca1f7f2013d977f55b4510f4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-aws.aarch64.vmdk.gz",
+                "sha256": "f46493f0d8bc8a16d7ed39b62b8ce1f792e74d011a1f82bfb2b5225e31cfd67f",
+                "uncompressed-sha256": "9f9cd4389c903b73d961b4e35e16a563ae443b98f3c4f34db5cd2a1f3d0d2ba0"
               }
             }
           }
         },
         "azure": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-azure.aarch64.vhd.gz",
-                "sha256": "bdb1c27084adfd753dd4193f5429f661647d69b2da3627a98d9f96d53dd4f657",
-                "uncompressed-sha256": "6e88349c5c6c0f5f80d5c1ffe251332dbe3680dc7a1760ab3e2041b7fa55872a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-azure.aarch64.vhd.gz",
+                "sha256": "b2774309bc70d2effa12fa80d2fb88671a99e873ec43f224c87c0bf60ba1de5e",
+                "uncompressed-sha256": "896b6507276e045ca62cd644d631a3b66df478d0362943e81f77ba1503b8ab5f"
               }
             }
           }
         },
         "gcp": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-gcp.aarch64.tar.gz",
-                "sha256": "098a8874ac7363a9ab7c76181878979e6a62f0116c2308405a3d417ae7a8ba3f",
-                "uncompressed-sha256": "5411ac95bb759371a4eff5219f3cd41c03ae01e6b931ef02c62a268c8b53b88b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-gcp.aarch64.tar.gz",
+                "sha256": "13369c10cd66a38b05d984bbb34ecfe92edbf7832897651dcf5978ccca668138",
+                "uncompressed-sha256": "814814a2793ac30cf15a66e6bbf837fd9ef827135b8e3f037544b29dfbf07b7e"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-metal4k.aarch64.raw.gz",
-                "sha256": "f53397b06d0162c2b554f310ec3244a8026e8ca1f6ea3d94af4d4bf12bfca4a4",
-                "uncompressed-sha256": "612878cc34163b6aadb3cbed99428ebc00114e3dd51b000f6d8be555a5c308b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-metal4k.aarch64.raw.gz",
+                "sha256": "975c7e6e246f9f186a08effbf951b24be1485897d6d2816c1c504fffd3001993",
+                "uncompressed-sha256": "62712e0bcbe4d81c8a087f1c6c488d7df5d6107f0ed472d0ccdc2dc122d88c1d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-live.aarch64.iso",
-                "sha256": "4d32e7f7fc377f86836bdd325a4d86834d9f7f7b640539835cd998c207e87ddd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-live.aarch64.iso",
+                "sha256": "0f9bcf663a7465a7cf93c393f97a183246302eb5e76d602a7e3ba9f53f82073a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-live-kernel-aarch64",
-                "sha256": "572fb8d3e90e2f18c6d80bcf7f9001e9f239cb8ebcf6344438de55e44b4ebb36"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-live-kernel-aarch64",
+                "sha256": "9d6115d6991892693f4e0866bfb392d8dc699775d44dd4a281d421b71a0425b5"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-live-initramfs.aarch64.img",
-                "sha256": "f922f0f990bc1245260e98f9f2585e2dab27f8a299ff994eb1a04fc7a171b236"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-live-initramfs.aarch64.img",
+                "sha256": "0293aaa7646df4d866f088b56d59d49db3f1b923301ca662131404176f71ae09"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-live-rootfs.aarch64.img",
-                "sha256": "247bd797f12046567d75acee41423fb98351a127387dc4629ecad02403a70a00"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-live-rootfs.aarch64.img",
+                "sha256": "1f5da6430069a8a99c948008db24a5e3e5d2fc7d75bf2664d1fec672bdd5f5e9"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-metal.aarch64.raw.gz",
-                "sha256": "1556512f6cc849afea46acecff9e0c74417dfe280b513e0a41f13492310c5693",
-                "uncompressed-sha256": "71e63f8e0bd060160c5db5e84b563000406b1602045e64394e12001c3d70b1f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-metal.aarch64.raw.gz",
+                "sha256": "7721daaa2099e52b5b01c24e679275f735674843d4943b2364b4b477f911feab",
+                "uncompressed-sha256": "7776afde7a2a1b2ccd5bf953ba55c8ea36d77c04aaab295ff63332b023b35687"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-openstack.aarch64.qcow2.gz",
-                "sha256": "aefcc7e65df079be9f6b62b0948d80c4f9310f71e08d725b3ca2722f1d92f0ad",
-                "uncompressed-sha256": "056a4222c69fb15273b613fb7fac37f1b36030a7af82af42a743de76109b57b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-openstack.aarch64.qcow2.gz",
+                "sha256": "3a4f03129bb9adcee790305bd77e9c8028279b7043bc6b186b5634a4393d2493",
+                "uncompressed-sha256": "b6a0947632e251686fc7c66656094e3698f11dc06d7a7465bd09c2aa77bc0a69"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/aarch64/rhcos-416.94.202404301731-0-qemu.aarch64.qcow2.gz",
-                "sha256": "de61c7329de874af00d5b37992d9694a71c8d9537683d3b154b9fb928f6653a1",
-                "uncompressed-sha256": "e02bb43c7b06c1200ab8b35469539ffc6aa10035f581e6408b08cbf3d45846a8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/aarch64/rhcos-416.94.202405132047-0-qemu.aarch64.qcow2.gz",
+                "sha256": "0f6e0ef5371dd16acd2c8cb76c16cc8a03e60198f38f854b743d940e80d0380e",
+                "uncompressed-sha256": "114e055a809d13730c1b12442c1ebd762972c7319444f41f14ef61b9f2b76f0d"
               }
             }
           }
@@ -111,217 +111,217 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-08458df331eb5bfde"
+              "release": "416.94.202405132047-0",
+              "image": "ami-09359af5929ffbaa3"
             },
             "ap-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0afe708eed50eb7a5"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0a590145e8741695a"
             },
             "ap-northeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-01c1d9609eda5f771"
+              "release": "416.94.202405132047-0",
+              "image": "ami-05f0a80fc1f7c385a"
             },
             "ap-northeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-03d5735f8cbc408c4"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0fac664b70b969e43"
             },
             "ap-northeast-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0ac40bd38c3edae59"
+              "release": "416.94.202405132047-0",
+              "image": "ami-05069094091e13d0c"
             },
             "ap-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0b037e280289ea8f6"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0e043bbdaeb6d33a7"
             },
             "ap-south-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0565fcdf8ebcd3473"
+              "release": "416.94.202405132047-0",
+              "image": "ami-023c8b7dab11db1a2"
             },
             "ap-southeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-079b8fdac5f8d00f0"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0dde08b7d239ecf2d"
             },
             "ap-southeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-027dd1c9e2d1bb9bd"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0d76b0dfb1f573ad4"
             },
             "ap-southeast-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-034658e691d3fb73c"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0e48b7ce1993e0aa2"
             },
             "ap-southeast-4": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0c6373b9f83089c8f"
+              "release": "416.94.202405132047-0",
+              "image": "ami-09ed4ff31882e104c"
             },
             "ca-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-07c6bdee36936ba65"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0c374f2d6a36dca55"
             },
             "ca-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-02f53750bdf81f0fa"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0287466d79397f3a0"
             },
             "eu-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-09a1e0045ed7aeaa5"
+              "release": "416.94.202405132047-0",
+              "image": "ami-07b7d7b9d3809406a"
             },
             "eu-central-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0862a64a124f32d4f"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0c91bba6d4bc2ead6"
             },
             "eu-north-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-04ff1a96ff172ea93"
+              "release": "416.94.202405132047-0",
+              "image": "ami-070279ed6529bb6a8"
             },
             "eu-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-03e172e6bfd6a0345"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0bda5627e6cf0cc3e"
             },
             "eu-south-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-01f6abf09dac21302"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0d5eb25c33b31827a"
             },
             "eu-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-01999559e02798fcc"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0f64b5bd68ec39c3e"
             },
             "eu-west-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0dfa523f35609912a"
+              "release": "416.94.202405132047-0",
+              "image": "ami-011ada4b6a0dfbfb5"
             },
             "eu-west-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-073f217b965e8c627"
+              "release": "416.94.202405132047-0",
+              "image": "ami-019fa9643661a1ae3"
             },
             "il-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-06627d5481c97c855"
+              "release": "416.94.202405132047-0",
+              "image": "ami-09a26c0b97ff1426c"
             },
             "me-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0398d8300e6c8a8f8"
+              "release": "416.94.202405132047-0",
+              "image": "ami-089b8e74675ac9937"
             },
             "me-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-08715c5dd1c1703e9"
+              "release": "416.94.202405132047-0",
+              "image": "ami-02b383f44079b1fd5"
             },
             "sa-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-09a9d752ff8517678"
+              "release": "416.94.202405132047-0",
+              "image": "ami-08d17e7e37ab9ea5c"
             },
             "us-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-01becc59d6c46f0a4"
+              "release": "416.94.202405132047-0",
+              "image": "ami-07346e941661b2ae0"
             },
             "us-east-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0ce21ca13278bc6f9"
+              "release": "416.94.202405132047-0",
+              "image": "ami-009c23f5c49ef08f2"
             },
             "us-gov-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-058fdbb8cbc200d7f"
+              "release": "416.94.202405132047-0",
+              "image": "ami-097ae85bd03408e25"
             },
             "us-gov-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-08303c426de9a80b7"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0951f3cbfa71e46c1"
             },
             "us-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-08cde85c05c56cd39"
+              "release": "416.94.202405132047-0",
+              "image": "ami-03c71a3222c63e74e"
             },
             "us-west-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0cd9ab3ecbcf4fa2e"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0b4c0a350ce56b511"
             }
           }
         },
         "gcp": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-416-94-202404301731-0-gcp-aarch64"
+          "name": "rhcos-416-94-202405132047-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "416.94.202404301731-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202404301731-0-azure.aarch64.vhd"
+          "release": "416.94.202405132047-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202405132047-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-metal4k.ppc64le.raw.gz",
-                "sha256": "4156dcd3f161ceeb9ab8a9784ae773f98ce85871fb6f599230692074860e8c44",
-                "uncompressed-sha256": "782ce335970b87c6f582045b670848137d0a61adf97adf09b4a1ad718d83557c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-metal4k.ppc64le.raw.gz",
+                "sha256": "734ca4fd4f5667ccca0a0854e30b3c77f6dc9e9fc437ad0686f5a12df2bf0ce6",
+                "uncompressed-sha256": "8a51ec2e9dab4a08e6a63d601a032138358bbbb0ffeaf7fca8933a21cd43979f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-live.ppc64le.iso",
-                "sha256": "115a42aa9fdfebe65af4e86ff03284b7779e32e85972d3b1e2873ab9dbe3d6bf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-live.ppc64le.iso",
+                "sha256": "a595c6c3ebaaa763a8895441eda6fb9383c8bc17644e1dc29ab9b55dbb44e408"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-live-kernel-ppc64le",
-                "sha256": "0750dc0ae3df1fec9b48e5a22657b7be7ab7619859a02a030979f2d28301197b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-live-kernel-ppc64le",
+                "sha256": "f64826cba7e16327b08e60b73eec866cee4f62886e6d301d622a56f684e19e97"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-live-initramfs.ppc64le.img",
-                "sha256": "b372a211ff882532a5ce4e6a06a499e0d768dc48d0b1a09f7d40451e3df2288f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-live-initramfs.ppc64le.img",
+                "sha256": "07cf6501e04fc3d8024e89b0e287107dfca4a6456af9bfa0bea00e258181f46a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-live-rootfs.ppc64le.img",
-                "sha256": "b539045e1ab3397f1b1b7d7626a80cba4e592f36e7081e27b11fba7fa4fa6a7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-live-rootfs.ppc64le.img",
+                "sha256": "ec8700805bf18ca6e2cc2db73402add6a3c884dd7207d21c4ea423cd25f1c5ff"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-metal.ppc64le.raw.gz",
-                "sha256": "b9d1fa23dc9d5611119160dc2ec2290f7301a6ffb6581c582ec9671f0e96b437",
-                "uncompressed-sha256": "f7ccb051973f0773b3b73369abf60a58249347a2a30ab17464e856262d26b096"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-metal.ppc64le.raw.gz",
+                "sha256": "3c1dc3a52958ecd9ea8f064201d669ca3b948a4da82139f3810e449799b0e5a6",
+                "uncompressed-sha256": "88ef862f56d06a42a2db365104e38158c1dbf3fde52ad9223548c46f1590c554"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "98bce34e8801056d9479f18af8b533227e98e73cbc62d06f59d0085b2d598c7e",
-                "uncompressed-sha256": "44f132af3f2e79db7c0cd47f53753fd41d42ae540f224e76a55e0ac944eaab7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "9d5287a4033772944005719dc8f36b040cdded67bd73e6174b5c10a2daca9175",
+                "uncompressed-sha256": "4df59b5e13278ed76d9bb8d159acf911bcb031350a03853d81a869ab99b3a448"
               }
             }
           }
         },
         "powervs": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-powervs.ppc64le.ova.gz",
-                "sha256": "b4ed2fe04b20f7dde323751aab80860ae456e6c10f794dd02fd12b9472e5521f",
-                "uncompressed-sha256": "272c2ec9d799f383e1382438d5b40ec390e21cf224932f767aca9b9886a1fed8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-powervs.ppc64le.ova.gz",
+                "sha256": "756e295006e6d8e8af7c18220b1abab763e34b377e0df48f8dddc2775da5cf8a",
+                "uncompressed-sha256": "465ccd0c9a91339046891e0e570ecd13ba70feebf8cfeece05bd61d28c8f64fa"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/ppc64le/rhcos-416.94.202404301731-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "2076be6887048701f71d464cc07bc5507b9b6f78f5f223ee3479bf8059d9b8a9",
-                "uncompressed-sha256": "3435a97d5b2085ea9bcbe29ae39d1c0642fc81ee85182517b9bbd97f6bb8cd1f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/ppc64le/rhcos-416.94.202405132047-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "b4791fce119b1cd8a216dbb8953ab57c820b5c55214b34ad86167232e46fcf07",
+                "uncompressed-sha256": "cca3643c612c7b671319e9550d7a3ebc99b307f6b3cea6186a56d095c104a2e8"
               }
             }
           }
@@ -331,64 +331,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "416.94.202404301731-0",
-              "object": "rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202405132047-0",
+              "object": "rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-416-94-202404301731-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-416-94-202405132047-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -397,88 +397,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "61d53c7a7fce1acd01734a5ee4866a28967bab80749f9e41aedd0121ea10746f",
-                "uncompressed-sha256": "216d611a35e1b135871777c4f22bb00fc86e334c3b91d321a2a2024224835b7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "b4889c385cf114b7d5415521735bc1d3a654c9aad0b1fba2449ad5493d262bc9",
+                "uncompressed-sha256": "ab7397915b9f09d7a22c1bcd74c1372c9c385fe61b1134ac4ba6a4034052a795"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-metal4k.s390x.raw.gz",
-                "sha256": "0744ab0c896032fcb553f5e0ecdaf0edfbd357346e85be9483e73bf6c3acd015",
-                "uncompressed-sha256": "da82fe17086fadc1f37db033ac8f7dd2da4ce534cd77732786db32a09df7410b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-metal4k.s390x.raw.gz",
+                "sha256": "097f1416386f3cd2601f2d2811d8d7ea41b6f6f6a479868542876f5325157336",
+                "uncompressed-sha256": "d053ffd71ad54fb66b7b58f105c2e874344ce8ca74515020ebaf00fbebd291e5"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-live.s390x.iso",
-                "sha256": "da1d02d6112c0748b0535a0d3e477a81d6736c4d345e443d54c89674f3ed5bb5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-live.s390x.iso",
+                "sha256": "20d94592f993bfa61e399b377fa93b8f7c3494a8062a8a8fa0004ed639d5b390"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-live-kernel-s390x",
-                "sha256": "300d9b5f50851a36f0fba99b09a3883fa28e4c13c01ded8c79c3f79f611eea22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-live-kernel-s390x",
+                "sha256": "979f738d99c70b99ed5855cb654d2651d50556518baf4538b6350449769711c2"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-live-initramfs.s390x.img",
-                "sha256": "b9283ed634237a04f30a5e90267fcec13f5ef3492f189193136f5baee10d1458"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-live-initramfs.s390x.img",
+                "sha256": "90c030d0191e51f6c0aa686afdedaa1ef382544b835aee7a44359c5583f8128c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-live-rootfs.s390x.img",
-                "sha256": "d9bf1f77a9c87c51a5a876a5669dd68acfdd4ca18dbf685c1ffbec6c99203435"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-live-rootfs.s390x.img",
+                "sha256": "02931d96d637278f42e8a458d78fe6fa6615b7ddc2a30dea8fb8ae00b40177a9"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-metal.s390x.raw.gz",
-                "sha256": "700bf29adc420a73957796292e6ab4a67d177a7486112c1513531fce2407b9f3",
-                "uncompressed-sha256": "317876ccf27a8151c94c20352e274e8ff76f20ab455ce0b4a7693b8156f2d800"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-metal.s390x.raw.gz",
+                "sha256": "d3ec7a8f3c38502efced5858695b32053d2bddddc9e29d344f3f95a730b9825b",
+                "uncompressed-sha256": "1452869fc852c33bb4297058f8665dcb6bdade8cd784ef7756f8e51d2e7dc4f3"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-openstack.s390x.qcow2.gz",
-                "sha256": "c2e2d55f6a9e6274e837673383b39de2475278c8fa42e08387dceff6377414a9",
-                "uncompressed-sha256": "307e9d36f024393c1c9abdcbe0fb7839fb2ffd6fac337da0d292e241aadb8680"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-openstack.s390x.qcow2.gz",
+                "sha256": "4ba7d9ba700b795a0c7886ad883887b1b44632a8ed35991514d2a174feb787a4",
+                "uncompressed-sha256": "c59a34829a4fa3a260e528be35939963e96851e42ae8d92135b4a8c014ff8f53"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-qemu.s390x.qcow2.gz",
-                "sha256": "ef84816273c1e7464e9eb4ba10f97a7cd9d1962d93d3450bddb81878b749a426",
-                "uncompressed-sha256": "f0470bfc8d0ca924ff39776c246cb1780a9a6bef1f7a4f8c211ce526e6eb1fba"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-qemu.s390x.qcow2.gz",
+                "sha256": "a05d8aaab83aee95349e6d300d1899a3ccabec3598a1573ebfc448f08281c4b6",
+                "uncompressed-sha256": "3145533207a80a7f6e2fae54544c3138ec2785e9fcd7ccd3b0694332d394b4b4"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/s390x/rhcos-416.94.202404301731-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "4dd25e7f4b9688341c2291484607c39f871b69c9ad381d7acb47069318e25a81",
-                "uncompressed-sha256": "5c9c5105d830633b12e8b24414441093a53a4647581d20341c7d1ee13026c2dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/s390x/rhcos-416.94.202405132047-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "4d273e0f866624e45b723ef67ef8181bbbb88fb6ba2476cb9a8d202b0ff10c92",
+                "uncompressed-sha256": "4ee6ad73e8b17dad91bf62d9f5647cc3134c7c9a36a6671e986b3a7e37e4042f"
               }
             }
           }
@@ -489,169 +489,169 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "afbe3961f89731ea083225acce39bf0f5c11d8a226c23a876585bc72382e55e8",
-                "uncompressed-sha256": "9de26c4c6e4f55b6ae220bd2f39f1e5c96770c86f9c7405aba737745c0a8472d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "4d8bb2f82527f1adc6655b796374250e6adf5e5fc15ed8260df7906c5030ef0f",
+                "uncompressed-sha256": "10e9ce42dfa5ba0271275afbeaff932860c89a5f2c3f34ff45d182a7b898b5f7"
               }
             }
           }
         },
         "aws": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-aws.x86_64.vmdk.gz",
-                "sha256": "99b50c164eca6a7ead833254fbcbafd9a0c40f5211c64c486be73de44da4e5e7",
-                "uncompressed-sha256": "57fac26c138e9cc095125e42bcb950c1da01e369556a76d0d115ac3dc68dc2fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-aws.x86_64.vmdk.gz",
+                "sha256": "ae52f4f3a64f1012177f3a92ebd401b808bb30dc5ed6052f1989e167505f22cf",
+                "uncompressed-sha256": "45d59df842bc65e76bd886e075676f635efd77ce8d79ed50e8e581d2b80f8789"
               }
             }
           }
         },
         "azure": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-azure.x86_64.vhd.gz",
-                "sha256": "86f9c710353cbfea8844154d59a909caa714f5e583b8396c5300ede1c9ad157a",
-                "uncompressed-sha256": "fffd85c7138874d3e279ae40daa6dbe955eb7385d111769d523e179320b11883"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-azure.x86_64.vhd.gz",
+                "sha256": "7dbe500553dad983033f293ba75b0f697f8cfc532fb30a6aa8202be90d7e31ae",
+                "uncompressed-sha256": "a7cc6bfa20ed4859fbc8df600bda281d2e6070bfbbeab3ae53a7dca50253a719"
               }
             }
           }
         },
         "azurestack": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-azurestack.x86_64.vhd.gz",
-                "sha256": "25e06e5b11e4c21d0cf2b0067708d27870a96a13118ef65ea5085024d17089c1",
-                "uncompressed-sha256": "940a195655610760aaec5092794677cfd02dc2be2a4790b8aec602154c02eb1d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-azurestack.x86_64.vhd.gz",
+                "sha256": "9423012030f7a6f20cd41d4e5f2b822b655f598c8137b2a2178f344b8d98155a",
+                "uncompressed-sha256": "e88e9a77ed463c7c79939810c28ce1dc51f739215ab1fbcddcb3465fef78d7f1"
               }
             }
           }
         },
         "gcp": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-gcp.x86_64.tar.gz",
-                "sha256": "df956ea189eeaa49ffa5a81245e5970a946c285319a934902f99296403bc6a26",
-                "uncompressed-sha256": "40e427dfa185a5b9a70e2bb3d011933e00cbe69e0760e9cf23a1b3c728f84f2c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-gcp.x86_64.tar.gz",
+                "sha256": "703b3ebdf0049407c88fd205e5e7959a10e7da17f423a5aafafafb8041aca8d2",
+                "uncompressed-sha256": "1ba1799f8c1c20e6f6ab2dedb007fb211944dc1eba71322cadd91fab1237afdd"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "2c33f3731537a90a58d5ef67f273684184267234f2d071115482b374b07f92fb",
-                "uncompressed-sha256": "462696f008fb52928a3a7052b67b01a1af241dfc65b7db954191891b4fdcb365"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "b4dcad7e6290a751672abfdd29f1b03968ff81c3332c49289f8c6d4d187d3097",
+                "uncompressed-sha256": "f9e4fa377a58d01a108ab9a646e2beade6368f8381cae61f87205cc3dfeff04f"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-kubevirt.x86_64.ociarchive",
-                "sha256": "b692119adb4c9d1dee200a11decd8309d880cc67fb083e45f5d38d6eb9faec78"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-kubevirt.x86_64.ociarchive",
+                "sha256": "1445bb359750586b044a7f8e84496da809f7707a46e1f6b6386b678db3571def"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-metal4k.x86_64.raw.gz",
-                "sha256": "6de05d50eb3602c9e2a2b7fd5322bbdc17316a0da6015d9bf6dd5795401e199f",
-                "uncompressed-sha256": "4826b7eebc5643fa88c9d9fef386207fc6f4eec39fdcfc28c4f7020dd54bd6d1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-metal4k.x86_64.raw.gz",
+                "sha256": "2477c4f386d85cce3e6a099e8ecd683077fe17a9435705b61cae84be8813e25a",
+                "uncompressed-sha256": "deb97458dc1b1043b69eea1cb793e73fd559077dcaf1108f60c45b9cecfe465e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-live.x86_64.iso",
-                "sha256": "dc96c9d00fe5b712f95804a9933502fe592da81fdf20de77e9e9e4b44b52d7fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-live.x86_64.iso",
+                "sha256": "80ebefd84bc6b05100d90d25e8979efec5fbd25746ca334eea44ed3198affa05"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-live-kernel-x86_64",
-                "sha256": "b8044d54fda2c785d1bd2a6ad27f717cd7bad71deed0ae97a9e444ebc3ad44d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-live-kernel-x86_64",
+                "sha256": "2716b309e7cea063d82a8da62577a74601a5aee37a869306712c412cf04804aa"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-live-initramfs.x86_64.img",
-                "sha256": "3d768deeb9b78f1e3eeed97cb5fb85135401efa29608dd76220ea573a40edbd8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-live-initramfs.x86_64.img",
+                "sha256": "9981e720f4d917cd5b0fc9047c078a46b9def6ac37f88b15cfe22bb7269269ae"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-live-rootfs.x86_64.img",
-                "sha256": "e676a048c26a0e29da882ddb6cf1c2d91d9372ce07eebd0c95cc1f9af981d0c2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-live-rootfs.x86_64.img",
+                "sha256": "3454cc12a29ac77d192b5dcb7233d9e90666b2465c1281a28e6774798cb5e2be"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-metal.x86_64.raw.gz",
-                "sha256": "401c3b2c8dcaf50ac4081c1b8d93afccb3ffd929ce579925c536ff21d5f16bd1",
-                "uncompressed-sha256": "827b9757c7ff3ba1be8f0412ad924bb94cfe390972e2cfb34afae513fedfb656"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-metal.x86_64.raw.gz",
+                "sha256": "4c37c43549a18e3c5d7c63a8c5e8e661ef33e7cf4587b529d946c823ef28fa8e",
+                "uncompressed-sha256": "dd1206caa43b0ac049f90170a9cd43fcd4b1a9683b4aa4947fa6d03b891f79ea"
               }
             }
           }
         },
         "nutanix": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-nutanix.x86_64.qcow2",
-                "sha256": "593dd8f0cefcede1a6cfe9618dfb2583bb9d97e8aed1cf95c3a0f9226e6762c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-nutanix.x86_64.qcow2",
+                "sha256": "349b0b3e03708214ab0ce5c3b731d7310dc3a90abeb2bafdb070406e0bea6d50"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-openstack.x86_64.qcow2.gz",
-                "sha256": "acc22c1b590a6f628f6bf37f902b8ebcd5ac704ee2b86042457e7e4d1bbf604c",
-                "uncompressed-sha256": "04e75f55c35ee2d04509241259dc2f0ad71ebafba56d6283efea73273f10a89b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-openstack.x86_64.qcow2.gz",
+                "sha256": "77074a948164f89590391fbba2d48e8f895915e5c6707785c6540e99ef46d584",
+                "uncompressed-sha256": "42049e61f5d06b25c44b74d3cb47eccc7564e36175cbf01b1d3d0f9feb3d7a0c"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-qemu.x86_64.qcow2.gz",
-                "sha256": "b2136238daf9de638b2ef48e300476cf3ddc007867789cab44c17271927c5fe2",
-                "uncompressed-sha256": "f1139b0bf8a11df04641fc01b1f9f90ef4eff54e3adade2aff5f5ca8fd749581"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-qemu.x86_64.qcow2.gz",
+                "sha256": "94b0994ce07a1e71cdd8eedc590e483db410618109d2dcfba6333896cc04e305",
+                "uncompressed-sha256": "d25ce17bb88ba4cfb67ebdd2d9333ee62145a8cf90d7921d1dcc9db1c85443fa"
               }
             }
           }
         },
         "vmware": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202404301731-0/x86_64/rhcos-416.94.202404301731-0-vmware.x86_64.ova",
-                "sha256": "f8e3dfacfff0d28a835e5e34b27ac456f7d672f385401f480b6988593873b4b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202405132047-0/x86_64/rhcos-416.94.202405132047-0-vmware.x86_64.ova",
+                "sha256": "194814f1718b01f35773681ba8f2e3084a3d2f53d8a4f5751223ce2d289b1150"
               }
             }
           }
@@ -661,270 +661,270 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-6wedm0tzu6jew2mki4wi"
+              "release": "416.94.202405132047-0",
+              "image": "m-6weh74sf8z7w8948xeu4"
             },
             "ap-northeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "m-mj7dop4q325y0ynqlbql"
+              "release": "416.94.202405132047-0",
+              "image": "m-mj71mbkqmxxjghmy6kad"
             },
             "ap-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-a2d8a03b22t40q36vcav"
+              "release": "416.94.202405132047-0",
+              "image": "m-a2d3urzk7hep433ielb4"
             },
             "ap-southeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-t4n5ax33g9bo1b0rqlgj"
+              "release": "416.94.202405132047-0",
+              "image": "m-t4n66615jhkz08w4v5me"
             },
             "ap-southeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "m-p0wjetseel5smh0w09l8"
+              "release": "416.94.202405132047-0",
+              "image": "m-p0wbl0esb9xyns47zvzv"
             },
             "ap-southeast-3": {
-              "release": "416.94.202404301731-0",
-              "image": "m-8psczvxjkwfrjojad6my"
+              "release": "416.94.202405132047-0",
+              "image": "m-8psb0a94q0ip836mdne2"
             },
             "ap-southeast-5": {
-              "release": "416.94.202404301731-0",
-              "image": "m-k1aaqxfdggw43uzergml"
+              "release": "416.94.202405132047-0",
+              "image": "m-k1a3hy6oeuuj6pv2vwva"
             },
             "ap-southeast-6": {
-              "release": "416.94.202404301731-0",
-              "image": "m-5tsc7j0im3tpz63ipy3x"
+              "release": "416.94.202405132047-0",
+              "image": "m-5ts5j36lt2d1afe2rcnp"
             },
             "ap-southeast-7": {
-              "release": "416.94.202404301731-0",
-              "image": "m-0jo1yc3hyx9qnw2zgt3k"
+              "release": "416.94.202405132047-0",
+              "image": "m-0jo55utzxdfgzi7v13oc"
             },
             "cn-beijing": {
-              "release": "416.94.202404301731-0",
-              "image": "m-2ze47mxoj2984urnvmyt"
+              "release": "416.94.202405132047-0",
+              "image": "m-2ze9iolij5r02z95bcaf"
             },
             "cn-chengdu": {
-              "release": "416.94.202404301731-0",
-              "image": "m-2vca0v0yflhmrfm4xnzn"
+              "release": "416.94.202405132047-0",
+              "image": "m-2vc0ctzg5bja91qfuksq"
             },
             "cn-fuzhou": {
-              "release": "416.94.202404301731-0",
-              "image": "m-gw03bnprmu5wdogbbpk7"
+              "release": "416.94.202405132047-0",
+              "image": "m-gw04ledysx19vh4bonsu"
             },
             "cn-guangzhou": {
-              "release": "416.94.202404301731-0",
-              "image": "m-7xv6lu6sge47i4zh0k6j"
+              "release": "416.94.202405132047-0",
+              "image": "m-7xv1xn3t4dcr4skqcvq4"
             },
             "cn-hangzhou": {
-              "release": "416.94.202404301731-0",
-              "image": "m-bp1e5mr36m5av3zk57ch"
+              "release": "416.94.202405132047-0",
+              "image": "m-bp1amas874gepsu0p00l"
             },
             "cn-heyuan": {
-              "release": "416.94.202404301731-0",
-              "image": "m-f8zei80xcqqmy40y6vxw"
+              "release": "416.94.202405132047-0",
+              "image": "m-f8z56urslg0n0y50x8ud"
             },
             "cn-hongkong": {
-              "release": "416.94.202404301731-0",
-              "image": "m-j6cajox1dw0mdurfj9n0"
+              "release": "416.94.202405132047-0",
+              "image": "m-j6c27tqjc9ek60f5tibe"
             },
             "cn-huhehaote": {
-              "release": "416.94.202404301731-0",
-              "image": "m-hp3cwvq7u3z80e5j341z"
+              "release": "416.94.202405132047-0",
+              "image": "m-hp3e01u438xfj0b1y764"
             },
             "cn-nanjing": {
-              "release": "416.94.202404301731-0",
-              "image": "m-gc78q7znmlgwfz42o2d1"
+              "release": "416.94.202405132047-0",
+              "image": "m-gc70psqqjljlcg0c8kw9"
             },
             "cn-qingdao": {
-              "release": "416.94.202404301731-0",
-              "image": "m-m5e9ol990dyf22mhbqhx"
+              "release": "416.94.202405132047-0",
+              "image": "m-m5ecuz92qyydlmb8egy2"
             },
             "cn-shanghai": {
-              "release": "416.94.202404301731-0",
-              "image": "m-uf6bjc9q1jk01er3wotm"
+              "release": "416.94.202405132047-0",
+              "image": "m-uf6daine27b12bossipa"
             },
             "cn-shenzhen": {
-              "release": "416.94.202404301731-0",
-              "image": "m-wz95nmz92gvkyclwnu0b"
+              "release": "416.94.202405132047-0",
+              "image": "m-wz966igo1jp3f6jflbb3"
             },
             "cn-wuhan-lr": {
-              "release": "416.94.202404301731-0",
-              "image": "m-n4a3bnprmu5wdmha7nl2"
+              "release": "416.94.202405132047-0",
+              "image": "m-n4aexve0yh79c8itlsk6"
             },
             "cn-wulanchabu": {
-              "release": "416.94.202404301731-0",
-              "image": "m-0jl9tbkk3x09pfuymuf2"
+              "release": "416.94.202405132047-0",
+              "image": "m-0jldsc083q6sxa19e3hn"
             },
             "cn-zhangjiakou": {
-              "release": "416.94.202404301731-0",
-              "image": "m-8vbbd56igevwtjgkzh2n"
+              "release": "416.94.202405132047-0",
+              "image": "m-8vbdb4neis6rtrauiefn"
             },
             "eu-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-gw8fe2tugr2v0phfbjvc"
+              "release": "416.94.202405132047-0",
+              "image": "m-gw84m84ilwwgq2y5cf4n"
             },
             "eu-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-d7ofypp3ky5xesz48f8p"
+              "release": "416.94.202405132047-0",
+              "image": "m-d7ociclgv9tvib5je26t"
             },
             "me-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-l4v4l6g4z3mwqmek7pzu"
+              "release": "416.94.202405132047-0",
+              "image": "m-l4v69psanoduywhha0h8"
             },
             "me-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-eb36gani9h1frbg39wbk"
+              "release": "416.94.202405132047-0",
+              "image": "m-eb3ek3x6klk36ci0bf7q"
             },
             "us-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-0xiaazk33ol7yax7xt8u"
+              "release": "416.94.202405132047-0",
+              "image": "m-0xi2hx3eq5k4pu7gzoeg"
             },
             "us-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "m-rj9aajlty788yi8m7v82"
+              "release": "416.94.202405132047-0",
+              "image": "m-rj9c0z6qw1hj7kdr8wgj"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0819526289ead9b76"
+              "release": "416.94.202405132047-0",
+              "image": "ami-069b02bcaec939a06"
             },
             "ap-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-04e0df1324a1a0f6f"
+              "release": "416.94.202405132047-0",
+              "image": "ami-03740900c79eef313"
             },
             "ap-northeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0c0b58061032728bb"
+              "release": "416.94.202405132047-0",
+              "image": "ami-02aad62b7e5bcd333"
             },
             "ap-northeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-09306de3dd2643286"
+              "release": "416.94.202405132047-0",
+              "image": "ami-00ed142b43023f3a2"
             },
             "ap-northeast-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-07e6644eb18bf9c3f"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0a59e830c25f820d9"
             },
             "ap-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0200fca86d76cfdb6"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0ecf643cf30624cd8"
             },
             "ap-south-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-060a2183ff94d9a4e"
+              "release": "416.94.202405132047-0",
+              "image": "ami-018f4e92ff105853e"
             },
             "ap-southeast-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-02505378db244f0fc"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0b2b846dfe6585bb8"
             },
             "ap-southeast-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-060559e5481ee0307"
+              "release": "416.94.202405132047-0",
+              "image": "ami-046bd0747f2722629"
             },
             "ap-southeast-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0908b9f5d33a94c00"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0d0047136992318a7"
             },
             "ap-southeast-4": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0f0c03a2764188b16"
+              "release": "416.94.202405132047-0",
+              "image": "ami-09c746a44f2c6359b"
             },
             "ca-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0802bba1b47052cdb"
+              "release": "416.94.202405132047-0",
+              "image": "ami-069ce1af3f2f64021"
             },
             "ca-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0681d51a89063bfd7"
+              "release": "416.94.202405132047-0",
+              "image": "ami-01819422b4181fefe"
             },
             "eu-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-07e3b1540ebca5899"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0f5e18ecc9b0fff27"
             },
             "eu-central-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0f6dcdb6f57017dfd"
+              "release": "416.94.202405132047-0",
+              "image": "ami-005d8147bbf245813"
             },
             "eu-north-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0a185f56e8e807008"
+              "release": "416.94.202405132047-0",
+              "image": "ami-07c4d50452d50bfd0"
             },
             "eu-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0057d1752ba05aaee"
+              "release": "416.94.202405132047-0",
+              "image": "ami-02584b24808022f13"
             },
             "eu-south-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-01eecbc7d0b3dd361"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0aa633a7a89e15a2e"
             },
             "eu-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0a9a929121e38916d"
+              "release": "416.94.202405132047-0",
+              "image": "ami-07ab39759659ee000"
             },
             "eu-west-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0e7c7e0969f94ddbe"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0c63884ce9624f7be"
             },
             "eu-west-3": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-09ca5e167bd15591d"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0968a30e3072e44f8"
             },
             "il-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-009da7c53d6716d47"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0b3158a84e3a45342"
             },
             "me-central-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-04f3ed6b9e69a9a65"
+              "release": "416.94.202405132047-0",
+              "image": "ami-035a448d2a1d1da36"
             },
             "me-south-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0f5c4faa309a8bf88"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0ac8a671c580f834f"
             },
             "sa-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0d31b2feb8e47c5ef"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0f518efb254abcc93"
             },
             "us-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0cfdd76ddf189c9b9"
+              "release": "416.94.202405132047-0",
+              "image": "ami-02b0e13d50b0b0d54"
             },
             "us-east-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0ae9b509738034a2c"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0eb607c51b9db2a44"
             },
             "us-gov-east-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-09f7cd7a24f3d6dbc"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0c8bdad40327ade28"
             },
             "us-gov-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-052f14651112bf4cf"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0c30c6dbb88b97ae6"
             },
             "us-west-1": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-0f04300bba8371695"
+              "release": "416.94.202405132047-0",
+              "image": "ami-0ac7c7c532c429a7a"
             },
             "us-west-2": {
-              "release": "416.94.202404301731-0",
-              "image": "ami-08052f88d49dcbb1a"
+              "release": "416.94.202405132047-0",
+              "image": "ami-02eb9049ecf3fa261"
             }
           }
         },
         "gcp": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-416-94-202404301731-0-gcp-x86-64"
+          "name": "rhcos-416-94-202405132047-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "416.94.202404301731-0",
+          "release": "416.94.202405132047-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.16-9.4-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f0107f56ffdb5f03601b7228aad63d6615ef342f31b69f1eb824a1291b84a7dc"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2002f1f3ba0ec26062058c79184e257ada564c503bdabff3d482a691b9155a94"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "416.94.202404301731-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202404301731-0-azure.x86_64.vhd"
+          "release": "416.94.202405132047-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202405132047-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.16 boot image metadata. Notable changes in this update is:

OCPBUGS-33528:RHCOS root reprovisioning went from ~5 mins to ~11 mins in Azure

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name 4.16-9.4                   \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=416.94.202405132047-0                                      \
    aarch64=416.94.202405132047-0                                     \
    s390x=416.94.202405132047-0                                       \
    ppc64le=416.94.202405132047-0
```