### PR TITLE
OSASINFRA-3456: OpenStack: do not use trunk for the Machines by default

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3984,7 +3984,8 @@ spec:
                   trunkSupport:
                     description: 'TrunkSupport holds a `0` or `1` value that indicates
                       whether or not to use trunk ports in your OpenShift cluster.
-                      Deprecated: this value is set by the installer automatically.'
+                      Deprecated: the machine manifest should be used to specify that
+                      trunk should be used.'
                     type: string
                 required:
                 - cloud

--- a/data/data/openstack/masters/private-network.tf
+++ b/data/data/openstack/masters/private-network.tf
@@ -156,16 +156,6 @@ resource "openstack_networking_port_v2" "ingress_port" {
   }
 }
 
-resource "openstack_networking_trunk_v2" "masters" {
-  name        = "${var.cluster_id}-master-trunk-${count.index}"
-  count       = var.openstack_trunk_support ? var.master_count : 0
-  description = local.description
-  tags        = ["openshiftClusterID=${var.cluster_id}"]
-
-  admin_state_up = "true"
-  port_id        = openstack_networking_port_v2.masters[count.index].id
-}
-
 // If external network is defined, assign the floating IP to one of the masters.
 //
 // Strictly speaking, this is not required to finish the installation. We

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -317,18 +317,8 @@ variable "openstack_master_flavor_name" {
   description = "Instance size for the master node(s). Example: `m1.medium`."
 }
 
-variable "openstack_trunk_support" {
-  type    = bool
-  default = false
-
-  description = <<EOF
-False if the OpenStack Neutron trunk extension is disabled and True if it is enabled.
-EOF
-
-}
-
 variable "openstack_octavia_support" {
-  type = bool
+  type    = bool
   default = false
 
   description = <<EOF
@@ -338,12 +328,12 @@ EOF
 }
 
 variable "openstack_master_server_group_name" {
-  type        = string
+  type = string
   description = "Name of the server group for the master nodes."
 }
 
 variable "openstack_master_server_group_policy" {
-  type        = string
+  type = string
   description = "Policy of the server group for the master nodes."
 }
 
@@ -351,11 +341,11 @@ variable "openstack_default_machines_port" {
   type = object({
     network_id = string
     fixed_ips = list(object({
-      subnet_id  = string
+      subnet_id = string
       ip_address = string
     }))
   })
-  default     = null
+  default = null
   description = "The masters' default control-plane port. If empty, the installer will create a new network."
 }
 
@@ -363,44 +353,44 @@ variable "openstack_machines_ports" {
   type = list(object({
     network_id = string
     fixed_ips = list(object({
-      subnet_id  = string
+      subnet_id = string
       ip_address = string
     }))
   }))
   description = "The control-plane port for each machine. If null, the default is used."
-  default     = [null, null, null]
+  default = [null, null, null]
 }
 
 variable "openstack_master_availability_zones" {
-  type        = list(string)
-  default     = [""]
+  type = list(string)
+  default = [""]
   description = "List of availability Zones to Schedule the masters on."
 }
 
 variable "openstack_master_root_volume_availability_zones" {
-  type        = list(string)
-  default     = [""]
+  type = list(string)
+  default = [""]
   description = "List of availability Zones to Schedule the masters root volumes on."
 }
 
 variable "openstack_master_root_volume_types" {
-  type        = list(string)
-  default     = [""]
+  type = list(string)
+  default = [""]
   description = "List of volume types used by the masters root volumes."
 }
 
 variable "openstack_worker_server_group_names" {
-  type        = set(string)
-  default     = []
+  type = set(string)
+  default = []
   description = "Names of the server groups for the worker nodes."
 }
 
 variable "openstack_worker_server_group_policy" {
-  type        = string
+  type = string
   description = "Policy of the server groups for the worker nodes."
 }
 
 variable "openstack_user_managed_load_balancer" {
-  type        = bool
+  type = bool
   description = "True if the load balancer that is used for the control plane VIPs is managed by the user."
 }

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -389,14 +389,6 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		pool.Platform.OpenStack = &mpool
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
-		trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
-			ic.Platform.OpenStack.Cloud,
-			"trunk",
-			nil,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to check for trunk support: %w", err)
-		}
 
 		for _, role := range []string{"master", "bootstrap"} {
 			openStackMachines, err := openstack.GenerateMachines(
@@ -405,7 +397,6 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 				&pool,
 				imageName,
 				role,
-				trunkSupport,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create machine objects: %w", err)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -331,15 +331,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
-			ic.Platform.OpenStack.Cloud,
-			"trunk",
-			nil,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to check for trunk support: %w", err)
-		}
-		machines, controlPlaneMachineSet, err = openstack.Machines(clusterID.InfraID, ic, &pool, imageName, "master", masterUserDataSecretName, trunkSupport)
+		machines, controlPlaneMachineSet, err = openstack.Machines(clusterID.InfraID, ic, &pool, imageName, "master", masterUserDataSecretName)
 		if err != nil {
 			return fmt.Errorf("failed to create master machine objects: %w", err)
 		}

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, trunkSupport bool) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -61,7 +61,6 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			osImage,
 			role,
 			userDataSecret,
-			trunkSupport,
 			failureDomain,
 		)
 		if err != nil {
@@ -99,7 +98,6 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		osImage,
 		role,
 		userDataSecret,
-		trunkSupport,
 		machinev1.OpenStackFailureDomain{RootVolume: &machinev1.RootVolume{}},
 	)
 	if err != nil {
@@ -159,7 +157,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, controlPlaneMachineSet, nil
 }
 
-func generateProviderSpec(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, role, userDataSecret string, trunkSupport bool, failureDomain machinev1.OpenStackFailureDomain) (*machinev1alpha1.OpenstackProviderSpec, error) {
+func generateProviderSpec(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, role, userDataSecret string, failureDomain machinev1.OpenStackFailureDomain) (*machinev1alpha1.OpenstackProviderSpec, error) {
 	var controlPlaneNetwork machinev1alpha1.NetworkParam
 	additionalNetworks := make([]machinev1alpha1.NetworkParam, 0, len(mpool.AdditionalNetworkIDs))
 	primarySubnet := ""
@@ -249,7 +247,7 @@ func generateProviderSpec(clusterID string, platform *openstack.Platform, mpool 
 		AvailabilityZone: failureDomain.AvailabilityZone,
 		SecurityGroups:   securityGroups,
 		ServerGroupName:  serverGroupName,
-		Trunk:            trunkSupport,
+		Trunk:            false,
 		Tags: []string{
 			fmt.Sprintf("openshiftClusterID=%s", clusterID),
 		},

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -24,7 +24,7 @@ const maxInt32 int64 = int64(^uint32(0)) >> 1
 // availability zones, Storage availability zones and Root volume types), when
 // more than one is specified, values of identical index are grouped in the
 // same MachineSet.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, trunkSupport bool) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -65,7 +65,6 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			osImage,
 			role,
 			userDataSecret,
-			trunkSupport,
 			failureDomains[idx],
 		)
 		if err != nil {

--- a/pkg/asset/machines/openstack/openstackmachines.go
+++ b/pkg/asset/machines/openstack/openstackmachines.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GenerateMachines returns manifests and runtime objects to provision the control plane (including bootstrap, if applicable) nodes using CAPI.
-func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role string, trunkSupport bool) ([]*asset.RuntimeFile, error) {
+func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role string) ([]*asset.RuntimeFile, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -44,7 +44,6 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			mpool,
 			osImage,
 			role,
-			trunkSupport,
 			failureDomain,
 		)
 		if err != nil {
@@ -110,7 +109,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 	return result, nil
 }
 
-func generateMachineSpec(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, role string, trunkSupport bool, failureDomain machinev1.OpenStackFailureDomain) (*capo.OpenStackMachineSpec, error) {
+func generateMachineSpec(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, role string, failureDomain machinev1.OpenStackFailureDomain) (*capo.OpenStackMachineSpec, error) {
 	port := capo.PortOpts{}
 
 	addressPairs := populateAllowedAddressPairs(platform)
@@ -192,8 +191,7 @@ func generateMachineSpec(clusterID string, platform *openstack.Platform, mpool *
 				Value: clusterID,
 			},
 		},
-
-		Trunk: trunkSupport,
+		Trunk: false,
 		Tags: []string{
 			fmt.Sprintf("openshiftClusterID=%s", clusterID),
 		},

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -584,15 +584,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 
 			imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-			trunkSupport, err := openstack.CheckNetworkExtensionAvailability(
-				ic.Platform.OpenStack.Cloud,
-				"trunk",
-				nil,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to check for trunk support: %w", err)
-			}
-			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", workerUserDataSecretName, trunkSupport)
+			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", workerUserDataSecretName)
 			if err != nil {
 				return fmt.Errorf("failed to create worker machine objects: %w", err)
 			}

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -187,7 +187,6 @@ func TFVars(
 		IngressFloatingIP                 string                            `json:"openstack_ingress_floating_ip,omitempty"`
 		APIVIPs                           []string                          `json:"openstack_api_int_ips,omitempty"`
 		IngressVIPs                       []string                          `json:"openstack_ingress_ips,omitempty"`
-		TrunkSupport                      bool                              `json:"openstack_trunk_support,omitempty"`
 		OctaviaSupport                    bool                              `json:"openstack_octavia_support,omitempty"`
 		RootVolumeSize                    int                               `json:"openstack_master_root_volume_size,omitempty"`
 		BootstrapShim                     string                            `json:"openstack_bootstrap_shim_ignition,omitempty"`
@@ -214,7 +213,6 @@ func TFVars(
 		IngressFloatingIP:                 installConfig.Config.Platform.OpenStack.IngressFloatingIP,
 		APIVIPs:                           installConfig.Config.Platform.OpenStack.APIVIPs,
 		IngressVIPs:                       installConfig.Config.Platform.OpenStack.IngressVIPs,
-		TrunkSupport:                      masterSpecs[0].Trunk,
 		OctaviaSupport:                    octaviaSupport,
 		RootVolumeSize:                    rootVolumeSize,
 		BootstrapShim:                     bootstrapIgn,

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -53,7 +53,7 @@ type Platform struct {
 
 	// TrunkSupport holds a `0` or `1` value that indicates whether or not to use trunk ports
 	// in your OpenShift cluster.
-	// Deprecated: this value is set by the installer automatically.
+	// Deprecated: the machine manifest should be used to specify that trunk should be used.
 	// +optional
 	DeprecatedTrunkSupport string `json:"trunkSupport,omitempty"`
 


### PR DESCRIPTION
As Kuryr is removed the creation of trunks for the machines is not a requirement anymore. To reduce the amount of resources we manage by default, let's avoid creating it as is not a requirement. This commit will disable trunk creation by default and let the user enable trunk by modifying the generated Machine manifests. Also, the terraform support for creation of Machines with Trunk is being removed.