### PR TITLE
OCPBUGS-34953: fix bogus analyze message when gather fails

### DIFF
--- a/pkg/gather/service/analyze_test.go
+++ b/pkg/gather/service/analyze_test.go
@@ -54,7 +54,7 @@ func TestAnalyzeGatherBundle(t *testing.T) {
 		{
 			name: "no files",
 			expectedOutput: []logrus.Entry{
-				{Level: logrus.ErrorLevel, Message: "The bootstrap machine did not execute the release-image.service systemd unit"},
+				{Level: logrus.ErrorLevel, Message: "Invalid log bundle or the bootstrap machine could not be reached and bootstrap logs were not collected"},
 			},
 		},
 		{


### PR DESCRIPTION
Give a better error message when the gather logs are not collected rather than
```
time="2024-06-05T08:34:45-04:00" level=error msg="The bootstrap machine did not execute the release-image.service systemd unit"
```
The release-image service could have been executed but we don't know if the installer cannot connect to the bootstrap node (e.g, in a private install).