### PR TITLE
CORS-3546: Nutanix: add gpus and dataDisks support

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -708,11 +708,176 @@ spec:
                             cores to assign a vm.
                           format: int64
                           type: integer
+                        dataDisks:
+                          description: DataDisks holds information of the data disks
+                            to attach to the Machine's VM
+                          items:
+                            description: DataDisk defines a data disk for a Machine
+                              VM.
+                            properties:
+                              dataSourceImage:
+                                description: dataSource refers to a data source image
+                                  for the VM disk.
+                                properties:
+                                  name:
+                                    description: Name is the name of the storage container
+                                      resource in the Prism Element.
+                                    type: string
+                                  referenceName:
+                                    description: ReferenceName is the identifier of
+                                      the storage resource configured in the FailureDomain.
+                                    type: string
+                                  uuid:
+                                    description: UUID is the UUID of the storage container
+                                      resource in the Prism Element.
+                                    type: string
+                                required:
+                                - uuid
+                                type: object
+                              deviceProperties:
+                                description: deviceProperties are the properties of
+                                  the disk device.
+                                properties:
+                                  adapterType:
+                                    description: adapterType is the adapter type of
+                                      the disk address. If the deviceType is "Disk",
+                                      the valid adapterType can be "SCSI", "IDE",
+                                      "PCI", "SATA" or "SPAPR". If the deviceType
+                                      is "CDRom", the valid adapterType can be "IDE"
+                                      or "SATA".
+                                    enum:
+                                    - SCSI
+                                    - IDE
+                                    - PCI
+                                    - SATA
+                                    - SPAPR
+                                    type: string
+                                  deviceIndex:
+                                    default: 0
+                                    description: deviceIndex is the index of the disk
+                                      address. The valid values are non-negative integers,
+                                      with the default value 0. For a Machine VM,
+                                      the deviceIndex for the disks with the same
+                                      deviceType.adapterType combination should start
+                                      from 0 and increase consecutively afterwards.
+                                      Note that for each Machine VM, the Disk.SCSI.0
+                                      and CDRom.IDE.0 are reserved to be used by the
+                                      VM's system. So for dataDisks of Disk.SCSI and
+                                      CDRom.IDE, the deviceIndex should start from
+                                      1.
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  deviceType:
+                                    default: Disk
+                                    description: deviceType specifies the disk device
+                                      type. The valid values are "Disk" and "CDRom",
+                                      and the default is "Disk".
+                                    enum:
+                                    - Disk
+                                    - CDRom
+                                    type: string
+                                required:
+                                - adapterType
+                                - deviceIndex
+                                - deviceType
+                                type: object
+                              diskSize:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: diskSize is size (in Quantity format)
+                                  of the disk to attach to the VM. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format
+                                  for the Quantity format and example documentation.
+                                  The minimum diskSize is 1GB.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageConfig:
+                                description: storageConfig are the storage configuration
+                                  parameters of the VM disks.
+                                properties:
+                                  diskMode:
+                                    allOf:
+                                    - enum:
+                                      - Standard
+                                      - Flash
+                                    - enum:
+                                      - Standard
+                                      - Flash
+                                    default: Standard
+                                    description: diskMode specifies the disk mode.
+                                      The valid values are Standard and Flash, and
+                                      the default is Standard.
+                                    type: string
+                                  storageContainer:
+                                    description: storageContainer refers to the storage_container
+                                      used by the VM disk.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the storage
+                                          container resource in the Prism Element.
+                                        type: string
+                                      referenceName:
+                                        description: ReferenceName is the identifier
+                                          of the storage resource configured in the
+                                          FailureDomain.
+                                        type: string
+                                      uuid:
+                                        description: UUID is the UUID of the storage
+                                          container resource in the Prism Element.
+                                        type: string
+                                    required:
+                                    - uuid
+                                    type: object
+                                required:
+                                - diskMode
+                                type: object
+                            required:
+                            - diskSize
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: set
                         failureDomains:
                           description: FailureDomains optionally configures a list
                             of failure domain names that will be applied to the MachinePool
                           items:
                             type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        gpus:
+                          description: GPUs is a list of GPU devices to attach to
+                            the machine's VM.
+                          items:
+                            description: NutanixGPU holds the identity of a Nutanix
+                              GPU resource in the Prism Central
+                            properties:
+                              deviceID:
+                                description: deviceID is the GPU device ID with the
+                                  integer value.
+                                format: int32
+                                type: integer
+                              name:
+                                description: name is the GPU device name
+                                type: string
+                              type:
+                                description: type is the identifier type of the GPU
+                                  device. Valid values are Name and DeviceID.
+                                enum:
+                                - Name
+                                - DeviceID
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: deviceID configuration is required when type
+                                is DeviceID, and forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''DeviceID'' ?  has(self.deviceID)
+                                : !has(self.deviceID)'
+                            - message: name configuration is required when type is
+                                Name, and forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
+                                : !has(self.name)'
                           type: array
                           x-kubernetes-list-type: set
                         memoryMiB:
@@ -1615,11 +1780,174 @@ spec:
                           cores to assign a vm.
                         format: int64
                         type: integer
+                      dataDisks:
+                        description: DataDisks holds information of the data disks
+                          to attach to the Machine's VM
+                        items:
+                          description: DataDisk defines a data disk for a Machine
+                            VM.
+                          properties:
+                            dataSourceImage:
+                              description: dataSource refers to a data source image
+                                for the VM disk.
+                              properties:
+                                name:
+                                  description: Name is the name of the storage container
+                                    resource in the Prism Element.
+                                  type: string
+                                referenceName:
+                                  description: ReferenceName is the identifier of
+                                    the storage resource configured in the FailureDomain.
+                                  type: string
+                                uuid:
+                                  description: UUID is the UUID of the storage container
+                                    resource in the Prism Element.
+                                  type: string
+                              required:
+                              - uuid
+                              type: object
+                            deviceProperties:
+                              description: deviceProperties are the properties of
+                                the disk device.
+                              properties:
+                                adapterType:
+                                  description: adapterType is the adapter type of
+                                    the disk address. If the deviceType is "Disk",
+                                    the valid adapterType can be "SCSI", "IDE", "PCI",
+                                    "SATA" or "SPAPR". If the deviceType is "CDRom",
+                                    the valid adapterType can be "IDE" or "SATA".
+                                  enum:
+                                  - SCSI
+                                  - IDE
+                                  - PCI
+                                  - SATA
+                                  - SPAPR
+                                  type: string
+                                deviceIndex:
+                                  default: 0
+                                  description: deviceIndex is the index of the disk
+                                    address. The valid values are non-negative integers,
+                                    with the default value 0. For a Machine VM, the
+                                    deviceIndex for the disks with the same deviceType.adapterType
+                                    combination should start from 0 and increase consecutively
+                                    afterwards. Note that for each Machine VM, the
+                                    Disk.SCSI.0 and CDRom.IDE.0 are reserved to be
+                                    used by the VM's system. So for dataDisks of Disk.SCSI
+                                    and CDRom.IDE, the deviceIndex should start from
+                                    1.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                deviceType:
+                                  default: Disk
+                                  description: deviceType specifies the disk device
+                                    type. The valid values are "Disk" and "CDRom",
+                                    and the default is "Disk".
+                                  enum:
+                                  - Disk
+                                  - CDRom
+                                  type: string
+                              required:
+                              - adapterType
+                              - deviceIndex
+                              - deviceType
+                              type: object
+                            diskSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: diskSize is size (in Quantity format) of
+                                the disk to attach to the VM. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format
+                                for the Quantity format and example documentation.
+                                The minimum diskSize is 1GB.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageConfig:
+                              description: storageConfig are the storage configuration
+                                parameters of the VM disks.
+                              properties:
+                                diskMode:
+                                  allOf:
+                                  - enum:
+                                    - Standard
+                                    - Flash
+                                  - enum:
+                                    - Standard
+                                    - Flash
+                                  default: Standard
+                                  description: diskMode specifies the disk mode. The
+                                    valid values are Standard and Flash, and the default
+                                    is Standard.
+                                  type: string
+                                storageContainer:
+                                  description: storageContainer refers to the storage_container
+                                    used by the VM disk.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the storage
+                                        container resource in the Prism Element.
+                                      type: string
+                                    referenceName:
+                                      description: ReferenceName is the identifier
+                                        of the storage resource configured in the
+                                        FailureDomain.
+                                      type: string
+                                    uuid:
+                                      description: UUID is the UUID of the storage
+                                        container resource in the Prism Element.
+                                      type: string
+                                  required:
+                                  - uuid
+                                  type: object
+                              required:
+                              - diskMode
+                              type: object
+                          required:
+                          - diskSize
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: set
                       failureDomains:
                         description: FailureDomains optionally configures a list of
                           failure domain names that will be applied to the MachinePool
                         items:
                           type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      gpus:
+                        description: GPUs is a list of GPU devices to attach to the
+                          machine's VM.
+                        items:
+                          description: NutanixGPU holds the identity of a Nutanix
+                            GPU resource in the Prism Central
+                          properties:
+                            deviceID:
+                              description: deviceID is the GPU device ID with the
+                                integer value.
+                              format: int32
+                              type: integer
+                            name:
+                              description: name is the GPU device name
+                              type: string
+                            type:
+                              description: type is the identifier type of the GPU
+                                device. Valid values are Name and DeviceID.
+                              enum:
+                              - Name
+                              - DeviceID
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: deviceID configuration is required when type
+                              is DeviceID, and forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''DeviceID'' ?  has(self.deviceID)
+                              : !has(self.deviceID)'
+                          - message: name configuration is required when type is Name,
+                              and forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
+                              : !has(self.name)'
                         type: array
                         x-kubernetes-list-type: set
                       memoryMiB:
@@ -3465,11 +3793,174 @@ spec:
                           cores to assign a vm.
                         format: int64
                         type: integer
+                      dataDisks:
+                        description: DataDisks holds information of the data disks
+                          to attach to the Machine's VM
+                        items:
+                          description: DataDisk defines a data disk for a Machine
+                            VM.
+                          properties:
+                            dataSourceImage:
+                              description: dataSource refers to a data source image
+                                for the VM disk.
+                              properties:
+                                name:
+                                  description: Name is the name of the storage container
+                                    resource in the Prism Element.
+                                  type: string
+                                referenceName:
+                                  description: ReferenceName is the identifier of
+                                    the storage resource configured in the FailureDomain.
+                                  type: string
+                                uuid:
+                                  description: UUID is the UUID of the storage container
+                                    resource in the Prism Element.
+                                  type: string
+                              required:
+                              - uuid
+                              type: object
+                            deviceProperties:
+                              description: deviceProperties are the properties of
+                                the disk device.
+                              properties:
+                                adapterType:
+                                  description: adapterType is the adapter type of
+                                    the disk address. If the deviceType is "Disk",
+                                    the valid adapterType can be "SCSI", "IDE", "PCI",
+                                    "SATA" or "SPAPR". If the deviceType is "CDRom",
+                                    the valid adapterType can be "IDE" or "SATA".
+                                  enum:
+                                  - SCSI
+                                  - IDE
+                                  - PCI
+                                  - SATA
+                                  - SPAPR
+                                  type: string
+                                deviceIndex:
+                                  default: 0
+                                  description: deviceIndex is the index of the disk
+                                    address. The valid values are non-negative integers,
+                                    with the default value 0. For a Machine VM, the
+                                    deviceIndex for the disks with the same deviceType.adapterType
+                                    combination should start from 0 and increase consecutively
+                                    afterwards. Note that for each Machine VM, the
+                                    Disk.SCSI.0 and CDRom.IDE.0 are reserved to be
+                                    used by the VM's system. So for dataDisks of Disk.SCSI
+                                    and CDRom.IDE, the deviceIndex should start from
+                                    1.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                deviceType:
+                                  default: Disk
+                                  description: deviceType specifies the disk device
+                                    type. The valid values are "Disk" and "CDRom",
+                                    and the default is "Disk".
+                                  enum:
+                                  - Disk
+                                  - CDRom
+                                  type: string
+                              required:
+                              - adapterType
+                              - deviceIndex
+                              - deviceType
+                              type: object
+                            diskSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: diskSize is size (in Quantity format) of
+                                the disk to attach to the VM. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format
+                                for the Quantity format and example documentation.
+                                The minimum diskSize is 1GB.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageConfig:
+                              description: storageConfig are the storage configuration
+                                parameters of the VM disks.
+                              properties:
+                                diskMode:
+                                  allOf:
+                                  - enum:
+                                    - Standard
+                                    - Flash
+                                  - enum:
+                                    - Standard
+                                    - Flash
+                                  default: Standard
+                                  description: diskMode specifies the disk mode. The
+                                    valid values are Standard and Flash, and the default
+                                    is Standard.
+                                  type: string
+                                storageContainer:
+                                  description: storageContainer refers to the storage_container
+                                    used by the VM disk.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the storage
+                                        container resource in the Prism Element.
+                                      type: string
+                                    referenceName:
+                                      description: ReferenceName is the identifier
+                                        of the storage resource configured in the
+                                        FailureDomain.
+                                      type: string
+                                    uuid:
+                                      description: UUID is the UUID of the storage
+                                        container resource in the Prism Element.
+                                      type: string
+                                  required:
+                                  - uuid
+                                  type: object
+                              required:
+                              - diskMode
+                              type: object
+                          required:
+                          - diskSize
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: set
                       failureDomains:
                         description: FailureDomains optionally configures a list of
                           failure domain names that will be applied to the MachinePool
                         items:
                           type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      gpus:
+                        description: GPUs is a list of GPU devices to attach to the
+                          machine's VM.
+                        items:
+                          description: NutanixGPU holds the identity of a Nutanix
+                            GPU resource in the Prism Central
+                          properties:
+                            deviceID:
+                              description: deviceID is the GPU device ID with the
+                                integer value.
+                              format: int32
+                              type: integer
+                            name:
+                              description: name is the GPU device name
+                              type: string
+                            type:
+                              description: type is the identifier type of the GPU
+                                device. Valid values are Name and DeviceID.
+                              enum:
+                              - Name
+                              - DeviceID
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: deviceID configuration is required when type
+                              is DeviceID, and forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''DeviceID'' ?  has(self.deviceID)
+                              : !has(self.deviceID)'
+                          - message: name configuration is required when type is Name,
+                              and forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
+                              : !has(self.name)'
                         type: array
                         x-kubernetes-list-type: set
                       memoryMiB:
@@ -3512,6 +4003,30 @@ spec:
                       description: FailureDomain configures failure domain information
                         for the Nutanix platform.
                       properties:
+                        dataSourceImages:
+                          description: DataSourceImages identifies the datasource
+                            images in the Prism Element.
+                          items:
+                            description: StorageResourceReference holds reference
+                              information of a storage resource (storage container,
+                              data source image, etc.)
+                            properties:
+                              name:
+                                description: Name is the name of the storage container
+                                  resource in the Prism Element.
+                                type: string
+                              referenceName:
+                                description: ReferenceName is the identifier of the
+                                  storage resource configured in the FailureDomain.
+                                type: string
+                              uuid:
+                                description: UUID is the UUID of the storage container
+                                  resource in the Prism Element.
+                                type: string
+                            required:
+                            - uuid
+                            type: object
+                          type: array
                         name:
                           description: Name defines the unique name of a failure domain.
                           maxLength: 64
@@ -3554,6 +4069,30 @@ spec:
                           required:
                           - uuid
                           type: object
+                        storageContainers:
+                          description: StorageContainers identifies the storage containers
+                            in the Prism Element.
+                          items:
+                            description: StorageResourceReference holds reference
+                              information of a storage resource (storage container,
+                              data source image, etc.)
+                            properties:
+                              name:
+                                description: Name is the name of the storage container
+                                  resource in the Prism Element.
+                                type: string
+                              referenceName:
+                                description: ReferenceName is the identifier of the
+                                  storage resource configured in the FailureDomain.
+                                type: string
+                              uuid:
+                                description: UUID is the UUID of the storage container
+                                  resource in the Prism Element.
+                                type: string
+                            required:
+                            - uuid
+                            type: object
+                          type: array
                         subnetUUIDs:
                           description: SubnetUUIDs identifies the network subnets
                             of the Prism Element. Currently we only support one subnet
@@ -3562,7 +4101,7 @@ spec:
                             type: string
                           minItems: 1
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       required:
                       - name
                       - prismElement

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -450,7 +450,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		mpool.NumCPUs = 8
 		mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Nutanix)
-		if err = mpool.ValidateConfig(ic.Platform.Nutanix); err != nil {
+		if err = mpool.ValidateConfig(ic.Platform.Nutanix, "master"); err != nil {
 			return fmt.Errorf("failed to generate Cluster API machine manifests for control-plane: %w", err)
 		}
 		pool.Platform.Nutanix = &mpool

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -498,7 +498,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		mpool.NumCPUs = 8
 		mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Nutanix)
-		if err = mpool.ValidateConfig(ic.Platform.Nutanix); err != nil {
+		if err = mpool.ValidateConfig(ic.Platform.Nutanix, "master"); err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
 		pool.Platform.Nutanix = &mpool

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -648,8 +648,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 			mpool := defaultNutanixMachinePoolPlatform()
 			mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Nutanix)
-			if err = mpool.ValidateConfig(ic.Platform.Nutanix); err != nil {
-				return errors.Wrap(err, "failed to create master machine objects")
+			if err = mpool.ValidateConfig(ic.Platform.Nutanix, "worker"); err != nil {
+				return errors.Wrap(err, "failed to create worker machine objects")
 			}
 			pool.Platform.Nutanix = &mpool
 			imageName := nutanixtypes.RHCOSImageName(clusterID.InfraID)

--- a/pkg/types/nutanix/machinepool.go
+++ b/pkg/types/nutanix/machinepool.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	nutanixclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	machinev1 "github.com/openshift/api/machine/v1"
@@ -57,6 +58,16 @@ type MachinePool struct {
 	// +optional
 	Categories []machinev1.NutanixCategory `json:"categories,omitempty"`
 
+	// GPUs is a list of GPU devices to attach to the machine's VM.
+	// +listType=set
+	// +optional
+	GPUs []machinev1.NutanixGPU `json:"gpus"`
+
+	// DataDisks holds information of the data disks to attach to the Machine's VM
+	// +listType=set
+	// +optional
+	DataDisks []DataDisk `json:"dataDisks"`
+
 	// FailureDomains optionally configures a list of failure domain names
 	// that will be applied to the MachinePool
 	// +listType=set
@@ -64,12 +75,61 @@ type MachinePool struct {
 	FailureDomains []string `json:"failureDomains,omitempty"`
 }
 
-// OSDisk defines the disk for a virtual machine.
+// OSDisk defines the system disk for a Machine VM.
 type OSDisk struct {
 	// DiskSizeGiB defines the size of disk in GiB.
 	//
 	// +optional
 	DiskSizeGiB int64 `json:"diskSizeGiB,omitempty"`
+}
+
+// StorageResourceReference holds reference information of a storage resource (storage container, data source image, etc.)
+type StorageResourceReference struct {
+	// ReferenceName is the identifier of the storage resource configured in the FailureDomain.
+	// +optional
+	ReferenceName string `json:"referenceName,omitempty"`
+
+	// UUID is the UUID of the storage container resource in the Prism Element.
+	// +kubebuilder:validation:Required
+	UUID string `json:"uuid"`
+
+	// Name is the name of the storage container resource in the Prism Element.
+	// +optional
+	Name string `json:"name,omitempty"`
+}
+
+// StorageConfig specifies the storage configuration parameters for VM disks.
+type StorageConfig struct {
+	// diskMode specifies the disk mode.
+	// The valid values are Standard and Flash, and the default is Standard.
+	// +kubebuilder:default=Standard
+	// +kubebuilder:validation:Enum=Standard;Flash
+	DiskMode machinev1.NutanixDiskMode `json:"diskMode"`
+
+	// storageContainer refers to the storage_container used by the VM disk.
+	// +optional
+	StorageContainer *StorageResourceReference `json:"storageContainer,omitempty"`
+}
+
+// DataDisk defines a data disk for a Machine VM.
+type DataDisk struct {
+	// diskSize is size (in Quantity format) of the disk to attach to the VM.
+	// See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format for the Quantity format and example documentation.
+	// The minimum diskSize is 1GB.
+	// +kubebuilder:validation:Required
+	DiskSize resource.Quantity `json:"diskSize"`
+
+	// deviceProperties are the properties of the disk device.
+	// +optional
+	DeviceProperties *machinev1.NutanixVMDiskDeviceProperties `json:"deviceProperties,omitempty"`
+
+	// storageConfig are the storage configuration parameters of the VM disks.
+	// +optional
+	StorageConfig *StorageConfig `json:"storageConfig,omitempty"`
+
+	// dataSource refers to a data source image for the VM disk.
+	// +optional
+	DataSourceImage *StorageResourceReference `json:"dataSourceImage,omitempty"`
 }
 
 // Set sets the values from `required` to `p`.
@@ -109,10 +169,18 @@ func (p *MachinePool) Set(required *MachinePool) {
 	if len(required.FailureDomains) > 0 {
 		p.FailureDomains = required.FailureDomains
 	}
+
+	if len(required.GPUs) > 0 {
+		p.GPUs = required.GPUs
+	}
+
+	if len(required.DataDisks) > 0 {
+		p.DataDisks = required.DataDisks
+	}
 }
 
 // ValidateConfig validates the MachinePool configuration.
-func (p *MachinePool) ValidateConfig(platform *Platform) error {
+func (p *MachinePool) ValidateConfig(platform *Platform, role string) error {
 	nc, err := CreateNutanixClientFromPlatform(platform)
 	if err != nil {
 		return fmt.Errorf("fail to create nutanix client. %w", err)
@@ -134,43 +202,9 @@ func (p *MachinePool) ValidateConfig(platform *Platform) error {
 
 	// validate project if configured
 	if p.Project != nil {
-		switch p.Project.Type {
-		case machinev1.NutanixIdentifierName:
-			if p.Project.Name == nil || *p.Project.Name == "" {
-				errList = append(errList, field.Required(fldPath.Child("project", "name"), "missing projct name"))
-			} else {
-				projectName := *p.Project.Name
-				filter := fmt.Sprintf("name==%s", projectName)
-				res, err := nc.V3.ListProject(ctx, &nutanixclientv3.DSMetadata{
-					Filter: &filter,
-				})
-				switch {
-				case err != nil:
-					errMsg = fmt.Sprintf("failed to find project with name %q. error: %v", projectName, err)
-					errList = append(errList, field.Invalid(fldPath.Child("project", "name"), projectName, errMsg))
-				case len(res.Entities) == 0:
-					errMsg = fmt.Sprintf("found no project with name %q.", projectName)
-					errList = append(errList, field.Invalid(fldPath.Child("project", "name"), projectName, errMsg))
-				case len(res.Entities) > 1:
-					errMsg = fmt.Sprintf("found more than one (%v) projects with name %q.", len(res.Entities), projectName)
-					errList = append(errList, field.Invalid(fldPath.Child("project", "name"), projectName, errMsg))
-				default:
-					p.Project.Type = machinev1.NutanixIdentifierUUID
-					p.Project.UUID = res.Entities[0].Metadata.UUID
-				}
-			}
-		case machinev1.NutanixIdentifierUUID:
-			if p.Project.UUID == nil || *p.Project.UUID == "" {
-				errList = append(errList, field.Required(fldPath.Child("project", "uuid"), "missing projct uuid"))
-			} else {
-				if _, err = nc.V3.GetProject(ctx, *p.Project.UUID); err != nil {
-					errMsg = fmt.Sprintf("failed to get the project with uuid %s. error: %v", *p.Project.UUID, err)
-					errList = append(errList, field.Invalid(fldPath.Child("project", "uuid"), *p.Project.UUID, errMsg))
-				}
-			}
-		default:
-			errMsg = fmt.Sprintf("invalid project identifier type, valid types are: %q, %q.", machinev1.NutanixIdentifierName, machinev1.NutanixIdentifierUUID)
-			errList = append(errList, field.Invalid(fldPath.Child("project", "type"), p.Project.Type, errMsg))
+		fldErr := p.validateProjectConfig(ctx, nc, fldPath)
+		if fldErr != nil {
+			errList = append(errList, fldErr)
 		}
 	}
 
@@ -192,8 +226,234 @@ func (p *MachinePool) ValidateConfig(platform *Platform) error {
 		}
 	}
 
+	// validate GPUs if configured, currently only "worker" machines allow GPUs.
+	if len(p.GPUs) > 0 {
+		if role == "master" {
+			errList = append(errList, field.Forbidden(fldPath.Child("gpus"), "'gpus' are not supported for 'master' nodes, you can only configure it for 'worker' nodes."))
+		} else {
+			fldErrs := p.validateGPUsConfig(ctx, nc, platform, fldPath)
+			for _, fldErr := range fldErrs {
+				errList = append(errList, fldErr)
+			}
+		}
+	}
+
+	// validate DataDisks if configured, currently only "worker" machines allow DataDisks.
+	if len(p.DataDisks) > 0 {
+		if role == "master" {
+			errList = append(errList, field.Forbidden(fldPath.Child("gpus"), "'dataDisks' are not supported for 'master' nodes, you can only configure it for 'worker' nodes."))
+		} else {
+			fldErrs := p.validateDataDisksConfig(ctx, nc, platform, fldPath)
+			for _, fldErr := range fldErrs {
+				errList = append(errList, fldErr)
+			}
+		}
+	}
+
 	if len(errList) > 0 {
 		return fmt.Errorf(errList.ToAggregate().Error())
 	}
 	return nil
+}
+
+// validateProjectConfig validates the Project configuration in the machinePool.
+func (p *MachinePool) validateProjectConfig(ctx context.Context, nc *nutanixclientv3.Client, fldPath *field.Path) *field.Error {
+	if p.Project != nil {
+		switch p.Project.Type {
+		case machinev1.NutanixIdentifierName:
+			if p.Project.Name == nil || *p.Project.Name == "" {
+				return field.Required(fldPath.Child("project", "name"), "missing projct name")
+			}
+
+			projectName := *p.Project.Name
+			filter := fmt.Sprintf("name==%s", projectName)
+			res, err := nc.V3.ListProject(ctx, &nutanixclientv3.DSMetadata{
+				Filter: &filter,
+			})
+			switch {
+			case err != nil:
+				return field.Invalid(fldPath.Child("project", "name"), projectName,
+					fmt.Sprintf("failed to find project with name %q. error: %v", projectName, err))
+			case len(res.Entities) == 0:
+				return field.Invalid(fldPath.Child("project", "name"), projectName,
+					fmt.Sprintf("unable to find project with name %q.", projectName))
+			case len(res.Entities) > 1:
+				return field.Invalid(fldPath.Child("project", "name"), projectName,
+					fmt.Sprintf("found more than one (%v) projects with name %q.", len(res.Entities), projectName))
+			default:
+				p.Project.Type = machinev1.NutanixIdentifierUUID
+				p.Project.UUID = res.Entities[0].Metadata.UUID
+			}
+		case machinev1.NutanixIdentifierUUID:
+			if p.Project.UUID == nil || *p.Project.UUID == "" {
+				return field.Required(fldPath.Child("project", "uuid"), "missing projct uuid")
+			} else {
+				if _, err := nc.V3.GetProject(ctx, *p.Project.UUID); err != nil {
+					return field.Invalid(fldPath.Child("project", "uuid"), *p.Project.UUID,
+						fmt.Sprintf("failed to get the project with uuid %s. error: %v", *p.Project.UUID, err))
+				}
+			}
+		default:
+			return field.Invalid(fldPath.Child("project", "type"), p.Project.Type,
+				fmt.Sprintf("invalid project identifier type, valid types are: %q, %q.", machinev1.NutanixIdentifierName, machinev1.NutanixIdentifierUUID))
+		}
+	}
+
+	return nil
+}
+
+// validateGPUsConfig validates the GPUs configuration in the machinePool.
+func (p *MachinePool) validateGPUsConfig(ctx context.Context, nc *nutanixclientv3.Client, platform *Platform, fldPath *field.Path) (fldErrs []*field.Error) {
+	if len(p.GPUs) == 0 {
+		return fldErrs
+	}
+
+	peUUIDs := []string{}
+	for _, fdName := range p.FailureDomains {
+		if fd, err := platform.GetFailureDomainByName(fdName); err == nil {
+			peUUIDs = append(peUUIDs, fd.PrismElement.UUID)
+		}
+	}
+	if len(peUUIDs) == 0 {
+		peUUIDs = append(peUUIDs, platform.PrismElements[0].UUID)
+	}
+
+	for _, peUUID := range peUUIDs {
+		peGPUs, err := GetGPUsForPE(ctx, nc, peUUID)
+		if err != nil || len(peGPUs) == 0 {
+			err = fmt.Errorf("no available GPUs found in Prism Element cluster (uuid: %s): %w", peUUID, err)
+			fldErrs = append(fldErrs, field.InternalError(fldPath.Child("gpus"), err))
+			return fldErrs
+		}
+
+		for _, gpu := range p.GPUs {
+			switch gpu.Type {
+			case machinev1.NutanixGPUIdentifierDeviceID:
+				if gpu.DeviceID == nil {
+					fldErrs = append(fldErrs, field.Required(fldPath.Child("gpus", "deviceID"), "missing gpu deviceID"))
+				} else {
+					_, err := GetGPUFromList(ctx, nc, gpu, peGPUs)
+					if err != nil {
+						fldErrs = append(fldErrs, field.Invalid(fldPath.Child("gpus", "deviceID"), *gpu.DeviceID, err.Error()))
+					}
+				}
+			case machinev1.NutanixGPUIdentifierName:
+				if gpu.Name == nil || *gpu.Name == "" {
+					fldErrs = append(fldErrs, field.Required(fldPath.Child("gpus", "name"), "missing gpu name"))
+				} else {
+					_, err := GetGPUFromList(ctx, nc, gpu, peGPUs)
+					if err != nil {
+						fldErrs = append(fldErrs, field.Invalid(fldPath.Child("gpus", "name"), gpu.Name, err.Error()))
+					}
+				}
+			default:
+				errMsg := fmt.Sprintf("invalid gpu identifier type, the valid values: %q, %q.", machinev1.NutanixGPUIdentifierDeviceID, machinev1.NutanixGPUIdentifierName)
+				fldErrs = append(fldErrs, field.Invalid(fldPath.Child("gpus", "type"), gpu.Type, errMsg))
+			}
+		}
+	}
+
+	return fldErrs
+}
+
+// validateDataDisksConfig validates the DataDisks configuration in the machinePool.
+func (p *MachinePool) validateDataDisksConfig(ctx context.Context, nc *nutanixclientv3.Client, platform *Platform, fldPath *field.Path) (fldErrs []*field.Error) {
+	var err error
+	var errMsg string
+
+	for _, disk := range p.DataDisks {
+		// the minimum diskSize is 1Gi bytes
+		diskSizeBytes := disk.DiskSize.Value()
+		if diskSizeBytes < 1024*1024*1024 {
+			fldErrs = append(fldErrs, field.Invalid(fldPath.Child("dataDisks", "diskSize"), fmt.Sprintf("%v bytes", diskSizeBytes), "The minimum diskSize is 1Gi bytes."))
+		}
+
+		if disk.DeviceProperties != nil {
+			switch disk.DeviceProperties.DeviceType {
+			case machinev1.NutanixDiskDeviceTypeDisk:
+				switch disk.DeviceProperties.AdapterType {
+				case machinev1.NutanixDiskAdapterTypeSCSI, machinev1.NutanixDiskAdapterTypeIDE, machinev1.NutanixDiskAdapterTypePCI, machinev1.NutanixDiskAdapterTypeSATA, machinev1.NutanixDiskAdapterTypeSPAPR:
+					// valid configuration
+				default:
+					// invalid configuration
+					fldErrs = append(fldErrs, field.Invalid(fldPath.Child("deviceProperties", "adapterType"), disk.DeviceProperties.AdapterType,
+						fmt.Sprintf("invalid adapter type for the %q device type, the valid values: %q, %q, %q, %q, %q.",
+							machinev1.NutanixDiskDeviceTypeDisk, machinev1.NutanixDiskAdapterTypeSCSI, machinev1.NutanixDiskAdapterTypeIDE,
+							machinev1.NutanixDiskAdapterTypePCI, machinev1.NutanixDiskAdapterTypeSATA, machinev1.NutanixDiskAdapterTypeSPAPR)))
+				}
+			case machinev1.NutanixDiskDeviceTypeCDROM:
+				switch disk.DeviceProperties.AdapterType {
+				case machinev1.NutanixDiskAdapterTypeIDE, machinev1.NutanixDiskAdapterTypeSATA:
+					// valid configuration
+				default:
+					// invalid configuration
+					fldErrs = append(fldErrs, field.Invalid(fldPath.Child("deviceProperties", "adapterType"), disk.DeviceProperties.AdapterType,
+						fmt.Sprintf("invalid adapter type for the %q device type, the valid values: %q, %q.",
+							machinev1.NutanixDiskDeviceTypeCDROM, machinev1.NutanixDiskAdapterTypeIDE, machinev1.NutanixDiskAdapterTypeSATA)))
+				}
+			default:
+				fldErrs = append(fldErrs, field.Invalid(fldPath.Child("deviceProperties", "deviceType"), disk.DeviceProperties.DeviceType,
+					fmt.Sprintf("invalid device type, the valid types are: %q, %q.", machinev1.NutanixDiskDeviceTypeDisk, machinev1.NutanixDiskDeviceTypeCDROM)))
+			}
+
+			if disk.DeviceProperties.DeviceIndex < 0 {
+				fldErrs = append(fldErrs, field.Invalid(fldPath.Child("deviceProperties", "deviceIndex"),
+					disk.DeviceProperties.DeviceIndex, "invalid device index, the valid values are non-negative integers."))
+			}
+		}
+
+		if disk.StorageConfig != nil {
+			if disk.StorageConfig.DiskMode != machinev1.NutanixDiskModeStandard && disk.StorageConfig.DiskMode != machinev1.NutanixDiskModeFlash {
+				fldErrs = append(fldErrs, field.Invalid(fldPath.Child("storageConfig", "diskMode"), disk.StorageConfig.DiskMode,
+					fmt.Sprintf("invalid disk mode, the valid values: %q, %q.", machinev1.NutanixDiskModeStandard, machinev1.NutanixDiskModeFlash)))
+			}
+
+			storageContainerRef := disk.StorageConfig.StorageContainer
+			if storageContainerRef != nil {
+				if storageContainerRef.ReferenceName != "" {
+					for _, fdName := range p.FailureDomains {
+						_, err := platform.GetStorageContainerFromFailureDomain(fdName, storageContainerRef.ReferenceName)
+						if err != nil {
+							fldErrs = append(fldErrs, field.Invalid(fldPath.Child("storageConfig", "storageContainer", "referenceName"), storageContainerRef.ReferenceName,
+								fmt.Sprintf("not found storageContainer with the referenceName in the failureDomain %q configuration.", fdName)))
+						}
+					}
+				} else if storageContainerRef.UUID == "" {
+					fldErrs = append(fldErrs, field.Required(fldPath.Child("storageConfig", "storageContainer", "uuid"), "missing storageContainer uuid"))
+				}
+			}
+		}
+
+		if disk.DataSourceImage != nil {
+			dsImgRef := disk.DataSourceImage
+			if dsImgRef.ReferenceName != "" {
+				for _, fdName := range p.FailureDomains {
+					_, err = platform.GetDataSourceImageFromFailureDomain(fdName, disk.DataSourceImage.ReferenceName)
+					if err != nil {
+						fldErrs = append(fldErrs, field.Invalid(fldPath.Child("storageConfig", "dataSourceImage", "referenceName"), disk.DataSourceImage.ReferenceName,
+							fmt.Sprintf("not found datasource image with the referenceName in the failureDomain %q configuration.", fdName)))
+					}
+				}
+			} else {
+				switch {
+				case dsImgRef.UUID != "":
+					if _, err = nc.V3.GetImage(ctx, dsImgRef.UUID); err != nil {
+						errMsg = fmt.Sprintf("failed to find the dataSource image with uuid %s: %v", dsImgRef.UUID, err)
+						fldErrs = append(fldErrs, field.Invalid(fldPath.Child("dataDisks", "dataSourceImage", "uuid"), dsImgRef.UUID, errMsg))
+					}
+				case dsImgRef.Name != "":
+					if dsImgUUID, err := FindImageUUIDByName(ctx, nc, dsImgRef.Name); err != nil {
+						errMsg = fmt.Sprintf("failed to find the dataSource image with name %q: %v", dsImgRef.UUID, err)
+						fldErrs = append(fldErrs, field.Invalid(fldPath.Child("dataDisks", "dataSourceImage", "name"), dsImgRef.Name, errMsg))
+					} else {
+						dsImgRef.UUID = *dsImgUUID
+					}
+				default:
+					fldErrs = append(fldErrs, field.Required(fldPath.Child("dataDisks", "dataSourceImage"), "both the dataSourceImage's uuid and name are empty, you need to configure one."))
+				}
+			}
+		}
+	}
+
+	return fldErrs
 }

--- a/pkg/types/nutanix/platform.go
+++ b/pkg/types/nutanix/platform.go
@@ -134,8 +134,16 @@ type FailureDomain struct {
 	// Currently we only support one subnet for a failure domain.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
-	// +listType=atomic
+	// +listType=set
 	SubnetUUIDs []string `json:"subnetUUIDs"`
+
+	// StorageContainers identifies the storage containers in the Prism Element.
+	// +optional
+	StorageContainers []StorageResourceReference `json:"storageContainers,omitempty"`
+
+	// DataSourceImages identifies the datasource images in the Prism Element.
+	// +optional
+	DataSourceImages []StorageResourceReference `json:"dataSourceImages,omitempty"`
 }
 
 // GetFailureDomainByName returns the NutanixFailureDomain pointer with the input name.
@@ -148,4 +156,36 @@ func (p Platform) GetFailureDomainByName(fdName string) (*FailureDomain, error) 
 	}
 
 	return nil, fmt.Errorf("not found the defined failure domain with name %q", fdName)
+}
+
+// GetStorageContainerFromFailureDomain returns the storage container configuration with the provided reference and failuer domain names.
+// Returns nil and error if not found.
+func (p Platform) GetStorageContainerFromFailureDomain(fdName, storageContainerRefName string) (*StorageResourceReference, error) {
+	for _, fd := range p.FailureDomains {
+		if fd.Name == fdName {
+			for _, sc := range fd.StorageContainers {
+				if sc.ReferenceName == storageContainerRefName {
+					return &sc, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("not found the storage container with reference name %q in failureDomain %q", storageContainerRefName, fdName)
+}
+
+// GetDataSourceImageFromFailureDomain returns the datasource image configuration with the provided reference and failuer domain names.
+// Returns nil and error if not found.
+func (p Platform) GetDataSourceImageFromFailureDomain(fdName, dataSourceRefName string) (*StorageResourceReference, error) {
+	for _, fd := range p.FailureDomains {
+		if fd.Name == fdName {
+			for _, dsi := range fd.DataSourceImages {
+				if dsi.ReferenceName == dataSourceRefName {
+					return &dsi, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("not found the datasource image with reference name %q in failureDomain %q", dataSourceRefName, fdName)
 }

--- a/pkg/types/nutanix/validation/machinepool.go
+++ b/pkg/types/nutanix/validation/machinepool.go
@@ -1,13 +1,15 @@
 package validation
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/nutanix"
 )
 
 // ValidateMachinePool checks that the specified machine pool is valid.
-func ValidateMachinePool(p *nutanix.MachinePool, fldPath *field.Path) field.ErrorList {
+func ValidateMachinePool(p *nutanix.MachinePool, fldPath *field.Path, role string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if p.DiskSizeGiB < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGiB"), p.DiskSizeGiB, "storage disk size must be positive"))
@@ -24,5 +26,24 @@ func ValidateMachinePool(p *nutanix.MachinePool, fldPath *field.Path) field.Erro
 	if p.NumCoresPerSocket >= 0 && p.NumCPUs >= 0 && p.NumCoresPerSocket > p.NumCPUs {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("coresPerSocket"), p.NumCoresPerSocket, "cores per socket must be less than number of CPUs"))
 	}
+
+	ntxPlatform := &nutanix.Platform{
+		PrismCentral: nutanix.PrismCentral{
+			Endpoint: nutanix.PrismEndpoint{Address: "test-pc", Port: 8080},
+			Username: "test-username-pc",
+			Password: "test-password-pc",
+		},
+		PrismElements: []nutanix.PrismElement{{
+			UUID:     "test-pe-uuid",
+			Endpoint: nutanix.PrismEndpoint{Address: "test-pe", Port: 8081},
+		}},
+		SubnetUUIDs: []string{"b06179c8-dea3-4f8e-818a-b2e88fbc2201"},
+	}
+
+	err := p.ValidateConfig(ntxPlatform, role)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, "", fmt.Sprintf("invalid configuration: %v", err)))
+	}
+
 	return allErrs
 }

--- a/pkg/types/nutanix/validation/machinepool_test.go
+++ b/pkg/types/nutanix/validation/machinepool_test.go
@@ -3,15 +3,20 @@ package validation
 import (
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
+	machinev1 "github.com/openshift/api/machine/v1"
 	"github.com/openshift/installer/pkg/types/nutanix"
 )
 
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
 		name           string
+		role           string
 		pool           *nutanix.MachinePool
 		expectedErrMsg string
 	}{
@@ -26,41 +31,84 @@ func TestValidateMachinePool(t *testing.T) {
 					DiskSizeGiB: -1,
 				},
 			},
-			expectedErrMsg: `^test-path\.diskSizeGiB: Invalid value: -1: storage disk size must be positive$`,
+			expectedErrMsg: `test-path.diskSizeGiB: Invalid value: -1: storage disk size must be positive`,
 		}, {
 			name: "negative CPUs",
 			pool: &nutanix.MachinePool{
 				NumCPUs: -1,
 			},
-			expectedErrMsg: `^test-path\.cpus: Invalid value: -1: number of CPUs must be positive$`,
+			expectedErrMsg: `test-path.cpus: Invalid value: -1: number of CPUs must be positive`,
 		}, {
 			name: "negative cores",
 			pool: &nutanix.MachinePool{
 				NumCoresPerSocket: -1,
 			},
-			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: -1: cores per socket must be positive$`,
+			expectedErrMsg: `test-path.coresPerSocket: Invalid value: -1: cores per socket must be positive`,
 		}, {
 			name: "negative memory",
 			pool: &nutanix.MachinePool{
 				MemoryMiB: -1,
 			},
-			expectedErrMsg: `^test-path\.memoryMiB: Invalid value: -1: memory size must be positive$`,
+			expectedErrMsg: `test-path.memoryMiB: Invalid value: -1: memory size must be positive`,
 		}, {
 			name: "less CPUs than cores per socket",
 			pool: &nutanix.MachinePool{
 				NumCPUs:           1,
 				NumCoresPerSocket: 8,
 			},
-			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs$`,
+			expectedErrMsg: `test-path.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs`,
+		}, {
+			name: "gpus not supported for master nodes",
+			role: "master",
+			pool: &nutanix.MachinePool{
+				GPUs: []machinev1.NutanixGPU{
+					{Type: machinev1.NutanixGPUIdentifierName, Name: ptr.To("gpu-1")},
+				},
+			},
+			expectedErrMsg: `'gpus' are not supported for 'master' nodes`,
+		}, {
+			name: "dataDisks not supported for master nodes",
+			role: "master",
+			pool: &nutanix.MachinePool{
+				DataDisks: []nutanix.DataDisk{{
+					DiskSize: resource.MustParse("1Gi"),
+				}},
+			},
+			expectedErrMsg: `'dataDisks' are not supported for 'master' nodes`,
+		}, {
+			name: "dataDisk size less than 1GB",
+			role: "worker",
+			pool: &nutanix.MachinePool{
+				DataDisks: []nutanix.DataDisk{{
+					DiskSize: resource.MustParse("0.5Gi"),
+				}},
+			},
+			expectedErrMsg: `The minimum diskSize is 1Gi bytes.`,
+		}, {
+			name: "negative dataDisk deviceIndex",
+			role: "worker",
+			pool: &nutanix.MachinePool{
+				DataDisks: []nutanix.DataDisk{{
+					DiskSize: resource.MustParse("1Gi"),
+					DeviceProperties: &machinev1.NutanixVMDiskDeviceProperties{
+						DeviceType:  machinev1.NutanixDiskDeviceTypeDisk,
+						AdapterType: machinev1.NutanixDiskAdapterTypeSCSI,
+						DeviceIndex: int32(-1),
+					},
+				}},
+			},
+			expectedErrMsg: `invalid device index, the valid values are non-negative integers.`,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateMachinePool(tc.pool, field.NewPath("test-path")).ToAggregate()
+			gs := gomega.NewWithT(t)
+
+			err := ValidateMachinePool(tc.pool, field.NewPath("test-path"), tc.role).ToAggregate()
 			if tc.expectedErrMsg == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Regexp(t, tc.expectedErrMsg, err)
+				gs.Expect(err.Error()).To(gomega.ContainSubstring(tc.expectedErrMsg))
 			}
 		})
 	}

--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -98,6 +98,26 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 				if len(fd.SubnetUUIDs) != 1 || p.SubnetUUIDs[0] == "" {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "subnetUUIDs"), "", "must specify one failure domain subnet uuid"))
 				}
+
+				for _, sc := range fd.StorageContainers {
+					if sc.ReferenceName == "" {
+						allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "storageContainers", "referenceName"), fmt.Sprintf("failureDomain %q: missing storageContainer referenceName", fd.Name)))
+					}
+
+					if sc.UUID == "" {
+						allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "storageContainers", "uuid"), fmt.Sprintf("failureDomain %q: missing storageContainer uuid", fd.Name)))
+					}
+				}
+
+				for _, dsImg := range fd.DataSourceImages {
+					if dsImg.ReferenceName == "" {
+						allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "dataSourceImages", "referenceName"), fmt.Sprintf("failureDomain %q: missing dataSourceImage referenceName", fd.Name)))
+					}
+
+					if dsImg.UUID == "" && dsImg.Name == "" {
+						allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "dataSourceImages"), fmt.Sprintf("failureDomain %q: both the dataSourceImage's uuid and name are empty, you need to configure one.", fd.Name)))
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Add suport for the feature stories:
[OCPSTRAT-1314](https://issues.redhat.com//browse/OCPSTRAT-1314): Allow creating Nutanix worker VMs with GPUs
[OCPSTRAT-1394](https://issues.redhat.com//browse/OCPSTRAT-1394): Allow creating Nutanix VMs with multiple disks

The api changes are in https://github.com/openshift/api/pull/1935

I did the manual testing and passed.
