### PR TITLE
Add command to create OpenStack flavor before installation

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -7,7 +7,7 @@ The following dependencies must be installed on your system before you can build
 ### Fedora, CentOS, RHEL
 
 ```sh
-sudo yum install golang-bin gcc-c++
+sudo dnf install golang-bin gcc-c++ zip
 ```
 
 If you need support for [libvirt destroy](libvirt/README.md#cleanup), you should also install `libvirt-devel`.
@@ -18,7 +18,7 @@ We follow a hard flattening approach; i.e. direct and inherited dependencies are
 
 Dependencies are managed with [Go Modules](https://github.com/golang/go/wiki/Modules) but committed directly to the repository.
 
-We require at least Go 1.20.
+We require at least Go 1.22.
 
 - Add or update a dependency with `go get <dependency>@<version>`.
 - If you want to use a fork of a project or ensure that a dependency is not updated even when another dependency requires a newer version of it, manually add a [replace directive in the go.mod file](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive). 

--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -37,7 +37,7 @@ repository to ensure you get a new enough version of qemu-kvm.
 On Fedora, CentOS/RHEL:
 
 ```sh
-sudo yum install libvirt-devel libvirt-daemon-kvm libvirt-client
+sudo dnf install libvirt-devel libvirt-daemon-kvm libvirt-client
 ```
 
 Then start libvirtd:

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -132,7 +132,11 @@ See the [OpenShift documentation](https://docs.openshift.com/container-platform/
 
 ### Bootstrap Node
 
-The bootstrap node is a temporary node that is responsible for standing up the control plane on the masters. Only one bootstrap node will be stood up and it will be deprovisioned once the production control plane is ready. To do so, you need 1 instance, and 1 port. We recommend a flavor with a minimum of 16 GB RAM, 4 vCPUs, and 100 GB Disk (or Root Volume).
+The bootstrap node is a temporary node that is responsible for standing up the control plane on the masters. Only one bootstrap node will be stood up and it will be deprovisioned once the production control plane is ready. To do so, you need 1 instance, and 1 port. We recommend a flavor with a minimum of 16 GB RAM, 4 vCPUs, and 100 GB Disk (or Root Volume), it can be created using below command:
+
+```sh
+openstack flavor create --ram 16384 --disk 128 --vcpu 4 okd-cluster
+```
 
 ### Image Registry Requirements
 


### PR DESCRIPTION
Help user to avoid problem when installer fails with error saying that selected flavor does not meet minimal requirements.