### PR TITLE
OCPBUGS-36728: capi: delete artifacts on cluster destroy

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -66,47 +65,47 @@ func runDestroyCmd(directory string, reportQuota bool) error {
 	timer.StartTimer(timer.TotalTimeElapsed)
 	destroyer, err := destroy.New(logrus.StandardLogger(), directory)
 	if err != nil {
-		return errors.Wrap(err, "Failed while preparing to destroy cluster")
+		return fmt.Errorf("Failed while preparing to destroy cluster: %w", err)
 	}
 	quota, err := destroyer.Run()
 	if err != nil {
-		return errors.Wrap(err, "Failed to destroy cluster")
+		return fmt.Errorf("Failed to destroy cluster: %w", err)
 	}
 
 	if reportQuota {
 		if err := quotaasset.WriteQuota(directory, quota); err != nil {
-			return errors.Wrap(err, "failed to record quota")
+			return fmt.Errorf("failed to record quota: %w", err)
 		}
 	}
 
 	store, err := assetstore.NewStore(directory)
 	if err != nil {
-		return errors.Wrap(err, "failed to create asset store")
+		return fmt.Errorf("failed to create asset store: %w", err)
 	}
 	for _, asset := range clusterTarget.assets {
 		if err := store.Destroy(asset); err != nil {
-			return errors.Wrapf(err, "failed to destroy asset %q", asset.Name())
+			return fmt.Errorf("failed to destroy asset %q: %w", asset.Name(), err)
 		}
 	}
 
 	// delete the state file as well
 	err = store.DestroyState()
 	if err != nil {
-		return errors.Wrap(err, "failed to remove state file")
+		return fmt.Errorf("failed to remove state file: %w", err)
 	}
 
 	// delete terraform files
 	tfstateFiles, err := filepath.Glob(filepath.Join(directory, "*.tfstate"))
 	if err != nil {
-		return errors.Wrap(err, "failed to glob for tfstate files")
+		return fmt.Errorf("failed to glob for tfstate files: %w", err)
 	}
 	tfvarsFiles, err := filepath.Glob(filepath.Join(directory, "*.tfvars.json"))
 	if err != nil {
-		return errors.Wrap(err, "failed to glob for tfvars files")
+		return fmt.Errorf("failed to glob for tfvars files: %w", err)
 	}
 	for _, f := range append(tfstateFiles, tfvarsFiles...) {
 		if err := os.Remove(f); err != nil {
-			return errors.Wrapf(err, "failed to remove terraform file %q", f)
+			return fmt.Errorf("failed to remove terraform file %q: %w", f, err)
 		}
 	}
 

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -111,6 +112,10 @@ func runDestroyCmd(directory string, reportQuota bool) error {
 
 	// ensure capi etcd data store is cleaned up
 	clusterapi.System().CleanEtcd()
+	// remove cluster api artifacts as well
+	if err := os.RemoveAll(filepath.Join(directory, clusterapi.ArtifactsDir)); err != nil {
+		return fmt.Errorf("failed to remove clusterapi artifacts: %w", err)
+	}
 
 	timer.StopTimer(timer.TotalTimeElapsed)
 	timer.LogSummary()


### PR DESCRIPTION
Otherwise trying to run a new install with the same workdir will result
in the following error:
```
$ openshift-install create cluster --dir=. --log-level=info
[...]
FATAL failed to fetch Cluster: failed to load asset "Cluster": local infrastructure provisioning artifacts already exist. There may already be a running cluster
```

Also using the opportunity to replace the deprecated github.com/pkg/errors dep