### PR TITLE
OCPBUGS-35533: Fix ethertype for masters service router SG creation

### DIFF
--- a/pkg/infrastructure/openstack/preprovision/securitygroups.go
+++ b/pkg/infrastructure/openstack/preprovision/securitygroups.go
@@ -203,7 +203,7 @@ func SecurityGroups(ctx context.Context, installConfig *installconfig.InstallCon
 			addRules(ctx, r, masterGroup.ID, serviceOVNDB, ipVersion, CIDRs)
 			addRules(ctx, r, workerGroup.ID, serviceRouter, ipVersion, CIDRs)
 			if mastersSchedulable {
-				addRules(ctx, r, masterGroup.ID, serviceRouter, rules.EtherType4, CIDRs)
+				addRules(ctx, r, masterGroup.ID, serviceRouter, ipVersion, CIDRs)
 			}
 		}
 


### PR DESCRIPTION
This prevented the creation of security groups for dualstack compact clusters.