### PR TITLE
METAL-1039: Allow baremetal platform without MAPI

### DIFF
--- a/data/unpack_test.go
+++ b/data/unpack_test.go
@@ -16,7 +16,7 @@ func TestUnpack(t *testing.T) {
 	}
 
 	expected := "# Bootstrap Module"
-	content, err := os.ReadFile(filepath.Join(path, "baremetal", "bootstrap", "README.md"))
+	content, err := os.ReadFile(filepath.Join(path, "libvirt", "bootstrap", "README.md"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -395,6 +395,10 @@ func (m *Master) GenerateWithContext(ctx context.Context, dependencies asset.Par
 		// Use managed user data secret, since we always have up to date images
 		// available in the cluster
 		masterUserDataSecretName = "master-user-data-managed"
+		enabledCaps := installConfig.Config.GetEnabledCapabilities()
+		if !enabledCaps.Has(configv1.ClusterVersionCapabilityMachineAPI) {
+			break
+		}
 		machines, err = baremetal.Machines(clusterID.InfraID, ic, &pool, "master", masterUserDataSecretName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -501,15 +501,18 @@ func (w *Worker) GenerateWithContext(ctx context.Context, dependencies asset.Par
 			mpool.Set(pool.Platform.BareMetal)
 			pool.Platform.BareMetal = &mpool
 
-			// Use managed user data secret, since images used by MachineSet
-			// are always up to date
-			workerUserDataSecretName = "worker-user-data-managed"
-			sets, err := baremetal.MachineSets(clusterID.InfraID, ic, &pool, "", "worker", workerUserDataSecretName)
-			if err != nil {
-				return errors.Wrap(err, "failed to create worker machine objects")
-			}
-			for _, set := range sets {
-				machineSets = append(machineSets, set)
+			enabledCaps := installConfig.Config.GetEnabledCapabilities()
+			if enabledCaps.Has(configv1.ClusterVersionCapabilityMachineAPI) {
+				// Use managed user data secret, since images used by MachineSet
+				// are always up to date
+				workerUserDataSecretName = "worker-user-data-managed"
+				sets, err := baremetal.MachineSets(clusterID.InfraID, ic, &pool, "", "worker", workerUserDataSecretName)
+				if err != nil {
+					return errors.Wrap(err, "failed to create worker machine objects")
+				}
+				for _, set := range sets {
+					machineSets = append(machineSets, set)
+				}
 			}
 		case gcptypes.Name:
 			mpool := defaultGCPMachinePoolPlatform(pool.Architecture)

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -52,6 +52,15 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "bare metal hosts are missing",
 		},
 		{
+			name: "no_hosts_machineapi_disabled",
+			config: installConfig().
+				Capabilities(types.Capabilities{BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
+					AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityIngress,
+						configv1.ClusterVersionCapabilityBaremetal}}).
+				BareMetalPlatform(
+					platform().Hosts()).build(),
+		},
+		{
 			name: "toofew_masters_norole",
 			config: installConfig().
 				BareMetalPlatform(
@@ -1001,6 +1010,11 @@ func (icb *installConfigBuilder) BareMetalPlatform(builder *platformBuilder) *in
 	icb.InstallConfig.Platform = types.Platform{
 		BareMetal: builder.build(),
 	}
+	return icb
+}
+
+func (icb *installConfigBuilder) Capabilities(capabilities types.Capabilities) *installConfigBuilder {
+	icb.InstallConfig.Capabilities = &capabilities
 	return icb
 }
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -200,9 +200,9 @@ func ValidateInstallConfig(c *types.InstallConfig, usingAgentMethod bool) field.
 
 		if c.Capabilities.BaselineCapabilitySet == configv1.ClusterVersionCapabilitySetNone {
 			enabledCaps := sets.New[configv1.ClusterVersionCapability](c.Capabilities.AdditionalEnabledCapabilities...)
-			if enabledCaps.Has(configv1.ClusterVersionCapabilityBaremetal) && !enabledCaps.Has(configv1.ClusterVersionCapabilityMachineAPI) {
+			if enabledCaps.Has(configv1.ClusterVersionCapabilityMarketplace) && !enabledCaps.Has(configv1.ClusterVersionCapabilityOperatorLifecycleManager) {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("additionalEnabledCapabilities"), c.Capabilities.AdditionalEnabledCapabilities,
-					"the baremetal capability requires the MachineAPI capability"))
+					"the marketplace capability requires the OperatorLifecycleManager capability"))
 			}
 			if c.Platform.BareMetal != nil && !enabledCaps.Has(configv1.ClusterVersionCapabilityBaremetal) {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("additionalEnabledCapabilities"), c.Capabilities.AdditionalEnabledCapabilities,

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -683,6 +683,8 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "valid baremetal platform",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.Capabilities = &types.Capabilities{BaselineCapabilitySet: "v4.11"}
+				c.Capabilities.AdditionalEnabledCapabilities = append(c.Capabilities.AdditionalEnabledCapabilities, configv1.ClusterVersionCapabilityIngress, configv1.ClusterVersionCapabilityCloudCredential, configv1.ClusterVersionCapabilityCloudControllerManager, configv1.ClusterVersionCapabilityOperatorLifecycleManager)
 				c.Platform = types.Platform{
 					BareMetal: validBareMetalPlatform(),
 				}
@@ -1426,6 +1428,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Platform = types.Platform{BareMetal: validBareMetalPlatform()}
+				c.Capabilities = &types.Capabilities{BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetCurrent}
 				c.CredentialsMode = types.PassthroughCredentialsMode
 				return c
 			}(),
@@ -1547,16 +1550,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `additionalEnabledCapabilities: Invalid value: \[\]v1.ClusterVersionCapability{"marketplace"}: the marketplace capability requires the OperatorLifecycleManager capability`,
-		},
-		{
-			name: "invalid capability baremetal specified without MachineAPI",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Capabilities = &types.Capabilities{BaselineCapabilitySet: "None",
-					AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{"baremetal"}}
-				return c
-			}(),
-			expectedError: `additionalEnabledCapabilities: Invalid value: \[\]v1.ClusterVersionCapability{"baremetal"}: the baremetal capability requires the MachineAPI capability`,
 		},
 		{
 			name: "valid additional enabled capability specified",
@@ -2201,16 +2194,15 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "featureGates: Forbidden: featureGates can only be used with the CustomNoUpgrade feature set",
 		},
 		{
-			name: "return error when MAPI disabled w/o baremetal with baseline none",
+			name: "valid disabled MAPI with baseline none and baremetal enabled",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Capabilities = &types.Capabilities{
 					BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySetNone,
-					AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityBaremetal},
+					AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityIngress, configv1.ClusterVersionCapabilityCloudCredential, configv1.ClusterVersionCapabilityCloudControllerManager},
 				}
 				return c
 			}(),
-			expectedError: `the baremetal capability requires the MachineAPI capability`,
 		},
 		{
 			name: "valid disabled MAPI capability configuration",


### PR DESCRIPTION
There are use cases for using the baremetal platform while disabling MAPI (for example to use CAPI).
The installer will skip rendering BMH, Machine and MachineSet CRs in case MAPI is disabled
This also removes the validation preventing this configuration to allow users to `create ignition-configs`.
The validations still apply for the `create cluster` target
    
Fixes [METAL-1039](https://issues.redhat.com//browse/METAL-1039)
