### PR TITLE
AGENT-910: node-joiner multi-arch support

### DIFF
--- a/pkg/asset/agent/joiner/addnodesconfig.go
+++ b/pkg/asset/agent/joiner/addnodesconfig.go
@@ -35,7 +35,8 @@ type Config struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Hosts []agent.Host `json:"hosts,omitempty"`
+	CPUArchitecture string       `json:"cpuArchitecture,omitempty"`
+	Hosts           []agent.Host `json:"hosts,omitempty"`
 }
 
 // Params is used to store the command line parameters.

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -25,6 +25,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 	cases := []struct {
 		name                string
 		workflow            workflow.AgentWorkflowType
+		nodesConfig         AddNodesConfig
 		objects             []runtime.Object
 		openshiftObjects    []runtime.Object
 		expectedClusterInfo ClusterInfo
@@ -144,11 +145,126 @@ func TestClusterInfo_Generate(t *testing.T) {
 				OSImageLocation: "http://my-coreosimage-url/416.94.202402130130-0",
 			},
 		},
+		{
+			name:     "architecture specified in nodesConfig as arm64 and target cluster is amd64",
+			workflow: workflow.AgentWorkflowTypeAddNodes,
+			nodesConfig: AddNodesConfig{
+				Config: Config{
+					CPUArchitecture: "arm64",
+				},
+			},
+			openshiftObjects: []runtime.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "version",
+					},
+					Spec: configv1.ClusterVersionSpec{
+						ClusterID: "1b5ba46b-7e56-47b1-a326-a9eebddfb38c",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								Image:   "registry.ci.openshift.org/ocp/release@sha256:65d9b652d0d23084bc45cb66001c22e796d43f5e9e005c2bc2702f94397d596e",
+								Version: "4.15.0",
+							},
+						},
+					},
+				},
+				&configv1.Proxy{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.ProxySpec{
+						HTTPProxy:  "http://proxy",
+						HTTPSProxy: "https://proxy",
+						NoProxy:    "localhost",
+					},
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pull-secret",
+						Namespace: "openshift-config",
+					},
+					Data: map[string][]byte{
+						".dockerconfigjson": []byte("c3VwZXJzZWNyZXQK"),
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "user-ca-bundle",
+						Namespace: "openshift-config",
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": "--- bundle ---",
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{
+							Architecture: "amd64",
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "cluster-config-v1",
+						Namespace: "kube-system",
+					},
+					Data: map[string]string{
+						"install-config": makeInstallConfig(t),
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "coreos-bootimages",
+						Namespace: "openshift-machine-config-operator",
+					},
+					Data: map[string]string{
+						"stream": makeCoreOsBootImages(t, buildStreamData()),
+					},
+				},
+			},
+			expectedClusterInfo: ClusterInfo{
+				ClusterID:    "1b5ba46b-7e56-47b1-a326-a9eebddfb38c",
+				ClusterName:  "ostest",
+				ReleaseImage: "registry.ci.openshift.org/ocp/release@sha256:65d9b652d0d23084bc45cb66001c22e796d43f5e9e005c2bc2702f94397d596e",
+				Version:      "4.15.0",
+				APIDNSName:   "api.ostest.test.metalkube.org",
+				Namespace:    "cluster0",
+				PullSecret:   "c3VwZXJzZWNyZXQK",
+				UserCaBundle: "--- bundle ---",
+				Architecture: "arm64",
+				Proxy: &types.Proxy{
+					HTTPProxy:  "http://proxy",
+					HTTPSProxy: "https://proxy",
+					NoProxy:    "localhost",
+				},
+				ImageDigestSources: []types.ImageDigestSource{
+					{
+						Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						Mirrors: []string{
+							"registry.example.com:5000/ocp4/openshift4",
+						},
+					},
+				},
+				PlatformType:    v1beta1.BareMetalPlatformType,
+				SSHKey:          "my-ssh-key",
+				OSImage:         buildStreamData(),
+				OSImageLocation: "http://my-coreosimage-url/416.94.202402130130-1",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			agentWorkflow := &workflow.AgentWorkflow{Workflow: tc.workflow}
-			addNodesConfig := &AddNodesConfig{}
+			addNodesConfig := &tc.nodesConfig
 			parents := asset.Parents{}
 			parents.Add(agentWorkflow)
 			parents.Add(addNodesConfig)
@@ -194,6 +310,20 @@ func buildStreamData() *stream.Stream {
 							"iso": {
 								Disk: &stream.Artifact{
 									Location: "http://my-coreosimage-url/416.94.202402130130-0",
+								},
+							},
+						},
+					},
+				},
+			},
+			"aarch64": {
+				Artifacts: map[string]stream.PlatformArtifacts{
+					"metal": {
+						Release: "416.94.202402130130-0",
+						Formats: map[string]stream.ImageFormat{
+							"iso": {
+								Disk: &stream.Artifact{
+									Location: "http://my-coreosimage-url/416.94.202402130130-1",
 								},
 							},
 						},


### PR DESCRIPTION
Allow the CPU architecture to be specified in nodes-config.yaml.