### PR TITLE
no-jira: bootstrap: add shellcheck directives to follow sourced files

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euoE pipefail ## -E option will cause functions to inherit trap
 
+# shellcheck source=bootstrap-service-record.sh
 . /usr/local/bin/bootstrap-service-record.sh
 
+# shellcheck source=release-image.sh.template
 . /usr/local/bin/release-image.sh
+# shellcheck source=bootstrap-cluster-gather.sh
 . /usr/local/bin/bootstrap-cluster-gather.sh
+# shellcheck source=bootstrap-verify-api-server-urls.sh
 . /usr/local/bin/bootstrap-verify-api-server-urls.sh
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}

--- a/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC1091  # using path on bootstrap machine
+# shellcheck source=bootstrap-service-record.sh
 . /usr/local/bin/bootstrap-service-record.sh
 
  /usr/bin/kubelet \


### PR DESCRIPTION
Just noticed this while hacking on the installer code; shellcheck has a `source=` directive that allows it to follow which file is being sourced in the git repo. This gets rid of one `disable` directive in the process.