### PR TITLE
CORS-2951: Add deprecation notice for OpenShiftSDN for 4.14 users

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -324,8 +324,12 @@ func validateNetworking(n *types.Networking, singleNodeOpenShift bool, fldPath *
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkType"), "network provider type required"))
 	}
 
-	if singleNodeOpenShift && n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType OpenShiftSDN is currently not supported on Single Node OpenShift"))
+	if n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
+		if singleNodeOpenShift {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType OpenShiftSDN is currently not supported on Single Node OpenShift"))
+		} else {
+			logrus.Warnf("networkType OpenShiftSDN is deprecated, please consider using OVNKubernetes")
+		}
 	}
 
 	if len(n.MachineNetwork) > 0 {


### PR DESCRIPTION
OpenShiftSDN CNI plugin will no longer be supported from 4.15. Add deprecation notice for 4.14 users to swicth to OVNKubernetes.