### PR TITLE
[release-4.14] OCPBUGS-33401: PowerVS: Add composite_instance to listServiceInstances

### DIFF
--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -642,8 +642,7 @@ func (c *Client) ListServiceInstances(ctx context.Context) ([]string, error) {
 			if response != nil && response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusInternalServerError {
 				continue
 			}
-
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
+			if resourceInstance.Type != nil && (*resourceInstance.Type == "service_instance" || *resourceInstance.Type == "composite_instance") {
 				serviceInstances = append(serviceInstances, fmt.Sprintf("%s %s", *resource.Name, *resource.GUID))
 			}
 		}
@@ -718,7 +717,7 @@ func (c *Client) ServiceInstanceIDToCRN(ctx context.Context, id string) (string,
 				continue
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
+			if resourceInstance.Type != nil && (*resourceInstance.Type == "service_instance" || *resourceInstance.Type == "composite_instance") {
 				if resourceInstance.GUID != nil && *resourceInstance.GUID == id {
 					if resourceInstance.CRN == nil {
 						return "", nil

--- a/pkg/destroy/powervs/serviceinstance.go
+++ b/pkg/destroy/powervs/serviceinstance.go
@@ -122,7 +122,7 @@ func (o *ClusterUninstaller) listServiceInstances() (cloudResources, error) {
 				o.Logger.Debugf("listServiceInstances: type: %v", *resourceInstance.Type)
 			}
 
-			if resourceInstance.Type != nil && *resourceInstance.Type == "service_instance" {
+			if resourceInstance.Type != nil && (*resourceInstance.Type == "service_instance" || *resourceInstance.Type == "composite_instance") {
 				if strings.Contains(*resource.Name, o.InfraID) {
 					result = append(result, cloudResource{
 						key:      *resource.ID,


### PR DESCRIPTION
Issue observed:
`level=fatal msg=failed to fetch Terraform Variables: failed to fetch dependency of "Terraform Variables": failed to generate asset "Platform Provisioning Check": platform:powervs:serviceinstance has an invalid guid `

Cause:
The new workspaces that are created has resource instance type as "composite_instance" whereas for the older ones its "service_instance", due to this change the above error was seen. This PR checks for composite_instances also while listing service instances