### PR TITLE
CORS-3609: aws: support existing IAM instance profiles

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -148,10 +148,17 @@ spec:
                             the ec2 instance. If set, the AMI should belong to the
                             same region as the cluster.
                           type: string
+                        iamProfile:
+                          description: IAMProfile is the name of the IAM instance
+                            profile to use for the machine. Leave unset to have the
+                            installer create the IAM Profile on your behalf. Cannot
+                            be specified together with iamRole.
+                          type: string
                         iamRole:
                           description: IAMRole is the name of the IAM Role to use
                             for the instance profile of the machine. Leave unset to
                             have the installer create the IAM Role on your behalf.
+                            Cannot be specified together with iamProfile.
                           type: string
                         metadataService:
                           description: EC2MetadataOptions defines metadata service
@@ -1061,10 +1068,17 @@ spec:
                           the ec2 instance. If set, the AMI should belong to the same
                           region as the cluster.
                         type: string
+                      iamProfile:
+                        description: IAMProfile is the name of the IAM instance profile
+                          to use for the machine. Leave unset to have the installer
+                          create the IAM Profile on your behalf. Cannot be specified
+                          together with iamRole.
+                        type: string
                       iamRole:
                         description: IAMRole is the name of the IAM Role to use for
                           the instance profile of the machine. Leave unset to have
-                          the installer create the IAM Role on your behalf.
+                          the installer create the IAM Role on your behalf. Cannot
+                          be specified together with iamProfile.
                         type: string
                       metadataService:
                         description: EC2MetadataOptions defines metadata service interaction
@@ -2185,10 +2199,17 @@ spec:
                           the ec2 instance. If set, the AMI should belong to the same
                           region as the cluster.
                         type: string
+                      iamProfile:
+                        description: IAMProfile is the name of the IAM instance profile
+                          to use for the machine. Leave unset to have the installer
+                          create the IAM Profile on your behalf. Cannot be specified
+                          together with iamRole.
+                        type: string
                       iamRole:
                         description: IAMRole is the name of the IAM Role to use for
                           the instance profile of the machine. Leave unset to have
-                          the installer create the IAM Role on your behalf.
+                          the installer create the IAM Role on your behalf. Cannot
+                          be specified together with iamProfile.
                         type: string
                       metadataService:
                         description: EC2MetadataOptions defines metadata service interaction

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -40,6 +40,10 @@ const (
 	// cluster with user-supplied IAM roles for instances.
 	PermissionDeleteSharedInstanceRole PermissionGroup = "delete-shared-instance-role"
 
+	// PermissionDeleteSharedInstanceProfile is a set of permissions required when the installer destroys resources from
+	// a cluster with user-supplied IAM instance profiles for instances.
+	PermissionDeleteSharedInstanceProfile PermissionGroup = "delete-shared-instance-profile"
+
 	// PermissionCreateHostedZone is a set of permissions required when the installer creates a route53 hosted zone.
 	PermissionCreateHostedZone PermissionGroup = "create-hosted-zone"
 
@@ -259,6 +263,10 @@ var permissions = map[PermissionGroup][]string{
 	PermissionDeleteSharedInstanceRole: {
 		"iam:UntagRole",
 	},
+	// Permissions required for deleting a cluster with shared instance profiles
+	PermissionDeleteSharedInstanceProfile: {
+		"iam:UntagInstanceProfile",
+	},
 	PermissionCreateHostedZone: {
 		"route53:CreateHostedZone",
 	},
@@ -385,6 +393,10 @@ func RequiredPermissionGroups(ic *types.InstallConfig) []PermissionGroup {
 		permissionGroups = append(permissionGroups, PermissionDeleteSharedInstanceRole)
 	}
 
+	if includesExistingInstanceProfile(ic) {
+		permissionGroups = append(permissionGroups, PermissionDeleteSharedInstanceProfile)
+	}
+
 	return permissionGroups
 }
 
@@ -464,4 +476,20 @@ func includesKMSEncryptionKey(installConfig *types.InstallConfig) bool {
 	}
 
 	return len(mpool.KMSKeyARN) > 0
+}
+
+// includesExistingInstanceProfile checks if at least one BYO instance profile is included in the install-config.
+func includesExistingInstanceProfile(installConfig *types.InstallConfig) bool {
+	mpool := aws.MachinePool{}
+	mpool.Set(installConfig.AWS.DefaultMachinePlatform)
+
+	if mp := installConfig.ControlPlane; mp != nil {
+		mpool.Set(mp.Platform.AWS)
+	}
+
+	for _, compute := range installConfig.Compute {
+		mpool.Set(compute.Platform.AWS)
+	}
+
+	return len(mpool.IAMProfile) > 0
 }

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -227,6 +227,85 @@ func TestIncludesExistingInstanceRole(t *testing.T) {
 	})
 }
 
+func TestIncludesExistingInstanceProfile(t *testing.T) {
+	t.Run("Should be true when", func(t *testing.T) {
+		t.Run("instance profile specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMProfile: "custom-default-profile",
+			}
+			assert.True(t, includesExistingInstanceProfile(&ic))
+		})
+		t.Run("instance profile specified for controlPlane", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMProfile: "custom-master-profile",
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceProfile(&ic))
+		})
+		t.Run("instance profile specified for compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMProfile: "custom-worker-profile",
+						},
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceProfile(&ic))
+		})
+		t.Run("instance profile specified for controlPlane and compute", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						IAMProfile: "custom-master-profile",
+					},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{
+							IAMProfile: "custom-worker-profile",
+						},
+					},
+				},
+			}
+			assert.True(t, includesExistingInstanceProfile(&ic))
+		})
+	})
+	t.Run("Should be false when", func(t *testing.T) {
+		t.Run("no machine types specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			assert.False(t, includesExistingInstanceProfile(&ic))
+		})
+		t.Run("no instance profiles specified", func(t *testing.T) {
+			ic := basicInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{}
+			ic.ControlPlane = &types.MachinePool{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{},
+				},
+			}
+			ic.Compute = []types.MachinePool{
+				{
+					Platform: types.MachinePoolPlatform{
+						AWS: &aws.MachinePool{},
+					},
+				},
+			}
+			assert.False(t, includesExistingInstanceProfile(&ic))
+		})
+	})
+}
+
 func TestIAMRolePermissions(t *testing.T) {
 	t.Run("Should include", func(t *testing.T) {
 		t.Run("create and delete shared IAM role permissions", func(t *testing.T) {

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -316,6 +316,13 @@ func TestIAMRolePermissions(t *testing.T) {
 				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
 				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
 			})
+			t.Run("when instance profile specified for controlPlane", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.ControlPlane.Platform.AWS.IAMProfile = "custom-master-profile"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+			})
 			t.Run("when role specified for compute", func(t *testing.T) {
 				ic := validInstallConfig()
 				ic.Compute[0].Platform.AWS.IAMRole = "custom-worker-role"
@@ -323,9 +330,16 @@ func TestIAMRolePermissions(t *testing.T) {
 				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
 				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
 			})
+			t.Run("when instance profile specified for compute", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.Compute[0].Platform.AWS.IAMProfile = "custom-worker-profile"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+			})
 		})
 		t.Run("create IAM role permissions", func(t *testing.T) {
-			t.Run("when no existing roles are specified", func(t *testing.T) {
+			t.Run("when no existing roles and instance profiles are specified", func(t *testing.T) {
 				ic := validInstallConfig()
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.Contains(t, requiredPerms, PermissionCreateInstanceRole)
@@ -351,6 +365,72 @@ func TestIAMRolePermissions(t *testing.T) {
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.NotContains(t, requiredPerms, PermissionCreateInstanceRole)
 			assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+		})
+		t.Run("when instance profile specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMProfile: "custom-default-profile",
+			}
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceRole)
+			assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+		})
+		t.Run("when instance profile specified for controlPlane and compute", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.ControlPlane.Platform.AWS.IAMProfile = "custom-master-profile"
+			ic.Compute[0].Platform.AWS.IAMProfile = "custom-worker-profile"
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceRole)
+			assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceRole)
+		})
+	})
+}
+
+func TestIAMProfilePermissions(t *testing.T) {
+	t.Run("Should include", func(t *testing.T) {
+		t.Run("create and delete shared instance profile permissions", func(t *testing.T) {
+			t.Run("when instance profile specified for controlPlane", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.ControlPlane.Platform.AWS.IAMProfile = "custom-master-profile"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceProfile)
+				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceProfile)
+			})
+			t.Run("when instance profile specified for compute", func(t *testing.T) {
+				ic := validInstallConfig()
+				ic.Compute[0].Platform.AWS.IAMProfile = "custom-worker-profile"
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceProfile)
+				assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceProfile)
+			})
+		})
+		t.Run("create instance profile permissions", func(t *testing.T) {
+			t.Run("when no existing instance profiles are specified", func(t *testing.T) {
+				ic := validInstallConfig()
+				requiredPerms := RequiredPermissionGroups(ic)
+				assert.Contains(t, requiredPerms, PermissionCreateInstanceProfile)
+				assert.NotContains(t, requiredPerms, PermissionDeleteSharedInstanceProfile)
+			})
+		})
+	})
+
+	t.Run("Should not include create instance profile permissions", func(t *testing.T) {
+		t.Run("when instance profile specified for defaultMachinePlatform", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
+				IAMProfile: "custom-default-profile",
+			}
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceProfile)
+			assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceProfile)
+		})
+		t.Run("when instance profile specified for controlPlane and compute", func(t *testing.T) {
+			ic := validInstallConfig()
+			ic.ControlPlane.Platform.AWS.IAMProfile = "custom-master-profile"
+			ic.Compute[0].Platform.AWS.IAMProfile = "custom-worker-profile"
+			requiredPerms := RequiredPermissionGroups(ic)
+			assert.NotContains(t, requiredPerms, PermissionCreateInstanceProfile)
+			assert.Contains(t, requiredPerms, PermissionDeleteSharedInstanceProfile)
 		})
 	})
 }

--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -49,6 +49,11 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 		imds = capa.HTTPTokensStateRequired
 	}
 
+	instanceProfile := in.Pool.Platform.AWS.IAMProfile
+	if len(instanceProfile) == 0 {
+		instanceProfile = fmt.Sprintf("%s-master-profile", clusterID)
+	}
+
 	var result []*asset.RuntimeFile
 
 	for idx := int64(0); idx < total; idx++ {
@@ -91,7 +96,7 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 				InstanceType:         mpool.InstanceType,
 				AMI:                  capa.AMIReference{ID: ptr.To(mpool.AMIID)},
 				SSHKeyName:           ptr.To(""),
-				IAMInstanceProfile:   fmt.Sprintf("%s-master-profile", clusterID),
+				IAMInstanceProfile:   instanceProfile,
 				Subnet:               subnet,
 				PublicIP:             ptr.To(in.PublicIP),
 				AdditionalTags:       in.Tags,

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -81,6 +81,11 @@ func MachineSets(in *MachineSetInput) ([]*machineapi.MachineSet, error) {
 			})
 		}
 
+		instanceProfile := mpool.IAMProfile
+		if len(instanceProfile) == 0 {
+			instanceProfile = fmt.Sprintf("%s-%s-profile", in.ClusterID, in.Role)
+		}
+
 		provider, err := provider(&machineProviderInput{
 			clusterID:        in.ClusterID,
 			region:           in.InstallConfigPlatformAWS.Region,
@@ -90,6 +95,7 @@ func MachineSets(in *MachineSetInput) ([]*machineapi.MachineSet, error) {
 			zone:             az,
 			role:             "worker",
 			userDataSecret:   in.UserDataSecret,
+			instanceProfile:  instanceProfile,
 			root:             &mpool.EC2RootVolume,
 			imds:             mpool.EC2Metadata,
 			userTags:         in.InstallConfigPlatformAWS.UserTags,

--- a/pkg/destroy/aws/ec2helpers.go
+++ b/pkg/destroy/aws/ec2helpers.go
@@ -276,18 +276,6 @@ func terminateEC2InstanceByInstance(ctx context.Context, ec2Client *ec2.EC2, iam
 		return nil
 	}
 
-	if instance.IamInstanceProfile != nil {
-		parsed, err := arn.Parse(*instance.IamInstanceProfile.Arn)
-		if err != nil {
-			return errors.Wrap(err, "parse ARN for IAM instance profile")
-		}
-
-		err = deleteIAMInstanceProfile(ctx, iamClient, parsed, logger)
-		if err != nil {
-			return errors.Wrapf(err, "deleting %s", parsed.String())
-		}
-	}
-
 	_, err := ec2Client.TerminateInstancesWithContext(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{instance.InstanceId},
 	})

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -379,7 +379,7 @@ KIND:     InstallConfig
 VERSION:  v1
 
 RESOURCE: <string>
-  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf.
+  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf. Cannot be specified together with iamProfile.
 	`,
 	}, {
 		path: []string{"controlPlane", "platform", "aws", "iamRole"},
@@ -388,7 +388,7 @@ KIND:     InstallConfig
 VERSION:  v1
 
 RESOURCE: <string>
-  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf.
+  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf. Cannot be specified together with iamProfile.
 	`,
 	}, {
 		path: []string{"platform", "aws", "defaultMachinePlatform", "iamRole"},
@@ -397,7 +397,34 @@ KIND:     InstallConfig
 VERSION:  v1
 
 RESOURCE: <string>
-  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf.
+  IAMRole is the name of the IAM Role to use for the instance profile of the machine. Leave unset to have the installer create the IAM Role on your behalf. Cannot be specified together with iamProfile.
+	`,
+	}, {
+		path: []string{"compute", "platform", "aws", "iamProfile"},
+		desc: `
+KIND:     InstallConfig
+VERSION:  v1
+
+RESOURCE: <string>
+  IAMProfile is the name of the IAM instance profile to use for the machine. Leave unset to have the installer create the IAM Profile on your behalf. Cannot be specified together with iamRole.
+	`,
+	}, {
+		path: []string{"controlPlane", "platform", "aws", "iamProfile"},
+		desc: `
+KIND:     InstallConfig
+VERSION:  v1
+
+RESOURCE: <string>
+  IAMProfile is the name of the IAM instance profile to use for the machine. Leave unset to have the installer create the IAM Profile on your behalf. Cannot be specified together with iamRole.
+	`,
+	}, {
+		path: []string{"platform", "aws", "defaultMachinePlatform", "iamProfile"},
+		desc: `
+KIND:     InstallConfig
+VERSION:  v1
+
+RESOURCE: <string>
+  IAMProfile is the name of the IAM instance profile to use for the machine. Leave unset to have the installer create the IAM Profile on your behalf. Cannot be specified together with iamRole.
 	`,
 	}}
 	for _, test := range cases {

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -32,8 +32,15 @@ type MachinePool struct {
 
 	// IAMRole is the name of the IAM Role to use for the instance profile of the machine.
 	// Leave unset to have the installer create the IAM Role on your behalf.
+	// Cannot be specified together with iamProfile.
 	// +optional
 	IAMRole string `json:"iamRole,omitempty"`
+
+	// IAMProfile is the name of the IAM instance profile to use for the machine.
+	// Leave unset to have the installer create the IAM Profile on your behalf.
+	// Cannot be specified together with iamRole.
+	// +optional
+	IAMProfile string `json:"iamProfile,omitempty"`
 
 	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines, where each ID
 	// is presented in the format sg-xxxx.
@@ -80,6 +87,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.IAMRole != "" {
 		a.IAMRole = required.IAMRole
+	}
+
+	if required.IAMProfile != "" {
+		a.IAMProfile = required.IAMProfile
 	}
 
 	if len(required.AdditionalSecurityGroupIDs) > 0 {


### PR DESCRIPTION
Allow a user to use an existing IAM instance profile while deploying  OpenShift on AWS.

This is important not only for self-managed customers who want to reduce the required permissions needed for IAM accounts but also for IC regions.

Depends on https://github.com/openshift/installer/pull/8688 for the BYO roles permission fixes.