### PR TITLE
MGMT-17226: Add imagebased installer skeleton

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -161,3 +161,13 @@ aliases:
     - pawanpinjarkar
     - rwsu
     - zaneb
+  imagebased-reviewers:
+    - eranco74
+    - javipolo
+    - mresvanis
+    - tsorya
+  imagebased-approvers:
+    - eranco74
+    - patrickdillon
+    - tsorya
+    - zaneb

--- a/cmd/openshift-install/imagebased.go
+++ b/cmd/openshift-install/imagebased.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newImageBasedCmd(ctx context.Context) *cobra.Command {
+	imagebasedCmd := &cobra.Command{
+		Use:   "image-based",
+		Short: "Commands for supporting cluster installation using the Image-based installer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	imagebasedCmd.AddCommand(newImageBasedCreateCmd(ctx))
+	return imagebasedCmd
+}
+
+func newImageBasedCreateCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Commands for generating image-based installer artifacts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(createImageConfigTemplateCmd())
+	cmd.AddCommand(createImageCmd())
+	cmd.AddCommand(createConfigTemplateCmd())
+	cmd.AddCommand(createConfigImageCmd())
+
+	return cmd
+}
+
+func createImageConfigTemplateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "image-config-template",
+		Short: "Generates a template of the Image-based Installation ISO config manifest used by the Image-based installer",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Info("Create image config template command")
+		},
+	}
+}
+
+func createImageCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "image",
+		Short: "Generates a bootable ISO image containing all the information needed to deploy a cluster",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Info("Create image command")
+		},
+	}
+}
+
+func createConfigTemplateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config-template",
+		Short: "Generates a template of the Image-based Config ISO config manifest used by the Image-based installer",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Info("Create config template command")
+		},
+	}
+}
+
+func createConfigImageCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config-image",
+		Short: "Generates an ISO containing configuration files only",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Info("Create config image command")
+		},
+	}
+}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -59,6 +59,7 @@ func installerMain() {
 		newExplainCmd(),
 		newAgentCmd(ctx),
 		newListFeaturesCmd(),
+		newImageBasedCmd(ctx),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/cmd/openshift-install/testdata/imagebased/OWNERS
+++ b/cmd/openshift-install/testdata/imagebased/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - imagebased-approvers
+reviewers:
+  - imagebased-reviewers

--- a/data/data/imagebased/OWNERS
+++ b/data/data/imagebased/OWNERS
@@ -1,0 +1,7 @@
+# This file just uses aliases defined in OWNERS_ALIASES.
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - imagebased-approvers
+reviewers:
+  - imagebased-reviewers

--- a/pkg/asset/imagebased/OWNERS
+++ b/pkg/asset/imagebased/OWNERS
@@ -1,0 +1,7 @@
+# This file just uses aliases defined in OWNERS_ALIASES.
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - imagebased-approvers
+reviewers:
+  - imagebased-reviewers

--- a/pkg/types/imagebased/OWNERS
+++ b/pkg/types/imagebased/OWNERS
@@ -1,0 +1,7 @@
+# This file just uses aliases defined in OWNERS_ALIASES.
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - imagebased-approvers
+reviewers:
+  - imagebased-reviewers


### PR DESCRIPTION
This PR adds the image-based installer (IBI) skeleton folders and {,sub}commands, as well as the respective owner aliases and `OWNERS`.

For a detailed description of this feature please see the respective enhancement: https://github.com/openshift/enhancements/blob/master/enhancements/installer/image-based-installer.md.

@zaneb @patrickdillon @eranco74 