### PR TITLE
AGENT-862: Change day-2 monitor timeout back to 90 minutes

### DIFF
--- a/pkg/agent/monitoraddnodes.go
+++ b/pkg/agent/monitoraddnodes.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	timeout = 1 * time.Minute
+	timeout = 90 * time.Minute
 )
 
 const (


### PR DESCRIPTION
It was mistakenly changed to 1 minute.