### PR TITLE
OCPBUGS-35197: capi/aws: do not set proxy for masters

### DIFF
--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -112,10 +112,6 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 		if in.Role == "bootstrap" {
 			awsMachine.Name = capiutils.GenerateBoostrapMachineName(clusterID)
 			awsMachine.Labels["install.openshift.io/bootstrap"] = ""
-			awsMachine.Spec.Ignition.StorageType = capa.IgnitionStorageTypeOptionClusterObjectStore
-		} else {
-			// master machines should get ignition from the MCS on the bootstrap node
-			awsMachine.Spec.Ignition.StorageType = capa.IgnitionStorageTypeOptionUnencryptedUserData
 		}
 
 		// Handle additional security groups.

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -166,11 +167,6 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 			return fmt.Errorf("failed to create CAPA tags from UserTags: %w", err)
 		}
 
-		ignition, err := aws.CapaIgnitionWithCertBundleAndProxy(installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
-		if err != nil {
-			return fmt.Errorf("failed to generation CAPA ignition: %w", err)
-		}
-
 		pool.Platform.AWS = &mpool
 		awsMachines, err := aws.GenerateMachines(clusterID.InfraID, &aws.MachineInput{
 			Role:     "master",
@@ -178,12 +174,22 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 			Subnets:  subnets,
 			Tags:     tags,
 			PublicIP: false,
-			Ignition: ignition,
+			Ignition: &v1beta2.Ignition{
+				Version: "3.2",
+				// master machines should get ignition from the MCS on the bootstrap node
+				StorageType: v1beta2.IgnitionStorageTypeOptionUnencryptedUserData,
+			},
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
 		c.FileList = append(c.FileList, awsMachines...)
+
+		ignition, err := aws.CapaIgnitionWithCertBundleAndProxy(installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
+		if err != nil {
+			return fmt.Errorf("failed to generation CAPA ignition: %w", err)
+		}
+		ignition.StorageType = v1beta2.IgnitionStorageTypeOptionClusterObjectStore
 
 		pool := *ic.ControlPlane
 		pool.Name = "bootstrap"


### PR DESCRIPTION
Ignition proxy should be configured for bootstrap only.