### PR TITLE
OCPBUGS-35430: Support CAPI provider custom timeouts

### DIFF
--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -2,6 +2,7 @@ package clusterapi
 
 import (
 	"context"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -116,4 +117,12 @@ type PostDestroyer interface {
 // PostDestroyerInput collects args passed to the PostDestroyer hook.
 type PostDestroyerInput struct {
 	Metadata types.ClusterMetadata
+}
+
+// Timeouts allows platform provider to override the timeouts for certain phases.
+type Timeouts interface {
+	// When waiting for the network infrastructure to become ready.
+	NetworkTimeout() time.Duration
+	// When waiting for the machines to provision.
+	ProvisionTimeout() time.Duration
 }

--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -29,6 +29,7 @@ type Provider struct {
 	clusterapi.InfraProvider
 }
 
+var _ clusterapi.Timeouts = (*Provider)(nil)
 var _ clusterapi.InfraReadyProvider = (*Provider)(nil)
 var _ clusterapi.Provider = (*Provider)(nil)
 var _ clusterapi.PostProvider = (*Provider)(nil)
@@ -55,6 +56,18 @@ func leftInContext(ctx context.Context) time.Duration {
 
 const privatePrefix = "api-int."
 const publicPrefix = "api."
+
+// NetworkTimeout allows platform provider to override the timeout
+// when waiting for the network infrastructure to become ready.
+func (p Provider) NetworkTimeout() time.Duration {
+	return 30 * time.Minute
+}
+
+// ProvisionTimeout allows platform provider to override the timeout
+// when waiting for the machines to provision.
+func (p Provider) ProvisionTimeout() time.Duration {
+	return 15 * time.Minute
+}
 
 // InfraReady is called once cluster.Status.InfrastructureReady
 // is true, typically after load balancers have been provisioned. It can be used


### PR DESCRIPTION
Query the CAPI provider for the timeouts needed during provisioning.  This is optional to support.
  
The current default of 15 minutes is sufficient for normal CAPI installations.  However, given how the current PowerVS CAPI provider waits for some resources to be created before creating the load balancers, it is possible that the LBs will not create before the 15 minute timeout. An issue was created to track this [1].

[1] https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1837