### PR TITLE
OCPBUGS-37226: Persist image-based config manifests from state instead of template

### DIFF
--- a/pkg/asset/imagebased/configimage/configiso.go
+++ b/pkg/asset/imagebased/configimage/configiso.go
@@ -91,14 +91,14 @@ func (ci *ConfigImage) Generate(_ context.Context, dependencies asset.Parents) e
 	return nil
 }
 
-// PersistToFile writes the iso image in the assets folder.
+// PersistToFile writes the ISO image in the assets folder.
 func (ci *ConfigImage) PersistToFile(directory string) error {
 	defer os.RemoveAll(ci.tmpPath)
 
 	// If the tmpPath is not set then it means that either one of the Config
 	// dependencies or the asset itself failed for some reason
 	if ci.tmpPath == "" {
-		return errors.New("cannot generate Config image due to configuration errors")
+		return errors.New("cannot generate config image due to configuration errors")
 	}
 
 	configImageFile := filepath.Join(directory, configImageFilename)

--- a/pkg/asset/imagebased/configimage/imagebased_config.go
+++ b/pkg/asset/imagebased/configimage/imagebased_config.go
@@ -85,10 +85,12 @@ networkConfig:
 
 // PersistToFile writes the image-based-config.yaml file to the assets folder.
 func (i *ImageBasedConfig) PersistToFile(directory string) error {
-	templatePath := filepath.Join(directory, imageBasedConfigFilename)
-	templateByte := []byte(i.Template)
+	if i.File == nil {
+		return nil
+	}
 
-	err := os.WriteFile(templatePath, templateByte, 0o600)
+	configPath := filepath.Join(directory, imageBasedConfigFilename)
+	err := os.WriteFile(configPath, i.File.Data, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/imagebased/image/ignition.go
+++ b/pkg/asset/imagebased/image/ignition.go
@@ -71,7 +71,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 
 	ibiConfig := configAsset.Config
 	if ibiConfig == nil {
-		return nil
+		return fmt.Errorf("%s is required", configFilename)
 	}
 
 	config := &igntypes.Config{

--- a/pkg/asset/imagebased/image/image.go
+++ b/pkg/asset/imagebased/image/image.go
@@ -60,8 +60,8 @@ func (i *Image) Generate(_ context.Context, dependencies asset.Parents) error {
 
 // PersistToFile writes the ISO image in the assets folder.
 func (i *Image) PersistToFile(directory string) error {
-	if i.Config == nil {
-		return fmt.Errorf("imagebased installation configuration is nil")
+	if i.Config == nil || len(i.IgnitionByte) == 0 {
+		return fmt.Errorf("could not generate image because of configuration errors")
 	}
 
 	// Create a tmp folder to store all the pieces required to generate the image-based installer artifacts.

--- a/pkg/asset/imagebased/image/imagebased_config.go
+++ b/pkg/asset/imagebased/image/imagebased_config.go
@@ -94,10 +94,12 @@ pullSecret: '<your-pull-secret>'
 
 // PersistToFile writes the image-based-installation-config.yaml file to the assets folder.
 func (i *ImageBasedInstallationConfig) PersistToFile(directory string) error {
-	templatePath := filepath.Join(directory, configFilename)
-	templateByte := []byte(i.Template)
+	if i.File == nil {
+		return nil
+	}
 
-	err := os.WriteFile(templatePath, templateByte, 0o600)
+	configPath := filepath.Join(directory, configFilename)
+	err := os.WriteFile(configPath, i.File.Data, 0o600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR enhances the user experience of the `openshift-install image-based create {image-config,config}-template --dir assets` commands, by not emptying the respective `image-based-installation-config.yaml` and `image-based-config.yaml` when the afore-mentioned commands are run twice.

Although this doesn't impact the respective ISO generation, as the config manifests seem to be empty but kept in the openshift-install state, i.e. trying to generate the ISOs will work as expected. 