### PR TITLE
OCPBUGS-35293: Add ELB V2 permission to set security groups on API server load balancer

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -124,6 +124,7 @@ var permissions = map[PermissionGroup][]string{
 		"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
 		"elasticloadbalancing:RegisterTargets",
 		"elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+		"elasticloadbalancing:SetSecurityGroups",
 
 		// IAM related perms
 		"iam:AddRoleToInstanceProfile",


### PR DESCRIPTION
Installs with CAPA require a new AWS permission to set Security Groups on load balancers.  This is a new permission that wasn't required in 4.15 and below because we did not attach Security Groups to API server load balancers. 

See https://issues.redhat.com/browse/OCPBUGS-35293