### PR TITLE
no-jira: docs/user/azure: fix byo vnet security groups

### DIFF
--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -44,7 +44,7 @@ The installer can use an existing VNet and subnets when provisioning an OpenShif
 
 ### Cluster Isolation
 
-When pre-existing subnets are provided, the installer will not create a network security group (NSG) or alter an existing one attached to the subnet. This restriction means that no security rules are created. If multiple clusters are installed to the same VNet and isolation is desired, it must be enforced through an administrative task after the cluster is installed.
+When pre-existing subnets are provided, the installer will not create a network security group (NSG) or alter an existing one attached to the subnet. Because cluster components do not modify the user-provided network security groups, which the Kubernetes controllers update, a pseudo-network security group is created for the Kubernetes controller to modify without impacting the rest of the environment. If multiple clusters are installed to the same VNet and isolation is desired, it must be enforced through an administrative task after the cluster is installed.
 
 ## Examples
 


### PR DESCRIPTION
Our in-repo docs indicate that the installer will not create security groups, but that is inaccurate. The official docs are correct:

https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-vnet.html

This commit updates the in-repo docs to match the official docs.

I am not creating a bug for this, as the official docs are already correct.