### PR TITLE
OCPBUGS-35037: aws: delete ignition bucket on bootstrap destroy

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -151,7 +151,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 				},
 			},
 			S3Bucket: &capa.S3Bucket{
-				Name:                    fmt.Sprintf("openshift-bootstrap-data-%s", clusterID.InfraID),
+				Name:                    GetIgnitionBucketName(clusterID.InfraID),
 				PresignedURLDuration:    &metav1.Duration{Duration: 1 * time.Hour},
 				BestEffortDeleteObjects: ptr.To(ic.Config.AWS.BestEffortDeleteIgnition),
 			},
@@ -264,4 +264,9 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 			Namespace:  awsCluster.Namespace,
 		},
 	}, nil
+}
+
+// GetIgnitionBucketName returns the name of the bucket for the given cluster.
+func GetIgnitionBucketName(infraID string) string {
+	return fmt.Sprintf("openshift-bootstrap-data-%s", infraID)
 }

--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -322,7 +322,7 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 		return fmt.Errorf("failed to create aws session: %w", err)
 	}
 
-	bucketName := fmt.Sprintf("openshift-bootstrap-data-%s", in.Metadata.InfraID)
+	bucketName := awsmanifest.GetIgnitionBucketName(in.Metadata.InfraID)
 	if err := removeS3Bucket(ctx, session, bucketName); err != nil {
 		if p.bestEffortDeleteIgnition {
 			logrus.Warnf("failed to delete ignition bucket %s: %v", bucketName, err)

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -394,9 +394,9 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 
 	machineDeletionTimeout := 5 * time.Minute
 	logrus.Infof("Waiting up to %v for bootstrap machine deletion %s/%s...", machineDeletionTimeout, machineNamespace, machineName)
-	ctx, cancel := context.WithTimeout(ctx, machineDeletionTimeout)
-	wait.UntilWithContext(ctx, func(context.Context) {
-		err := sys.Client().Get(ctx, client.ObjectKey{
+	cctx, cancel := context.WithTimeout(ctx, machineDeletionTimeout)
+	wait.UntilWithContext(cctx, func(context.Context) {
+		err := sys.Client().Get(cctx, client.ObjectKey{
 			Name:      machineName,
 			Namespace: machineNamespace,
 		}, &clusterv1.Machine{})
@@ -410,14 +410,25 @@ func (i *InfraProvider) DestroyBootstrap(ctx context.Context, dir string) error 
 		}
 	}, 2*time.Second)
 
-	err = ctx.Err()
+	err = cctx.Err()
 	if err != nil && !errors.Is(err, context.Canceled) {
 		logrus.Warnf("Timeout deleting bootstrap machine: %s", err)
-	} else {
-		logrus.Infof("Finished destroying bootstrap resources")
 	}
 	clusterapi.System().Teardown()
 
+	if p, ok := i.impl.(PostDestroyer); ok {
+		postDestroyInput := PostDestroyerInput{
+			Metadata: *metadata,
+		}
+		if err := p.PostDestroy(ctx, postDestroyInput); err != nil {
+			return fmt.Errorf("failed during post-destroy hook: %w", err)
+		}
+		logrus.Debugf("Finished running post-destroy hook")
+	} else {
+		logrus.Infof("no post-destroy requirements for the %s provider", i.impl.Name())
+	}
+
+	logrus.Infof("Finished destroying bootstrap resources")
 	return nil
 }
 

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -106,3 +106,14 @@ type BootstrapDestroyInput struct {
 	Client   client.Client
 	Metadata types.ClusterMetadata
 }
+
+// PostDestroyer allows platform-specific behavior after bootstrap has been destroyed and
+// ClusterAPI has stopped running.
+type PostDestroyer interface {
+	PostDestroy(ctx context.Context, in PostDestroyerInput) error
+}
+
+// PostDestroyerInput collects args passed to the PostDestroyer hook.
+type PostDestroyerInput struct {
+	Metadata types.ClusterMetadata
+}


### PR DESCRIPTION
This change adds a platform-specific post-destroy hook to the cluster-api infra.

For some platforms, it might be necessary to execute destroy tasks _after_ the cluster-api system has stopped so that it won't try to reconcile the changes.

This commits adds a post-destroy hook that runs during the bootstrap  destroy process but after cluster-api has shutdown.

It then leverage the post-destroy hook to delete the S3 ignition bucket after the cluster-api system has stopped running.

Because of the `BestEffortDeleteIgnition` option, we need to save its value to the provider while the cluster-api system is still running during the bootstrap destroy process. While not ideal, this solution offers the least impact to consumers of the Installer code as opposed to saving that value into the metadata.