### PR TITLE
OCPBUGS-35400: For GCP, only configure kmsKeyServiceAccount if set

### DIFF
--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -173,11 +173,13 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 
 	if mpool.OSDisk.EncryptionKey != nil {
 		encryptionKey := &capg.CustomerEncryptionKey{
-			KeyType:              capg.CustomerManagedKey,
-			KMSKeyServiceAccount: ptr.To(mpool.OSDisk.EncryptionKey.KMSKeyServiceAccount),
+			KeyType: capg.CustomerManagedKey,
 			ManagedKey: &capg.ManagedKey{
 				KMSKeyName: generateDiskEncryptionKeyLink(mpool.OSDisk.EncryptionKey.KMSKey, installConfig.Config.GCP.ProjectID),
 			},
+		}
+		if mpool.OSDisk.EncryptionKey.KMSKeyServiceAccount != "" {
+			encryptionKey.KMSKeyServiceAccount = ptr.To(mpool.OSDisk.EncryptionKey.KMSKeyServiceAccount)
 		}
 		gcpMachine.Spec.RootDiskEncryptionKey = encryptionKey
 	}


### PR DESCRIPTION
CAPG has a kubebuilder validation for kmsKeyServiceAccount https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/api/v1beta1/gcpmachine_types.go#L207 that is failing when the string is empty (no value is set). This field should only be configured if the ServiceAccount it not empty.