### PR TITLE
AGENT-862: Extend monitor-add-nodes to support multiple nodes

### DIFF
--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -75,10 +75,8 @@ func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, ssh
 		logrus.Fatal(err)
 	}
 
-	restclient, err := NewNodeZeroRestClient(ctx, rendezvousIP, sshKey, authToken)
-	if err != nil {
-		logrus.Fatal(err)
-	}
+	restclient := NewNodeZeroRestClient(ctx, rendezvousIP, sshKey, authToken)
+
 	kubeclient, err := NewClusterKubeAPIClient(ctx, kubeconfigPath)
 	if err != nil {
 		logrus.Fatal(err)

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	timeout time.Duration = 1 * time.Minute
+	timeout = 1 * time.Minute
 )
 
 const (

--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -144,9 +144,8 @@ func MonitorSingleNode(waitContext context.Context, cluster *Cluster, nodeIPAddr
 			if !mon.clusterHasSecondCSRPending() {
 				mon.logStatus("Node is Ready")
 			} else {
-				// TODO: There appears to be a bug where the node becomes Ready
-				// before second CSR is approved. Log Pending CSRs for now, so users
-				// are aware there are still some waiting their approval even
+				// The node becomes Ready before second CSR is approved. Log Pending CSRs
+				// so users are aware there are still some waiting their approval even
 				// though the node status is Ready.
 				mon.logStatus("Node is Ready but has CSRs pending approval. Until all CSRs are approved, the node may not be fully functional.")
 				mon.logCSRsPendingApproval(secondCSRSignerName)

--- a/pkg/agent/rest.go
+++ b/pkg/agent/rest.go
@@ -33,7 +33,7 @@ type NodeZeroRestClient struct {
 }
 
 // NewNodeZeroRestClient Initialize a new rest client to interact with the Agent Rest API on node zero.
-func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, token string) (*NodeZeroRestClient, error) {
+func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, token string) *NodeZeroRestClient {
 	restClient := &NodeZeroRestClient{}
 
 	// Get SSH Keys which can be used to determine if Rest API failures are due to network connectivity issues
@@ -57,7 +57,7 @@ func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, token stri
 	restClient.config = config
 	restClient.NodeZeroIP = rendezvousIP
 
-	return restClient, nil
+	return restClient
 }
 
 // FindRendezvouIPAndSSHKeyFromAssetStore returns the rendezvousIP and public ssh key.

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -3,8 +3,6 @@ package nodejoiner
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
-
 	agentpkg "github.com/openshift/installer/pkg/agent"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
@@ -16,15 +14,18 @@ func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) e
 		return err
 	}
 
-	cluster, err := agentpkg.NewCluster(context.Background(), "", ips[0], kubeconfigPath, "", workflow.AgentWorkflowTypeAddNodes)
-	if err != nil {
-		// TODO exit code enumerate
-		logrus.Exit(1)
-	}
+	// sshKey is not required parameter for monitor-add-nodes
+	sshKey := ""
 
-	if err != nil {
-		return err
+	clusters := []*agentpkg.Cluster{}
+	for _, ip := range ips {
+		cluster, err := agentpkg.NewCluster(context.Background(), directory, ip, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeAddNodes)
+		if err != nil {
+			return err
+		}
+		clusters = append(clusters, cluster)
 	}
+	agentpkg.MonitorAddNodes(clusters, ips)
 
-	return agentpkg.MonitorAddNodes(cluster, ips[0])
+	return nil
 }

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -18,14 +18,15 @@ func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) e
 	sshKey := ""
 
 	clusters := []*agentpkg.Cluster{}
+	ctx := context.Background()
 	for _, ip := range ips {
-		cluster, err := agentpkg.NewCluster(context.Background(), directory, ip, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeAddNodes)
+		cluster, err := agentpkg.NewCluster(ctx, directory, ip, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeAddNodes)
 		if err != nil {
 			return err
 		}
 		clusters = append(clusters, cluster)
 	}
-	agentpkg.MonitorAddNodes(clusters, ips)
+	agentpkg.MonitorAddNodes(ctx, clusters, ips)
 
 	return nil
 }


### PR DESCRIPTION
Multiple IP addresses can now be specified for monitoring at the same time.