### PR TITLE
OCPBUGS-34638: destroy/gcp: set value for DiscardLocalSsd

### DIFF
--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -130,7 +130,12 @@ func (o *ClusterUninstaller) stopInstance(ctx context.Context, item cloudResourc
 	o.Logger.Debugf("Stopping compute instance %s in zone %s", item.name, item.zone)
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
-	op, err := o.computeSvc.Instances.Stop(o.ProjectID, item.zone, item.name).RequestId(o.requestID("stopinstance", item.zone, item.name)).Context(ctx).Do()
+	op, err := o.computeSvc.Instances.
+		Stop(o.ProjectID, item.zone, item.name).
+		RequestId(o.requestID("stopinstance", item.zone, item.name)).
+		DiscardLocalSsd(true).
+		Context(ctx).
+		Do()
 	if err != nil && !isNoOp(err) {
 		o.resetRequestID("stopinstance", item.zone, item.name)
 		return errors.Wrapf(err, "failed to stop instance %s in zone %s", item.name, item.zone)


### PR DESCRIPTION
Instance types for which `OnHostMaintenance` is set to `Terminate`, GCP requires the `DiscardLocalSsd` value to be defined, otherwise we get the following error when destroying a cluster:
```
WARNING failed to stop instance jiwei-0530b-q9t8w-worker-c-ck6s8 in zone us-central1-c: googleapi: Error 400: VM has a Local SSD attached but an undefined value for `discard-local-ssd`. If using gcloud, please add `--discard-local-ssd=false` or `--discard-local-ssd=true` to your command., badRequest
```

We are setting the value to `true` because we are about to destroy the cluster, which means destroying the instances and all cluster-owned resources.