### PR TITLE
OCPBUGS-35309: Add S3 permission to allow attaching S3 bucket policy

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -175,6 +175,7 @@ var permissions = map[PermissionGroup][]string{
 		"s3:GetReplicationConfiguration",
 		"s3:ListBucket",
 		"s3:PutBucketAcl",
+		"s3:PutBucketPolicy",
 		"s3:PutBucketTagging",
 		"s3:PutEncryptionConfiguration",
 


### PR DESCRIPTION
The installer did not attach an S3 bootstrap bucket policy in the past, this new permission is required because of new functionality in CAPA.

CAPA is placing a policy that denies non SSL encrypted traffic to the bucket, this shouldn't have an effect on installs, adding the IAM policy to allow the policy to be added results in a successful install. 

S3 bootstrap bucket policy example:

```
"Statement": [
    {
        "Sid": "ForceSSLOnlyAccess",
        "Principal": {
            "AWS": [
                "*"
            ]
        },
        "Effect": "Deny",
        "Action": [
            "s3:*"
        ],
        "Resource": [
            "arn:aws:s3:::openshift-bootstrap-data-jamesh-sts-2r5f7/*"
        ],
        "Condition": {
            "Bool": {
                "aws:SecureTransport": false
            }
        }
    }
]
```

See bug: https://issues.redhat.com/browse/OCPBUGS-35309