### PR TITLE
OCPBUGS-35547: Configured logger for controller-runtime

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -13,6 +13,7 @@ import (
 	terminal "golang.org/x/term"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
@@ -32,6 +33,8 @@ func main() {
 	klogv2.InitFlags(&fsv2)
 	fsv2.Set("stderrthreshold", "4")
 	klogv2.SetOutput(io.Discard)
+
+	ctrl.SetLogger(klogv2.Background())
 
 	installerMain()
 }


### PR DESCRIPTION
OCPBUGS-35547

### Changes
- Set logger for controller-runtime package to prevent error output pertaining to:
`[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed`