### PR TITLE
SPLAT-1670: install pwsh from ci mirrored image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -23,6 +23,7 @@ RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.17:cli as cli
 FROM quay.io/ocp-splat/govc:v0.30.7 as govc
+FROM quay.io/ocp-splat/pwsh:v7.3.12 as pwsh
 FROM quay.io/multi-arch/yq:3.3.0 as yq3
 FROM quay.io/multi-arch/yq:4.30.5 as yq4
 
@@ -31,23 +32,33 @@ COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 
+# Install VMware plugin for powershell
+COPY --from=pwsh /opt/microsoft/powershell /opt/microsoft/powershell
+COPY --from=pwsh /root/.local/share/powershell/Modules /root/.local/share/powershell/Modules
+COPY --from=pwsh /usr/local/share/powershell/Modules /usr/local/share/powershell/Modules
+RUN ln -s /opt/microsoft/powershell/7/pwsh /bin/pwsh
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Create settings directory /output/.local/share/VMware/PowerCLI
+RUN mkdir -p /output/.local/share/VMware/PowerCLI && chmod -R 777 /output/.local
+
+# Install azure-cli
+COPY --from=pwsh /go/src/github.com/openshift/installer/azure-cli /go/src/github.com/openshift/installer/azure-cli
+RUN ln -s /go/src/github.com/openshift/installer/azure-cli/bin/az /bin/az
+
 COPY --from=govc /govc /bin/govc
 
-RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
-    sh -c 'echo -e "[packages-microsoft-com-prod]\nname=packages-microsoft-com-prod\nbaseurl=https://packages.microsoft.com/rhel/9/prod\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/microsoft-prod.repo' && \
-    sh -c 'echo -e "[google-cloud-cli]\nname=Google Cloud CLI\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
+RUN sh -c 'echo -e "[google-cloud-cli]\nname=Google Cloud CLI\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
 
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y \
-      azure-cli-2.49.0-1.el9 \
+    yum install --setopt=tsflags=nodocs -y \      
       gettext \
       google-cloud-cli-447.0.0-1 \
       gzip \
       jq \
       unzip \
       openssh-clients \
-      openssl \
-      powershell \
+      openssl \      
       python3-pip \
       python3-pyyaml \
       bind-utils \
@@ -74,7 +85,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Download the latest IBM Cloud release binary
 ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
-RUN mkdir /output && HOME=/output && \ 
+RUN HOME=/output && \ 
     echo "-4" > $HOME/.curlrc && \
     curl -fsSL ${IBMCLI_URI} | sh && \    
     ibmcloud plugin install vpc-infrastructure -f && \
@@ -86,10 +97,6 @@ RUN mkdir /output && HOME=/output && \
     ibmcloud version && \
     ibmcloud plugin list
 
-# Install VMware plugin for powershell.  Create settings directory /output/.local/share/VMware/PowerCLI
-RUN pwsh -Command 'Install-Module VMware.PowerCLI -Force -Scope AllUsers' && \
-    pwsh -Command 'Install-Module -Name EPS -RequiredVersion 1.0 -Force -Scope AllUsers' && \
-    mkdir -p /output/.local/share/VMware/PowerCLI && chmod -R 777 /output/.local
 
 RUN chown 1000:1000 /output && chmod -R g=u "/output/.bluemix/"
 USER 1000:1000


### PR DESCRIPTION
installs image which is mirrored and build based on:
- https://github.com/openshift-splat-team/pwsh
- https://quay.io/repository/ocp-splat/pwsh