### PR TITLE
AGENT-928: allow user to specify sshKey via config file

### DIFF
--- a/pkg/asset/agent/joiner/addnodesconfig_test.go
+++ b/pkg/asset/agent/joiner/addnodesconfig_test.go
@@ -27,7 +27,26 @@ func TestAddNodesConfig_Load(t *testing.T) {
 		},
 		{
 			name:          "empty nodes-config.yaml",
-			expectedError: "invalid nodes configuration: hosts: Required value: at least one host must be defined",
+			expectedError: "hosts: Required value: at least one host must be defined",
+		},
+		{
+			name: "ssh key",
+			nodesConfigData: `hosts:
+- hostname: master-0
+  interfaces:
+  - name: eth0
+    macAddress: 00:ef:29:72:b9:771
+sshKey: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q=="`,
+		},
+		{
+			name: "invalid ssh key",
+			nodesConfigData: `hosts:
+- hostname: master-0
+  interfaces:
+  - name: eth0
+    macAddress: 00:ef:29:72:b9:771
+sshKey: "not a valid ssh key"`,
+			expectedError: "sshKey: Invalid value: \"not a valid ssh key\": ssh: no key found",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -122,7 +122,7 @@ func (ci *ClusterInfo) Generate(_ context.Context, dependencies asset.Parents) e
 		return err
 	}
 
-	err = ci.retrieveInstallConfigData()
+	err = ci.retrieveInstallConfigData(addNodesConfig)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func (ci *ClusterInfo) retrieveArchitecture(addNodesConfig *AddNodesConfig) erro
 	return fmt.Errorf("unable to determine target cluster architecture")
 }
 
-func (ci *ClusterInfo) retrieveInstallConfigData() error {
+func (ci *ClusterInfo) retrieveInstallConfigData(addNodesConfig *AddNodesConfig) error {
 	clusterConfig, err := ci.Client.CoreV1().ConfigMaps("kube-system").Get(context.Background(), "cluster-config-v1", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -268,6 +268,10 @@ func (ci *ClusterInfo) retrieveInstallConfigData() error {
 	ci.ClusterName = installConfig.ObjectMeta.Name
 	ci.APIDNSName = fmt.Sprintf("api.%s.%s", ci.ClusterName, installConfig.BaseDomain)
 	ci.FIPS = installConfig.FIPS
+
+	if addNodesConfig.Config.SSHKey != "" {
+		ci.SSHKey = addNodesConfig.Config.SSHKey
+	}
 
 	return nil
 }

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -49,7 +49,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 				Version:      "4.15.0",
 				APIDNSName:   "api.ostest.test.metalkube.org",
 				Namespace:    "cluster0",
-				PullSecret:   "c3VwZXJzZWNyZXQK",
+				PullSecret:   "c3VwZXJzZWNyZXQK", // notsecret
 				UserCaBundle: "--- bundle ---",
 				Architecture: "amd64",
 				Proxy: &types.Proxy{
@@ -103,7 +103,7 @@ func TestClusterInfo_Generate(t *testing.T) {
 				Version:      "4.15.0",
 				APIDNSName:   "api.ostest.test.metalkube.org",
 				Namespace:    "cluster0",
-				PullSecret:   "c3VwZXJzZWNyZXQK",
+				PullSecret:   "c3VwZXJzZWNyZXQK", // notsecret
 				UserCaBundle: "--- bundle ---",
 				Architecture: "arm64",
 				Proxy: &types.Proxy{
@@ -146,6 +146,49 @@ func TestClusterInfo_Generate(t *testing.T) {
 				return objs, ocObjs
 			},
 			expectedError: "Platform: Unsupported value: \"aws\": supported values: \"baremetal\", \"vsphere\", \"none\", \"external\"",
+		},
+		{
+			name:     "sshKey from nodes-config.yaml",
+			workflow: workflow.AgentWorkflowTypeAddNodes,
+			objs:     defaultObjects(),
+			nodesConfig: AddNodesConfig{
+				Config: Config{
+					SSHKey: "ssh-key-from-config",
+				},
+			},
+			expectedClusterInfo: ClusterInfo{
+				ClusterID:    "1b5ba46b-7e56-47b1-a326-a9eebddfb38c",
+				ClusterName:  "ostest",
+				ReleaseImage: "registry.ci.openshift.org/ocp/release@sha256:65d9b652d0d23084bc45cb66001c22e796d43f5e9e005c2bc2702f94397d596e",
+				Version:      "4.15.0",
+				APIDNSName:   "api.ostest.test.metalkube.org",
+				Namespace:    "cluster0",
+				PullSecret:   "c3VwZXJzZWNyZXQK", // notsecret
+				UserCaBundle: "--- bundle ---",
+				Architecture: "amd64",
+				Proxy: &types.Proxy{
+					HTTPProxy:  "http://proxy",
+					HTTPSProxy: "https://proxy",
+					NoProxy:    "localhost",
+				},
+				ImageDigestSources: []types.ImageDigestSource{
+					{
+						Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						Mirrors: []string{
+							"registry.example.com:5000/ocp4/openshift4",
+						},
+					},
+				},
+				PlatformType:    v1beta1.BareMetalPlatformType,
+				SSHKey:          "ssh-key-from-config",
+				OSImage:         buildStreamData(),
+				OSImageLocation: "http://my-coreosimage-url/416.94.202402130130-0",
+				IgnitionEndpointWorker: &models.IgnitionEndpoint{
+					URL:           ptr.To("https://192.168.111.5:22623/config/worker"),
+					CaCertificate: ptr.To("LS0tL_FakeCertificate_LS0tCg=="),
+				},
+				FIPS: true,
+			},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This patch adds a new optional field for the nodes-config.yaml, so that the user will be able to configure the ssh key used fo adding the nodes (instead of reusing the one found in the cluster for the initial installation)