### PR TITLE
OCPBUGS-35041: capi: do not override KUBECONFIG

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -479,6 +479,13 @@ func (c *system) runController(ctx context.Context, ct *controller) error {
 		templateData := map[string]string{
 			"WebhookPort":    fmt.Sprintf("%d", wh.LocalServingPort),
 			"WebhookCertDir": wh.LocalServingCertDir,
+			"KubeconfigPath": c.lcp.KubeconfigPath,
+		}
+
+		// We cannot override KUBECONFIG, e.g., in case the user supplies a callback that needs to access the cluster,
+		// such as via credential_process in the AWS config file. The kubeconfig path is set in the controller instead.
+		if ct.Provider == nil || ct.Provider.Name != "azureaso" {
+			ct.Args = append(ct.Args, "--kubeconfig={{.KubeconfigPath}}")
 		}
 
 		args := make([]string, 0, len(ct.Args))
@@ -500,7 +507,10 @@ func (c *system) runController(ctx context.Context, ct *controller) error {
 			ct.Env = map[string]string{}
 		}
 		// Override KUBECONFIG to point to the local control plane.
-		ct.Env["KUBECONFIG"] = c.lcp.KubeconfigPath
+		// azureaso doesn't support the --kubeconfig parameter.
+		if ct.Provider != nil && ct.Provider.Name == "azureaso" {
+			ct.Env["KUBECONFIG"] = c.lcp.KubeconfigPath
+		}
 		for key, value := range ct.Env {
 			env = append(env, fmt.Sprintf("%s=%s", key, value))
 		}


### PR DESCRIPTION
Managed clusters might rely on the KUBECONFIG to reach their kube api server. Instead of using the env var and possibly causing issues, we can specify a custom kube config via cmdline argument for the capi controllers. That seems a more appropriate approach for an ephemeral kube API like the one spawned by envtest.