### PR TITLE
OCPBUGS-35852: capi: shutdown local controlplane as the last step

### DIFF
--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -138,6 +138,16 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	// Grab the client.
 	cl := capiSystem.Client()
 
+	// If we're skipping bootstrap destroy, shutdown the local control plane.
+	// Otherwise, we will shut it down after bootstrap destroy.
+	// This has to execute as the last defer in the stack since previous defers might still need the local controlplane.
+	if oi, ok := os.LookupEnv("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP"); ok && oi != "" {
+		defer func() {
+			logrus.Warn("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set, shutting down local control plane.")
+			clusterapi.System().Teardown()
+		}()
+	}
+
 	// Make sure to always return generated manifests, even if errors happened
 	defer func(ctx context.Context, cl client.Client) {
 		var errs []error
@@ -346,13 +356,6 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	}
 
 	logrus.Infof("Cluster API resources have been created. Waiting for cluster to become ready...")
-
-	// If we're skipping bootstrap destroy, shutdown the local control plane.
-	// Otherwise, we will shut it down after bootstrap destroy.
-	if oi, ok := os.LookupEnv("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP"); ok && oi != "" {
-		logrus.Warn("OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set, shutting down local control plane.")
-		clusterapi.System().Teardown()
-	}
 
 	return fileList, nil
 }


### PR DESCRIPTION
If OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set, we need to make sure the local controlplane shutdown happens as the last step in the defer stack chain, so previous steps that need to access it don't fail.

```
06-20 15:26:51.219  level=warning msg=OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set, shutting down local control plane.
06-20 15:26:51.219  level=info msg=Shutting down local Cluster API control plane...
06-20 15:26:51.473  level=info msg=Stopped controller: Cluster API
06-20 15:26:51.473  level=info msg=Stopped controller: aws infrastructure provider
06-20 15:26:52.830  level=info msg=Local Cluster API system has completed operations
06-20 15:26:52.830  level=debug msg=Collecting applied cluster api manifests...
06-20 15:26:52.831  level=error msg=failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: [failed to get manifest openshift-cluster-api-guests: Get "https://127.0.0.1:46555/api/v1/namespaces/openshift-cluster-api-guests": dial tcp 127.0.0.1:46555: connect: connection refused[...]
```