### PR TITLE
OCPBUGS-35180: Prevent multiple invocations on CAPI

### DIFF
--- a/pkg/clusterapi/localcontrolplane.go
+++ b/pkg/clusterapi/localcontrolplane.go
@@ -107,10 +107,15 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 		return err
 	}
 
+	artifactsDirPath := filepath.Join(command.RootOpts.Dir, ArtifactsDir)
+	err = os.MkdirAll(artifactsDirPath, 0750)
+	if err != nil {
+		return fmt.Errorf("error creating cluster-api artifacts directory: %w", err)
+	}
+
 	kc := fromEnvTestConfig(c.Cfg)
 	{
-		dir := filepath.Join(command.RootOpts.Dir, "auth")
-		kf, err := os.Create(filepath.Join(dir, "envtest.kubeconfig"))
+		kf, err := os.Create(filepath.Join(artifactsDirPath, "envtest.kubeconfig"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR:

1. moves envtest kubeconfig from `<clusterdir>/auth/envtest.kubeconfig` to the hidden `<clusterdir>/.clusterapi_output/envtest.kubeconfig`
2. Prevents users from running `create cluster` repeatedly, unless they specify an envvar

Local testing.

After running `create cluster` then interrupting shortly after infrastructure provisioning begins, try running create cluster again:

```shell
[root@c5897d69ed85 /]# ./openshift-install create cluster --dir c
FATAL failed to fetch Cluster: failed to load asset "Cluster": local infrastructure provisioning artifacts already exist.  There may already be a running cluster 
```

If we specify `OPENSHIFT_INSTALL_REENTRANT` we can restart the install:

```shell
[root@c5897d69ed85 /]# OPENSHIFT_INSTALL_REENTRANT=true ./openshift-install create cluster --dir c
INFO Credentials loaded from the "default" profile in file "/root/.aws/credentials" 
INFO Creating infrastructure resources...   
```