### PR TITLE
OCPBUGS-34416: Validate OnHostMaintenance and ConfidentialCompute

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -474,6 +474,7 @@ spec:
                         GCP
                       properties:
                         confidentialCompute:
+                          default: Disabled
                           description: ConfidentialCompute Defines whether the instance
                             should have confidential compute enabled. If enabled OnHostMaintenance
                             is required to be set to "Terminate". If omitted, the
@@ -484,6 +485,7 @@ spec:
                           - Disabled
                           type: string
                         onHostMaintenance:
+                          default: Migrate
                           description: OnHostMaintenance determines the behavior when
                             a maintenance event occurs that might cause the instance
                             to reboot. Allowed values are "Migrate" and "Terminate".
@@ -1385,6 +1387,7 @@ spec:
                       GCP
                     properties:
                       confidentialCompute:
+                        default: Disabled
                         description: ConfidentialCompute Defines whether the instance
                           should have confidential compute enabled. If enabled OnHostMaintenance
                           is required to be set to "Terminate". If omitted, the platform
@@ -1395,6 +1398,7 @@ spec:
                         - Disabled
                         type: string
                       onHostMaintenance:
+                        default: Migrate
                         description: OnHostMaintenance determines the behavior when
                           a maintenance event occurs that might cause the instance
                           to reboot. Allowed values are "Migrate" and "Terminate".
@@ -3012,6 +3016,7 @@ spec:
                       their own platform configuration.
                     properties:
                       confidentialCompute:
+                        default: Disabled
                         description: ConfidentialCompute Defines whether the instance
                           should have confidential compute enabled. If enabled OnHostMaintenance
                           is required to be set to "Terminate". If omitted, the platform
@@ -3022,6 +3027,7 @@ spec:
                         - Disabled
                         type: string
                       onHostMaintenance:
+                        default: Migrate
                         description: OnHostMaintenance determines the behavior when
                           a maintenance event occurs that might cause the instance
                           to reboot. Allowed values are "Migrate" and "Terminate".

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -1,5 +1,26 @@
 package gcp
 
+// FeatureSwitch indicates whether the feature is enabled or disabled.
+type FeatureSwitch string
+
+// OnHostMaintenanceType indicates the setting for the OnHostMaintenance feature, but this is only
+// applicable when ConfidentialCompute is Enabled.
+type OnHostMaintenanceType string
+
+const (
+	// EnabledFeature indicates that the feature is configured as enabled.
+	EnabledFeature FeatureSwitch = "Enabled"
+
+	// DisabledFeature indicates that the feature is configured as disabled.
+	DisabledFeature FeatureSwitch = "Disabled"
+
+	// OnHostMaintenanceMigrate is the default, and it indicates that the OnHostMaintenance feature is set to Migrate.
+	OnHostMaintenanceMigrate OnHostMaintenanceType = "Migrate"
+
+	// OnHostMaintenanceTerminate indicates that the OnHostMaintenance feature is set to Terminate.
+	OnHostMaintenanceTerminate OnHostMaintenanceType = "Terminate"
+)
+
 // MachinePool stores the configuration for a machine pool installed on GCP.
 type MachinePool struct {
 	// Zones is list of availability zones that can be used.
@@ -38,6 +59,8 @@ type MachinePool struct {
 	// OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot.
 	// Allowed values are "Migrate" and "Terminate".
 	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is "Migrate".
+	// +kubebuilder:default="Migrate"
+	// +default="Migrate"
 	// +kubebuilder:validation:Enum=Migrate;Terminate;
 	// +optional
 	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
@@ -45,6 +68,8 @@ type MachinePool struct {
 	// ConfidentialCompute Defines whether the instance should have confidential compute enabled.
 	// If enabled OnHostMaintenance is required to be set to "Terminate".
 	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+	// +kubebuilder:default="Disabled"
+	// +default="Disabled"
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
 	ConfidentialCompute string `json:"confidentialCompute,omitempty"`

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -36,6 +36,10 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 		}
 	}
 
+	if p.ConfidentialCompute == string(gcp.EnabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("OnHostMaintenance"), p.OnHostMaintenance, "OnHostMaintenace must be set to Terminate when ConfidentialCompute is Enabled"))
+	}
+
 	for i, tag := range p.Tags {
 		if tag == "" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("tags").Index(i), tag, fmt.Sprintf("tag can not be empty")))

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -85,6 +85,21 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 			expected: `^test-path\.diskSizeGB: Invalid value: 66000: exceeding maximum GCP disk size limit, must be below 65536$`,
 		},
+		{
+			name: "enable confidential compute with correct on host maintenance",
+			pool: &gcp.MachinePool{
+				ConfidentialCompute: string(gcp.EnabledFeature),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+		},
+		{
+			name: "enable confidential compute with incorrect on host maintenance",
+			pool: &gcp.MachinePool{
+				ConfidentialCompute: string(gcp.EnabledFeature),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceMigrate),
+			},
+			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is Enabled`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
** The OnHostMaintenance and ConfidentialCompute values were not validated. 
** The OnHostMaintenance value should be set to Terminate when ConfidentialCompute is Enabled, otherwise the value can be Terminate or Migrate.
** Added default values to the MachinePool for both fields.