### PR TITLE
OCPBUGS-37104: openstack: Validate controlPlanePort has subnet

### DIFF
--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -141,7 +141,7 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			networking:    validNetworking(),
-			expectedError: `^test-path\.controlPlanePort.fixedIPs: Invalid value: "fake": invalid subnet ID`,
+			expectedError: `^test-path\.controlPlanePort.fixedIPs\[0\]\.subnet.id: Invalid value: "fake": invalid subnet ID`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Reject a controlPlanePort where the subnet filter is not set.

The rest of the code (both in pre-flight validation and in machine generation) assumes that a subnet filter is set on the controlPlanePort.