### PR TITLE
OCPBUGS-36390: aws: do not require create permissions when BYO IAM role 

### DIFF
--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -411,3 +411,72 @@ func TestKMSKeyPermissions(t *testing.T) {
 		})
 	})
 }
+
+func TestVPCPermissions(t *testing.T) {
+	t.Run("Should include", func(t *testing.T) {
+		t.Run("create network permissions when VPC not specified", func(t *testing.T) {
+			t.Run("for standard regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Subnets = nil
+				ic.AWS.HostedZone = ""
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
+			})
+			t.Run("for secret regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Region = "us-iso-east-1"
+				ic.AWS.Subnets = nil
+				ic.AWS.HostedZone = ""
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
+			})
+		})
+		t.Run("delete network permissions when VPC not specified for standard region", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.Subnets = nil
+			ic.AWS.HostedZone = ""
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.Contains(t, requiredPerms, PermissionDeleteNetworking)
+		})
+		t.Run("delete shared network permissions when VPC specified for standard region", func(t *testing.T) {
+			ic := validInstallConfig()
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.Contains(t, requiredPerms, PermissionDeleteSharedNetworking)
+		})
+	})
+	t.Run("Should not include", func(t *testing.T) {
+		t.Run("create network permissions when VPC specified", func(t *testing.T) {
+			ic := validInstallConfig()
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateNetworking)
+		})
+		t.Run("delete network permissions", func(t *testing.T) {
+			t.Run("when VPC specified", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteNetworking)
+			})
+			t.Run("on secret regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Region = "us-iso-east-1"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteNetworking)
+			})
+		})
+		t.Run("delete shared network permissions", func(t *testing.T) {
+			t.Run("when VPC not specified", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Subnets = nil
+				ic.AWS.HostedZone = ""
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedNetworking)
+			})
+			t.Run("on secret regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Region = "us-iso-east-1"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedNetworking)
+			})
+		})
+	})
+}

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -516,3 +516,17 @@ func TestPrivateZonePermissions(t *testing.T) {
 		})
 	})
 }
+
+func TestPublicIPv4PoolPermissions(t *testing.T) {
+	t.Run("Should include IPv4Pool permissions when IPv4 pool specified", func(t *testing.T) {
+		ic := validInstallConfig()
+		ic.AWS.PublicIpv4Pool = "custom-ipv4-pool"
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.Contains(t, requiredPerms, PermissionPublicIpv4Pool)
+	})
+	t.Run("Should not include IPv4Pool permissions when IPv4 pool not specified", func(t *testing.T) {
+		ic := validInstallConfig()
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.NotContains(t, requiredPerms, PermissionPublicIpv4Pool)
+	})
+}

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -559,3 +559,17 @@ func TestBasePermissions(t *testing.T) {
 		assert.NotContains(t, requiredPerms, PermissionDeleteBase)
 	})
 }
+
+func TestDeleteIgnitionPermissions(t *testing.T) {
+	t.Run("Should include delete ignition permissions", func(t *testing.T) {
+		ic := validInstallConfig()
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.Contains(t, requiredPerms, PermissionDeleteIgnitionObjects)
+	})
+	t.Run("Should not include delete ignition permission when specified", func(t *testing.T) {
+		ic := validInstallConfig()
+		ic.AWS.BestEffortDeleteIgnition = true
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.NotContains(t, requiredPerms, PermissionDeleteIgnitionObjects)
+	})
+}

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -1,0 +1,277 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+)
+
+func basicInstallConfig() types.InstallConfig {
+	return types.InstallConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ClusterMetaName",
+		},
+		Platform: types.Platform{
+			AWS: &aws.Platform{},
+		},
+	}
+}
+
+func TestIncludesCreateInstanceRole(t *testing.T) {
+	t.Run("Should be true when", func(t *testing.T) {
+		t.Run("no machine types specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			assert.True(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("no IAM roles specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{},
+					},
+				},
+			}
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{}
+			assert.True(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM role specified for controlPlane", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			assert.True(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM role specified for compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMRole: "custom-master-role",
+						},
+					},
+				},
+			}
+			assert.True(t, includesCreateInstanceRole(&ic))
+		})
+	})
+
+	t.Run("Should be false when", func(t *testing.T) {
+		t.Run("IAM role specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			assert.False(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM roles specified for controlPlane and compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMRole: "custom-master-role",
+						},
+					},
+				},
+			}
+			assert.False(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM roles specified for controlPlane and defaultMachinePlatform, compute is nil", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			assert.False(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM roles specified for controlPlane and defaultMachinePlatform, compute is not nil", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{},
+					},
+				},
+			}
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			assert.False(t, includesCreateInstanceRole(&ic))
+		})
+		t.Run("IAM roles specified for compute and defaultMachinePlatform", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMRole: "custom-master-role",
+						},
+					},
+				},
+			}
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			assert.False(t, includesCreateInstanceRole(&ic))
+		})
+	})
+}
+
+func TestIncludesExistingInstanceRole(t *testing.T) {
+	t.Run("Should be true when", func(t *testing.T) {
+		t.Run("IAM role specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			assert.True(t, includesExistingInstanceRole(&ic))
+		})
+		t.Run("IAM role specified for controlPlane", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceRole(&ic))
+		})
+		t.Run("IAM role specified for compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMRole: "custom-master-role",
+						},
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceRole(&ic))
+		})
+		t.Run("IAM role specified for controlPlane and compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMRole: "custom-master-role",
+					},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMRole: "custom-master-role",
+						},
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceRole(&ic))
+		})
+	})
+	t.Run("Should be false when", func(t *testing.T) {
+		t.Run("no machine types specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			assert.False(t, includesExistingInstanceRole(&ic))
+		})
+		t.Run("no IAM roles specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{}
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{},
+					},
+				},
+			}
+			assert.False(t, includesExistingInstanceRole(&ic))
+		})
+	})
+}
+
+func TestIAMRolePermissions(t *testing.T) {
+	t.Run("Should include", func(t *testing.T) {
+		t.Run("create and delete shared IAM role permissions", func(t *testing.T) {
+			t.Run("when role specified for controlPlane", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.ControlPlane.Platform.AWS.IAMRole = "custom-master-role"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
+				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+			})
+			t.Run("when role specified for compute", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.Compute[0].Platform.AWS.IAMRole = "custom-worker-role"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
+				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+			})
+		})
+		t.Run("create IAM role permissions", func(t *testing.T) {
+			t.Run("when no existing roles are specified", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+			})
+		})
+	})
+
+	t.Run("Should not include create IAM role permissions", func(t *testing.T) {
+		t.Run("when role specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMRole: "custom-default-role",
+			}
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceRole)
+			assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+		})
+		t.Run("when role specified for controlPlane and compute", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.ControlPlane.Platform.AWS.IAMRole = "custom-master-role"
+			ic.Compute[0].Platform.AWS.IAMRole = "custom-worker-role"
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceRole)
+			assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+		})
+	})
+}

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -530,3 +530,32 @@ func TestPublicIPv4PoolPermissions(t *testing.T) {
 		assert.NotContains(t, requiredPerms, PermissionPublicIpv4Pool)
 	})
 }
+
+func TestBasePermissions(t *testing.T) {
+	t.Run("Should include", func(t *testing.T) {
+		t.Run("base create permissions", func(t *testing.T) {
+			t.Run("on standard regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateBase)
+			})
+			t.Run("on secret regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.AWS.Region = "us-iso-east-1"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateBase)
+			})
+		})
+		t.Run("base delete permissions on standard regions", func(t *testing.T) {
+			ic := validInstallConfig()
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.Contains(t, requiredPerms, PermissionDeleteBase)
+		})
+	})
+	t.Run("Should not include base delete permissions on secret regions", func(t *testing.T) {
+		ic := validInstallConfig()
+		ic.AWS.Region = "us-iso-east-1"
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.NotContains(t, requiredPerms, PermissionDeleteBase)
+	})
+}

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -480,3 +480,39 @@ func TestVPCPermissions(t *testing.T) {
 		})
 	})
 }
+
+func TestPrivateZonePermissions(t *testing.T) {
+	t.Run("Should include", func(t *testing.T) {
+		t.Run("create hosted zone permissions when PHZ not specified", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.HostedZone = ""
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.Contains(t, requiredPerms, PermissionCreateHostedZone)
+		})
+		t.Run("delete hosted zone permissions when PHZ not specified on standard regions", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.HostedZone = ""
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.Contains(t, requiredPerms, PermissionDeleteHostedZone)
+		})
+	})
+	t.Run("Should not include", func(t *testing.T) {
+		t.Run("create hosted zone permissions when PHZ specified", func(t *testing.T) {
+			ic := validInstallConfig()
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateHostedZone)
+		})
+		t.Run("delete hosted zone permissions", func(t *testing.T) {
+			t.Run("on secret regions", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteHostedZone)
+			})
+			t.Run("when PHZ specified", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.NotContains(t, requiredPerms, PermissionDeleteHostedZone)
+			})
+		})
+	})
+}

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -104,6 +104,14 @@ func (a *PlatformPermsCheck) Generate(ctx context.Context, dependencies asset.Pa
 			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteIgnitionObjects)
 		}
 
+		if awsconfig.IncludesCreateInstanceRole(ic.Config) {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateInstanceRole)
+		}
+
+		if awsconfig.IncludesExistingInstanceRole(ic.Config) {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedInstanceRole)
+		}
+
 		ssn, err := ic.AWS.Session(ctx)
 		if err != nil {
 			return err

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
-	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -54,63 +53,7 @@ func (a *PlatformPermsCheck) Generate(ctx context.Context, dependencies asset.Pa
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case aws.Name:
-		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase}
-		usingExistingVPC := len(ic.Config.AWS.Subnets) != 0
-		usingExistingPrivateZone := len(ic.Config.AWS.HostedZone) != 0
-
-		if !usingExistingVPC {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking)
-		}
-
-		if !usingExistingPrivateZone {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateHostedZone)
-		}
-
-		var ec2RootVolume = aws.EC2RootVolume{}
-		var awsMachinePoolUsingKMS, masterMachinePoolUsingKMS bool
-		if ic.Config.AWS.DefaultMachinePlatform != nil && ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume != ec2RootVolume {
-			awsMachinePoolUsingKMS = len(ic.Config.AWS.DefaultMachinePlatform.EC2RootVolume.KMSKeyARN) != 0
-		}
-		if ic.Config.ControlPlane != nil &&
-			ic.Config.ControlPlane.Name == types.MachinePoolControlPlaneRoleName &&
-			ic.Config.ControlPlane.Platform.AWS != nil &&
-			ic.Config.ControlPlane.Platform.AWS.EC2RootVolume != ec2RootVolume {
-			masterMachinePoolUsingKMS = len(ic.Config.ControlPlane.Platform.AWS.EC2RootVolume.KMSKeyARN) != 0
-		}
-		// Add KMS encryption keys, if provided.
-		if awsMachinePoolUsingKMS || masterMachinePoolUsingKMS {
-			logrus.Debugf("Adding %s to the group of permissions to validate", awsconfig.PermissionKMSEncryptionKeys)
-			permissionGroups = append(permissionGroups, awsconfig.PermissionKMSEncryptionKeys)
-		}
-
-		// Add delete permissions for non-C2S installs.
-		if !aws.IsSecretRegion(ic.Config.AWS.Region) {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteBase)
-			if usingExistingVPC {
-				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedNetworking)
-			} else {
-				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteNetworking)
-			}
-			if !usingExistingPrivateZone {
-				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteHostedZone)
-			}
-		}
-
-		if ic.Config.AWS.PublicIpv4Pool != "" {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionPublicIpv4Pool)
-		}
-
-		if !ic.Config.AWS.BestEffortDeleteIgnition {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteIgnitionObjects)
-		}
-
-		if awsconfig.IncludesCreateInstanceRole(ic.Config) {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateInstanceRole)
-		}
-
-		if awsconfig.IncludesExistingInstanceRole(ic.Config) {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedInstanceRole)
-		}
+		permissionGroups := awsconfig.RequiredPermissionGroups(ic.Config)
 
 		ssn, err := ic.AWS.Session(ctx)
 		if err != nil {


### PR DESCRIPTION
The Installer is unconditionally requiring permissions needed to create IAM roles even when the users use existing roles. They should be included only when needed.

This PR kind of reverts https://github.com/openshift/installer/pull/5286. IAM roles created by the Installer are now consistently tagged with "owned". We should also tag BYO roles so we know which clusters are using them, and so that it's
not deleted by the installer during cluster destroy.