### PR TITLE
OCPBUGS-34457: [release-4.16] bump envtest binaries version

### DIFF
--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -15,7 +15,9 @@ copy_cluster_api_to_mirror() {
   # Clean the mirror, but preserve the README file.
   rm -rf "${CLUSTER_API_MIRROR_DIR:?}/*.zip"
 
-  sync_envtest
+  if test "${SKIP_ENVTEST}" != y; then
+    sync_envtest
+  fi
 
   # Zip every binary in the folder into a single zip file.
   zip -j1 "${CLUSTER_API_MIRROR_DIR}/cluster-api.zip" "${CLUSTER_API_BIN_DIR}"/*

--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -5,7 +5,7 @@ set -e
 TARGET_OS_ARCH=$(go env GOOS)_$(go env GOARCH)
 CLUSTER_API_BIN_DIR="${PWD}/cluster-api/bin/${TARGET_OS_ARCH}"
 CLUSTER_API_MIRROR_DIR="${PWD}/pkg/clusterapi/mirror/"
-ENVTEST_K8S_VERSION="1.28.0"
+ENVTEST_K8S_VERSION="1.29.3"
 ENVTEST_ARCH=$(go env GOOS)-$(go env GOARCH)
 
 copy_cluster_api_to_mirror() {

--- a/hack/build-cluster-api.sh
+++ b/hack/build-cluster-api.sh
@@ -5,7 +5,7 @@ set -e
 TARGET_OS_ARCH=$(go env GOOS)_$(go env GOARCH)
 CLUSTER_API_BIN_DIR="${PWD}/cluster-api/bin/${TARGET_OS_ARCH}"
 CLUSTER_API_MIRROR_DIR="${PWD}/pkg/clusterapi/mirror/"
-ENVTEST_K8S_VERSION="1.29.3"
+ENVTEST_K8S_VERSION="1.29.5"
 ENVTEST_ARCH=$(go env GOOS)-$(go env GOARCH)
 
 copy_cluster_api_to_mirror() {
@@ -36,8 +36,8 @@ sync_envtest() {
     fi
   fi
 
-  bucket="https://storage.googleapis.com/kubebuilder-tools"
-  tar_file="kubebuilder-tools-${ENVTEST_K8S_VERSION}-${ENVTEST_ARCH}.tar.gz"
+  bucket="https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v${ENVTEST_K8S_VERSION}"
+  tar_file="envtest-v${ENVTEST_K8S_VERSION}-${ENVTEST_ARCH}.tar.gz"
   dst="${CLUSTER_API_BIN_DIR}/${tar_file}"
   if ! [ -f "${CLUSTER_API_BIN_DIR}/${tar_file}" ]; then
     echo "Downloading envtest binaries"

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -7,6 +7,7 @@ FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ARG TAGS="baremetal fipscapable"
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=etcd /usr/bin/etcd /usr/bin/etcd

--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -15,7 +15,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 # FIPS support is offered via the baremetal-installer image
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS="altinfra"
-ARG OPENSHIFT_INSTALL_CLUSTER_API=""
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -41,6 +41,7 @@ RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_arm64 terraform/bin/linux_arm64

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -10,6 +10,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 # FIPS support is offered via the baremetal-installer image
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -11,6 +11,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 # FIPS support is offered via the baremetal-installer image
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -8,6 +8,7 @@ FROM registry.ci.openshift.org/ocp/4.16:hyperkube AS kas
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ARG TAGS="libvirt fipscapable"
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=etcd /usr/bin/etcd /usr/bin/etcd

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -9,6 +9,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 # FIPS support is offered via the baremetal-installer image
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/


### PR DESCRIPTION
We are using 1.29.5 in CI/release [1], so let's try to match that for local dev. The closest version available in kubebuilder-tools is 1.29.3.

[1] https://github.com/openshift/kubernetes/pull/1972