### PR TITLE
Private domains in survey for PowerVS for 4.15

### DIFF
--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -12,6 +12,7 @@ import (
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	ibmcloudconfig "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -23,6 +24,7 @@ import (
 
 type baseDomain struct {
 	BaseDomain string
+	Publish    types.PublishingStrategy
 }
 
 var _ asset.Asset = (*baseDomain)(nil)
@@ -86,6 +88,7 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 			return err
 		}
 		a.BaseDomain = zone.Name
+		a.Publish = zone.Publish
 		return nil
 	default:
 		//Do nothing

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -85,6 +85,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		},
 		SSHKey:     sshPublicKey.Key,
 		BaseDomain: baseDomain.BaseDomain,
+		Publish:    baseDomain.Publish,
 		PullSecret: pullSecret.PullSecret,
 	}
 

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 	sshPublicKey := &sshPublicKey{}
-	baseDomain := &baseDomain{"test-domain"}
+	baseDomain := &baseDomain{"test-domain", types.ExternalPublishingStrategy}
 	clusterName := &clusterName{"test-cluster"}
 	pullSecret := &pullSecret{`{"auths":{"example.com":{"auth":"authorization value"}}}`}
 	platform := &platform{


### PR DESCRIPTION
Backport of #8303 where survey question for base domain shows private domains as well, and making steps to deploy an `Internal` cluster a bit simpler by writing out `baseDomain` and `publish` accordingly.