### PR TITLE
OCPBUGS-33662: aws: don't always require s3:Delete* permissions

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -45,6 +45,9 @@ const (
 
 	// PermissionPublicIpv4Pool is an additional set of permissions required when the installer uses public IPv4 pools.
 	PermissionPublicIpv4Pool PermissionGroup = "public-ipv4-pool"
+
+	// PermissionDeleteIgnitionObjects is a permission set required when `preserveBootstrapIgnition` is not set.
+	PermissionDeleteIgnitionObjects PermissionGroup = "delete-ignition-objects"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -156,7 +159,6 @@ var permissions = map[PermissionGroup][]string{
 
 		// S3 related perms
 		"s3:CreateBucket",
-		"s3:DeleteBucket",
 		"s3:GetAccelerateConfiguration",
 		"s3:GetBucketAcl",
 		"s3:GetBucketCors",
@@ -177,7 +179,6 @@ var permissions = map[PermissionGroup][]string{
 		"s3:PutEncryptionConfiguration",
 
 		// More S3 (would be nice to limit 'Resource' to just the bucket we actually interact with...)
-		"s3:DeleteObject",
 		"s3:GetObject",
 		"s3:GetObjectAcl",
 		"s3:GetObjectTagging",
@@ -201,6 +202,7 @@ var permissions = map[PermissionGroup][]string{
 		"iam:ListInstanceProfiles",
 		"iam:ListRolePolicies",
 		"iam:ListUserPolicies",
+		"s3:DeleteBucket",
 		"s3:DeleteObject",
 		"s3:ListBucketVersions",
 		"tag:GetResources",
@@ -265,6 +267,12 @@ var permissions = map[PermissionGroup][]string{
 	PermissionPublicIpv4Pool: {
 		// Needed by terraform because of bootstrap EIP created
 		"ec2:DisassociateAddress",
+	},
+	PermissionDeleteIgnitionObjects: {
+		// Needed by terraform during the bootstrap destroy stage.
+		"s3:DeleteBucket",
+		// Needed by capa which always deletes the ignition objects once the VMs are up.
+		"s3:DeleteObject",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -102,6 +102,10 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionPublicIpv4Pool)
 		}
 
+		if !ic.Config.AWS.PreserveBootstrapIgnition {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteIgnitionObjects)
+		}
+
 		ssn, err := ic.AWS.Session(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
They shouldn't be required when `preserveBootstrapIgnition` is set in the install-config.yaml. Otherwise, the install fails with:

```
INFO Credentials loaded from the "denys3" profile in file "/home/cloud-user/.aws/credentials"
INFO Consuming Install Config from target directory
WARNING Action not allowed with tested creds          action=s3:DeleteBucket
WARNING Action not allowed with tested creds          action=s3:DeleteObject
WARNING Action not allowed with tested creds          action=s3:DeleteObject
WARNING Tested creds not able to perform all requested actions
FATAL failed to fetch Cluster: failed to fetch dependency of "Cluster": failed to generate asset "Platform Permissions Check": validate AWS credentials: current credentials insufficient for performing cluster installation
```