### PR TITLE
OCPBUGS-33874: Delete SSH bootstrap rule with SDK

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -31,6 +31,14 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 		return nil, fmt.Errorf("failed to get user tags: %w", err)
 	}
 
+	sshRuleCidr := []string{"0.0.0.0/0"}
+	if ic.Config.Publish == types.InternalPublishingStrategy {
+		sshRuleCidr = []string{}
+		for _, machineNetwork := range ic.Config.Networking.MachineNetwork {
+			sshRuleCidr = append(sshRuleCidr, machineNetwork.CIDR.String())
+		}
+	}
+
 	awsCluster := &capa.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterID.InfraID,
@@ -142,7 +150,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 						Protocol:    capa.SecurityGroupProtocolTCP,
 						FromPort:    22,
 						ToPort:      22,
-						CidrBlocks:  []string{"0.0.0.0/0"},
+						CidrBlocks:  sshRuleCidr,
 					},
 				},
 			},

--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -13,13 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	awsmanifest "github.com/openshift/installer/pkg/asset/manifests/aws"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -200,7 +196,17 @@ func getHostedZoneIDForNLB(ctx context.Context, awsSession *session.Session, reg
 // DestroyBootstrap removes aws bootstrap resources not handled
 // by the deletion of the bootstrap machine by the capi controllers.
 func (*Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapDestroyInput) error {
-	if err := removeSSHRule(ctx, in.Client, in.Metadata.InfraID); err != nil {
+	region := in.Metadata.ClusterPlatformMetadata.AWS.Region
+	session, err := awsconfig.GetSessionWithOptions(
+		awsconfig.WithRegion(region),
+		awsconfig.WithServiceEndpoints(region, in.Metadata.ClusterPlatformMetadata.AWS.ServiceEndpoints),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create aws session for bootstrap destroy: %w", err)
+	}
+	ec2Client := ec2.New(session)
+
+	if err := removeSSHRule(ctx, ec2Client, in.Metadata.AWS.Identifier); err != nil {
 		return fmt.Errorf("failed to remove bootstrap SSH rule: %w", err)
 	}
 	return nil
@@ -208,65 +214,91 @@ func (*Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapDe
 
 // removeSSHRule removes the SSH rule for accessing the bootstrap node
 // by removing the rule from the cluster spec and updating the object.
-func removeSSHRule(ctx context.Context, cl k8sClient.Client, infraID string) error {
-	awsCluster := &capa.AWSCluster{}
-	key := k8sClient.ObjectKey{
-		Name:      infraID,
-		Namespace: capiutils.Namespace,
-	}
-	if err := cl.Get(ctx, key, awsCluster); err != nil {
-		return fmt.Errorf("failed to get AWSCluster: %w", err)
+func removeSSHRule(ctx context.Context, client *ec2.EC2, filters []map[string]string) error {
+	logrus.Debug("Removing Bootstrap SSH security rule...")
+	tagKey, err := getClusterOwnedKey(filters)
+	if err != nil {
+		return err
 	}
 
-	postBootstrapRules := []capa.IngressRule{}
-	for _, rule := range awsCluster.Spec.NetworkSpec.AdditionalControlPlaneIngressRules {
-		if strings.EqualFold(rule.Description, awsmanifest.BootstrapSSHDescription) {
-			continue
-		}
-		postBootstrapRules = append(postBootstrapRules, rule)
+	sg, err := getControlPlaneSecurityGroup(ctx, client, tagKey)
+	if err != nil {
+		return fmt.Errorf("unable to get controlplane security group: %w", err)
 	}
 
-	awsCluster.Spec.NetworkSpec.AdditionalControlPlaneIngressRules = postBootstrapRules
-
-	if err := cl.Update(ctx, awsCluster); err != nil {
-		return fmt.Errorf("failed to update AWSCluster during bootstrap destroy: %w", err)
-	}
-	logrus.Debug("Updated AWSCluster to remove bootstrap SSH rule")
-
-	timeout := 5 * time.Minute
-	untilTime := time.Now().Add(timeout)
-	timezone, _ := untilTime.Zone()
-	logrus.Infof("Waiting up to %v (until %v %s) for bootstrap SSH rule to be destroyed...", timeout, untilTime.Format(time.Kitchen), timezone)
-	if err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
-		Duration: time.Second * 10,
-		Factor:   float64(1.5),
-		Steps:    32,
-		Cap:      timeout,
-	}, func(ctx context.Context) (bool, error) {
-		c := &capa.AWSCluster{}
-		if err := cl.Get(ctx, key, c); err != nil {
-			return false, err
-		}
-		if sg, ok := c.Status.Network.SecurityGroups[capa.SecurityGroupControlPlane]; ok {
-			for _, r := range sg.IngressRules {
-				if r.Description == awsmanifest.BootstrapSSHDescription {
-					return false, nil
-				}
-			}
-			return true, nil
-		}
-		// This shouldn't happen, but if control plane SG is not found, return an error.
-		keys := make([]capa.SecurityGroupRole, 0, len(c.Status.Network.SecurityGroups))
-		for sgr := range c.Status.Network.SecurityGroups {
-			keys = append(keys, sgr)
-		}
-		return false, fmt.Errorf("controlplane not found in cluster security groups: %v", keys)
-	}); err != nil {
-		if wait.Interrupted(err) {
-			return fmt.Errorf("bootstrap ssh rule was not removed within %v: %w", timeout, err)
-		}
-		return fmt.Errorf("unable to remove bootstrap ssh rule: %w", err)
+	rule, err := getSSHRule(sg)
+	if err != nil {
+		return fmt.Errorf("unable to get bootstrap SSH rule: %w", err)
 	}
 
+	_, err = client.RevokeSecurityGroupIngressWithContext(ctx, &ec2.RevokeSecurityGroupIngressInput{
+		GroupId:       sg.GroupId,
+		IpPermissions: rule,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to revoke bootstrap SSH security rule: %w", err)
+	}
+	logrus.Debug("Removed Bootstrap SSH security rule")
 	return nil
+}
+
+// getClusterOwnedKey returns a key for one of the cluster-owned filters
+// from the cluster metadata.
+func getClusterOwnedKey(filters []map[string]string) (string, error) {
+	for _, filter := range filters {
+		for k, v := range filter {
+			// We want either the k8s owned tag or capi owned tag
+			// doesn't matter which, we just don't want the cluster id.
+			if v == "owned" {
+				return k, nil
+			}
+		}
+	}
+	return "", errors.New("cluster owned filter was not found in metadata identifiers")
+}
+
+func getControlPlaneSecurityGroup(ctx context.Context, client *ec2.EC2, tagKey string) (*ec2.SecurityGroup, error) {
+	res, err := client.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("description"),
+				Values: []*string{aws.String(string(capa.SecurityGroupControlPlane))},
+			},
+			{
+				Name:   aws.String("tag-key"),
+				Values: []*string{&tagKey},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.SecurityGroups) == 0 {
+		return nil, errors.New("no matching controlplane security group found")
+	}
+
+	if len(res.SecurityGroups) > 1 {
+		sgs := []string{}
+		for _, sg := range res.SecurityGroups {
+			logrus.Warnf("Found multiple controlplane security groups %s: %s - %s", *sg.GroupId, *sg.GroupName, *sg.Description)
+			sgs = append(sgs, *sg.GroupId)
+		}
+		return nil, fmt.Errorf("found multiple controlplane security groups: %v", sgs)
+	}
+
+	return res.SecurityGroups[0], nil
+}
+
+func getSSHRule(sg *ec2.SecurityGroup) ([]*ec2.IpPermission, error) {
+	rules := []*ec2.IpPermission{}
+	for _, rule := range sg.IpPermissions {
+		if rule.ToPort == aws.Int64(22) {
+			rules = append(rules, rule)
+		}
+	}
+	if len(rules) == 0 {
+		return nil, errors.New("unable to find bootstrap SSH ingress rule")
+	}
+	return rules, nil
 }


### PR DESCRIPTION
Uses the Go SDK to destroy the SSH bootstrap rule instead of the
previous CAPI-based installation. Using the SDK in this manner
allows us to remove only the SSH rule without triggering a full
cluster reconcile.