### PR TITLE
CORS-3566: Azure CAPI: disable natgw by setting node subnet id

### DIFF
--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -79,7 +79,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		// Because the node subnet does not already exist, we are using an arbitrary value.
 		// We could populate this with the proper subnet ID in the case of BYO VNET, but
 		// the value currently has no practical effect.
-		nodeSubnetID = clusterID.InfraID
+		nodeSubnetID = "UNKNOWN"
 	}
 
 	azureCluster := &capz.AzureCluster{


### PR DESCRIPTION
Setting the ID on the Subnet disables natgw creation. See: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/21479a9a4c640b43e0bef028487c522c55605d06/api/v1beta1/azurecluster_default.go#L160

Because the node subnet does not already exist, we are using an arbitrary value. We could populate this with the proper subnet ID in the case of BYO VNET, but the value currently has no practical effect.