### PR TITLE
CORS-3209: Set UserTags on CAPG resources

### DIFF
--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	gcpconsts "github.com/openshift/installer/pkg/constants/gcp"
 	"github.com/openshift/installer/pkg/types"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
@@ -141,6 +142,7 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 			RootDeviceType:        ptr.To(capg.DiskType(mpool.OSDisk.DiskType)),
 			RootDeviceSize:        mpool.OSDisk.DiskSizeGB,
 			AdditionalNetworkTags: mpool.Tags,
+			ResourceManagerTags:   gcpmanifests.GetTagsFromInstallConfig(installConfig),
 		},
 	}
 	gcpMachine.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPMachine"))

--- a/pkg/asset/machines/gcp/gcpmachines_test.go
+++ b/pkg/asset/machines/gcp/gcpmachines_test.go
@@ -65,6 +65,11 @@ func Test_GenerateMachines(t *testing.T) {
 			installConfig:     getICWithServiceAccountControlPlaneMachine(),
 			expectedGCPConfig: getGCPMachineWithServiceAccountControlPlaneMachine(),
 		},
+		{
+			name:              "usertags",
+			installConfig:     getICWithUserTags(),
+			expectedGCPConfig: getGCPMachineWithTags(),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -179,6 +184,13 @@ func getICWithServiceAccountControlPlaneMachine() *installconfig.InstallConfig {
 	return ic
 }
 
+func getICWithUserTags() *installconfig.InstallConfig {
+	ic := getBaseInstallConfig()
+	ic.Config.Platform.GCP.UserTags = []gcptypes.UserTag{{ParentID: "my-project", Key: "foo", Value: "bar"},
+		{ParentID: "other-project", Key: "id", Value: "1234"}}
+	return ic
+}
+
 func getBaseGCPMachine() *capg.GCPMachine {
 	subnet := "012345678-master-subnet"
 	image := "rhcos-415-92-202311241643-0-gcp-x86-64"
@@ -203,6 +215,7 @@ func getBaseGCPMachine() *capg.GCPMachine {
 				Email:  "012345678-m@my-project.iam.gserviceaccount.com",
 				Scopes: []string{compute.CloudPlatformScope},
 			},
+			ResourceManagerTags: []capg.ResourceManagerTag{},
 		},
 	}
 	gcpMachine.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPMachine"))
@@ -281,4 +294,16 @@ func getBaseCapiMachine() *capi.Machine {
 	}
 	capiMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
 	return capiMachine
+}
+
+func getGCPMachineWithTags() *capg.GCPMachine {
+	gcpMachine := getBaseGCPMachine()
+	gcpMachine.Spec.ResourceManagerTags = []capg.ResourceManagerTag{
+		{ParentID: "my-project",
+			Key:   "foo",
+			Value: "bar"},
+		{ParentID: "other-project",
+			Key:   "id",
+			Value: "1234"}}
+	return gcpMachine
 }

--- a/pkg/asset/manifests/gcp/cluster.go
+++ b/pkg/asset/manifests/gcp/cluster.go
@@ -155,6 +155,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 				APIServerInstanceGroupTagOverride: ptr.To(InstanceGroupRoleTag),
 				LoadBalancerType:                  ptr.To(capgLoadBalancerType),
 			},
+			ResourceManagerTags: GetTagsFromInstallConfig(installConfig),
 		},
 	}
 	gcpCluster.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPCluster"))
@@ -246,4 +247,18 @@ func getSubnet(ctx context.Context, project, region, subnetName string) (*comput
 	}
 
 	return subnet, nil
+}
+
+// GetTagsFromInstallConfig will return a slice of ResourceManagerTags from UserTags in install-config.
+func GetTagsFromInstallConfig(installConfig *installconfig.InstallConfig) []capg.ResourceManagerTag {
+	tags := make([]capg.ResourceManagerTag, len(installConfig.Config.Platform.GCP.UserTags))
+	for i, tag := range installConfig.Config.Platform.GCP.UserTags {
+		tags[i] = capg.ResourceManagerTag{
+			ParentID: tag.ParentID,
+			Key:      tag.Key,
+			Value:    tag.Value,
+		}
+	}
+
+	return tags
 }


### PR DESCRIPTION
Set the UserTags from install-config.yaml on the machine and cluster resources in CAPG.