### PR TITLE
OCPBUGS-34638: GCP: Set `discard_local_ssd` based on onHostMaintenance

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -114,6 +114,12 @@ resource "google_compute_instance" "bootstrap" {
     for_each = var.gcp_master_on_host_maintenance != "" ? [1] : []
     content {
       on_host_maintenance = var.gcp_master_on_host_maintenance
+      dynamic "on_instance_stop_action" {
+        for_each = var.gcp_master_on_host_maintenance == "Terminate"
+        content {
+          discard_local_ssd = true
+        }
+      }
     }
   }
 

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -75,6 +75,12 @@ resource "google_compute_instance" "master" {
     for_each = var.on_host_maintenance != "" ? [1] : []
     content {
       on_host_maintenance = var.on_host_maintenance
+      dynamic "on_instance_stop_action" {
+        for_each = var.on_host_maintenance == "Terminate"
+        content {
+          discard_local_ssd = true
+        }
+      }
     }
   }
 


### PR DESCRIPTION
According to https://github.com/hashicorp/terraform-provider-google/blob/189a9465aa7dcf8628894bd63ad9a0e42e256239/website/docs/r/compute_instance_template.html.markdown?plain=1#L623, `discard_local_ssd` only supports `true` at this time.