### PR TITLE
OCPBUGS-36378: capi: start controllers after WaitGroup is created

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -463,7 +463,7 @@ func (c *system) runController(ctx context.Context, ct *controller) error {
 	// If the provider is not empty, we extract it to the binaries directory.
 	if ct.Provider != nil {
 		if err := ct.Provider.Extract(c.lcp.BinDir); err != nil {
-			logrus.Fatal(err)
+			return fmt.Errorf("failed to extract provider %q: %w", ct.Name, err)
 		}
 	}
 

--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -316,13 +316,6 @@ func (c *system) Run(ctx context.Context) error {
 	// We only show controller logs if the log level is DEBUG or above
 	c.logWriter = logrus.StandardLogger().WriterLevel(logrus.DebugLevel)
 
-	// Run the controllers.
-	for _, ct := range controllers {
-		if err := c.runController(ctx, ct); err != nil {
-			return fmt.Errorf("failed to run controller %q: %w", ct.Name, err)
-		}
-	}
-
 	// We create a wait group to wait for the controllers to stop,
 	// this waitgroup is a global, and is used by the Teardown function
 	// which is expected to be called when the program exits.
@@ -346,6 +339,13 @@ func (c *system) Run(ctx context.Context) error {
 			logrus.Warnf("Failed to stop local Cluster API control plane: %v", err)
 		}
 	}()
+
+	// Run the controllers.
+	for _, ct := range controllers {
+		if err := c.runController(ctx, ct); err != nil {
+			return fmt.Errorf("failed to run controller %q: %w", ct.Name, err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR introduces 2 changes to fix capi binaries running after the openshift-installer exits in case of failures:

1. [do not exit if controller fails to extract.](https://github.com/openshift/installer/commit/2e34347dfe43e1eb0e7eb60f39185c4d37229e62): doing `logrus.Fatal` when a controller fails to be extracted means that we abort the installer process without giving it a chance to stop the capi-related processes that are still running.
2. [capi: start controllers after WaitGroup is created](https://github.com/openshift/installer/commit/b8df7d43770d95d4b67486219649d8cdd10c7bea): so the installer has a chance to stop controllers that are already running.