### PR TITLE
CFE-920: Update GCP userLabels and userTags configs description

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3514,9 +3514,8 @@ spec:
                     description: userLabels has additional keys and values that the
                       installer will add as labels to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
-                      these labels. This is a TechPreview feature and requires setting
-                      CustomNoUpgrade featureSet with GCPLabelsTags featureGate enabled
-                      or TechPreviewNoUpgrade featureSet to configure labels.
+                      these labels. GCPLabelsTags featureGate is defined for managing
+                      this feature and is enabled by default.
                     items:
                       description: UserLabel is a label to apply to GCP resources
                         created for the cluster.
@@ -3553,10 +3552,8 @@ spec:
                       installer will add as tags to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
                       these tags. Tag key and tag value should be the shortnames of
-                      the tag key and tag value resource. This is a TechPreview feature
-                      and requires setting CustomNoUpgrade featureSet with GCPLabelsTags
-                      featureGate enabled or TechPreviewNoUpgrade featureSet to configure
-                      tags.
+                      the tag key and tag value resource. GCPLabelsTags featureGate
+                      is defined for managing this feature and is enabled by default.
                     items:
                       description: UserTag is a tag to apply to GCP resources created
                         for the cluster.

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.3-0.20240416171357-98239ba02cb2
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.33.1
-	github.com/openshift/api v0.0.0-20240808203820-e69593239e49
+	github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e
 	github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift/api v0.0.0-20240808203820-e69593239e49 h1:sw+VD/623xdBnqm1r5DUfch1R7lm7uE5wiYkJt6ioRI=
-github.com/openshift/api v0.0.0-20240808203820-e69593239e49/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
+github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e h1:gEw+Gxu4r3g9WAYOIclpQDXP2UM7xl4xGPjoHDnBriA=
+github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6 h1:U6ve+dnHlHhAELoxX+rdFOHVhoaYl0l9qtxwYtsO6C0=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8 h1:+fZLKbycDo4JeLwPGVSAgf2XPaJGLM341l9ZfrrlxG0=

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -52,17 +52,15 @@ type Platform struct {
 
 	// userLabels has additional keys and values that the installer will add as
 	// labels to all resources that it creates on GCP. Resources created by the
-	// cluster itself may not include these labels. This is a TechPreview feature
-	// and requires setting CustomNoUpgrade featureSet with GCPLabelsTags featureGate
-	// enabled or TechPreviewNoUpgrade featureSet to configure labels.
+	// cluster itself may not include these labels. GCPLabelsTags featureGate is
+	// defined for managing this feature and is enabled by default.
 	UserLabels []UserLabel `json:"userLabels,omitempty"`
 
 	// userTags has additional keys and values that the installer will add as
 	// tags to all resources that it creates on GCP. Resources created by the
 	// cluster itself may not include these tags. Tag key and tag value should
-	// be the shortnames of the tag key and tag value resource. This is a TechPreview
-	// feature and requires setting CustomNoUpgrade featureSet with GCPLabelsTags
-	// featureGate enabled or TechPreviewNoUpgrade featureSet to configure tags.
+	// be the shortnames of the tag key and tag value resource. GCPLabelsTags featureGate
+	// is defined for managing this feature and is enabled by default.
 	UserTags []UserTag `json:"userTags,omitempty"`
 
 	// UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -18,19 +18,21 @@ func TestFeatureGates(t *testing.T) {
 		expected      string
 	}{
 		{
-			name: "GCP UserTags is allowed with Feature Gates enabled",
+			name: "GCP UserTags is allowed with default enabled Feature Gates",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.FeatureSet = v1.TechPreviewNoUpgrade
+				c.FeatureSet = v1.Default
 				c.GCP = validGCPPlatform()
 				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
 				return c
 			}(),
 		},
 		{
-			name: "GCP UserTags is not allowed without Feature Gates",
+			name: "GCP UserTags is not allowed when GCPLabelsTags Feature Gate is disabled",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = v1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPLabelsTags=false"}
 				c.GCP = validGCPPlatform()
 				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
 				return c
@@ -38,14 +40,26 @@ func TestFeatureGates(t *testing.T) {
 			expected: `^platform.gcp.userTags: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
-			name: "GCP UserLabels is allowed with Feature Gates enabled",
+			name: "GCP UserLabels is allowed with default enabled Feature Gates",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.FeatureSet = v1.TechPreviewNoUpgrade
+				c.FeatureSet = v1.Default
 				c.GCP = validGCPPlatform()
 				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
 				return c
 			}(),
+		},
+		{
+			name: "GCP UserLabels is not allowed when GCPLabelsTags Feature Gate is disabled",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.FeatureSet = v1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPLabelsTags=false"}
+				c.GCP = validGCPPlatform()
+				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
+				return c
+			}(),
+			expected: `^platform.gcp.userLabels: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
 			name: "GCP UserProvisionedDNS is not allowed without Feature Gates",
@@ -56,16 +70,6 @@ func TestFeatureGates(t *testing.T) {
 				return c
 			}(),
 			expected: `^platform.gcp.userProvisionedDNS: Forbidden: this field is protected by the GCPClusterHostedDNS feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
-		{
-			name: "GCP UserLabels is not allowed without Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.GCP = validGCPPlatform()
-				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
-				return c
-			}(),
-			expected: `^platform.gcp.userLabels: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
 			name: "vSphere hosts is allowed with Feature Gates enabled",

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -179,7 +179,7 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("bhb").
 					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateAlibabaPlatform = newFeatureGate("AlibabaPlatform").

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1036,7 +1036,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runtime-spec v1.2.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/openshift/api v0.0.0-20240808203820-e69593239e49
+# github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e
 ## explicit; go 1.22.0
 github.com/openshift/api/annotations
 github.com/openshift/api/config/v1


### PR DESCRIPTION
Updated GCP userLabels and userTags configs description to indicate feature is enabled by default but still can be managed through `GCPLabelsTags` feature gate.