### PR TITLE
no-jira: PowerVS: Block disconnected deploys in 4.17

### DIFF
--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -176,8 +176,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		}
 
 		powerVSCluster.Spec.DHCPServer.DNSServer = &dnsServerIP
-		// Disable SNAT for disconnected scenario.
-		powerVSCluster.Spec.DHCPServer.Snat = ptr.To(len(installConfig.Config.DeprecatedImageContentSources) == 0 && len(installConfig.Config.ImageDigestSources) == 0)
+		// TODO(mjturek): Restore once work is finished in 4.18 for disconnected scenario.
+		if !(len(installConfig.Config.DeprecatedImageContentSources) == 0 && len(installConfig.Config.ImageDigestSources) == 0) {
+			return nil, fmt.Errorf("deploying a disconnected cluster directly in 4.17 is not supported for Power VS. Please deploy disconnected in 4.16 and upgrade to 4.17")
+		}
 	}
 
 	// If a VPC was specified, pass all subnets in it to cluster API


### PR DESCRIPTION
Disconnected with CAPI will not work in 4.17, error out explaining how to get a 4.17 disconnected cluster.