### PR TITLE
OCPBUGS-37780: aws: do not allow edge pools of different arch

### DIFF
--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -387,6 +387,42 @@ func TestValidate(t *testing.T) {
 		instanceTypes: validInstanceTypes(),
 		expectErr:     `^\[controlPlane.platform.aws.type: Invalid value: "m5.xlarge": instance type supported architectures \[amd64\] do not match specified architecture arm64, compute\[0\].platform.aws.type: Invalid value: "m6g.xlarge": instance type supported architectures \[arm64\] do not match specified architecture amd64\]$`,
 	}, {
+		name: "mismatched compute pools architectures",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfigEdgeSubnets()
+			c.Compute[0].Architecture = types.ArchitectureAMD64
+			c.Compute[1].Architecture = types.ArchitectureARM64
+			return c
+		}(),
+		availZones:     validAvailZones(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		edgeSubnets:    validEdgeSubnets(),
+		expectErr:      `^compute\[1\].architecture: Invalid value: "arm64": all compute machine pools must be of the same architecture$`,
+	}, {
+		name: "valid compute pools architectures",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfigEdgeSubnets()
+			c.Compute[0].Architecture = types.ArchitectureAMD64
+			return c
+		}(),
+		availZones:     validAvailZones(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		edgeSubnets:    validEdgeSubnets(),
+	}, {
+		name: "mismatched compute pools architectures 2",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfigEdgeSubnets()
+			c.Compute[1].Architecture = types.ArchitectureARM64
+			return c
+		}(),
+		availZones:     validAvailZones(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		edgeSubnets:    validEdgeSubnets(),
+		expectErr:      `^compute\[1\].architecture: Invalid value: "arm64": all compute machine pools must be of the same architecture$`,
+	}, {
 		name: "invalid no private subnets",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()


### PR DESCRIPTION
When we enabled the multi-arch day0 feature via the MultiArchInstallAWS feature gate, we inadvertently allowed "worker" and "edge" compute machine pools to have different architectures.

This change introduces a validation to check all the compute pools use the same architecture and errors out otherwise.