### PR TITLE
OCPBUGS-36316: Power VS: Allow pending network for internal publishing strategy

### DIFF
--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -425,7 +425,7 @@ func (c *Client) GetDNSZones(ctx context.Context, publish types.PublishingStrate
 			}
 
 			for _, zone := range listZonesResponse.Dnszones {
-				if *zone.State == "ACTIVE" {
+				if *zone.State == "ACTIVE" || *zone.State == "PENDING_NETWORK_ADD" {
 					zoneStruct := DNSZoneResponse{
 						Name:            *zone.Name,
 						ID:              *zone.ID,


### PR DESCRIPTION
An IBM Cloud DNS zone does not go into "Active" state unless a permitted network is added to it and so if we try to use a DNS Zone which does not have a VPC attached as a permitted network, the installer fails with the error "failed to get DNS Zone id" when such a zone is attempted to be used. We already have code to attach a permitted network to a DNS Zone, but it cannot be used unless the DNS Zone is in "Active" state. The zone does not even show up in the install-config survey