### PR TITLE
AGENT-937: Check Authentication Token for Node Boot-Up on day2

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-auth-token-status.sh
+++ b/data/data/agent/files/usr/local/bin/agent-auth-token-status.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# shellcheck disable=SC1091
+source "issue_status.sh"
+
+status_issue="65_token"
+
+export TZ=UTC
+check_token_expiry() {
+  expiry_epoch=$(date -d "${AGENT_AUTH_TOKEN_EXPIRY}" +%s)
+  current_epoch=$(date +%s)
+
+  if [ "$current_epoch" -gt "$expiry_epoch" ]; then
+    printf '\\e{lightred}The authentication token has expired. Please generate a new ISO using the "oc adm node-image create" command, then reboot the node.\\e{reset}'| set_issue "${status_issue}"
+    exit 1
+  fi
+}
+
+while true; do
+  check_token_expiry
+  sleep 5
+done

--- a/data/data/agent/systemd/units/agent-auth-token-status.service
+++ b/data/data/agent/systemd/units/agent-auth-token-status.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=service that displays a message if agent auth token is expired.
+Wants=network-online.target
+After=network-online.target agent-interactive-console.service
+ConditionPathExists=/etc/assisted/add-nodes.env
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/assisted/add-nodes.env
+ExecStart=/usr/local/bin/agent-auth-token-status.sh
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/agent-auth-token-status.service
+++ b/data/data/agent/systemd/units/agent-auth-token-status.service
@@ -11,4 +11,4 @@ ExecStart=/usr/local/bin/agent-auth-token-status.sh
 Restart=no
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target agent-add-node.service

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -93,7 +93,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 
 	publicKey := "-----BEGIN EC PUBLIC KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PUBLIC KEY-----\n"
 	token := "someToken"
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -395,6 +395,7 @@ func commonFiles() []string {
 		"/usr/local/bin/load-config-iso.sh",
 		"/etc/udev/rules.d/80-agent-config-image.rules",
 		"/usr/local/bin/add-node.sh",
+		"/usr/local/bin/agent-auth-token-status.sh",
 		"/usr/local/bin/common.sh",
 	}
 }


### PR DESCRIPTION
- Adds a new systemd service `agent-auth-token-status.service`.
- The new service checks if token is valid.
- If expired, display a message on the boot window. `The authentication token has expired. Please generate a new ISO using the "oc adm node-image create" command, then reboot the node.`
- This new service is only run on addnodes workflow i.e. adding a node on day2.
- This new service runs after the TUI and helps users know what corrective action ( re-generate ISO) to be taken.