### PR TITLE
OCPBUGS-35020: capi/aws: don't use S3 stub for masters

### DIFF
--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -112,6 +112,10 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 		if in.Role == "bootstrap" {
 			awsMachine.Name = capiutils.GenerateBoostrapMachineName(clusterID)
 			awsMachine.Labels["install.openshift.io/bootstrap"] = ""
+			awsMachine.Spec.Ignition.StorageType = capa.IgnitionStorageTypeOptionClusterObjectStore
+		} else {
+			// master machines should get ignition from the MCS on the bootstrap node
+			awsMachine.Spec.Ignition.StorageType = capa.IgnitionStorageTypeOptionUnencryptedUserData
 		}
 
 		// Handle additional security groups.

--- a/pkg/asset/machines/aws/awsmachines_test.go
+++ b/pkg/asset/machines/aws/awsmachines_test.go
@@ -30,7 +30,9 @@ var stubMachineInputManagedVpc = &MachineInput{
 	Subnets:  make(map[string]string, 0),
 	Tags:     capa.Tags{},
 	PublicIP: false,
-	Ignition: &capa.Ignition{},
+	Ignition: &capa.Ignition{
+		StorageType: capa.IgnitionStorageTypeOptionUnencryptedUserData,
+	},
 }
 
 func stubDeepCopyMachineInput(in *MachineInput) *MachineInput {
@@ -115,7 +117,9 @@ func TestGenerateMachines(t *testing.T) {
 								Encrypted: ptr.To(true),
 							},
 							UncompressedUserData: ptr.To(true),
-							Ignition:             &capa.Ignition{},
+							Ignition: &capa.Ignition{
+								StorageType: capa.IgnitionStorageTypeOptionUnencryptedUserData,
+							},
 						},
 					}
 					infraMachineFiles = append(infraMachineFiles, &asset.RuntimeFile{
@@ -169,7 +173,9 @@ func TestGenerateMachines(t *testing.T) {
 								Encrypted: ptr.To(true),
 							},
 							UncompressedUserData: ptr.To(true),
-							Ignition:             &capa.Ignition{},
+							Ignition: &capa.Ignition{
+								StorageType: capa.IgnitionStorageTypeOptionUnencryptedUserData,
+							},
 						},
 					}
 					infraMachineFiles = append(infraMachineFiles, &asset.RuntimeFile{


### PR DESCRIPTION
They should get their ignition from the MCS running on the bootstrap node. The s3 stub is only needed for bootstrap.