### PR TITLE
OCPBUGS-37588: PowerVS: Add support for persistent Transit Gateways

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4819,6 +4819,10 @@ spec:
                       is completed.  Leave unset to allow the installer to create
                       a service instance during cluster creation.
                     type: string
+                  tgName:
+                    description: TGName is the name of a pre-created TransitGateway
+                      inside IBM Cloud.
+                    type: string
                   userID:
                     description: UserID is the login for the user's IBM Cloud account.
                     type: string

--- a/pkg/asset/cluster/powervs/powervs.go
+++ b/pkg/asset/cluster/powervs/powervs.go
@@ -24,5 +24,6 @@ func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) *powervs.Me
 		Zone:                 config.Platform.PowerVS.Zone,
 		ServiceInstanceGUID:  config.Platform.PowerVS.ServiceInstanceGUID,
 		ServiceEndpoints:     config.Platform.PowerVS.ServiceEndpoints,
+		TransitGatewayName:   config.Platform.PowerVS.TGName,
 	}
 }

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -166,6 +166,11 @@ func (a *PlatformProvisionCheck) Generate(ctx context.Context, dependencies asse
 		if err != nil {
 			return err
 		}
+
+		err = powervsconfig.ValidateTransitGateway(client, ic.Config)
+		if err != nil {
+			return err
+		}
 	case external.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -54,6 +54,7 @@ type API interface {
 	GetVPCSubnets(ctx context.Context, vpcID string) ([]vpcv1.Subnet, error)
 
 	// TG
+	TransitGatewayID(ctx context.Context, name string) (string, error)
 	GetTGConnectionVPC(ctx context.Context, gatewayID string, vpcSubnetID string) (string, error)
 	GetAttachedTransitGateway(ctx context.Context, svcInsID string) (string, error)
 
@@ -1092,6 +1093,27 @@ func (c *Client) GetDatacenterCapabilities(ctx context.Context, region string) (
 		return nil, fmt.Errorf("failed to get datacenter capabilities: %w", err)
 	}
 	return getOk.Payload.Capabilities, nil
+}
+
+// TransitGatewayID checks to see if the name is an existing transit gateway name.
+func (c *Client) TransitGatewayID(ctx context.Context, name string) (string, error) {
+	var (
+		gateways []transitgatewayapisv1.TransitGateway
+		gateway  transitgatewayapisv1.TransitGateway
+		err      error
+	)
+
+	gateways, err = c.getTransitGateways(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, gateway = range gateways {
+		if *gateway.Name == name {
+			return *gateway.ID, nil
+		}
+	}
+
+	return "", nil
 }
 
 // GetAttachedTransitGateway finds an existing Transit Gateway attached to the provided PowerVS cloud instance.

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -452,3 +452,18 @@ func (mr *MockAPIMockRecorder) SetVPCServiceURLForRegion(ctx, region interface{}
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVPCServiceURLForRegion", reflect.TypeOf((*MockAPI)(nil).SetVPCServiceURLForRegion), ctx, region)
 }
+
+// TransitGatewayID mocks base method.
+func (m *MockAPI) TransitGatewayID(ctx context.Context, name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransitGatewayID", ctx, name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransitGatewayID indicates an expected call of TransitGatewayID.
+func (mr *MockAPIMockRecorder) TransitGatewayID(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitGatewayID", reflect.TypeOf((*MockAPI)(nil).TransitGatewayID), ctx, name)
+}

--- a/pkg/asset/installconfig/powervs/validation.go
+++ b/pkg/asset/installconfig/powervs/validation.go
@@ -307,3 +307,26 @@ func ValidateServiceInstance(client API, ic *types.InstallConfig) error {
 
 	return nil
 }
+
+// ValidateTransitGateway validates the optional transit gateway name in our install config.
+func ValidateTransitGateway(client API, ic *types.InstallConfig) error {
+	var (
+		id  string
+		err error
+	)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	defer cancel()
+
+	if len(ic.PowerVS.TGName) > 0 {
+		id, err = client.TransitGatewayID(ctx, ic.PowerVS.TGName)
+		if err != nil {
+			return err
+		}
+		if id == "" {
+			return errors.New("platform:powervs:tgName has an invalid name")
+		}
+	}
+
+	return nil
+}

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -86,7 +86,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		}
 	}
 
-	transitGatewayName = fmt.Sprintf("%s-tg", clusterID.InfraID)
+	transitGatewayName = installConfig.Config.Platform.PowerVS.TGName
+	if transitGatewayName == "" {
+		transitGatewayName = fmt.Sprintf("%s-tg", clusterID.InfraID)
+	}
 
 	cosName = fmt.Sprintf("%s-cos", clusterID.InfraID)
 

--- a/pkg/destroy/powervs/cloud-instance.go
+++ b/pkg/destroy/powervs/cloud-instance.go
@@ -20,7 +20,7 @@ const (
 func (o *ClusterUninstaller) listCloudInstances() (cloudResources, error) {
 	o.Logger.Debugf("Listing virtual Cloud service instances")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	options := o.vpcSvc.NewListInstancesOptions()
@@ -68,7 +68,7 @@ func (o *ClusterUninstaller) destroyCloudInstance(item cloudResource) error {
 		response              *core.DetailedResponse
 	)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	getInstanceOptions = o.vpcSvc.NewGetInstanceOptions(item.id)
@@ -109,13 +109,13 @@ func (o *ClusterUninstaller) destroyCloudInstances() error {
 	}
 
 	items := o.insertPendingItems(cloudInstanceTypeName, firstPassList.list())
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyCloudInstances: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/cloud-sshkey.go
+++ b/pkg/destroy/powervs/cloud-sshkey.go
@@ -33,13 +33,13 @@ func (o *ClusterUninstaller) listCloudSSHKeys() (cloudResources, error) {
 		sshKey           vpcv1.Key
 	)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listCloudSSHKeys: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -139,13 +139,13 @@ func (o *ClusterUninstaller) deleteCloudSSHKey(item cloudResource) error {
 		err              error
 	)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteCloudSSHKey: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -185,14 +185,14 @@ func (o *ClusterUninstaller) destroyCloudSSHKeys() error {
 
 	items := o.insertPendingItems(cloudSSHKeyTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyCloudSSHKeys: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/cloud-subnet.go
+++ b/pkg/destroy/powervs/cloud-subnet.go
@@ -19,13 +19,13 @@ const cloudSubnetTypeName = "cloudSubnet"
 func (o *ClusterUninstaller) listCloudSubnets() (cloudResources, error) {
 	o.Logger.Debugf("Listing virtual Cloud Subnets")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listCloudSubnets: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -67,13 +67,13 @@ func (o *ClusterUninstaller) deleteCloudSubnet(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteCloudSubnet: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -117,14 +117,14 @@ func (o *ClusterUninstaller) destroyCloudSubnets() error {
 
 	items := o.insertPendingItems(cloudSubnetTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyCloudSubnets: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/cloud-transit-gateways.go
+++ b/pkg/destroy/powervs/cloud-transit-gateways.go
@@ -10,6 +10,8 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/networking-go-sdk/transitgatewayapisv1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 )
 
 const (
@@ -132,6 +134,39 @@ func (o *ClusterUninstaller) listTransitGateways() (cloudResources, error) {
 // Destroy a specified transit gateway.
 func (o *ClusterUninstaller) destroyTransitGateway(item cloudResource) error {
 	var (
+		deleteTransitGatewayOptions *transitgatewayapisv1.DeleteTransitGatewayOptions
+		response                    *core.DetailedResponse
+		err                         error
+
+		ctx    context.Context
+		cancel func()
+	)
+
+	ctx, cancel = contextWithTimeout()
+	defer cancel()
+
+	err = o.destroyTransitGatewayConnections(item)
+	if err != nil {
+		return err
+	}
+
+	// We can delete the transit gateway now!
+	deleteTransitGatewayOptions = o.tgClient.NewDeleteTransitGatewayOptions(item.id)
+
+	response, err = o.tgClient.DeleteTransitGatewayWithContext(ctx, deleteTransitGatewayOptions)
+	if err != nil {
+		o.Logger.Fatalf("destroyTransitGateway: DeleteTransitGatewayWithContext returns %v with response %v", err, response)
+	}
+
+	o.deletePendingItems(item.typeName, []cloudResource{item})
+	o.Logger.Infof("Deleted Transit Gateway %q", item.name)
+
+	return nil
+}
+
+// Destroy the connections for a specified transit gateway.
+func (o *ClusterUninstaller) destroyTransitGatewayConnections(item cloudResource) error {
+	var (
 		firstPassList cloudResources
 
 		err error
@@ -145,9 +180,6 @@ func (o *ClusterUninstaller) destroyTransitGateway(item cloudResource) error {
 			Factor: 1.5,
 			Cap:    10 * time.Minute,
 			Steps:  math.MaxInt32}
-
-		deleteTransitGatewayOptions *transitgatewayapisv1.DeleteTransitGatewayOptions
-		response                    *core.DetailedResponse
 	)
 
 	firstPassList, err = o.listTransitConnections(item)
@@ -213,18 +245,7 @@ func (o *ClusterUninstaller) destroyTransitGateway(item cloudResource) error {
 		o.Logger.Fatalf("destroyTransitGateway: ExponentialBackoffWithContext (list) returns %v", err)
 	}
 
-	// We can delete the transit gateway now!
-	deleteTransitGatewayOptions = o.tgClient.NewDeleteTransitGatewayOptions(item.id)
-
-	response, err = o.tgClient.DeleteTransitGatewayWithContext(ctx, deleteTransitGatewayOptions)
-	if err != nil {
-		o.Logger.Fatalf("destroyTransitGateway: DeleteTransitGatewayWithContext returns %v with response %v", err, response)
-	}
-
-	o.deletePendingItems(item.typeName, []cloudResource{item})
-	o.Logger.Infof("Deleted Transit Gateway %q", item.name)
-
-	return nil
+	return err
 }
 
 // Destroy a specified transit gateway connection.
@@ -256,7 +277,7 @@ func (o *ClusterUninstaller) destroyTransitConnection(item cloudResource) error 
 	return nil
 }
 
-// listTransitGateways lists Transit Connections for a Transit Gateway in the IBM Cloud.
+// listTransitConnections lists Transit Connections for a Transit Gateway in the IBM Cloud.
 func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudResources, error) {
 	o.Logger.Debugf("Listing Transit Gateways Connections (%s)", item.name)
 
@@ -276,6 +297,8 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 	ctx, cancel = contextWithTimeout()
 	defer cancel()
 
+	o.Logger.Debugf("listTransitConnections: searching for ID %s", item.id)
+
 	listConnectionsOptions = o.tgClient.NewListConnectionsOptions()
 	listConnectionsOptions.SetLimit(perPage)
 	listConnectionsOptions.SetNetworkID("")
@@ -289,7 +312,8 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 			return nil, err
 		}
 		for _, transitConnection = range transitConnectionCollections.Connections {
-			if !strings.Contains(*transitConnection.TransitGateway.Name, o.InfraID) {
+			if *transitConnection.TransitGateway.ID != item.id {
+				o.Logger.Debugf("listTransitConnections: SKIP: %s, %s, %s", *transitConnection.ID, *transitConnection.Name, *transitConnection.TransitGateway.Name)
 				continue
 			}
 
@@ -372,9 +396,53 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 	return cloudResources{}.insert(result...), nil
 }
 
-// destroyTransitGateways searches for transit gateways that have a name that starts with
-// the cluster's infra ID.
+// We either deal with an existing TG or destroy TGs matching a name.
 func (o *ClusterUninstaller) destroyTransitGateways() error {
+	var (
+		client *powervsconfig.Client
+		tgID   string
+		item   cloudResource
+		err    error
+
+		ctx    context.Context
+		cancel func()
+	)
+
+	ctx, cancel = contextWithTimeout()
+	defer cancel()
+
+	// Old style: delete all TGs matching by name
+	if o.TransitGatewayName == "" {
+		return o.innerDestroyTransitGateways()
+	}
+
+	// New style: delete just TG connections for existing TG
+	client, err = powervsconfig.NewClient()
+	if err != nil {
+		return err
+	}
+
+	tgID, err = client.TransitGatewayID(ctx, o.TransitGatewayName)
+	if err != nil {
+		return err
+	}
+
+	item = cloudResource{
+		key:      tgID,
+		name:     o.TransitGatewayName,
+		status:   "",
+		typeName: transitGatewayConnectionTypeName,
+		id:       tgID,
+	}
+
+	err = o.destroyTransitGatewayConnections(item)
+
+	return err
+}
+
+// innerDestroyTransitGateways searches for transit gateways that have a name that starts with
+// the cluster's infra ID.
+func (o *ClusterUninstaller) innerDestroyTransitGateways() error {
 	var (
 		firstPassList cloudResources
 

--- a/pkg/destroy/powervs/cloud-transit-gateways.go
+++ b/pkg/destroy/powervs/cloud-transit-gateways.go
@@ -157,14 +157,14 @@ func (o *ClusterUninstaller) destroyTransitGateway(item cloudResource) error {
 
 	items = o.insertPendingItems(transitGatewayConnectionTypeName, firstPassList.list())
 
-	ctx, cancel = o.contextWithTimeout()
+	ctx, cancel = contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
-		case <-o.Context.Done():
-			o.Logger.Debugf("destroyTransitGateway: case <-o.Context.Done()")
-			return o.Context.Err() // we're cancelled, abort
+		case <-ctx.Done():
+			o.Logger.Debugf("destroyTransitGateway: case <-ctx.Done()")
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 
@@ -238,7 +238,7 @@ func (o *ClusterUninstaller) destroyTransitConnection(item cloudResource) error 
 		err                                   error
 	)
 
-	ctx, cancel = o.contextWithTimeout()
+	ctx, cancel = contextWithTimeout()
 	defer cancel()
 
 	// ...Options(transitGatewayID string, id string)
@@ -273,7 +273,7 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 		moreData                           = true
 	)
 
-	ctx, cancel = o.contextWithTimeout()
+	ctx, cancel = contextWithTimeout()
 	defer cancel()
 
 	listConnectionsOptions = o.tgClient.NewListConnectionsOptions()
@@ -398,14 +398,14 @@ func (o *ClusterUninstaller) destroyTransitGateways() error {
 
 	items = o.insertPendingItems(transitGatewayTypeName, firstPassList.list())
 
-	ctx, cancel = o.contextWithTimeout()
+	ctx, cancel = contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
-		case <-o.Context.Done():
-			o.Logger.Debugf("destroyTransitGateways: case <-o.Context.Done()")
-			return o.Context.Err() // we're cancelled, abort
+		case <-ctx.Done():
+			o.Logger.Debugf("destroyTransitGateways: case <-ctx.Done()")
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/cloudobjectstorage.go
+++ b/pkg/destroy/powervs/cloudobjectstorage.go
@@ -25,7 +25,7 @@ const cosResourceID = "dff97f5c-bc5e-4455-b470-411c3edbe49c"
 func (o *ClusterUninstaller) listCOSInstances() (cloudResources, error) {
 	o.Logger.Debugf("Listing COS instances")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	var (
@@ -147,7 +147,7 @@ func (o *ClusterUninstaller) findReclaimedCOSInstance(item cloudResource) (*reso
 
 	getReclamationOptions = o.controllerSvc.NewListReclamationsOptions()
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	reclamations, response, err = o.controllerSvc.ListReclamationsWithContext(ctx, getReclamationOptions)
@@ -191,7 +191,7 @@ func (o *ClusterUninstaller) destroyCOSInstance(item cloudResource) error {
 
 	getOptions = o.controllerSvc.NewGetResourceInstanceOptions(item.id)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	_, response, err = o.controllerSvc.GetResourceInstanceWithContext(ctx, getOptions)
@@ -250,14 +250,14 @@ func (o *ClusterUninstaller) destroyCOSInstances() error {
 
 	items := o.insertPendingItems(cosTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyCOSInstances: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/dhcp.go
+++ b/pkg/destroy/powervs/dhcp.go
@@ -166,14 +166,14 @@ func (o *ClusterUninstaller) destroyDHCPNetworks() error {
 
 	items := o.insertPendingItems(dhcpTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyDHCPNetworks: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/dns-dns.go
+++ b/pkg/destroy/powervs/dns-dns.go
@@ -20,13 +20,13 @@ const (
 func (o *ClusterUninstaller) listDNSRecords() (cloudResources, error) {
 	o.Logger.Debugf("Listing DNS records")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listDNSRecords: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -103,13 +103,13 @@ func (o *ClusterUninstaller) destroyDNSRecord(item cloudResource) error {
 		err      error
 	)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("destroyDNSRecord: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -159,14 +159,14 @@ func (o *ClusterUninstaller) destroyDNSRecords() error {
 
 	items := o.insertPendingItems(cisDNSRecordTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyDNSRecords: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/dns-resource.go
+++ b/pkg/destroy/powervs/dns-resource.go
@@ -22,13 +22,13 @@ const (
 func (o *ClusterUninstaller) listResourceRecords() (cloudResources, error) {
 	o.Logger.Debugf("Listing DNS resource records")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listResourceRecords: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -78,13 +78,13 @@ func (o *ClusterUninstaller) destroyResourceRecord(item cloudResource) error {
 		err      error
 	)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("destroyResourceRecord: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -141,14 +141,14 @@ func (o *ClusterUninstaller) destroyResourceRecords() error {
 
 	items := o.insertPendingItems(ibmDNSRecordTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyResourceRecords: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/image.go
+++ b/pkg/destroy/powervs/image.go
@@ -23,13 +23,13 @@ func (o *ClusterUninstaller) listImages() (cloudResources, error) {
 		return cloudResources{}.insert(result...), nil
 	}
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listImages: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -68,13 +68,13 @@ func (o *ClusterUninstaller) deleteImage(item cloudResource) error {
 	var img *models.Image
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteImage: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -119,14 +119,14 @@ func (o *ClusterUninstaller) destroyImages() error {
 		o.Logger.Debugf("destroyImages: firstPassList: %v / %v", item.name, item.id)
 	}
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyImages: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/job.go
+++ b/pkg/destroy/powervs/job.go
@@ -26,13 +26,13 @@ func (o *ClusterUninstaller) listJobs() (cloudResources, error) {
 		return cloudResources{}.insert(result...), nil
 	}
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listJobs: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -80,13 +80,13 @@ func (o *ClusterUninstaller) deleteJob(item cloudResource) (DeleteJobResult, err
 	var job *models.Job
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteJob: case <-ctx.Done()")
-		return DeleteJobError, o.Context.Err() // we're cancelled, abort
+		return DeleteJobError, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -138,14 +138,14 @@ func (o *ClusterUninstaller) destroyJobs() error {
 
 	items := o.insertPendingItems(jobTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyJobs: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/loadbalancer.go
+++ b/pkg/destroy/powervs/loadbalancer.go
@@ -19,13 +19,13 @@ const loadBalancerTypeName = "load balancer"
 func (o *ClusterUninstaller) listLoadBalancers() (cloudResources, error) {
 	o.Logger.Debugf("Listing load balancers")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listLoadBalancers: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -68,13 +68,13 @@ func (o *ClusterUninstaller) deleteLoadBalancer(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteLoadBalancer: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -134,14 +134,14 @@ func (o *ClusterUninstaller) destroyLoadBalancers() error {
 
 	items := o.insertPendingItems(loadBalancerTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyLoadBalancers: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/power-instance.go
+++ b/pkg/destroy/powervs/power-instance.go
@@ -96,14 +96,14 @@ func (o *ClusterUninstaller) destroyPowerInstances() error {
 
 	items := o.insertPendingItems(powerInstanceTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyPowerInstances: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/power-sshkey.go
+++ b/pkg/destroy/powervs/power-sshkey.go
@@ -23,13 +23,13 @@ func (o *ClusterUninstaller) listPowerSSHKeys() (cloudResources, error) {
 		return cloudResources{}.insert(result...), nil
 	}
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listPowerSSHKeys: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -71,13 +71,13 @@ func (o *ClusterUninstaller) listPowerSSHKeys() (cloudResources, error) {
 func (o *ClusterUninstaller) deletePowerSSHKey(item cloudResource) error {
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deletePowerSSHKey: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -113,14 +113,14 @@ func (o *ClusterUninstaller) destroyPowerSSHKeys() error {
 
 	items := o.insertPendingItems(powerSSHKeyTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyPowerSSHKeys: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/power-subnet.go
+++ b/pkg/destroy/powervs/power-subnet.go
@@ -85,14 +85,14 @@ func (o *ClusterUninstaller) destroyPowerSubnets() error {
 
 	items := o.insertPendingItems(powerSubnetTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyPowerSubnets: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -69,18 +69,19 @@ type User struct {
 
 // ClusterUninstaller holds the various options for the cluster we want to delete.
 type ClusterUninstaller struct {
-	APIKey         string
-	BaseDomain     string
-	CISInstanceCRN string
-	ClusterName    string
-	DNSInstanceCRN string
-	DNSZone        string
-	InfraID        string
-	Logger         logrus.FieldLogger
-	Region         string
-	ServiceGUID    string
-	VPCRegion      string
-	Zone           string
+	APIKey             string
+	BaseDomain         string
+	CISInstanceCRN     string
+	ClusterName        string
+	DNSInstanceCRN     string
+	DNSZone            string
+	InfraID            string
+	Logger             logrus.FieldLogger
+	Region             string
+	ServiceGUID        string
+	VPCRegion          string
+	Zone               string
+	TransitGatewayName string
 
 	managementSvc      *resourcemanagerv2.ResourceManagerV2
 	controllerSvc      *resourcecontrollerv2.ResourceControllerV2
@@ -133,6 +134,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.VPCRegion = %v", metadata.ClusterPlatformMetadata.PowerVS.VPCRegion)
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.Zone = %v", metadata.ClusterPlatformMetadata.PowerVS.Zone)
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID = %v", metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID)
+	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName = %v", metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName)
 
 	// Handle an optional setting in install-config.yaml
 	if metadata.ClusterPlatformMetadata.PowerVS.VPCRegion == "" {
@@ -158,6 +160,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		pendingItemTracker: newPendingItemTracker(),
 		resourceGroupID:    metadata.ClusterPlatformMetadata.PowerVS.PowerVSResourceGroup,
 		ServiceGUID:        metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID,
+		TransitGatewayName: metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName,
 	}, nil
 }
 

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -73,7 +73,6 @@ type ClusterUninstaller struct {
 	BaseDomain     string
 	CISInstanceCRN string
 	ClusterName    string
-	Context        context.Context
 	DNSInstanceCRN string
 	DNSZone        string
 	InfraID        string
@@ -149,7 +148,6 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		APIKey:             APIKey,
 		BaseDomain:         metadata.ClusterPlatformMetadata.PowerVS.BaseDomain,
 		ClusterName:        metadata.ClusterName,
-		Context:            context.Background(),
 		Logger:             logger,
 		InfraID:            metadata.InfraID,
 		CISInstanceCRN:     metadata.ClusterPlatformMetadata.PowerVS.CISInstanceCRN,
@@ -172,7 +170,7 @@ func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	var ok bool
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	if ctx == nil {
@@ -306,7 +304,7 @@ func (o *ClusterUninstaller) executeStageFunction(f struct {
 	var ok bool
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	if ctx == nil {
@@ -497,7 +495,7 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 			return fmt.Errorf("loadSDKServices: creating zonesSvc: %w", err)
 		}
 
-		ctx, cancel := o.contextWithTimeout()
+		ctx, cancel := contextWithTimeout()
 		defer cancel()
 
 		// Get the Zone ID
@@ -717,8 +715,8 @@ func (o *ClusterUninstaller) ServiceInstanceNameToGUID(ctx context.Context, name
 	return "", nil
 }
 
-func (o *ClusterUninstaller) contextWithTimeout() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(o.Context, defaultTimeout)
+func contextWithTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), defaultTimeout)
 }
 
 func (o *ClusterUninstaller) timeout(ctx context.Context) bool {

--- a/pkg/destroy/powervs/publicgateway.go
+++ b/pkg/destroy/powervs/publicgateway.go
@@ -20,7 +20,7 @@ const (
 func (o *ClusterUninstaller) listAttachedSubnets(publicGatewayID string) (cloudResources, error) {
 	o.Logger.Debugf("Finding subnets attached to public gateway %s", publicGatewayID)
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	options := o.vpcSvc.NewListSubnetsOptions()
@@ -61,13 +61,13 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 
 	o.Logger.Debugf("Listing publicGateways")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listPublicGateways: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -161,13 +161,13 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 }
 
 func (o *ClusterUninstaller) deletePublicGateway(item cloudResource) error {
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deletePublicGateway: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -222,14 +222,14 @@ func (o *ClusterUninstaller) destroyPublicGateways() error {
 
 	items := o.insertPendingItems(publicGatewayTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyPublicGateways: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/securitygroup.go
+++ b/pkg/destroy/powervs/securitygroup.go
@@ -19,13 +19,13 @@ const securityGroupTypeName = "security group"
 func (o *ClusterUninstaller) listSecurityGroups() (cloudResources, error) {
 	o.Logger.Debugf("Listing security groups")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listSecurityGroups: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -67,13 +67,13 @@ func (o *ClusterUninstaller) deleteSecurityGroup(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteSecurityGroup: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -118,14 +118,14 @@ func (o *ClusterUninstaller) destroySecurityGroups() error {
 
 	items := o.insertPendingItems(securityGroupTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroySecurityGroups: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/serviceinstance.go
+++ b/pkg/destroy/powervs/serviceinstance.go
@@ -44,13 +44,13 @@ func (o *ClusterUninstaller) convertResourceGroupNameToID(resourceGroupID string
 func (o *ClusterUninstaller) listServiceInstances() (cloudResources, error) {
 	o.Logger.Debugf("Listing service instances")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listServiceInstances: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -163,13 +163,13 @@ func (o *ClusterUninstaller) listServiceInstances() (cloudResources, error) {
 
 // destroyServiceInstance destroys a service instance.
 func (o *ClusterUninstaller) destroyServiceInstance(item cloudResource) error {
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("destroyServiceInstance: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -225,14 +225,14 @@ func (o *ClusterUninstaller) destroyServiceInstances() error {
 
 	items := o.insertPendingItems(serviceInstanceTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyServiceInstances: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/destroy/powervs/vpc.go
+++ b/pkg/destroy/powervs/vpc.go
@@ -19,13 +19,13 @@ const vpcTypeName = "vpc"
 func (o *ClusterUninstaller) listVPCs() (cloudResources, error) {
 	o.Logger.Debugf("Listing VPCs")
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("listVPCs: case <-ctx.Done()")
-		return nil, o.Context.Err() // we're cancelled, abort
+		return nil, ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -68,13 +68,13 @@ func (o *ClusterUninstaller) deleteVPC(item cloudResource) error {
 	var deleteResponse *core.DetailedResponse
 	var err error
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
 		o.Logger.Debugf("deleteVPC: case <-ctx.Done()")
-		return o.Context.Err() // we're cancelled, abort
+		return ctx.Err() // we're cancelled, abort
 	default:
 	}
 
@@ -129,14 +129,14 @@ func (o *ClusterUninstaller) destroyVPCs() error {
 
 	items := o.insertPendingItems(vpcTypeName, firstPassList.list())
 
-	ctx, cancel := o.contextWithTimeout()
+	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
 			o.Logger.Debugf("destroyVPCs: case <-ctx.Done()")
-			return o.Context.Err() // we're cancelled, abort
+			return ctx.Err() // we're cancelled, abort
 		default:
 		}
 

--- a/pkg/types/powervs/metadata.go
+++ b/pkg/types/powervs/metadata.go
@@ -13,4 +13,5 @@ type Metadata struct {
 	Zone                 string                            `json:"zone"`
 	ServiceInstanceGUID  string                            `json:"serviceInstanceGUID"`
 	ServiceEndpoints     []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
+	TransitGatewayName   string                            `json:"transitGatewayName"`
 }

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -62,4 +62,9 @@ type Platform struct {
 	// There must only be one ServiceEndpoint for a service (no duplicates).
 	// +optional
 	ServiceEndpoints []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
+
+	// TGName is the name of a pre-created TransitGateway inside IBM Cloud.
+	//
+	// +optional
+	TGName string `json:"tgName,omitempty"`
 }


### PR DESCRIPTION
Creating and destroying transit gateways (TG) during CI testing is costing an abnormal amount of money.  Since the monetary cost for creating a TG is high, provide support for a user created TG when creating an OpenShift cluster.