### PR TITLE
AGENT-890: Simplify Agent ISO kargs setting

### DIFF
--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -30,7 +30,7 @@ type AgentArtifacts struct {
 	RendezvousIP         string
 	TmpPath              string
 	IgnitionByte         []byte
-	Kargs                []byte
+	Kargs                string
 	ISOPath              string
 	BootArtifactsBaseURL string
 }

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -125,6 +125,10 @@ func (a *AgentImage) updateIgnitionContent(agentArtifacts *AgentArtifacts) error
 		return err
 	}
 
+	return a.overwriteFileData(fileInfo)
+}
+
+func (a *AgentImage) overwriteFileData(fileInfo []isoeditor.FileData) error {
 	for _, fileData := range fileInfo {
 		filename := filepath.Join(a.tmpPath, fileData.Filename)
 		file, err := os.Create(filename)

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -129,21 +129,25 @@ func (a *AgentImage) updateIgnitionContent(agentArtifacts *AgentArtifacts) error
 }
 
 func (a *AgentImage) overwriteFileData(fileInfo []isoeditor.FileData) error {
+	var errs []error
 	for _, fileData := range fileInfo {
+		defer fileData.Data.Close()
+
 		filename := filepath.Join(a.tmpPath, fileData.Filename)
 		file, err := os.Create(filename)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		defer file.Close()
 
 		_, err = io.Copy(file, fileData.Data)
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func updateKargsFile(tmpPath, filename string, embedArea *regexp.Regexp, kargs []byte) error {

--- a/pkg/asset/agent/image/kargs.go
+++ b/pkg/asset/agent/image/kargs.go
@@ -61,10 +61,10 @@ func (a *Kargs) Name() string {
 }
 
 // KernelCmdLine returns the data to be appended to the kernel arguments.
-func (a *Kargs) KernelCmdLine() []byte {
+func (a *Kargs) KernelCmdLine() string {
 	cmdLine := a.consoleArgs
 	if a.fips {
 		cmdLine += " fips=1"
 	}
-	return []byte(cmdLine)
+	return cmdLine
 }

--- a/pkg/asset/agent/image/kargs_test.go
+++ b/pkg/asset/agent/image/kargs_test.go
@@ -101,7 +101,7 @@ func TestKargs_Generate(t *testing.T) {
 
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedArgs, string(kargs.KernelCmdLine()))
+				assert.Equal(t, tc.expectedArgs, kargs.KernelCmdLine())
 			} else {
 				assert.Regexp(t, tc.expectedErr, err.Error())
 			}


### PR DESCRIPTION
Defer to the implementation provided by assisted-image-service in
NewKargsReader(), so that we do not need to maintain any knowledge of
how kernel args are implemented in the installer.