### PR TITLE
MULTIARCH-4515: Add new files for agent-based installer (LPAR support for s390x)

### DIFF
--- a/cmd/openshift-install/testdata/agent/pxe/configurations/sno_s390x.txt
+++ b/cmd/openshift-install/testdata/agent/pxe/configurations/sno_s390x.txt
@@ -1,0 +1,78 @@
+skip # Verify a default configuration for the SNO topology for s390x architecture
+
+exec openshift-install agent create pxe-files --dir $WORK
+
+stderr 'Created boot artefacts for s390x'
+
+exists $WORK/boot-artifacts/agent.s390x-initrd.img
+exists $WORK/boot-artifacts/agent.s390x-rootfs.img
+exists $WORK/boot-artifacts/agent.s390x-kernel.img
+exists $WORK/boot-artifacts/agent.s390x-generic.ins
+exists $WORK/boot-artifacts/agent.s390x-initrd.addrsize
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+# no ipxe file in case of s390x
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 1
+  architecture: s390x
+compute: 
+- name: worker
+  replicas: 0
+  architecture: s390x
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+hosts:
+  - hostname: master-1
+    role: master
+    interfaces:
+      - name: eth0
+        macAddress: 02:ec:01:00:00:89
+    networkConfig:
+      interfaces:
+        - name: eth0
+          type: ethernet
+          state: up
+          mac-address: 02:ec:01:00:00:89
+          ipv4:
+            enabled: true
+            address:
+              - ip: 172.23.236.86
+                prefix-length: 24
+            dhcp: false
+      dns-resolver:
+        config:
+          server:
+            - 172.23.236.86
+      routes:
+        config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 172.23.236.86
+            next-hop-interface: eth0
+            table-id: 254

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.33.0
 	github.com/openshift/api v0.0.0-20240517002838-931fa9860c01
-	github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17
+	github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0
 	github.com/openshift/assisted-service/models v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -1973,8 +1973,8 @@ github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/openshift/api v0.0.0-20240517002838-931fa9860c01 h1:X3PJCyGHG5aM9yUTb8yaLjR43Qp1lvsT2rMlcdl4G+c=
 github.com/openshift/api v0.0.0-20240517002838-931fa9860c01/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
-github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17 h1:rsTD5h6S3dCgAClbwWi/6AIo2twckeJEf+j4EZYkwII=
-github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
+github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6 h1:U6ve+dnHlHhAELoxX+rdFOHVhoaYl0l9qtxwYtsO6C0=
+github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8 h1:+fZLKbycDo4JeLwPGVSAgf2XPaJGLM341l9ZfrrlxG0=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8/go.mod h1:PmMnbVno5ocinfELDdKOaatvT5ucJLrau+fjHQNeCiY=
 github.com/openshift/assisted-service/client v0.0.0-20230831114549-1922eda29cf8 h1:9NpCGby6O44BlWqWCbd8wcN4QwBebR8McQGrjTwhlzQ=

--- a/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initrd_addrsize.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initrd_addrsize.go
@@ -1,0 +1,50 @@
+package isoeditor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+)
+
+const initrdAddrsizePathInISO = "images/initrd.addrsize"
+
+func NewInitrdAddrsizeReader(iafsPath string, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	iafsReader, err := os.Open(iafsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open base initrd.addrsize: %w", err)
+	}
+	return NewInitrdAddrsizeReaderFromStream(iafsReader, initrdFile)
+}
+
+func NewInitrdAddrsizeReaderFromISO(isoPath string, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	iafsReader, err := GetFileFromISO(isoPath, initrdAddrsizePathInISO)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open base initrd.addrsize from ISO: %w", err)
+	}
+	return NewInitrdAddrsizeReaderFromStream(iafsReader, initrdFile)
+}
+
+func NewInitrdAddrsizeReaderFromStream(irfsReader io.ReadSeekCloser, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	// get the size of the initrd including the embedded ignition
+	sizeOfInitrd, err := initrdFile.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine size of initrd: %v", err)
+	}
+
+	addrsizeBytes := new(bytes.Buffer)
+	err = binary.Write(addrsizeBytes, binary.BigEndian, sizeOfInitrd)
+	if err != nil {
+		return nil, fmt.Errorf("error during write buffer: %v", err)
+	}
+	initrdPSW := make([]byte, 8)
+	m, err := irfsReader.Read(initrdPSW)
+	if err != nil || m != 8 {
+		return nil, fmt.Errorf("failed to read initrd.addrsize: %v", err)
+	}
+
+	return bytes.NewReader(append(initrdPSW, addrsizeBytes.Bytes()...)), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -990,7 +990,7 @@ github.com/openshift/api/machineconfiguration/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operator/v1alpha1
 github.com/openshift/api/route/v1
-# github.com/openshift/assisted-image-service v0.0.0-20240506123319-82517255ca17
+# github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 ## explicit; go 1.21
 github.com/openshift/assisted-image-service/pkg/isoeditor
 github.com/openshift/assisted-image-service/pkg/overlay


### PR DESCRIPTION
This PR is adding the LPAR support (s390x) for agend-based installer and bump the version dependencies.

For LPAR support two additional files are needed: ins-file (generic.ins) and initrd.addrsize. Both files are generated for s390x only.

 How was this PR tested:

- Build locally ("/hack/build.sh")
- create install-config.yaml and agent-config.yaml (use iPXE script)
- Create installer files (new files are created)

`-rw-r--r--. 1 root root       149 Jun  7 17:48 agent.s390x-generic.ins`
`-rw-r--r--. 1 root root        16 Jun  7 17:48 agent.s390x-initrd.addrsize`



