### PR TITLE
OCPBUGS-36302: pkg/asset/machines/azure: Don't set disk encryption set to nil

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -184,7 +184,6 @@ func GenerateMachines(platform *azure.Platform, pool *types.MachinePool, userDat
 		})
 	}
 
-	osDisk.ManagedDisk.DiskEncryptionSet = nil
 	bootstrapAzureMachine := &capz.AzureMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: capiutils.GenerateBoostrapMachineName(clusterID),


### PR DESCRIPTION
The disk encryption set ID was getting set to nil before being passed to the bootstrap machine struct. Since the managed disk properties is a pointer, it was nil before the manifests were being written to disk.

https://issues.redhat.com/browse/OCPBUGS-36302