### PR TITLE
OCPBUGS-33925: tfvars: change asset's name

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -82,7 +82,7 @@ const (
 	// https://www.terraform.io/docs/configuration/variables.html#variable-files
 	TfPlatformVarsFileName = "terraform.platform.auto.tfvars.json"
 
-	tfvarsAssetName = "Terraform Variables"
+	tfvarsAssetName = "Cluster Infrastructure Variables"
 )
 
 // TerraformVariables depends on InstallConfig, Manifests,


### PR DESCRIPTION
Now that some platforms are using CAPI by default, an error during the tfvars asset generation can be confusing by making it look like we're still using terraform:

```
05-19 17:36:32.935  level=fatal msg=failed to fetch Terraform Variables: failed to fetch dependency of "Terraform Variables": failed to generate asset "Platform Provisioning Check": baseDomain: Invalid value: "qe.devcluster.openshift.com": the zone already has record sets for the domain of the cluster: [api.gpei-0519a.qe.devcluster.openshift.com. (A)]
```

By changing the asset's name and leaving the rest unchanged, we can eliminate such confusion and avoid breaking other platforms still using terraform, until we're ready to stop generating tfvars json files altogether.