### PR TITLE
OCPBUGS-34040: Add --dir /tmp to node-joiner-monitor.sh

### DIFF
--- a/docs/user/agent/add-node/node-joiner-monitor.sh
+++ b/docs/user/agent/add-node/node-joiner-monitor.sh
@@ -100,7 +100,7 @@ spec:
   - name: node-joiner-monitor
     imagePullPolicy: IfNotPresent
     image: $nodeJoinerPullspec
-    command: ["/bin/sh", "-c", "node-joiner monitor-add-nodes $ipAddresses --log-level=info; sleep 5"]    
+    command: ["/bin/sh", "-c", "node-joiner monitor-add-nodes $ipAddresses --dir /tmp --log-level=info; sleep 5"]
 EOF
 )
 echo "$nodeJoinerPod" | oc apply -f -


### PR DESCRIPTION
The containerized monitor-add-nodes does not have the correct permissions to write to the current working directory. Set the working directory to /tmp in the container command.