### PR TITLE
MULTIARCH-4813: Make CPMS active by default for Power VS platform

### DIFF
--- a/pkg/asset/machines/powervs/machines.go
+++ b/pkg/asset/machines/powervs/machines.go
@@ -80,7 +80,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		},
 		Spec: machinev1.ControlPlaneMachineSetSpec{
 			Replicas: &replicas,
-			State:    machinev1.ControlPlaneMachineSetStateInactive,
+			State:    machinev1.ControlPlaneMachineSetStateActive,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"machine.openshift.io/cluster-api-machine-role": role,


### PR DESCRIPTION
CPMSO support for Power VS was added via PR: https://github.com/openshift/installer/pull/7226

It was in inactive state and now we have done enough testing by making it active and wants to make it active by default.