### PR TITLE
AGENT-900: enable fips for add-nodes workflow

### DIFF
--- a/hack/build-node-joiner.sh
+++ b/hack/build-node-joiner.sh
@@ -44,6 +44,11 @@ then
 	GOOS='' GOARCH='' go generate ./data
 fi
 
+if (echo "${TAGS}" | grep -q '\bfipscapable\b')
+then
+	export CGO_ENABLED=1
+fi
+
 echo "building node-joiner"
 
 # shellcheck disable=SC2086

--- a/pkg/asset/agent/image/kargs.go
+++ b/pkg/asset/agent/image/kargs.go
@@ -2,12 +2,14 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
@@ -22,6 +24,7 @@ type Kargs struct {
 func (a *Kargs) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&workflow.AgentWorkflow{},
+		&joiner.ClusterInfo{},
 		&manifests.AgentClusterInstall{},
 	}
 }
@@ -29,21 +32,25 @@ func (a *Kargs) Dependencies() []asset.Asset {
 // Generate generates the kernel args configurations for the agent ISO image and PXE assets.
 func (a *Kargs) Generate(_ context.Context, dependencies asset.Parents) error {
 	agentWorkflow := &workflow.AgentWorkflow{}
+	clusterInfo := &joiner.ClusterInfo{}
 	agentClusterInstall := &manifests.AgentClusterInstall{}
-	dependencies.Get(agentClusterInstall, agentWorkflow)
+	dependencies.Get(agentClusterInstall, agentWorkflow, clusterInfo)
 
-	// Not required for AddNodes workflow
-	if agentWorkflow.Workflow == workflow.AgentWorkflowTypeAddNodes {
-		return nil
+	switch agentWorkflow.Workflow {
+	case workflow.AgentWorkflowTypeInstall:
+		a.fips = agentClusterInstall.FIPSEnabled()
+		// Add kernel args for external oci platform
+		if agentClusterInstall.GetExternalPlatformName() == string(models.PlatformTypeOci) {
+			logrus.Debugf("Added kernel args to enable serial console for %s %s platform", hiveext.ExternalPlatformType, string(models.PlatformTypeOci))
+			a.consoleArgs = " console=ttyS0"
+		}
+
+	case workflow.AgentWorkflowTypeAddNodes:
+		a.fips = clusterInfo.FIPS
+
+	default:
+		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
 	}
-
-	// Add kernel args for external oci platform
-	if agentClusterInstall.GetExternalPlatformName() == string(models.PlatformTypeOci) {
-		logrus.Debugf("Added kernel args to enable serial console for %s %s platform", hiveext.ExternalPlatformType, string(models.PlatformTypeOci))
-		a.consoleArgs = " console=ttyS0"
-	}
-
-	a.fips = agentClusterInstall.FIPSEnabled()
 
 	return nil
 }

--- a/pkg/asset/agent/image/kargs_test.go
+++ b/pkg/asset/agent/image/kargs_test.go
@@ -1,0 +1,110 @@
+package image
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent/joiner"
+	"github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
+)
+
+func TestKargs_Generate(t *testing.T) {
+	cases := []struct {
+		name                string
+		workflow            workflow.AgentWorkflowType
+		agentClusterInstall *manifests.AgentClusterInstall
+		clusterInfo         *joiner.ClusterInfo
+		expectedArgs        string
+		expectedErr         string
+	}{
+		{
+			name:         "install workflow - default",
+			workflow:     workflow.AgentWorkflowTypeInstall,
+			expectedArgs: "",
+		},
+		{
+			name:     "install workflow - fips enabled",
+			workflow: workflow.AgentWorkflowTypeInstall,
+			agentClusterInstall: &manifests.AgentClusterInstall{
+				Config: &v1beta1.AgentClusterInstall{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"agent-install.openshift.io/install-config-overrides": `{"fips": true}`,
+						},
+					},
+				},
+			},
+			expectedArgs: " fips=1",
+		},
+		{
+			name:     "install workflow - oci with fips enabled",
+			workflow: workflow.AgentWorkflowTypeInstall,
+			agentClusterInstall: &manifests.AgentClusterInstall{
+				Config: &v1beta1.AgentClusterInstall{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"agent-install.openshift.io/install-config-overrides": `{"fips": true}`,
+						},
+					},
+					Spec: v1beta1.AgentClusterInstallSpec{
+						ExternalPlatformSpec: &v1beta1.ExternalPlatformSpec{
+							PlatformName: "oci",
+						},
+					},
+				},
+			},
+			expectedArgs: " console=ttyS0 fips=1",
+		},
+		{
+			name:         "add-nodes workflow - default",
+			workflow:     workflow.AgentWorkflowTypeAddNodes,
+			expectedArgs: "",
+		},
+		{
+			name:     "add-nodes workflow - fips enabled",
+			workflow: workflow.AgentWorkflowTypeAddNodes,
+			clusterInfo: &joiner.ClusterInfo{
+				FIPS: true,
+			},
+			expectedArgs: " fips=1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dependencies := []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: tc.workflow},
+			}
+			aci := &manifests.AgentClusterInstall{
+				Config: &v1beta1.AgentClusterInstall{},
+			}
+			if tc.agentClusterInstall != nil {
+				aci = tc.agentClusterInstall
+			}
+			ci := &joiner.ClusterInfo{}
+			if tc.clusterInfo != nil {
+				ci = tc.clusterInfo
+			}
+
+			dependencies = append(dependencies, ci)
+			dependencies = append(dependencies, aci)
+			parents := asset.Parents{}
+			parents.Add(dependencies...)
+
+			kargs := &Kargs{}
+			err := kargs.Generate(context.Background(), parents)
+
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedArgs, string(kargs.KernelCmdLine()))
+			} else {
+				assert.Regexp(t, tc.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -50,6 +50,7 @@ type ClusterInfo struct {
 	OSImage                       *stream.Stream
 	OSImageLocation               string
 	IgnitionEndpointWorker        *models.IgnitionEndpoint
+	FIPS                          bool
 }
 
 var _ asset.WritableAsset = (*ClusterInfo)(nil)
@@ -244,6 +245,7 @@ func (ci *ClusterInfo) retrieveInstallConfigData() error {
 	ci.SSHKey = installConfig.SSHKey
 	ci.ClusterName = installConfig.ObjectMeta.Name
 	ci.APIDNSName = fmt.Sprintf("api.%s.%s", ci.ClusterName, installConfig.BaseDomain)
+	ci.FIPS = installConfig.FIPS
 
 	return nil
 }

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -161,6 +161,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 					URL:           ptr.To("https://192.168.111.5:22623/config/worker"),
 					CaCertificate: ptr.To("LS0tL_FakeCertificate_LS0tCg=="),
 				},
+				FIPS: true,
 			},
 		},
 		{
@@ -276,6 +277,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 				SSHKey:          "my-ssh-key",
 				OSImage:         buildStreamData(),
 				OSImageLocation: "http://my-coreosimage-url/416.94.202402130130-1",
+				FIPS:            true,
 			},
 		},
 	}
@@ -314,6 +316,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 			assert.Equal(t, tc.expectedClusterInfo.OSImageLocation, clusterInfo.OSImageLocation)
 			assert.Equal(t, tc.expectedClusterInfo.OSImage, clusterInfo.OSImage)
 			assert.Equal(t, tc.expectedClusterInfo.IgnitionEndpointWorker, clusterInfo.IgnitionEndpointWorker)
+			assert.Equal(t, tc.expectedClusterInfo.FIPS, clusterInfo.FIPS)
 		})
 	}
 }
@@ -382,6 +385,7 @@ func makeInstallConfig(t *testing.T) string {
 			BareMetal: &baremetal.Platform{},
 		},
 		SSHKey: "my-ssh-key",
+		FIPS:   true,
 	}
 	data, err := yaml.Marshal(ic)
 	if err != nil {


### PR DESCRIPTION
If the target cluster had fips enabled, then it will be set also for the live ISO