### PR TITLE
AGENT-854: day2 add-nodes workflow validations

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -78,9 +78,6 @@ func (a *OptionalInstallConfig) validateInstallConfig(ctx context.Context, insta
 	if err := a.validateSupportedPlatforms(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
 	}
-	if err := a.validatePlatformsByName(installConfig); err != nil {
-		allErrs = append(allErrs, err...)
-	}
 
 	if err := a.validateSupportedArchs(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
@@ -114,6 +111,7 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 	return append(allErrs, a.validatePlatformsByName(installConfig)...)
 }
 
+// ValidateSupportedPlatforms verifies if the specified platform/arch is supported or not.
 func ValidateSupportedPlatforms(platform types.Platform, controlPlaneArch string) field.ErrorList {
 	var allErrs field.ErrorList
 

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -78,6 +78,9 @@ func (a *OptionalInstallConfig) validateInstallConfig(ctx context.Context, insta
 	if err := a.validateSupportedPlatforms(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
 	}
+	if err := a.validatePlatformsByName(installConfig); err != nil {
+		allErrs = append(allErrs, err...)
+	}
 
 	if err := a.validateSupportedArchs(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
@@ -107,23 +110,34 @@ func (a *OptionalInstallConfig) validateInstallConfig(ctx context.Context, insta
 }
 
 func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.InstallConfig) field.ErrorList {
+	allErrs := ValidateSupportedPlatforms(installConfig.Platform, string(installConfig.ControlPlane.Architecture))
+	return append(allErrs, a.validatePlatformsByName(installConfig)...)
+}
+
+func ValidateSupportedPlatforms(platform types.Platform, controlPlaneArch string) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fieldPath := field.NewPath("Platform")
 
-	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(installConfig.Platform)) {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedInstallerPlatforms()))
+	if platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(platform)) {
+		allErrs = append(allErrs, field.NotSupported(fieldPath, platform.Name(), SupportedInstallerPlatforms()))
 	}
-	if installConfig.Platform.Name() != none.Name && installConfig.ControlPlane.Architecture == types.ArchitecturePPC64LE {
-		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitecturePPC64LE, none.Name)))
+	if platform.Name() != none.Name && controlPlaneArch == types.ArchitecturePPC64LE {
+		allErrs = append(allErrs, field.Invalid(fieldPath, platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitecturePPC64LE, none.Name)))
 	}
-	if installConfig.Platform.Name() != none.Name && installConfig.ControlPlane.Architecture == types.ArchitectureS390X {
-		allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitectureS390X, none.Name)))
+	if platform.Name() != none.Name && controlPlaneArch == types.ArchitectureS390X {
+		allErrs = append(allErrs, field.Invalid(fieldPath, platform.Name(), fmt.Sprintf("CPU architecture \"%s\" only supports platform \"%s\".", types.ArchitectureS390X, none.Name)))
 	}
+	return allErrs
+}
+
+func (a *OptionalInstallConfig) validatePlatformsByName(installConfig *types.InstallConfig) field.ErrorList {
+	var allErrs field.ErrorList
+
 	if installConfig.Platform.Name() == external.Name {
 		if installConfig.Platform.External.PlatformName == string(models.PlatformTypeOci) &&
 			installConfig.Platform.External.CloudControllerManager != external.CloudControllerManagerTypeExternal {
-			fieldPath = field.NewPath("Platform", "External", "CloudControllerManager")
+			fieldPath := field.NewPath("Platform", "External", "CloudControllerManager")
 			allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Platform.External.CloudControllerManager, fmt.Sprintf("When using external %s platform, %s must be set to %s", string(models.PlatformTypeOci), fieldPath, external.CloudControllerManagerTypeExternal)))
 		}
 	}

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -12,11 +12,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -24,6 +26,18 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/external"
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/ibmcloud"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/nutanix"
+	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/ovirt"
+	"github.com/openshift/installer/pkg/types/powervs"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 // ClusterInfo it's an asset used to retrieve config info
@@ -121,7 +135,7 @@ func (ci *ClusterInfo) Generate(_ context.Context, dependencies asset.Parents) e
 
 	ci.Namespace = "cluster0"
 
-	return nil
+	return ci.validate().ToAggregate()
 }
 
 func (ci *ClusterInfo) initClients(kubeconfig string) error {
@@ -337,4 +351,63 @@ func (*ClusterInfo) Files() []*asset.File {
 // Load returns agent config asset from the disk.
 func (*ClusterInfo) Load(f asset.FileFetcher) (bool, error) {
 	return false, nil
+}
+
+func (ci *ClusterInfo) validate() field.ErrorList {
+	var allErrs field.ErrorList
+
+	if err := ci.validateSupportedPlatforms(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	return allErrs
+}
+
+func (ci *ClusterInfo) validateSupportedPlatforms() field.ErrorList {
+	var allErrs field.ErrorList
+
+	infra, err := ci.OpenshiftClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return append(allErrs, field.InternalError(nil, err))
+	}
+	platform, err := ci.toTypesPlatform(infra.Spec.PlatformSpec.Type)
+	if err != nil {
+		return append(allErrs, field.InternalError(nil, err))
+	}
+	return agent.ValidateSupportedPlatforms(platform, ci.Architecture)
+}
+
+func (ci *ClusterInfo) toTypesPlatform(platformType configv1.PlatformType) (types.Platform, error) {
+	platform := types.Platform{}
+
+	switch platformType {
+	case configv1.AWSPlatformType:
+		platform.AWS = &aws.Platform{}
+	case configv1.AzurePlatformType:
+		platform.Azure = &azure.Platform{}
+	case configv1.BareMetalPlatformType:
+		platform.BareMetal = &baremetal.Platform{}
+	case configv1.GCPPlatformType:
+		platform.GCP = &gcp.Platform{}
+	case configv1.OpenStackPlatformType:
+		platform.OpenStack = &openstack.Platform{}
+	case configv1.NonePlatformType:
+		platform.None = &none.Platform{}
+	case configv1.VSpherePlatformType:
+		platform.VSphere = &vsphere.Platform{}
+	case configv1.OvirtPlatformType:
+		platform.Ovirt = &ovirt.Platform{}
+	case configv1.IBMCloudPlatformType:
+		platform.IBMCloud = &ibmcloud.Platform{}
+	case configv1.PowerVSPlatformType:
+		platform.PowerVS = &powervs.Platform{}
+	case configv1.NutanixPlatformType:
+		platform.Nutanix = &nutanix.Platform{}
+	case configv1.ExternalPlatformType:
+		platform.External = &external.Platform{}
+	default:
+		return platform, fmt.Errorf("unable to convert platform type %v", platformType)
+	}
+
+	return platform, nil
 }

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -85,6 +85,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 				},
 			},
 			objs: func(t *testing.T) ([]runtime.Object, []runtime.Object) {
+				t.Helper()
 				objs, ocObjs := defaultObjects()(t)
 				for i, o := range objs {
 					if node, ok := o.(*corev1.Node); ok {
@@ -133,6 +134,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 			name:     "not supported platform",
 			workflow: workflow.AgentWorkflowTypeAddNodes,
 			objs: func(t *testing.T) ([]runtime.Object, []runtime.Object) {
+				t.Helper()
 				objs, ocObjs := defaultObjects()(t)
 				for i, o := range ocObjs {
 					if infra, ok := o.(*configv1.Infrastructure); ok {
@@ -269,6 +271,7 @@ func makeInstallConfig(t *testing.T) string {
 
 func defaultObjects() func(t *testing.T) ([]runtime.Object, []runtime.Object) {
 	return func(t *testing.T) ([]runtime.Object, []runtime.Object) {
+		t.Helper()
 		objects := []runtime.Object{
 			&corev1.Secret{
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -99,6 +100,9 @@ func (n *NMStateConfig) Generate(_ context.Context, dependencies asset.Parents) 
 		clusterNamespace = installConfig.ClusterNamespace()
 
 	case workflow.AgentWorkflowTypeAddNodes:
+		if err := validateHostHostnameAndIPs(agentHosts, clusterInfo.Nodes); err != nil {
+			return err
+		}
 		clusterName = clusterInfo.ClusterName
 		clusterNamespace = clusterInfo.Namespace
 
@@ -435,4 +439,49 @@ func validateHostCount(installConfig *types.InstallConfig, agentHosts *agentconf
 	}
 
 	return nil
+}
+
+func validateHostHostnameAndIPs(agentHosts *agentconfig.AgentHosts, nodes *corev1.NodeList) error {
+	for _, host := range agentHosts.Hosts {
+		hostIPs, err := getAllHostIPs(host.NetworkConfig)
+		if err != nil {
+			return err
+		}
+
+		for _, node := range nodes.Items {
+			for _, addr := range node.Status.Addresses {
+				if _, found := hostIPs[addr.Address]; found {
+					return fmt.Errorf("address conflict found. The configured address %s is already used by the cluster node %s", addr.Address, node.GetName())
+				}
+				if host.Hostname != "" && host.Hostname == addr.Address {
+					return fmt.Errorf("hostname conflict found. The configured hostname %s is already used in the cluster", addr.Address)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getAllHostIPs(config aiv1beta1.NetConfig) (map[string]struct{}, error) {
+	var nmStateConfig nmStateConfig
+	hostIPs := make(map[string]struct{})
+
+	err := yaml.Unmarshal(config.Raw, &nmStateConfig)
+	if err != nil {
+		return hostIPs, fmt.Errorf("error unmarshalling NMStateConfig: %w", err)
+	}
+
+	for _, intf := range nmStateConfig.Interfaces {
+		for _, addr4 := range intf.IPV4.Address {
+			if addr4.IP != "" {
+				hostIPs[addr4.IP] = struct{}{}
+			}
+		}
+		for _, addr6 := range intf.IPV6.Address {
+			if addr6.IP != "" {
+				hostIPs[addr6.IP] = struct{}{}
+			}
+		}
+	}
+	return hostIPs, nil
 }


### PR DESCRIPTION
This patch introduces a set of validations required when running the `ClusterInfo` asset as part of the day2 add-nodes workflow