### PR TITLE
OCPBUGS-37107: Power VS: Disable SNAT when specifying imageContentSources

### DIFF
--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -176,6 +176,8 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		}
 
 		powerVSCluster.Spec.DHCPServer.DNSServer = &dnsServerIP
+		// Disable SNAT for disconnected scenario.
+		powerVSCluster.Spec.DHCPServer.Snat = ptr.To(len(installConfig.Config.DeprecatedImageContentSources) == 0 && len(installConfig.Config.ImageDigestSources) == 0)
 	}
 
 	// If a VPC was specified, pass all subnets in it to cluster API


### PR DESCRIPTION
When doing a disconnected deploy we'll need to disable SNAT