### PR TITLE
MGMT-18364: add image-based installation ISO integration tests

### DIFF
--- a/cmd/openshift-install/testdata/imagebased/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/assets/default_assets.txt
@@ -1,0 +1,17 @@
+# Verify that the most relevant assets are properly generated in the installation ISO
+
+exec openshift-install image-based create image --dir $WORK
+
+exists $WORK/rhcos-ibi.iso
+
+ignitionImgContains rhcos-ibi.iso config.ign
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+installationDisk: /dev/vda
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'

--- a/cmd/openshift-install/testdata/imagebased/image/validations/invalid-image-digest-sources.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/invalid-image-digest-sources.txt
@@ -1,0 +1,18 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'imageDigestSources\[0\].source: Invalid value: "": failed to parse: invalid reference format'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+installationDisk: /dev/vda
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+imageDigestSources:
+  - source: ""
+    mirrors: []

--- a/cmd/openshift-install/testdata/imagebased/image/validations/invalid-proxy.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/invalid-proxy.txt
@@ -1,0 +1,17 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'proxy.httpProxy: Invalid value: "localhost": parse "localhost": invalid URI for request'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+installationDisk: /dev/vda
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+proxy:
+  httpProxy: localhost

--- a/cmd/openshift-install/testdata/imagebased/image/validations/no-installation-disk.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/no-installation-disk.txt
@@ -1,0 +1,14 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'Required value: you must specify an installationDisk'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'

--- a/cmd/openshift-install/testdata/imagebased/image/validations/no-pull-secret.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/no-pull-secret.txt
@@ -1,0 +1,14 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'Required value: you must specify a pullSecret'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+installationDisk: /dev/vda

--- a/cmd/openshift-install/testdata/imagebased/image/validations/no-seed-image.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/no-seed-image.txt
@@ -1,0 +1,14 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'Required value: you must specify a seedImage'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedVersion: 4.16.0
+installationDisk: /dev/vda
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'

--- a/cmd/openshift-install/testdata/imagebased/image/validations/no-seed-version.txt
+++ b/cmd/openshift-install/testdata/imagebased/image/validations/no-seed-version.txt
@@ -1,0 +1,14 @@
+! exec openshift-install image-based create image --dir $WORK
+
+stderr 'Required value: you must specify a seedVersion'
+
+! exists $WORK/rhcos-ibi.iso
+
+-- image-based-installation-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'

--- a/cmd/openshift-install/testdata/imagebased/imageconfigtemplate/image-config-template.txt
+++ b/cmd/openshift-install/testdata/imagebased/imageconfigtemplate/image-config-template.txt
@@ -1,0 +1,39 @@
+# Verify the generated default template for image-based-installation-config.yaml
+
+exec openshift-install image-based create image-config-template --dir $WORK
+
+stderr 'level=info msg=Image-Config-Template created in:'
+
+exists $WORK/image-based-installation-config.yaml
+
+cmp $WORK/image-based-installation-config.yaml $WORK/expected/image-based-installation-config.yaml
+
+-- expected/image-based-installation-config.yaml --
+#
+# Note: This is a sample ImageBasedInstallationConfig file showing
+# which fields are available to aid you in creating your
+# own image-based-installation-config.yaml file.
+#
+apiVersion: v1beta1
+kind: ImageBasedInstallationConfig
+metadata:
+  name: example-image-based-installation-config
+# The following fields are required
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+seedVersion: 4.16.0
+installationDisk: /dev/vda
+pullSecret: '<your-pull-secret>'
+# networkConfig is optional and contains the network configuration for the host in NMState format.
+# See https://nmstate.io/examples.html for examples.
+# networkConfig:
+#   interfaces:
+#     - name: eth0
+#       type: ethernet
+#       state: up
+#       mac-address: 00:00:00:00:00:00
+#       ipv4:
+#         enabled: true
+#         address:
+#           - ip: 192.168.122.2
+#             prefix-length: 23
+#         dhcp: false


### PR DESCRIPTION
This PR adds [testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) integration tests for the `image-based` installer, specifically for the installation ISO and its configuration template creation.