### PR TITLE
CORS-3562: azure: Setting experimental MachinePool featuregate to false

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -182,6 +182,7 @@ func (c *system) Run(ctx context.Context) error {
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
+					"--feature-gates=MachinePool=false",
 				},
 				map[string]string{},
 			),


### PR DESCRIPTION
This feature gate was set to a default of true upstream via https://github.com/kubernetes-sigs/cluster-api/pull/10141. Setting it to false locally. Will enable this feature gate at a later time.

