### PR TITLE
OCPBUGS-36660: CORS-3591: 4.17 default channel incorrectly points to stable-4.16

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.16
+  channel: stable-4.17
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
a reoccurring issue, reported by me in the past in OCPBUGS-889, and by @shellyyang1989 in OCPBUGS-26511   
while branching to the next release, default channel must be updated to match, otherwise it will be impossible for the cluster to search for updates in the update graph, unless corrected manually. 

this PR updates the channel of the current master, from which 4.17.0-ec.x builds are currently delivered.

/cc @gpei @r4f4 
for review. thanks!