### PR TITLE
OCPBUGS-36677: Power VS: Enable incoming traffic on port 5000 during restricted network installation

### DIFF
--- a/data/data/powervs/cluster/loadbalancer/sg.tf
+++ b/data/data/powervs/cluster/loadbalancer/sg.tf
@@ -1,5 +1,5 @@
 locals {
-  tcp_ports = [22623, 10258, 6443, 22]
+  tcp_ports = var.enable_snat == false ? [22623, 10258, 6443, 22, 5000] : [22623, 10258, 6443, 22]
 }
 
 resource "ibm_is_security_group" "ocp_security_group" {

--- a/data/data/powervs/cluster/loadbalancer/variables.tf
+++ b/data/data/powervs/cluster/loadbalancer/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_id" {
   description = "The ID created by the installer to uniquely identify the created cluster."
 }
 
+variable "enable_snat" {
+  type        = bool
+  description = "Boolean indicating if SNAT should be enabled or disabled."
+  default     = true
+}
+
 variable "master_count" {
   type        = string
   description = "The number of master nodes."

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -107,6 +107,7 @@ module "loadbalancer" {
   source = "./loadbalancer"
 
   cluster_id     = var.cluster_id
+  enable_snat    = var.powervs_enable_snat
   master_count   = var.master_count
   resource_group = var.powervs_resource_group
   vpc_id         = module.vpc.vpc_id


### PR DESCRIPTION
If source network address translation is not allowed, i.e. during an installation in a restricted network, incoming traffic on port 5000 should be allowed as the user created image registry is accessible on this port. Allow it.