### PR TITLE
OCPBUGS-33973: Openstack UPI - Reintroduce unique resource names.

### DIFF
--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -19,7 +19,7 @@
       - "{{ os_sg_master }}"
       allowed_address_pairs:
       - ip_address: "{{ os_apiVIP }}"
-    when: os_subnet6 is not defined
+    when: os_subnet6_range is not defined
 
   - name: 'Create the bootstrap dualstack server port'
     os_port:
@@ -30,7 +30,7 @@
       allowed_address_pairs:
       - ip_address: "{{ os_apiVIP }}"
       - ip_address: "{{ os_apiVIP6 }}"
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - name: 'Set bootstrap port tag'
     command:

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -3,8 +3,14 @@
 
   vars_files:
   - metadata.json
+  - netid.json
 
   tasks:
+  - name: "Check if metadata.json exists"
+    ansible.builtin.stat:
+      path: metadata.json
+    register: sym
+
   - name: 'Compute resource names'
     set_fact:
       cluster_id_tag: "openshiftClusterID={{ infraID }}"
@@ -24,3 +30,14 @@
       os_compute_server_group_name: "{{ infraID }}-worker"
       # Ignition files
       os_bootstrap_ignition: "{{ infraID }}-bootstrap-ignition.json"
+    when: sym.stat.exists
+
+  - name: 'Compute network resource names'
+    set_fact:
+      os_network: "{{ os_net_id }}-network"
+      os_subnet: "{{ os_net_id }}-nodes"
+      os_subnet6: "{{ os_net_id }}-nodes-v6"
+      os_router: "{{ os_net_id }}-external-router"
+      # Port names
+      os_port_api: "{{ os_net_id }}-api-port"
+      os_port_ingress: "{{ os_net_id }}-ingress-port"

--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -21,7 +21,7 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
-    when: os_subnet6 is not defined
+    when: os_subnet6_range is not defined
 
   - name: 'Create the dualstack Compute ports'
     openstack.cloud.port:
@@ -34,7 +34,7 @@
       - ip_address: "{{ os_ingressVIP6 }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - name: 'Set Compute ports tag'
     ansible.builtin.command:

--- a/upi/openstack/control-plane.yaml
+++ b/upi/openstack/control-plane.yaml
@@ -22,7 +22,7 @@
       - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
-    when: os_subnet6 is not defined
+    when: os_subnet6_range is not defined
 
   - name: 'Create the dualstack Control Plane ports'
     openstack.cloud.port:
@@ -37,7 +37,7 @@
       - ip_address: "{{ os_ingressVIP6 }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - name: 'Set Control Plane ports tag'
     ansible.builtin.command:

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -4,13 +4,6 @@ all:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
-      # Network resource names
-      os_network: ocp-network
-      os_port_api: ocp-api-port
-      os_port_ingress: ocp-ingress-port
-      os_router: ocp-external-router
-      os_subnet: ocp-subnet-v4
-
       # User-provided values
       os_subnet_range: '10.0.0.0/16'
       os_flavor_master: 'm1.xlarge'
@@ -73,11 +66,8 @@ all:
       # nodes is zero
       os_master_schedulable: "{{ os_compute_nodes_number | int == 0 }}"
 
-      # Name of the IPv6 subnet. Uncomment to enable dual-stack support
-      #os_subnet6: ocp-subnet-v6
-
-      # IPv6 subnet CIDR
-      os_subnet6_range: 'fd2e:6f44:5dd8:c956::/64'
+      # IPv6 subnet CIDR. Uncomment to enable dual-stack support.
+      #os_subnet6_range: 'fd2e:6f44:5dd8:c956::/64'
 
       # Modes are one of: slaac, dhcpv6-stateful or dhcpv6-stateless
       os_subnet6_address_mode: slaac

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -5,6 +5,8 @@
 # openstacksdk
 # netaddr
 
+- ansible.builtin.import_playbook: common.yaml
+
 - hosts: all
   gather_facts: no
 
@@ -30,7 +32,7 @@
       ip_version: 6
       ipv6_address_mode: "{{ os_subnet6_address_mode }}"
       ipv6_ra_mode: "{{ os_subnet6_router_advertisements_mode }}"
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - name: 'Create external router for IPv4'
     openstack.cloud.router:
@@ -40,7 +42,7 @@
     when:
     - os_external_network is defined
     - os_external_network|length>0
-    - os_subnet6 is not defined
+    - os_subnet6_range is not defined
 
   - name: 'Create external router for dualstack'
     openstack.cloud.router:
@@ -52,7 +54,7 @@
     when:
     - os_external_network is defined
     - os_external_network|length>0
-    - os_subnet6 is defined
+    - os_subnet6_range is defined
 
   - name: 'Create the API port'
     openstack.cloud.port:
@@ -62,7 +64,7 @@
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_apiVIP }}"
     register: _api_ports
-    when: os_subnet6 is not defined
+    when: os_subnet6_range is not defined
 
   - set_fact:
       api_ports: "{{ _api_ports }}"
@@ -73,7 +75,7 @@
       name: "{{ os_port_api }}"
       network: "{{ os_network }}"
     register: _api_ports
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - set_fact:
       api_ports: "{{ _api_ports }}"
@@ -87,7 +89,7 @@
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_ingressVIP }}"
     register: _ingress_ports
-    when: os_subnet6 is not defined
+    when: os_subnet6_range is not defined
 
   - set_fact:
       ingress_ports: "{{ _ingress_ports }}"
@@ -98,7 +100,7 @@
       name: "{{ os_port_ingress }}"
       network: "{{ os_network }}"
     register: _ingress_ports
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - set_fact:
       ingress_ports: "{{ _ingress_ports }}"

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -408,4 +408,4 @@
         port_range_min: 30000
         port_range_max: 32767
 
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined

--- a/upi/openstack/update-network-resources.yaml
+++ b/upi/openstack/update-network-resources.yaml
@@ -22,7 +22,7 @@
   - name: 'Set tags on primary cluster subnet IPv6'
     ansible.builtin.command:
       cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet6 }}"
-    when: os_subnet6 is defined
+    when: os_subnet6_range is defined
 
   - name: 'Set tags on the API VIP port'
     ansible.builtin.command:


### PR DESCRIPTION
We experienced issues caused by network resources created with the same name, which makes ansible playbooks to behave differently.

Due to fact, that there is not yet OpenShift infraID accessible on the stage of creating network resources, there is a need to create deployment unique identifier in some other way. This patch implements generating such identifier independent from OpenShift deployment id.