### PR TITLE
OCPBUGS-36453: PowerVS: add .ssh directory

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -97,6 +97,8 @@ RUN pwsh -Command 'Install-Module VMware.PowerCLI -Force -Scope AllUsers' && \
     pwsh -Command 'Install-Module -Name EPS -RequiredVersion 1.0 -Force -Scope AllUsers' && \
     mkdir -p /output/.local/share/VMware/PowerCLI && chmod -R 777 /output/.local
 
+RUN mkdir /output/.ssh && chown 1000:1000 "/output/.ssh/" && chmod -R g=u "/output/.ssh/"
+
 RUN chown 1000:1000 /output && chmod -R g=u "/output/.bluemix/"
 USER 1000:1000
 ENV PATH /bin


### PR DESCRIPTION
Now that PowerVS uses the upi-installer image, it is encountering the following error:
```
mkdir: cannot create directory '/output/.ssh': Permission denied
cp: cannot create regular file '/output/.ssh/': Not a directory
```