### PR TITLE
no-jira: hack: bump golangci-lint version

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -5,5 +5,5 @@ podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golangci/golangci-lint:v1.54.2 \
+    docker.io/golangci/golangci-lint:v1.59.0 \
     golangci-lint run --new-from-rev=dcf8122 "${@}"


### PR DESCRIPTION
We are using golangci-lint v1.59.0 in CI, so let's match that in local dev. That version is needed for Golang 1.22 support.

This is a fallout of https://github.com/openshift/installer/pull/8473.