### PR TITLE
OCPBUGS-33496: ensure ipv6 bootstrap VM client-id is predictable

### DIFF
--- a/data/data/bootstrap/none/files/etc/NetworkManager/conf.d/99-ipv6.conf
+++ b/data/data/bootstrap/none/files/etc/NetworkManager/conf.d/99-ipv6.conf
@@ -1,0 +1,3 @@
+[connection]
+ipv6.dhcp-duid=ll
+ipv6.dhcp-iaid=mac


### PR DESCRIPTION
In https://github.com/openshift/installer/pull/5110 we hade sure that for Baremetal IPI the IPv6 bootstrap VM client-id is predictable. This however did not cover UPI deployments.

With this change deployments with platform `none` will also use predictable client-id.

Fixes: OCPBUGS-33496