### PR TITLE
OCPBUGS-38499: Fix integration tests

### DIFF
--- a/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/configimage/manifests/default_manifests.txt
@@ -6,8 +6,9 @@ exists $WORK/agentconfig.noarch.iso
 
 isocmp agentconfig.noarch.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
 isocmp agentconfig.noarch.iso /etc/assisted/manifests/cluster-image-set.yaml expected/cluster-image-set.yaml
-isocmp agentconfig.noarch.iso /etc/assisted/manifests/pull-secret.yaml expected/pull-secret.yaml
 isocmp agentconfig.noarch.iso /etc/assisted/manifests/cluster-deployment.yaml expected/cluster-deployment.yaml
+
+existsInIso agentconfig.noarch.iso /etc/assisted/manifests/pull-secret.yaml
 
 -- install-config.yaml --
 apiVersion: v1
@@ -106,19 +107,3 @@ metadata:
 spec:
   releaseImage: $RELEASE_IMAGE
 status: {}
--- expected/pull-secret.yaml --
-apiVersion: v1
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: ostest-pull-secret
-  namespace: cluster0
-stringData:
-  .dockerconfigjson: |-
-    {
-      "auths": {
-        "quay.io": {
-          "auth": "c3VwZXItc2VjcmV0Cg=="
-        }
-      }
-    }

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -8,7 +8,8 @@ isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expec
 isocmp agent.x86_64.iso /etc/assisted/manifests/cluster-deployment.yaml expected/cluster-deployment.yaml
 isocmp agent.x86_64.iso /etc/assisted/manifests/cluster-image-set.yaml expected/cluster-image-set.yaml
 isocmp agent.x86_64.iso /etc/assisted/manifests/infraenv.yaml expected/infraenv.yaml
-isocmp agent.x86_64.iso /etc/assisted/manifests/pull-secret.yaml expected/pull-secret.yaml
+
+existsInIso agent.x86_64.iso /etc/assisted/manifests/pull-secret.yaml
 
 -- install-config.yaml --
 apiVersion: v1
@@ -135,19 +136,3 @@ status:
     rootfs: ""
   debugInfo:
     eventsURL: ""
--- expected/pull-secret.yaml --
-apiVersion: v1
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: ostest-pull-secret
-  namespace: cluster0
-stringData:
-  .dockerconfigjson: |-
-    {
-      "auths": {
-        "quay.io": {
-          "auth": "c3VwZXItc2VjcmV0Cg=="
-        }
-      }
-    }

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/configurations/from-ztp-manifests.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/configurations/from-ztp-manifests.txt
@@ -10,11 +10,13 @@ exec openshift-install agent create unconfigured-ignition --dir $WORK
 exists $WORK/unconfigured-agent.ign
 ! exists $WORK/auth/kubeconfig
 ! exists $WORK/auth/kubeadmin-password
+
+unconfiguredIgnContains /etc/assisted/manifests/pull-secret.yaml
 ! unconfiguredIgnContains /etc/assisted/manifests/agent-cluster-install.yaml
 ! unconfiguredIgnContains /etc/assisted/manifests/cluster-deployment.yaml
+
 unconfiguredIgnCmp /etc/assisted/manifests/cluster-image-set.yaml expected/cluster-image-set.yaml
 unconfiguredIgnCmp /etc/assisted/manifests/infraenv.yaml expected/infraenv.yaml
-unconfiguredIgnCmp /etc/assisted/manifests/pull-secret.yaml expected/pull-secret.yaml
 
 -- cluster-manifests/infraenv.yaml --
 apiVersion: agent-install.openshift.io/v1beta1
@@ -85,19 +87,3 @@ status:
     rootfs: ""
   debugInfo:
     eventsURL: ""
--- expected/pull-secret.yaml --
-apiVersion: v1
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: ostest-pull-secret
-  namespace: cluster0
-stringData:
-  .dockerconfigjson: |-
-    {
-      "auths": {
-        "quay.io": {
-          "auth": "c3VwZXItc2VjcmV0Cg=="
-        }
-      }
-    }

--- a/cmd/openshift-install/testdata/agent/unconfigured-ignition/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/unconfigured-ignition/manifests/default_manifests.txt
@@ -8,11 +8,12 @@ exists $WORK/unconfigured-agent.ign
 ! exists $WORK/auth/kubeconfig
 ! exists $WORK/auth/kubeadmin-password
 
+unconfiguredIgnContains /etc/assisted/manifests/pull-secret.yaml
 ! unconfiguredIgnContains /etc/assisted/manifests/agent-cluster-install.yaml
 ! unconfiguredIgnContains /etc/assisted/manifests/cluster-deployment.yaml
+
 unconfiguredIgnCmp /etc/assisted/manifests/cluster-image-set.yaml expected/cluster-image-set.yaml
 unconfiguredIgnCmp /etc/assisted/manifests/infraenv.yaml expected/infraenv.yaml
-unconfiguredIgnCmp /etc/assisted/manifests/pull-secret.yaml expected/pull-secret.yaml
 
 -- install-config.yaml --
 apiVersion: v1
@@ -85,19 +86,3 @@ status:
     rootfs: ""
   debugInfo:
     eventsURL: ""
--- expected/pull-secret.yaml --
-apiVersion: v1
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: ostest-pull-secret
-  namespace: cluster0
-stringData:
-  .dockerconfigjson: |-
-    {
-      "auths": {
-        "quay.io": {
-          "auth": "c3VwZXItc2VjcmV0Cg=="
-        }
-      }
-    }

--- a/pkg/asset/agent/manifests/clusterimageset.go
+++ b/pkg/asset/agent/manifests/clusterimageset.go
@@ -189,7 +189,7 @@ func (a *ClusterImageSet) validateReleaseVersion(ctx context.Context, workflowTy
 	}
 
 	if a.Config.Spec.ReleaseImage != releaseImage.PullSpec {
-		allErrs = append(allErrs, field.Forbidden(fieldPath, fmt.Sprintf("value must be equal to %s", releaseImage.PullSpec)))
+		allErrs = append(allErrs, field.Invalid(fieldPath, a.Config.Spec.ReleaseImage, fmt.Sprintf("value must be equal to %s", releaseImage.PullSpec)))
 	}
 
 	return allErrs

--- a/pkg/asset/agent/manifests/clusterimageset_test.go
+++ b/pkg/asset/agent/manifests/clusterimageset_test.go
@@ -62,7 +62,7 @@ func TestClusterImageSet_Generate(t *testing.T) {
 				getValidOptionalInstallConfig(),
 				&releaseimage.Image{},
 			},
-			expectedError: "invalid ClusterImageSet configuration: Spec.ReleaseImage: Forbidden: value must be equal to " + currentRelease,
+			expectedError: "invalid ClusterImageSet configuration: Spec.ReleaseImage: Invalid value: \"\": value must be equal to " + currentRelease,
 		},
 		{
 			name: "valid configuration",
@@ -182,7 +182,7 @@ metadata:
   name: openshift-v4.10.0
 spec:
   releaseImage: 99.999`,
-			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Forbidden: value must be equal to %s", currentRelease),
+			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Invalid value: \"99.999\": value must be equal to %s", currentRelease),
 		},
 		{
 			name:          "not-yaml",
@@ -192,7 +192,7 @@ spec:
 		{
 			name:          "empty",
 			data:          "",
-			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Forbidden: value must be equal to %s", currentRelease),
+			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Invalid value: \"\": value must be equal to %s", currentRelease),
 		},
 		{
 			name:       "file-not-found",


### PR DESCRIPTION
- Use $AUTH_FILE for the valid pullSecret in CI.
- Update the pull secret in the expected install-config file when AUTH_FILE is set.
- Check if the image files contain the pull-secret.yaml file.
- Use $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to replace test data and pass it to the test script environment. - This is typically set in a CI job to reference the ephemeral payload release.
- Skip errors when the test does not require reading install-config.yaml.