### PR TITLE
OCPBUGS-33668: Changed folder name to match cluster name instead of infra-id.

### DIFF
--- a/upi/vsphere/powercli/upi-functions.ps1
+++ b/upi/vsphere/powercli/upi-functions.ps1
@@ -300,7 +300,7 @@ function New-OpenshiftVMs {
             $ignition = [Convert]::ToBase64String($bytes)
 
             # Get correct template / folder
-            $folder = Get-Folder -Name $metadata.infraID -Location $node.datacenter
+            $folder = Get-Folder -Name $clustername -Location $node.datacenter
             $template = Get-VM -Name $vm_template -Location $($node.datacenter)
 
             # Clone the virtual machine from the imported template

--- a/upi/vsphere/powercli/upi.ps1
+++ b/upi/vsphere/powercli/upi.ps1
@@ -156,13 +156,13 @@ foreach ($fd in $fds)
 
     # If the folder already exists
     Write-Output "Checking for folder in failure domain $($fd.datacenter)/$($fd.cluster)"
-    $folder = Get-Folder -Name $metadata.infraID -Location $fd.datacenter -ErrorAction continue 2>$null
+    $folder = Get-Folder -Name $clustername -Location $fd.datacenter -ErrorAction continue 2>$null
 
     # Otherwise create the folder within the datacenter as defined in the upi-variables
     if (-Not $?) {
-        Write-Output "Creating folder $($metadata.infraID) in datacenter $($fd.datacenter)"
-        (get-view (Get-Datacenter -Name $fd.datacenter).ExtensionData.vmfolder).CreateFolder($metadata.infraID)
-        $folder = Get-Folder -Name $metadata.infraID -Location $fd.datacenter
+        Write-Output "Creating folder $($clustername) in datacenter $($fd.datacenter)"
+        (get-view (Get-Datacenter -Name $fd.datacenter).ExtensionData.vmfolder).CreateFolder($clustername)
+        $folder = Get-Folder -Name $clustername -Location $fd.datacenter
         New-TagAssignment -Entity $folder -Tag $tag > $null
     }
 
@@ -234,7 +234,7 @@ Write-Output "Creating LB"
 # Data needed for LB VM creation
 $rp = Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Name $($fds[0].cluster)) -Server $vcenter
 $datastoreInfo = Get-Datastore -Name $fds[0].datastore -Server $vcenter -Location $fds[0].datacenter
-$folder = Get-Folder -Name $metadata.infraID -Location $fds[0].datacenter
+$folder = Get-Folder -Name $clustername -Location $fds[0].datacenter
 $template = Get-VM -Name $vm_template -Location $fds[0].datacenter
 
 # Create LB for Cluster


### PR DESCRIPTION
OCPBUGS-33668

### Changes
- Updated powercli script to use cluster name as folder name instead of infra-id.