### PR TITLE
OCPBUGS-35038: capi/aws: add BootstrapDestroyer guard

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -29,6 +29,7 @@ var (
 	_ clusterapi.Provider           = (*Provider)(nil)
 	_ clusterapi.PreProvider        = (*Provider)(nil)
 	_ clusterapi.InfraReadyProvider = (*Provider)(nil)
+	_ clusterapi.BootstrapDestroyer = (*Provider)(nil)
 
 	errNotFound = errors.New("not found")
 )


### PR DESCRIPTION
Otherwise we might silently ignore the AWS destroy hook and not realize it.

Fallout from https://github.com/openshift/installer/pull/8359