### PR TITLE
OCPBUGS-35542: Cleanup capi artifacts

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -112,6 +112,11 @@ func runDestroyCmd(directory string, reportQuota bool) error {
 	// ensure capi etcd data store is cleaned up
 	clusterapi.System().CleanEtcd()
 
+	capiArtifactsDir := filepath.Join(command.RootOpts.Dir, clusterapi.ArtifactsDir)
+	if err := os.RemoveAll(capiArtifactsDir); err != nil {
+		logrus.Warnf("failed to remove %s: %v", capiArtifactsDir, err)
+	}
+
 	timer.StopTimer(timer.TotalTimeElapsed)
 	timer.LogSummary()
 


### PR DESCRIPTION
** The .cluster_api directory and the auth directory contain extra artifacts that should be removed on cluster destroy.