### PR TITLE
OCPBUGS-33661: capi/aws: rename `preserveBootstrapIgnition`

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2163,6 +2163,14 @@ spec:
                       for the cluster. If set, the AMI should belong to the same region
                       as the cluster.
                     type: string
+                  bestEffortDeleteIgnition:
+                    description: BestEffortDeleteIgnition is an optional field that
+                      can be used to ignore errors from S3 deletion of ignition objects
+                      during cluster bootstrap. The default behavior is to fail the
+                      installation if ignition objects cannot be deleted. Enable this
+                      functionality when there are known reasons disallowing their
+                      deletion.
+                    type: boolean
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on AWS for machine pools which do not define
@@ -2283,9 +2291,8 @@ spec:
                       \ This default is subject to change over time."
                     type: string
                   preserveBootstrapIgnition:
-                    description: PreserveBootstrapIgnition is an optional field that
-                      can be used to make the S3 deletion optional during bootstrap
-                      destroy.
+                    description: PreserveBootstrapIgnition is deprecated. Use bestEffortDeleteIgnition
+                      instead.
                     type: boolean
                   propagateUserTags:
                     description: PropagateUserTags is a flag that directs in-cluster

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -334,7 +334,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			WorkerIAMRoleName:         workerIAMRoleName,
 			Architecture:              installConfig.Config.ControlPlane.Architecture,
 			Proxy:                     installConfig.Config.Proxy,
-			PreserveBootstrapIgnition: installConfig.Config.AWS.PreserveBootstrapIgnition,
+			PreserveBootstrapIgnition: installConfig.Config.AWS.BestEffortDeleteIgnition,
 			MasterSecurityGroups:      securityGroups,
 			PublicIpv4Pool:            installConfig.Config.AWS.PublicIpv4Pool,
 		})

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -102,7 +102,7 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionPublicIpv4Pool)
 		}
 
-		if !ic.Config.AWS.PreserveBootstrapIgnition {
+		if !ic.Config.AWS.BestEffortDeleteIgnition {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteIgnitionObjects)
 		}
 

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -153,7 +153,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 			S3Bucket: &capa.S3Bucket{
 				Name:                    fmt.Sprintf("openshift-bootstrap-data-%s", clusterID.InfraID),
 				PresignedURLDuration:    &metav1.Duration{Duration: 1 * time.Hour},
-				BestEffortDeleteObjects: ptr.To(ic.Config.AWS.PreserveBootstrapIgnition),
+				BestEffortDeleteObjects: ptr.To(ic.Config.AWS.BestEffortDeleteIgnition),
 			},
 			ControlPlaneLoadBalancer: &capa.AWSLoadBalancerSpec{
 				Name:                   ptr.To(clusterID.InfraID + "-int"),

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -153,6 +153,9 @@ func Test_PrintFields(t *testing.T) {
     amiID <string>
       AMIID is the AMI that should be used to boot machines for the cluster. If set, the AMI should belong to the same region as the cluster.
 
+    bestEffortDeleteIgnition <boolean>
+      BestEffortDeleteIgnition is an optional field that can be used to ignore errors from S3 deletion of ignition objects during cluster bootstrap. The default behavior is to fail the installation if ignition objects cannot be deleted. Enable this functionality when there are known reasons disallowing their deletion.
+
     defaultMachinePlatform <object>
       DefaultMachinePlatform is the default configuration used when installing on AWS for machine pools which do not define their own platform configuration.
 
@@ -173,7 +176,7 @@ func Test_PrintFields(t *testing.T) {
  If this field is not set explicitly, it defaults to "Classic".  This default is subject to change over time.
 
     preserveBootstrapIgnition <boolean>
-      PreserveBootstrapIgnition is an optional field that can be used to make the S3 deletion optional during bootstrap destroy.
+      PreserveBootstrapIgnition is deprecated. Use bestEffortDeleteIgnition instead.
 
     propagateUserTags <boolean>
       PropagateUserTags is a flag that directs in-cluster operators to include the specified user tags in the tags of the AWS resources that the operators create.

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -102,10 +102,15 @@ type Platform struct {
 	// +optional
 	LBType configv1.AWSLBType `json:"lbType,omitempty"`
 
-	// PreserveBootstrapIgnition is an optional field that can be used to make the S3 deletion optional
-	// during bootstrap destroy.
+	// PreserveBootstrapIgnition is deprecated. Use bestEffortDeleteIgnition instead.
 	// +optional
 	PreserveBootstrapIgnition bool `json:"preserveBootstrapIgnition,omitempty"`
+
+	// BestEffortDeleteIgnition is an optional field that can be used to ignore errors from S3 deletion of ignition
+	// objects during cluster bootstrap. The default behavior is to fail the installation if ignition objects cannot be
+	// deleted. Enable this functionality when there are known reasons disallowing their deletion.
+	// +optional
+	BestEffortDeleteIgnition bool `json:"bestEffortDeleteIgnition,omitempty"`
 
 	// PublicIpv4Pool is an optional field that can be used to tell the installation process to use
 	// Public IPv4 address that you bring to your AWS account with BYOIP.

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -285,5 +285,9 @@ func convertAWS(config *types.InstallConfig) error {
 	if config.Platform.AWS.ExperimentalPropagateUserTag != nil {
 		config.Platform.AWS.PropagateUserTag = *config.Platform.AWS.ExperimentalPropagateUserTag
 	}
+	// BestEffortDeleteIgnition takes precedence when set
+	if !config.AWS.BestEffortDeleteIgnition {
+		config.AWS.BestEffortDeleteIgnition = config.AWS.PreserveBootstrapIgnition
+	}
 	return nil
 }


### PR DESCRIPTION
The name doesn't really reflect the purpose of the field, but the terraform implementation instead. Since the implementation has changed in capi/capa, let's rename it so users don't expect the ignition object to not be destroyed when there are enough permissions.

The old field is kept for the deprecation period but will be removed in the future in favor of the new `BestEffortDeleteIgnition`.