### PR TITLE
OCPBUGS-33681: Cleanup bootstrap resources for capg install

### DIFF
--- a/pkg/asset/ignition/bootstrap/gcp/storage.go
+++ b/pkg/asset/ignition/bootstrap/gcp/storage.go
@@ -131,6 +131,10 @@ func DestroyStorage(ctx context.Context, clusterID string) error {
 	}
 	bucketName := GetBootstrapStorageName(clusterID)
 
+	if err := client.Bucket(bucketName).Object(bootstrapIgnitionBucketObjName).Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete bucket object %s: %w", bootstrapIgnitionBucketObjName, err)
+	}
+
 	// Deleting a bucket will delete the managed folders and bucket objects.
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {
 		return fmt.Errorf("failed to delete bucket %s: %w", bucketName, err)

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -12,7 +12,6 @@ import (
 	capg "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openshift/installer/pkg/asset/cluster/metadata"
 	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/gcp"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
@@ -31,6 +30,7 @@ var _ clusterapi.PreProvider = (*Provider)(nil)
 var _ clusterapi.IgnitionProvider = (*Provider)(nil)
 var _ clusterapi.InfraReadyProvider = (*Provider)(nil)
 var _ clusterapi.PostProvider = (*Provider)(nil)
+var _ clusterapi.BootstrapDestroyer = (*Provider)(nil)
 
 // Name returns the name for the platform.
 func (p Provider) Name() string {
@@ -220,14 +220,10 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 }
 
 // DestroyBootstrap destroys the temporary bootstrap resources.
-func (p Provider) DestroyBootstrap(dir string) error {
+func (p Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapDestroyInput) error {
 	logrus.Warnf("Destroying GCP Bootstrap Resources")
-	metadata, err := metadata.Load(dir)
-	if err != nil {
-		return err
-	}
-	if err := gcp.DestroyStorage(context.Background(), metadata.ClusterID); err != nil {
-		return fmt.Errorf("failed to destroy storage")
+	if err := gcp.DestroyStorage(ctx, in.Metadata.InfraID); err != nil {
+		return fmt.Errorf("failed to destroy storage: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
** Bootstrap ignition bucket and bucket objects were not cleaned up after bootstrap completion. Now the resources will be removed.