### PR TITLE
AGENT-925: retrieve ignition endpoint to add a new node

### DIFF
--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -16,7 +16,7 @@ EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 EnvironmentFile=/etc/assisted/add-nodes.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-import-cluster -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env CLUSTER_ID --env CLUSTER_NAME --env CLUSTER_API_VIP_DNS_NAME $SERVICE_IMAGE /usr/local/bin/agent-installer-client importCluster
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-import-cluster -v /etc/assisted/clusterconfig:/clusterconfig -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env CLUSTER_ID --env CLUSTER_NAME --env CLUSTER_API_VIP_DNS_NAME $SERVICE_IMAGE /usr/local/bin/agent-installer-client importCluster
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -46,6 +47,7 @@ const nmConnectionsPath = "/etc/assisted/network"
 const extraManifestPath = "/etc/assisted/extra-manifests"
 const registriesConfPath = "/etc/containers/registries.conf"
 const registryCABundlePath = "/etc/pki/ca-trust/source/anchors/domain.crt"
+const clusterConfigPath = "/etc/assisted/clusterconfig"
 
 // Ignition is an asset that generates the agent installer ignition file.
 type Ignition struct {
@@ -194,6 +196,10 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		openshiftVersion = clusterInfo.Version
 		streamGetter = func(ctx context.Context) (*stream.Stream, error) {
 			return clusterInfo.OSImage, nil
+		}
+		// If defined, add the ignition endpoints
+		if err := addDay2IgnitionEndpoints(&config, *clusterInfo); err != nil {
+			return err
 		}
 
 	default:
@@ -528,6 +534,35 @@ func addHostConfig(config *igntypes.Config, agentHosts *agentconfig.AgentHosts) 
 		hostConfigFile := ignition.FileFromBytes(filepath.Join("/etc/assisted/hostconfig", path), "root", 0644, content)
 		config.Storage.Files = append(config.Storage.Files, hostConfigFile)
 	}
+	return nil
+}
+
+func addDay2IgnitionEndpoints(config *igntypes.Config, clusterInfo joiner.ClusterInfo) error {
+	if clusterInfo.IgnitionEndpointWorker == nil {
+		return nil
+	}
+
+	user := "root"
+	mode := 0644
+	config.Storage.Directories = append(config.Storage.Directories, igntypes.Directory{
+		Node: igntypes.Node{
+			Path: clusterConfigPath,
+			User: igntypes.NodeUser{
+				Name: &user,
+			},
+			Overwrite: util.BoolToPtr(true),
+		},
+		DirectoryEmbedded1: igntypes.DirectoryEmbedded1{
+			Mode: &mode,
+		},
+	})
+
+	workerIgnitionBytes, err := json.Marshal(clusterInfo.IgnitionEndpointWorker)
+	if err != nil {
+		return err
+	}
+	workerIgnitionFile := ignition.FileFromBytes(path.Join(clusterConfigPath, "worker-ignition-endpoint.json"), user, mode, workerIgnitionBytes)
+	config.Storage.Files = append(config.Storage.Files, workerIgnitionFile)
 	return nil
 }
 

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/stream-metadata-go/arch"
 	"github.com/coreos/stream-metadata-go/stream"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	"github.com/openshift/assisted-service/models"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
@@ -45,6 +48,7 @@ type ClusterInfo struct {
 	SSHKey                        string
 	OSImage                       *stream.Stream
 	OSImageLocation               string
+	IgnitionEndpointWorker        *models.IgnitionEndpoint
 }
 
 var _ asset.WritableAsset = (*ClusterInfo)(nil)
@@ -103,6 +107,10 @@ func (ci *ClusterInfo) Generate(dependencies asset.Parents) error {
 		return err
 	}
 	err = ci.retrieveOsImage()
+	if err != nil {
+		return err
+	}
+	err = ci.retrieveIgnitionEndpointWorker()
 	if err != nil {
 		return err
 	}
@@ -265,6 +273,48 @@ func (ci *ClusterInfo) retrieveOsImage() error {
 		return fmt.Errorf("no ISO found to download for %s", clusterArch)
 	}
 	ci.OSImageLocation = format.Disk.Location
+
+	return nil
+}
+
+// This method retrieves, if present, the secured ignition endpoint - along with its ca certificate.
+// These information will be used to configure subsequently the imported Assisted Service cluster,
+// so that the secure port (22623) could be used by the nodes to fetch the worker ignition.
+func (ci *ClusterInfo) retrieveIgnitionEndpointWorker() error {
+	workerUserDataManaged, err := ci.Client.CoreV1().Secrets("openshift-machine-api").Get(context.Background(), "worker-user-data-managed", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	userData := workerUserDataManaged.Data["userData"]
+
+	config := &igntypes.Config{}
+	err = json.Unmarshal(userData, config)
+	if err != nil {
+		return err
+	}
+
+	// Check if there is at least a CA certificate in the ignition
+	if len(config.Ignition.Security.TLS.CertificateAuthorities) == 0 {
+		return nil
+	}
+
+	// Get the first source and ca certificate (and strip the base64 data header)
+	ignEndpointURL := config.Ignition.Config.Merge[0].Source
+	caCertSource := *config.Ignition.Security.TLS.CertificateAuthorities[0].Source
+
+	hdrIndex := strings.Index(caCertSource, ",")
+	if hdrIndex == -1 {
+		return fmt.Errorf("error while parsing ignition endpoints ca certificate, invalid data url format")
+	}
+	caCert := caCertSource[hdrIndex+1:]
+
+	ci.IgnitionEndpointWorker = &models.IgnitionEndpoint{
+		URL:           ignEndpointURL,
+		CaCertificate: &caCert,
+	}
 
 	return nil
 }


### PR DESCRIPTION
This patch allows using the secure port, if configured, in the target cluster when adding a new node. The information are stored in the agent ISO, to be consumed by the agent-installer-client during the cluster import step.

Required by https://github.com/openshift/assisted-service/pull/6464