### PR TITLE
no-jira: Replace Equal with ErrorContains for image-based nmstatectl unit tests

### DIFF
--- a/pkg/asset/imagebased/configimage/imagebased_config_test.go
+++ b/pkg/asset/imagebased/configimage/imagebased_config_test.go
@@ -95,7 +95,7 @@ networkConfig:
       state: invalid`,
 
 			expectedFound: false,
-			expectedError: "invalid Image-based Config configuration: networkConfig: Invalid value: interfaces:\n- name: eth0\n  state: invalid\n  type: ethernet\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: interfaces: unknown variant `invalid`, expected one of `up`, `down`, `absent`, `unknown`, `ignore` at line 2 column 1",
+			expectedError: "networkConfig: Invalid value: interfaces:\n- name: eth0\n  state: invalid\n  type: ethernet\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: interfaces: unknown variant `invalid`",
 		},
 		{
 			name: "invalid-additional-ntp-sources",
@@ -135,7 +135,7 @@ networkConfig:
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found)
 			if tc.expectedError != "" {
-				assert.Equal(t, tc.expectedError, err.Error())
+				assert.ErrorContains(t, err, tc.expectedError)
 			} else {
 				assert.NoError(t, err)
 				if tc.expectedConfig != nil {

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -215,7 +215,7 @@ networkConfig:
 `,
 
 			expectedFound: false,
-			expectedError: "invalid Image-based Installation ISO Config: networkConfig: Invalid value: invalid: config\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: unknown field `invalid`, expected one of `hostname`, `dns-resolver`, `route-rules`, `routes`, `interfaces`, `ovs-db`, `ovn`",
+			expectedError: "networkConfig: Invalid value: invalid: config\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: unknown field `invalid`",
 		},
 		{
 			name: "invalid-imageDigestSources",
@@ -312,7 +312,7 @@ proxy:
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found)
 			if tc.expectedError != "" {
-				assert.Equal(t, tc.expectedError, err.Error())
+				assert.ErrorContains(t, err, tc.expectedError)
 			} else {
 				assert.NoError(t, err)
 				if tc.expectedConfig != nil {


### PR DESCRIPTION
This PR replaces `assert.Equal` with `assert.ErrorContains` for the `image-based` tests that require `nmstatectl`. This fixes the respective broken unit tests because of an `nmstatectl` version update, which changed the error message we were relying on absolute instead of partial matching.


Example of such broken unit tests: [https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_inst[…]ull-ci-openshift-installer-master-unit/1815798740611502080](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_installer/8235/pull-ci-openshift-installer-master-unit/1815798740611502080)