### PR TITLE
OCPBUGS-36861: Updates GCP worker role to access artifact registry

### DIFF
--- a/data/data/gcp/cluster/iam/main.tf
+++ b/data/data/gcp/cluster/iam/main.tf
@@ -19,3 +19,9 @@ resource "google_project_iam_member" "worker-storage-admin" {
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
 }
+
+resource "google_project_iam_member" "worker-artifact-registry-admin" {
+  project = var.project_id
+  role    = "roles/artifactregistry.admin"
+  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
+}


### PR DESCRIPTION
This change grants the worker-node role to grant the workers permissions to pull images from the artifact registry. This includes <subdomain>.pkg.dev images.