### PR TITLE
OCPBUGS-35044: aws: fix requiring s3:Delete* perms

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -202,8 +202,6 @@ var permissions = map[PermissionGroup][]string{
 		"iam:ListInstanceProfiles",
 		"iam:ListRolePolicies",
 		"iam:ListUserPolicies",
-		"s3:DeleteBucket",
-		"s3:DeleteObject",
 		"s3:ListBucketVersions",
 		"tag:GetResources",
 	},


### PR DESCRIPTION
This is a fallout of https://github.com/openshift/installer/pull/8547. If the perm is included in the `DeleteBase` group we still get:
```
WARNING Action not allowed with tested creds          action=s3:DeleteBucket
WARNING Action not allowed with tested creds          action=s3:DeleteObject
```