### PR TITLE
CORS-3483: azure: Set DisableExtensionOperations to avoid timeout issues

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -124,15 +124,16 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				},
 			},
 			Spec: capz.AzureMachineSpec{
-				VMSize:                 mpool.InstanceType,
-				FailureDomain:          ptr.To(zone),
-				Image:                  image,
-				OSDisk:                 osDisk, // required
-				AdditionalTags:         tags,
-				AdditionalCapabilities: additionalCapabilities,
-				AllocatePublicIP:       false,
-				EnableIPForwarding:     false,
-				SecurityProfile:        securityProfile,
+				VMSize:                     mpool.InstanceType,
+				FailureDomain:              ptr.To(zone),
+				Image:                      image,
+				OSDisk:                     osDisk, // required
+				AdditionalTags:             tags,
+				AdditionalCapabilities:     additionalCapabilities,
+				DisableExtensionOperations: ptr.To(true),
+				AllocatePublicIP:           false,
+				EnableIPForwarding:         false,
+				SecurityProfile:            securityProfile,
 			},
 		}
 		azureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))
@@ -179,11 +180,12 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 			},
 		},
 		Spec: capz.AzureMachineSpec{
-			VMSize:         mpool.InstanceType,
-			Image:          image,
-			FailureDomain:  ptr.To(mpool.Zones[0]),
-			OSDisk:         osDisk,
-			AdditionalTags: tags,
+			VMSize:                     mpool.InstanceType,
+			Image:                      image,
+			FailureDomain:              ptr.To(mpool.Zones[0]),
+			OSDisk:                     osDisk,
+			AdditionalTags:             tags,
+			DisableExtensionOperations: ptr.To(true),
 			// Do not allocate a public IP since it isn't
 			// accessible as we are using an outbound LB for the
 			// control plane. This is temporary until we have a


### PR DESCRIPTION
Setting the DisableExtensionOperations to true to reduce the chances of seeing timeout issues while provisioning VMs for Azure using CAPZ.