### PR TITLE
OCPBUGS-38055: fix/aws/edge: IAM profile must be same of workers

### DIFF
--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -83,7 +83,7 @@ func MachineSets(in *MachineSetInput) ([]*machineapi.MachineSet, error) {
 
 		instanceProfile := mpool.IAMProfile
 		if len(instanceProfile) == 0 {
-			instanceProfile = fmt.Sprintf("%s-%s-profile", in.ClusterID, in.Role)
+			instanceProfile = fmt.Sprintf("%s-worker-profile", in.ClusterID)
 		}
 
 		provider, err := provider(&machineProviderInput{


### PR DESCRIPTION
Setting edge compute pool  must use the same IAM Profile as `worker` when a BYO IAM Profile isn't set.

Reference:
- [IAM Profile update](https://github.com/openshift/installer/pull/8689/files#diff-e46d61c55e5e276e3c264d18cba0346777fe3e662d0180a173001b8282af7c6eR51-R54)
- [CI failures](https://sippy.dptools.openshift.org/sippy-ng/jobs/Presubmits/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22pull-ci-openshift-origin-master-e2e-aws-ovn-edge-zones%22%7D%5D%7D)
- [Sippy](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.17/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-edge-zones-manifest-validation%22%7D%5D%7D&sortField=timestamp&sort=desc)
- [Slack thread](https://redhat-internal.slack.com/archives/CBZHF4DHC/p1722964067282219)
 