### PR TITLE
CORS-3568: Support GCP pre-created Service Accounts for CAPG

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -582,11 +582,10 @@ spec:
                           type: string
                         serviceAccount:
                           description: ServiceAccount is the email of a gcp service
-                            account to be used for shared vpc installations. The provided
-                            service account will be attached to control-plane nodes
-                            in order to provide the permissions required by the cloud
-                            provider in the host project. This field is only supported
-                            in the control-plane machinepool.
+                            account to be used during installations. The provided
+                            service account can be attached to both control-plane
+                            nodes and worker nodes in order to provide the permissions
+                            required by the cloud provider.
                           type: string
                         tags:
                           description: Tags defines a set of network tags which will
@@ -1490,11 +1489,10 @@ spec:
                         type: string
                       serviceAccount:
                         description: ServiceAccount is the email of a gcp service
-                          account to be used for shared vpc installations. The provided
-                          service account will be attached to control-plane nodes
-                          in order to provide the permissions required by the cloud
-                          provider in the host project. This field is only supported
-                          in the control-plane machinepool.
+                          account to be used during installations. The provided service
+                          account can be attached to both control-plane nodes and
+                          worker nodes in order to provide the permissions required
+                          by the cloud provider.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will
@@ -3122,11 +3120,10 @@ spec:
                         type: string
                       serviceAccount:
                         description: ServiceAccount is the email of a gcp service
-                          account to be used for shared vpc installations. The provided
-                          service account will be attached to control-plane nodes
-                          in order to provide the permissions required by the cloud
-                          provider in the host project. This field is only supported
-                          in the control-plane machinepool.
+                          account to be used during installations. The provided service
+                          account can be attached to both control-plane nodes and
+                          worker nodes in order to provide the permissions required
+                          by the cloud provider.
                         type: string
                       tags:
                         description: Tags defines a set of network tags which will

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -2,8 +2,6 @@
 package gcp
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -15,7 +13,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
-	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
@@ -154,37 +151,9 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 		}
 	}
 
-	instanceServiceAccount := fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
-	// The installer will create a service account for compute nodes with the above naming convention.
-	// The same service account will be used for control plane nodes during a vanilla installation. During a
-	// xpn installation, the installer will attempt to use an existing service account either through the
-	// credentials or through a user supplied value from the install-config.
-	if role == "master" && len(platform.NetworkProjectID) > 0 {
-		instanceServiceAccount = mpool.ServiceAccount
-
-		if instanceServiceAccount == "" {
-			sess, err := gcpconfig.GetSession(context.TODO())
-			if err != nil {
-				return nil, err
-			}
-
-			// The JSON can be `nil` if auth is provided from env
-			// https://pkg.go.dev/golang.org/x/oauth2@v0.17.0/google#Credentials
-			if len(sess.Credentials.JSON) == 0 {
-				return nil, fmt.Errorf("could not extract service account from loaded credentials. Please specify a service account to be used for shared vpc installations in the install-config.yaml")
-			}
-
-			var found bool
-			serviceAccount := make(map[string]interface{})
-			err = json.Unmarshal(sess.Credentials.JSON, &serviceAccount)
-			if err != nil {
-				return nil, err
-			}
-			instanceServiceAccount, found = serviceAccount["client_email"].(string)
-			if !found {
-				return nil, errors.New("could not find google service account")
-			}
-		}
+	serviceAccountEmail := gcp.GetConfiguredServiceAccount(platform, mpool)
+	if serviceAccountEmail == "" {
+		serviceAccountEmail = gcp.GetDefaultServiceAccount(platform, clusterID, role[0:1])
 	}
 
 	shieldedInstanceConfig := machineapi.GCPShieldedInstanceConfig{}
@@ -225,7 +194,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			Subnetwork: subnetwork,
 		}},
 		ServiceAccounts: []machineapi.GCPServiceAccount{{
-			Email:  instanceServiceAccount,
+			Email:  serviceAccountEmail,
 			Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 		}},
 		Tags:                   append(mpool.Tags, []string{fmt.Sprintf("%s-%s", clusterID, role)}...),

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -74,10 +74,9 @@ type MachinePool struct {
 	// +optional
 	ConfidentialCompute string `json:"confidentialCompute,omitempty"`
 
-	// ServiceAccount is the email of a gcp service account to be used for shared
-	// vpc installations. The provided service account will be attached to control-plane nodes
-	// in order to provide the permissions required by the cloud provider in the host project.
-	// This field is only supported in the control-plane machinepool.
+	// ServiceAccount is the email of a gcp service account to be used during installations.
+	// The provided service account can be attached to both control-plane nodes
+	// and worker nodes in order to provide the permissions required by the cloud provider.
 	//
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty"`

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -114,3 +114,21 @@ type UserTag struct {
 func DefaultSubnetName(infraID, role string) string {
 	return fmt.Sprintf("%s-%s-subnet", infraID, role)
 }
+
+// GetConfiguredServiceAccount returns the service account email from a configured service account for
+// a control plane or compute node. Returns empty string if not configured.
+func GetConfiguredServiceAccount(platform *Platform, mpool *MachinePool) string {
+	if mpool != nil && mpool.ServiceAccount != "" {
+		return mpool.ServiceAccount
+	} else if platform.DefaultMachinePlatform != nil {
+		return platform.DefaultMachinePlatform.ServiceAccount
+	}
+
+	return ""
+}
+
+// GetDefaultServiceAccount returns the default service account email to use based on role.
+// The default should be used when an existing service account is not configured.
+func GetDefaultServiceAccount(platform *Platform, clusterID string, role string) string {
+	return fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
+}

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -54,20 +54,10 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	return allErrs
 }
 
-// ValidateServiceAccount checks that the service account is only supplied for control plane nodes and during
-// a shared vpn installation.
+// ValidateServiceAccount does not do any checks on the service account since it can be set for all nodes and
+// in non-shared vpn installations.
 func ValidateServiceAccount(platform *gcp.Platform, p *types.MachinePool, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if p.Platform.GCP.ServiceAccount != "" {
-		if p.Name != "master" {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccount"), p.Platform.GCP.ServiceAccount, fmt.Sprintf("service accounts only valid for master nodes, provided for %s nodes", p.Name)))
-		}
-		if platform.NetworkProjectID == "" {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccount"), p.Platform.GCP.ServiceAccount, "service accounts only valid for xpn installs"))
-		}
-	}
-	return allErrs
+	return field.ErrorList{}
 }
 
 // ValidateMasterDiskType checks that the specified disk type is valid for control plane.

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -204,7 +204,7 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			valid: false,
+			valid: true,
 		},
 		{
 			name:     "invalid GCP service account non xpn install",
@@ -218,7 +218,7 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			valid: false,
+			valid: true,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Support the configuration of pre-created Service Accounts for control plane and compute machines.