### PR TITLE
OCPBUGS-36142: azure: Fix HyperVGeneration for gen2 images.

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -384,7 +384,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 			CloudConfiguration:   cloudConfiguration,
 			OSType:               armcompute.OperatingSystemTypesLinux,
 			OSState:              armcompute.OperatingSystemStateTypesGeneralized,
-			HyperVGeneration:     armcompute.HyperVGenerationV1,
+			HyperVGeneration:     armcompute.HyperVGenerationV2,
 			Publisher:            "RedHat-gen2",
 			Offer:                "rhcos-gen2",
 			SKU:                  "gen2",


### PR DESCRIPTION
Fixing HyperVGeneration version for gen 2 images.