### PR TITLE
OCPBUGS-34295: wait for ip addresses to be present on machines

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -39,6 +39,10 @@ type Provider struct{}
 // Name gives the name of the provider, AWS.
 func (*Provider) Name() string { return awstypes.Name }
 
+// BootstrapHasPublicIP indicates that machine ready checks
+// should wait for an ExternalIP in the status.
+func (*Provider) BootstrapHasPublicIP() bool { return true }
+
 // PreProvision creates the IAM roles used by all nodes in the cluster.
 func (*Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) error {
 	if err := createIAMRoles(ctx, in.InfraID, in.InstallConfig); err != nil {

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -51,6 +51,10 @@ func (p *Provider) Name() string {
 	return aztypes.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (*Provider) BootstrapHasPublicIP() bool { return false }
+
 // PreProvision is called before provisioning using CAPI controllers has begun.
 func (p *Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) error {
 	session, err := in.InstallConfig.Azure.Session()

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -18,6 +18,12 @@ import (
 type Provider interface {
 	// Name provides the name for the cloud platform.
 	Name() string
+
+	// BootstrapHasPublicIP indicates whether a public IP address
+	// is expected on the bootstrap node in a public cluster.
+	// When BootstrapHasPublicIP returns true, the machine ready checks
+	// wait for an ExternalIP address to be populated in the machine status.
+	BootstrapHasPublicIP() bool
 }
 
 // PreProvider defines the PreProvision hook, which is called prior to

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -37,6 +37,10 @@ func (p Provider) Name() string {
 	return gcptypes.Name
 }
 
+// BootstrapHasPublicIP indicates that machine ready checks
+// should wait for an ExternalIP in the status.
+func (Provider) BootstrapHasPublicIP() bool { return true }
+
 // PreProvision is called before provisioning using CAPI controllers has initiated.
 // GCP resources that are not created by CAPG (and are required for other stages of the install) are
 // created here using the gcp sdk.

--- a/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
@@ -18,6 +18,10 @@ func (p Provider) Name() string {
 	return ibmcloudtypes.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (Provider) BootstrapHasPublicIP() bool { return false }
+
 // PreProvision creates the IBM Cloud objects required prior to running capibmcloud.
 func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInput) error {
 	return nil

--- a/pkg/infrastructure/nutanix/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/nutanix/clusterapi/clusterapi.go
@@ -23,6 +23,10 @@ func (p Provider) Name() string {
 	return nutanixtypes.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (Provider) BootstrapHasPublicIP() bool { return false }
+
 // PreProvision creates the resources required prior to running capi nutanix controller.
 func (p Provider) PreProvision(ctx context.Context, in infracapi.PreProvisionInput) error {
 	// create categories with name "kubernetes-io-cluster-<cluster_id>" and values ["owned", "shared"].

--- a/pkg/infrastructure/openstack/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/openstack/clusterapi/clusterapi.go
@@ -31,6 +31,10 @@ func (p Provider) Name() string {
 	return openstack.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (Provider) BootstrapHasPublicIP() bool { return false }
+
 var _ clusterapi.PreProvider = Provider{}
 
 // PreProvision tags the VIP ports, and creates the security groups and the

--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -38,6 +38,10 @@ func (p Provider) Name() string {
 	return powervstypes.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (Provider) BootstrapHasPublicIP() bool { return false }
+
 func leftInContext(ctx context.Context) time.Duration {
 	deadline, ok := ctx.Deadline()
 	if !ok {

--- a/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
@@ -27,6 +27,10 @@ func (p Provider) Name() string {
 	return vsphere.Name
 }
 
+// BootstrapHasPublicIP indicates that an ExternalIP is not
+// required in the machine ready checks.
+func (Provider) BootstrapHasPublicIP() bool { return false }
+
 func initializeFoldersAndTemplates(ctx context.Context, cachedImage string, failureDomain vsphere.FailureDomain, session *session.Session, diskType vsphere.DiskType, clusterID, tagID string) error {
 	finder := session.Finder
 


### PR DESCRIPTION
Often in CI, the capi installer is failing to gather the bootstrap log bundle (see [0] & [1] below) with the error:

```
 level=error msg=Attempted to gather debug logs after installation failure: must provide bootstrap host address 
```

This is due to a race condition where we might write the manifests to disk before the ip address is present in the status. This PR updates the logic when waiting for machines  to be ready, first it ensures we check all machines, not just masters (we were skipping bootstrap unintentionally). It also adds a requirement that IP addresses are present in the status before moving on.

[0] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-installer-8427-ci-4.17-e2e-aws-ovn/1792972823245885440

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-installer-8427-ci-4.17-e2e-aws-ovn/1792972825041047552
