### PR TITLE
OCPBUGS-34978: Power VS: Ensure that VPC has prerequesite resources for private

### DIFF
--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -40,7 +40,10 @@ type API interface {
 	GetDNSZones(ctx context.Context, publish types.PublishingStrategy) ([]DNSZoneResponse, error)
 	GetDNSInstancePermittedNetworks(ctx context.Context, dnsID string, dnsZone string) ([]string, error)
 	GetDNSCustomResolverIP(ctx context.Context, dnsID string, vpcID string) (string, error)
+	CreateDNSCustomResolver(ctx context.Context, name string, dnsID string, vpcID string) (*dnssvcsv1.CustomResolver, error)
+	EnableDNSCustomResolver(ctx context.Context, dnsID string, resolverID string) (*dnssvcsv1.CustomResolver, error)
 	CreateDNSRecord(ctx context.Context, publish types.PublishingStrategy, crnstr string, baseDomain string, hostname string, cname string) error
+	AddVPCToPermittedNetworks(ctx context.Context, vpcCRN string, dnsID string, dnsZone string) error
 
 	// VPC
 	GetVPCByName(ctx context.Context, vpcName string) (*vpcv1.VPC, error)
@@ -294,6 +297,46 @@ func (c *Client) GetDNSCustomResolverIP(ctx context.Context, dnsID string, vpcID
 	return "", fmt.Errorf("DNS server IP of custom resolver for %q not found", dnsID)
 }
 
+// CreateDNSCustomResolver creates a custom resolver associated with the specified VPC in the specified DNS zone.
+func (c *Client) CreateDNSCustomResolver(ctx context.Context, name string, dnsID string, vpcID string) (*dnssvcsv1.CustomResolver, error) {
+	createCustomResolverOptions := c.dnsServicesAPI.NewCreateCustomResolverOptions(dnsID)
+	createCustomResolverOptions.SetName(name)
+
+	subnets, err := c.GetVPCSubnets(ctx, vpcID)
+	if err != nil {
+		return nil, err
+	}
+
+	locations := []dnssvcsv1.LocationInput{}
+	for _, subnet := range subnets {
+		location, err := c.dnsServicesAPI.NewLocationInput(*subnet.CRN)
+		if err != nil {
+			return nil, err
+		}
+		location.Enabled = core.BoolPtr(true)
+		locations = append(locations, *location)
+	}
+	createCustomResolverOptions.SetLocations(locations)
+
+	customResolver, _, err := c.dnsServicesAPI.CreateCustomResolverWithContext(ctx, createCustomResolverOptions)
+	if err != nil {
+		return nil, err
+	}
+	return customResolver, nil
+}
+
+// EnableDNSCustomResolver enables a specified custom resolver.
+func (c *Client) EnableDNSCustomResolver(ctx context.Context, dnsID string, resolverID string) (*dnssvcsv1.CustomResolver, error) {
+	updateCustomResolverOptions := c.dnsServicesAPI.NewUpdateCustomResolverOptions(dnsID, resolverID)
+	updateCustomResolverOptions.SetEnabled(true)
+
+	customResolver, _, err := c.dnsServicesAPI.UpdateCustomResolverWithContext(ctx, updateCustomResolverOptions)
+	if err != nil {
+		return nil, err
+	}
+	return customResolver, nil
+}
+
 // GetDNSZoneIDByName gets the CIS zone ID from its domain name.
 func (c *Client) GetDNSZoneIDByName(ctx context.Context, name string, publish types.PublishingStrategy) (string, error) {
 	zones, err := c.GetDNSZones(ctx, publish)
@@ -413,6 +456,24 @@ func (c *Client) GetDNSInstancePermittedNetworks(ctx context.Context, dnsID stri
 		networks = append(networks, *network.PermittedNetwork.VpcCrn)
 	}
 	return networks, nil
+}
+
+// AddVPCToPermittedNetworks adds the specified VPC to the specified DNS zone.
+func (c *Client) AddVPCToPermittedNetworks(ctx context.Context, vpcCRN string, dnsID string, dnsZone string) error {
+	createPermittedNetworkOptions := c.dnsServicesAPI.NewCreatePermittedNetworkOptions(dnsID, dnsZone)
+	permittedNetwork, err := c.dnsServicesAPI.NewPermittedNetworkVpc(vpcCRN)
+	if err != nil {
+		return err
+	}
+
+	createPermittedNetworkOptions.SetPermittedNetwork(permittedNetwork)
+	createPermittedNetworkOptions.SetType("vpc")
+
+	_, _, err = c.dnsServicesAPI.CreatePermittedNetworkWithContext(ctx, createPermittedNetworkOptions)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // CreateDNSRecord Creates a DNS CNAME record in the given base domain and CRN.

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	dnssvcsv1 "github.com/IBM/networking-go-sdk/dnssvcsv1"
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	resourcemanagerv2 "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	vpcv1 "github.com/IBM/vpc-go-sdk/vpcv1"
@@ -67,6 +68,35 @@ func (mr *MockAPIMockRecorder) AddSecurityGroupRule(ctx, securityGroupID, rule i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSecurityGroupRule", reflect.TypeOf((*MockAPI)(nil).AddSecurityGroupRule), ctx, securityGroupID, rule)
 }
 
+// AddVPCToPermittedNetworks mocks base method.
+func (m *MockAPI) AddVPCToPermittedNetworks(ctx context.Context, vpcCRN, dnsID, dnsZone string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddVPCToPermittedNetworks", ctx, vpcCRN, dnsID, dnsZone)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddVPCToPermittedNetworks indicates an expected call of AddVPCToPermittedNetworks.
+func (mr *MockAPIMockRecorder) AddVPCToPermittedNetworks(ctx, vpcCRN, dnsID, dnsZone interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVPCToPermittedNetworks", reflect.TypeOf((*MockAPI)(nil).AddVPCToPermittedNetworks), ctx, vpcCRN, dnsID, dnsZone)
+}
+
+// CreateDNSCustomResolver mocks base method.
+func (m *MockAPI) CreateDNSCustomResolver(ctx context.Context, name, dnsID, vpcID string) (*dnssvcsv1.CustomResolver, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDNSCustomResolver", ctx, name, dnsID, vpcID)
+	ret0, _ := ret[0].(*dnssvcsv1.CustomResolver)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDNSCustomResolver indicates an expected call of CreateDNSCustomResolver.
+func (mr *MockAPIMockRecorder) CreateDNSCustomResolver(ctx, name, dnsID, vpcID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDNSCustomResolver", reflect.TypeOf((*MockAPI)(nil).CreateDNSCustomResolver), ctx, name, dnsID, vpcID)
+}
+
 // CreateDNSRecord mocks base method.
 func (m *MockAPI) CreateDNSRecord(ctx context.Context, publish types.PublishingStrategy, crnstr, baseDomain, hostname, cname string) error {
 	m.ctrl.T.Helper()
@@ -93,6 +123,21 @@ func (m *MockAPI) CreateSSHKey(ctx context.Context, serviceInstance, zone, sshKe
 func (mr *MockAPIMockRecorder) CreateSSHKey(ctx, serviceInstance, zone, sshKeyName, sshKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSSHKey", reflect.TypeOf((*MockAPI)(nil).CreateSSHKey), ctx, serviceInstance, zone, sshKeyName, sshKey)
+}
+
+// EnableDNSCustomResolver mocks base method.
+func (m *MockAPI) EnableDNSCustomResolver(ctx context.Context, dnsID, resolverID string) (*dnssvcsv1.CustomResolver, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableDNSCustomResolver", ctx, dnsID, resolverID)
+	ret0, _ := ret[0].(*dnssvcsv1.CustomResolver)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnableDNSCustomResolver indicates an expected call of EnableDNSCustomResolver.
+func (mr *MockAPIMockRecorder) EnableDNSCustomResolver(ctx, dnsID, resolverID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableDNSCustomResolver", reflect.TypeOf((*MockAPI)(nil).EnableDNSCustomResolver), ctx, dnsID, resolverID)
 }
 
 // GetAPIKey mocks base method.

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -181,6 +181,12 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	// If a VPC was specified, pass all subnets in it to cluster API
 	if installConfig.Config.Platform.PowerVS.VPCName != "" {
 		logrus.Debugf("GenerateClusterAssets: VPCName = %s", installConfig.Config.Platform.PowerVS.VPCName)
+		if installConfig.Config.Publish == types.InternalPublishingStrategy {
+			err = installConfig.PowerVS.EnsureVPCIsPermittedNetwork(context.TODO(), installConfig.Config.PowerVS.VPCName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error ensuring VPC is permitted: %s %w", installConfig.Config.PowerVS.VPCName, err)
+		}
 		subnets, err := installConfig.PowerVS.GetVPCSubnets(context.TODO(), vpcName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting subnets in specified VPC: %s %w", installConfig.Config.PowerVS.VPCName, err)


### PR DESCRIPTION
Currently the installer will not add your VPC as a permitted network for private DNS. Adding this ability to the installer will make using private DNS easier.