### PR TITLE
MGMT-18364: Add image-based config ISO integration tests

### DIFF
--- a/cmd/openshift-install/integration_test.go
+++ b/cmd/openshift-install/integration_test.go
@@ -19,3 +19,7 @@ func TestMain(m *testing.M) {
 func TestAgentIntegration(t *testing.T) {
 	runAllIntegrationTests(t, "testdata/agent")
 }
+
+func TestImageBasedIntegration(t *testing.T) {
+	runAllIntegrationTests(t, "testdata/imagebased")
+}

--- a/cmd/openshift-install/internal_integration_test.go
+++ b/cmd/openshift-install/internal_integration_test.go
@@ -122,6 +122,7 @@ func runIntegrationTest(t *testing.T, testFolder string) {
 			"unconfiguredIgnContains": unconfiguredIgnContains,
 			"unconfiguredIgnCmp":      unconfiguredIgnCmp,
 			"expandFile":              expandFile,
+			"isoContains":             isoContains,
 		},
 	})
 }
@@ -448,6 +449,27 @@ func initrdImgContains(ts *testscript.TestScript, neg bool, args []string) {
 	isoPathAbs := filepath.Join(workDir, isoPath)
 
 	err := checkFileFromInitrdImg(isoPathAbs, eFilePath)
+	ts.Check(err)
+}
+
+// [!] isoContains `isoPath` `file` check if the specified `file` is stored
+// within the ISO `isoPath` image.
+func isoContains(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) != 2 {
+		ts.Fatalf("usage: isoContains isoPath file")
+	}
+
+	workDir := ts.Getenv("WORK")
+	isoPath, filePath := args[0], args[1]
+	isoPathAbs := filepath.Join(workDir, isoPath)
+
+	disk, err := diskfs.Open(isoPathAbs, diskfs.WithOpenMode(diskfs.ReadOnly))
+	ts.Check(err)
+
+	fs, err := disk.GetFilesystem(0)
+	ts.Check(err)
+
+	_, err = fs.OpenFile(filePath, os.O_RDONLY)
 	ts.Check(err)
 }
 

--- a/cmd/openshift-install/testdata/imagebased/configimage/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/imagebased/configimage/assets/default_assets.txt
@@ -1,0 +1,42 @@
+# Verify that the most relevant assets are properly generated in the config ISO
+
+exec openshift-install image-based create config-image --dir $WORK
+
+exists $WORK/imagebasedconfig.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+isoContains imagebasedconfig.iso /cluster-configuration/manifest.json
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 1
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- image-based-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedConfig
+metadata:
+  name: ostest
+  namespace: cluster0
+hostname: ostest

--- a/cmd/openshift-install/testdata/imagebased/configtemplate/config-template.txt
+++ b/cmd/openshift-install/testdata/imagebased/configtemplate/config-template.txt
@@ -1,0 +1,39 @@
+# Verify the generated default template for image-based-config.yaml
+
+exec openshift-install image-based create config-template --dir $WORK
+
+stderr 'level=info msg=Config-Template created in:'
+
+exists $WORK/image-based-config.yaml
+
+cmp $WORK/image-based-config.yaml $WORK/expected/image-based-config.yaml
+
+-- expected/image-based-config.yaml --
+#
+# Note: This is a sample ImageBasedConfig file showing
+# which fields are available to aid you in creating your
+# own image-based-config.yaml file.
+#
+apiVersion: v1beta1
+kind: ImageBasedConfig
+metadata:
+  name: example-image-based-config
+additionalNTPSources:
+  - 0.rhel.pool.ntp.org
+  - 1.rhel.pool.ntp.org
+hostname: change-to-hostname
+releaseRegistry: quay.io
+# networkConfig contains the network configuration for the host in NMState format.
+# See https://nmstate.io/examples.html for examples.
+networkConfig:
+  interfaces:
+    - name: eth0
+      type: ethernet
+      state: up
+      mac-address: 00:00:00:00:00:00
+      ipv4:
+        enabled: true
+        address:
+          - ip: 192.168.122.2
+            prefix-length: 23
+        dhcp: false


### PR DESCRIPTION
This PR adds integration tests via [testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) (much like the respective `agent` integration tests) for the `openshift-install image-based {config-image,config-template}` subcommands. It also renames the integration tests source files to better reflect the fact that the latter now include tests additional to `agent` ones.