### PR TITLE
OCPBUGS-33745: save etcd data to its own directory

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
+	"github.com/openshift/installer/pkg/clusterapi"
 	"github.com/openshift/installer/pkg/destroy"
 	"github.com/openshift/installer/pkg/destroy/bootstrap"
 	quotaasset "github.com/openshift/installer/pkg/destroy/quota"
@@ -108,6 +109,9 @@ func runDestroyCmd(directory string, reportQuota bool) error {
 			return errors.Wrapf(err, "failed to remove terraform file %q", f)
 		}
 	}
+
+	// ensure capi etcd data store is cleaned up
+	clusterapi.System().CleanEtcd()
 
 	timer.StopTimer(timer.TotalTimeElapsed)
 	timer.LogSummary()

--- a/pkg/clusterapi/localcontrolplane.go
+++ b/pkg/clusterapi/localcontrolplane.go
@@ -54,6 +54,7 @@ type localControlPlane struct {
 	Client         client.Client
 	Cfg            *rest.Config
 	BinDir         string
+	EtcdDataDir    string
 	KubeconfigPath string
 	EtcdLog        *os.File
 	APIServerLog   *os.File
@@ -69,6 +70,7 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 	if err := UnpackEnvtestBinaries(c.BinDir); err != nil {
 		return fmt.Errorf("failed to unpack envtest binaries: %w", err)
 	}
+	c.EtcdDataDir = filepath.Join(command.RootOpts.Dir, ArtifactsDir, "etcd")
 
 	// Write etcd & kube-apiserver output to log files.
 	var err error
@@ -92,7 +94,7 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 		ControlPlaneStopTimeout:  10 * time.Second,
 		ControlPlane: envtest.ControlPlane{
 			Etcd: &envtest.Etcd{
-				DataDir: c.BinDir,
+				DataDir: c.EtcdDataDir,
 				Out:     c.EtcdLog,
 				Err:     c.EtcdLog,
 			},

--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -59,6 +59,7 @@ type Interface interface {
 	State() SystemState
 	Client() client.Client
 	Teardown()
+	CleanEtcd()
 }
 
 // System returns the cluster-api system.
@@ -391,6 +392,21 @@ func (c *system) Teardown() {
 
 		c.logWriter.Close()
 	})
+}
+
+// CleanEtcd removes the etcd database from the host.
+func (c *system) CleanEtcd() {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.lcp == nil {
+		return
+	}
+
+	// Clean up the etcd directory.
+	if err := os.RemoveAll(c.lcp.EtcdDataDir); err != nil {
+		logrus.Warnf("Unable to delete local etcd data directory %s. It is safe to remove the directory manually", c.lcp.EtcdDataDir)
+	}
 }
 
 // State returns the state of the cluster-api system.

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -350,6 +350,8 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 
 // DestroyBootstrap destroys the temporary bootstrap resources.
 func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error {
+	defer clusterapi.System().CleanEtcd()
+
 	metadata, err := metadata.Load(dir)
 	if err != nil {
 		return err


### PR DESCRIPTION
The standalone `openshift-install destroy bootstrap` command is failing because the etcd data directory is being removed whenever we call `Teardown`. This moves the etcd data dir to its own directory. This may create its own problem, though, as the etcd data can be sizable. In my testing it was over 60M:

```
[root@bc12788343a4 /]# du -sh c/etcd
67M	c/etcd
```

So we may want to either stick the etcd data in a /tmp dir or explicitly delete this once bootstrap destroy is complete.
