### PR TITLE
OCPBUGS-34243: unique AWS HostedZone Caller Ref

### DIFF
--- a/pkg/asset/installconfig/aws/route53.go
+++ b/pkg/asset/installconfig/aws/route53.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -248,9 +247,8 @@ func (c *Client) CreateHostedZone(ctx context.Context, input *HostedZoneInput) (
 	cfg := GetR53ClientCfg(c.ssn, input.Role)
 	svc := route53.New(c.ssn, cfg)
 
-	callRef := fmt.Sprintf("%d", time.Now().Unix())
 	res, err := svc.CreateHostedZoneWithContext(ctx, &route53.CreateHostedZoneInput{
-		CallerReference: aws.String(callRef),
+		CallerReference: aws.String(input.InfraID),
 		Name:            aws.String(input.Name),
 		HostedZoneConfig: &route53.HostedZoneConfig{
 			PrivateZone: aws.Bool(true),


### PR DESCRIPTION
The CallerReference used when creating an AWS Hosted Zone should be unqiue, as stated in the docs:

> A unique string that identifies the request
https://docs.aws.amazon.com/cli/latest/reference/route53/create-hosted-zone.html

Prior to this commit, the Caller Reference is simply a timestamp. We have seen an issue, when batch launching multiple simultaneous installs in CI that the call may happen at the same time and therefore have the same Caller Reference, which leads to the failure:

> failed to create private hosted zone: error creating private hosted zone:
> HostedZoneAlreadyExists: A hosted zone has already been created with
> the specified caller reference.

Instead, let's use the infraid, which is our typical way of distinguishing clusters and contains a short unique-ish id to
avoid collisions.