### PR TITLE
OCPBUGS-34493: baremetal: Don't always enable provisioning-interface.service

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-dnsmasq.container
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-dnsmasq.container
@@ -24,4 +24,3 @@ ExecStopPost=/usr/local/bin/dhcp-filter.sh remove
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target

--- a/data/data/bootstrap/baremetal/systemd/units/provisioning-interface.service.template
+++ b/data/data/bootstrap/baremetal/systemd/units/provisioning-interface.service.template
@@ -16,4 +16,3 @@ Restart=on-failure
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
In the baremetal bootstrap it is not sufficient to make ironic.service conditionally Require provisioning-interface.service, as 104eae17b879b84700c31072c3a6eba40fc5e8a1 attempted to do, when the latter is already enabled because it is WantedBy multi-user.target. As long as it is enabled, systemd will try to start it.

Do not install provisioning-interface.service, so that it will only be enabled when ironic.service requires it (i.e. when the provisioning network is not disabled). Similarly, do not install ironic-dnsmasq.service, so that it will only be enabled when ironic.service wants it (i.e. when the provisioning network is not disabled or unmanaged).