### PR TITLE
OCPBUGS-35494: capi/aws: allow 6443 for private cluster NLB

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -220,6 +220,17 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 				},
 			},
 		}
+	} else {
+		awsCluster.Spec.ControlPlaneLoadBalancer.IngressRules = append(
+			awsCluster.Spec.ControlPlaneLoadBalancer.IngressRules,
+			capa.IngressRule{
+				Description: "Kubernetes API Server traffic",
+				Protocol:    capa.SecurityGroupProtocolTCP,
+				FromPort:    6443,
+				ToPort:      6443,
+				CidrBlocks:  []string{"0.0.0.0/0"},
+			},
+		)
 	}
 
 	// Set the NetworkSpec.Subnets from VPC and zones (managed)


### PR DESCRIPTION
This is in line with what was done with terraform/aws. The difference there is that we didn't create a security group for the NLB at all.

With CAPA, we need to allow ingress on 6443 for the NLB for private cluster installs for cases when, e.g., privateLink is used. Otherwise the installer won't be able to reach the kube API and the install will be deemed "failed".