### PR TITLE
OCPBUGS-35054: capi/aws/byo-vpc/multi-cidr: fix group rules

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -126,7 +126,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 						Protocol:                 capa.SecurityGroupProtocolTCP,
 						FromPort:                 22623,
 						ToPort:                   22623,
-						SourceSecurityGroupRoles: []capa.SecurityGroupRole{"node", "controlplane"},
+						SourceSecurityGroupRoles: []capa.SecurityGroupRole{"node", "controlplane", "apiserver-lb"},
 					},
 					{
 						Description:              "controller-manager",


### PR DESCRIPTION
[OCPBUGS-35054](https://issues.redhat.com/browse/OCPBUGS-35054)

Added security group ingress rule to satisfy the ingress traffic
from internal network when the installation is BYO VPC where the machine
CIDR, provided in install config, isn't the primary for the VPC.

To recap the current CAPA provisioning:
- The SGs with suffix `node`, `lb` and `controlplane` are created and
  attached to the control plane nodes
- The SGs 'lb' is intended to create ingress rules from listeners (API,
  MCS, etc), but CAPA enforces the Primary CIDR block of VPC[1]
- When deploying BYO VPC with multi-CIDR (managed multi-cidr isn't
  supported), CAPA creates ingress rules in `lb` with primary CIDR of
  VPC, then the control plane instances tries to access the MCS endpoint
  in the first boot to load ignitions from bootstrap, it is blocked
  because the LB is created using subnets from the Secondary CIDR block,
  leading to failed control plane nodes provisioning.

This change add ingress rules to MCS (22623/TCP) to SG `controlplane` from
NLB's SG, similar already existing rules for API (reason why API is
working).

[1] https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5008
Upstream ref:
- Issue: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5008
