### PR TITLE
AGENT-922: Remove misleading inClusterConfig warning

### DIFF
--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -27,7 +27,13 @@ type ClusterKubeAPIClient struct {
 func NewClusterKubeAPIClient(ctx context.Context, kubeconfigPath string) (*ClusterKubeAPIClient, error) {
 	kubeClient := &ClusterKubeAPIClient{}
 
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	var kubeconfig *rest.Config
+	var err error
+	if kubeconfigPath != "" {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	} else {
+		kubeconfig, err = rest.InClusterConfig()
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading kubeconfig from assets")
 	}

--- a/pkg/agent/ocp.go
+++ b/pkg/agent/ocp.go
@@ -36,7 +36,13 @@ const (
 func NewClusterOpenShiftAPIClient(ctx context.Context, kubeconfigPath string) (*ClusterOpenShiftAPIClient, error) {
 	ocpClient := &ClusterOpenShiftAPIClient{}
 
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	var kubeconfig *rest.Config
+	var err error
+	if kubeconfigPath != "" {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	} else {
+		kubeconfig, err = rest.InClusterConfig()
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "creating kubeconfig for ocp config client")
 	}
@@ -58,7 +64,6 @@ func NewClusterOpenShiftAPIClient(ctx context.Context, kubeconfigPath string) (*
 	ocpClient.configPath = kubeconfigPath
 
 	return ocpClient, nil
-
 }
 
 // AreClusterOperatorsInitialized Waits for all Openshift cluster operators to initialize
@@ -104,7 +109,6 @@ func (ocp *ClusterOpenShiftAPIClient) IsConsoleRouteAvailable() (bool, error) {
 		}
 	}
 	return false, errors.Wrap(err, "Waiting for openshift-console route")
-
 }
 
 // IsConsoleRouteURLAvailable Check if the console route URL is available


### PR DESCRIPTION
Remove the "Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work." warning because it does work and would confuse the user when the monitor-add-nodes command is run in cluster.
