### PR TITLE
MULTIARCH-4828: Pass ServiceEndpoints from install-config to CAPI for PowerVS

### DIFF
--- a/pkg/asset/cluster/powervs/powervs.go
+++ b/pkg/asset/cluster/powervs/powervs.go
@@ -23,5 +23,6 @@ func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) *powervs.Me
 		VPCRegion:            config.Platform.PowerVS.VPCRegion,
 		Zone:                 config.Platform.PowerVS.Zone,
 		ServiceInstanceGUID:  config.Platform.PowerVS.ServiceInstanceGUID,
+		ServiceEndpoints:     config.Platform.PowerVS.ServiceEndpoints,
 	}
 }

--- a/pkg/types/powervs/metadata.go
+++ b/pkg/types/powervs/metadata.go
@@ -1,13 +1,16 @@
 package powervs
 
+import configv1 "github.com/openshift/api/config/v1"
+
 // Metadata contains Power VS metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	BaseDomain           string `json:"BaseDomain"`
-	CISInstanceCRN       string `json:"cisInstanceCRN"`
-	DNSInstanceCRN       string `json:"dnsInstanceCRN"`
-	PowerVSResourceGroup string `json:"powerVSResourceGroup"`
-	Region               string `json:"region"`
-	VPCRegion            string `json:"vpcRegion"`
-	Zone                 string `json:"zone"`
-	ServiceInstanceGUID  string `json:"serviceInstanceGUID"`
+	BaseDomain           string                            `json:"BaseDomain"`
+	CISInstanceCRN       string                            `json:"cisInstanceCRN"`
+	DNSInstanceCRN       string                            `json:"dnsInstanceCRN"`
+	PowerVSResourceGroup string                            `json:"powerVSResourceGroup"`
+	Region               string                            `json:"region"`
+	VPCRegion            string                            `json:"vpcRegion"`
+	Zone                 string                            `json:"zone"`
+	ServiceInstanceGUID  string                            `json:"serviceInstanceGUID"`
+	ServiceEndpoints     []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
 }


### PR DESCRIPTION
IBM Cloud CAPI would fail and abort if we pass in any service endpoint that's not supported. Therefore, we are adding extra logic before setting up the `--service-endpoint=` arg to CAPI so we can check what's supported and what's not supported, though we still let everything through to `metadata.json`.