### PR TITLE
OCPBUGS-35931: images/upi-installer: pin versions of ibmcloud plugins

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -77,10 +77,10 @@ ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
 RUN mkdir /output && HOME=/output && \ 
     echo "-4" > $HOME/.curlrc && \
     curl -fsSL ${IBMCLI_URI} | sh && \    
-    ibmcloud plugin install vpc-infrastructure -f && \
-    ibmcloud plugin install cloud-dns-services -f && \
-    ibmcloud plugin install cloud-internet-services -f && \
-    ibmcloud plugin install key-protect -f && \
+    ibmcloud plugin install vpc-infrastructure -f -v 11.3.0 && \
+    ibmcloud plugin install cloud-dns-services -f -v 0.7.3 && \
+    ibmcloud plugin install cloud-internet-services -f -v 1.16.2 && \
+    ibmcloud plugin install key-protect -f -v 0.10.0 && \
     cp /usr/local/bin/ibmcloud /bin/ibmcloud && \
     rm -f $HOME/.curlrc && \
     ibmcloud version && \


### PR DESCRIPTION
The latest version of the vpc-infrastructure plugin has started failing with
```
$ ibmcloud plugin install vpc-infrastructure -f
Looking up 'vpc-infrastructure' from repository 'IBM Cloud'...
Plug-in 'vpc-infrastructure[infrastructure-service/is] 11.4.0' found in repository 'IBM Cloud'
Attempting to download the binary file...
 24.06 MiB / 24.06 MiB [====================================================] 100.00% 0s
25231360 bytes downloaded
Installing binary...
FAILED
Plug-in directory '/output/.bluemix/plugins/vpc-infrastructure' already exists. Remove the directory and try again.
```
Let's pin to the previous version without this problem. And so that it doesn't happen with the other plugins, let's pin all of them to specific versions and just bump when we intend to.