### PR TITLE
no-jira: Update documentation on libvirt installs for devs

### DIFF
--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -1,3 +1,8 @@
+# Libvirt Support Update
+
+OpenShift Installer has stopped support for the libvirt platform starting 4.16. You can still use it with versions
+4.15 and older.
+
 # Libvirt HOWTO
 
 Launching clusters via libvirt is especially useful for operator development.


### PR DESCRIPTION
We are not supporting installing on platform 'libvirt' starting 4.16. Updating in-repo documenattion to reflect that.