### PR TITLE
OCPBUGS-37164: Handle empty config for image-based create image

### DIFF
--- a/pkg/asset/imagebased/image/ignition.go
+++ b/pkg/asset/imagebased/image/ignition.go
@@ -3,7 +3,6 @@ package image
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/coreos/ignition/v2/config/merge"
@@ -72,7 +71,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 
 	ibiConfig := configAsset.Config
 	if ibiConfig == nil {
-		return errors.New("image-based-installation-config.yaml is required")
+		return nil
 	}
 
 	config := &igntypes.Config{

--- a/pkg/asset/imagebased/image/registriesconf.go
+++ b/pkg/asset/imagebased/image/registriesconf.go
@@ -35,6 +35,10 @@ func (i *RegistriesConf) Generate(_ context.Context, dependencies asset.Parents)
 	ibiConfig := &ImageBasedInstallationConfig{}
 	dependencies.Get(ibiConfig)
 
+	if ibiConfig.Config == nil {
+		return nil
+	}
+
 	imageDigestSources := ibiConfig.Config.ImageDigestSources
 
 	if len(imageDigestSources) == 0 {


### PR DESCRIPTION
This PR fixes the `openshift-install image-based create image --dir assets` command panicking when there is no `image-based-installation-config.yaml` supplied.

/cc @eranco74 @tsorya 