### PR TITLE
OCPBUGS-35262: Do not create firewall rules for xpn installs

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -244,6 +244,14 @@ func (p Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapD
 	projectID := in.Metadata.GCP.ProjectID
 	if in.Metadata.GCP.NetworkProjectID != "" {
 		projectID = in.Metadata.GCP.NetworkProjectID
+
+		createFwRules, err := hasFirewallPermission(ctx, projectID)
+		if err != nil {
+			return fmt.Errorf("failed to remove bootstrap firewall rules: %w", err)
+		}
+		if !createFwRules {
+			return nil
+		}
 	}
 	if err := removeBootstrapFirewallRules(ctx, in.Metadata.InfraID, projectID); err != nil {
 		return fmt.Errorf("failed to remove bootstrap firewall rules: %w", err)


### PR DESCRIPTION
** Bootstrap firewall rules should not be created when the user does not have the permission to do so (during capg xpn installs).