### PR TITLE
OCPBUGS-36494: vSphere - If template is defined skip downloading

### DIFF
--- a/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
@@ -88,13 +88,17 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 	 * one folder per datacenter
 	 * one template per region/zone aka failuredomain
 	 */
+
 	installConfig := in.InstallConfig
 	clusterID := &installconfig.ClusterID{InfraID: in.InfraID}
-	var tagID string
+	var tagID, cachedImage string
+	var err error
 
-	cachedImage, err := cache.DownloadImageFile(in.RhcosImage.ControlPlane, cache.InstallerApplicationName)
-	if err != nil {
-		return fmt.Errorf("failed to use cached vsphere image: %w", err)
+	if downloadImage(installConfig) {
+		cachedImage, err = cache.DownloadImageFile(in.RhcosImage.ControlPlane, cache.InstallerApplicationName)
+		if err != nil {
+			return fmt.Errorf("failed to use cached vsphere image: %w", err)
+		}
 	}
 
 	for _, vcenter := range installConfig.Config.VSphere.VCenters {
@@ -130,4 +134,13 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 	}
 
 	return nil
+}
+
+func downloadImage(installConfig *installconfig.InstallConfig) bool {
+	for _, fd := range installConfig.Config.VSphere.FailureDomains {
+		if fd.Topology.Template == "" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
If the `template` field for each failure domain topology is defined there is no need to download the ova to cache.