### PR TITLE
OCPBUGS-35366: Update upi references to api-internal

### DIFF
--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -557,7 +557,7 @@ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-ig 
 ### Add bootstrap instance group to the internal load balancer backend service
 
 ```sh
-gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
+gcloud compute backend-services add-backend ${INFRA_ID}-api-internal --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
 ```
 
 ## Launch permanent control plane
@@ -717,7 +717,7 @@ If you are installing into a [Shared VPC (XPN)][sharedvpc],
 it is safe to remove any bootstrap-specific firewall rules at this time.
 
 ```sh
-gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
+gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
 gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
 gsutil rb gs://${INFRA_ID}-bootstrap-ignition
 gcloud deployment-manager deployments delete ${INFRA_ID}-bootstrap

--- a/upi/gcp/02_lb_int.py
+++ b/upi/gcp/02_lb_int.py
@@ -26,7 +26,7 @@ def GenerateConfig(context):
             'type': "HTTPS"
         }
     }, {
-        'name': context.properties['infra_id'] + '-api-internal-backend-service',
+        'name': context.properties['infra_id'] + '-api-internal',
         'type': 'compute.v1.regionBackendService',
         'properties': {
             'backends': backends,
@@ -40,7 +40,7 @@ def GenerateConfig(context):
         'name': context.properties['infra_id'] + '-api-internal-forwarding-rule',
         'type': 'compute.v1.forwardingRule',
         'properties': {
-            'backendService': '$(ref.' + context.properties['infra_id'] + '-api-internal-backend-service.selfLink)',
+            'backendService': '$(ref.' + context.properties['infra_id'] + '-api-internal.selfLink)',
             'IPAddress': '$(ref.' + context.properties['infra_id'] + '-cluster-ip.selfLink)',
             'loadBalancingScheme': 'INTERNAL',
             'ports': ['6443','22623'],


### PR DESCRIPTION
** Updated the UPI references in docs and scripts to use api-internal to the name to match those of the capg and terraform resources.