### PR TITLE
MULTIARCH-4777: gcp: support multi-arch nodes 

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	coreosarch "github.com/coreos/stream-metadata-go/arch"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/utils/ptr"
@@ -39,7 +38,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
-	rhcospkg "github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars"
 	awstfvars "github.com/openshift/installer/pkg/tfvars/aws"
 	azuretfvars "github.com/openshift/installer/pkg/tfvars/azure"
@@ -536,21 +534,6 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 		shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(url, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
 		if err != nil {
 			return fmt.Errorf("failed to create gcp ignition shim: %w", err)
-		}
-
-		archName := coreosarch.RpmArch(string(installConfig.Config.ControlPlane.Architecture))
-		st, err := rhcospkg.FetchCoreOSBuild(ctx)
-		if err != nil {
-			return err
-		}
-		streamArch, err := st.GetArchitecture(archName)
-		if err != nil {
-			return err
-		}
-
-		img := streamArch.Images.Gcp
-		if img == nil {
-			return fmt.Errorf("%s: No GCP build found", st.FormatPrefix(archName))
 		}
 
 		tags, err := gcpconfig.NewTagManager(client).GetUserTags(ctx,

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -583,6 +583,8 @@ func MultiArchFeatureGateEnabled(platform string, fgs featuregates.FeatureGate) 
 	switch platform {
 	case aws.Name:
 		return fgs.Enabled(features.FeatureGateMultiArchInstallAWS)
+	case gcp.Name:
+		return fgs.Enabled(features.FeatureGateMultiArchInstallGCP)
 	default:
 		return false
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1424,6 +1424,17 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 		},
 		{
+			name: "gcp cluster is heteregeneous",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.Compute[0].Architecture = types.ArchitectureARM64
+				c.FeatureSet = "CustomNoUpgrade"
+				c.FeatureGates = []string{"MultiArchInstallGCP=true"}
+				return c
+			}(),
+		},
+		{
 			name: "valid cloud credentials mode",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
This PR adds support for multi-arch nodes in GCP (amd64 controlPlane and arm64 compute, or vice-versa).

/hold

Depends on:
- [x] https://github.com/openshift/installer/pull/8698
- [x] CI jobs: so we can test the multi-arch part of this change.