### PR TITLE
OCPBUGS-35959: azure: Fix Accelerated network enablement

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -140,7 +140,7 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 				NetworkInterfaces: []capz.NetworkInterface{
 					{
 						SubnetName:            subnet,
-						AcceleratedNetworking: ptr.To(mpool.VMNetworkingType == azure.AcceleratedNetworkingEnabled),
+						AcceleratedNetworking: ptr.To(mpool.VMNetworkingType == string(azure.VMnetworkingTypeAccelerated) || mpool.VMNetworkingType == string(azure.AcceleratedNetworkingEnabled)),
 					},
 				},
 				Identity: capz.VMIdentityUserAssigned,


### PR DESCRIPTION
Aligning the CAPI installs with terraform installs by setting Accelerated Network to true if no vmNetworkingType is set or vmNetworkingType is set to Accelerated.