### PR TITLE
CORS-3565: CAPZ private clusters

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -277,12 +277,22 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		if err != nil {
 			return err
 		}
-		// useImageGallery := installConfig.Azure.CloudName != azuretypes.StackCloud
-		useImageGallery := false
-		masterUserDataSecretName := "master-user-data"
-		resourceGroupName := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
 
-		azureMachines, err := azure.GenerateMachines(installConfig.Config.Platform.Azure, &pool, masterUserDataSecretName, clusterID.InfraID, "master", capabilities, useImageGallery, installConfig.Config.Platform.Azure.UserTags, hyperVGen, subnet, resourceGroupName, session.Credentials.SubscriptionID)
+		azureMachines, err := azure.GenerateMachines(clusterID.InfraID,
+			installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID),
+			session.Credentials.SubscriptionID,
+			&azure.MachineInput{
+				Subnet:          subnet,
+				Role:            "master",
+				UserDataSecret:  "master-user-data",
+				HyperVGen:       hyperVGen,
+				UseImageGallery: false,
+				Private:         installConfig.Config.Publish == types.InternalPublishingStrategy,
+				UserTags:        installConfig.Config.Platform.Azure.UserTags,
+				Platform:        installConfig.Config.Platform.Azure,
+				Pool:            &pool,
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create master machine objects: %w", err)
 		}

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -47,17 +47,17 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	computeSubnet := installConfig.Config.Platform.Azure.ComputeSubnetName(clusterID.InfraID)
 	networkSecurityGroup := installConfig.Config.Platform.Azure.NetworkSecurityGroupName(clusterID.InfraID)
 
-	source := "*"
-	if installConfig.Config.Publish == types.InternalPublishingStrategy {
-		source = mainCIDR.String()
-	}
-
 	controlPlaneOutboundLB := &capz.LoadBalancerSpec{
 		Name:             clusterID.InfraID,
 		FrontendIPsCount: to.Ptr(int32(1)),
 	}
 	if installConfig.Config.Platform.Azure.OutboundType == azure.UserDefinedRoutingOutboundType {
 		controlPlaneOutboundLB = nil
+	}
+
+	source := "*"
+	if installConfig.Config.Publish == types.InternalPublishingStrategy {
+		source = mainCIDR.String()
 	}
 
 	securityGroup := capz.SecurityGroup{


### PR DESCRIPTION
No public endpoints are created. If the outbound type if load balancer, we still create a public load balancer with a public IP for egress.  I refactored GetMachines a bit while here. 

https://issues.redhat.com/browse/CORS-3565