### PR TITLE
OCPBUGS-34900: Increase timeout for bootstrap complete

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -451,7 +451,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config) *cluster
 		}
 	}
 
-	timeout := 30 * time.Minute
+	timeout := 45 * time.Minute
 
 	// Wait longer for baremetal, VSphere due to length of time it takes to boot
 	if platformName == baremetal.Name || platformName == vsphere.Name {


### PR DESCRIPTION
241ec4efe4cc1e4d90c1a8d5d8b2200701e53a9f introduced a new step that causes the `report-progress.sh` script to wait for the cluster to stabilize and have at least 2 API endpoint. On an observed OpenStack cluster, this added 8 minutes to the bootstrap phase, between when `bootkube.service` reported completion and when the `kube-system/bootstrap` config map was created. The wait for bootstrap to complete took 32 min, instead of 24 had it not waited for the cluster to have multiple API endpoints.

This commit bumps the timeout inside the `waitForBootstrapComplete()` function from 30 min to 45 min to account for this new step.