### PR TITLE
OCPBUGS-38118: failed to install Nutanix OCP 4.16 cluster with DHCP network

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vincent-petithory/dataurl"
 	utilsnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/data"
@@ -39,6 +40,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -111,6 +113,7 @@ func (a *Common) Dependencies() []asset.Asset {
 		&baremetal.IronicCreds{},
 		&CVOIgnore{},
 		&installconfig.InstallConfig{},
+		&installconfig.ClusterID{},
 		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
@@ -167,7 +170,8 @@ func (a *Common) Dependencies() []asset.Asset {
 func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootstrapTemplateData) error {
 	installConfig := &installconfig.InstallConfig{}
 	bootstrapSSHKeyPair := &tls.BootstrapSSHKeyPair{}
-	dependencies.Get(installConfig, bootstrapSSHKeyPair)
+	clusterID := &installconfig.ClusterID{}
+	dependencies.Get(installConfig, bootstrapSSHKeyPair, clusterID)
 
 	a.Config = &igntypes.Config{
 		Ignition: igntypes.Ignition{
@@ -217,6 +221,24 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 			igntypes.SSHAuthorizedKey(string(bootstrapSSHKeyPair.Public())),
 		}},
 	)
+
+	if platform == nutanixtypes.Name {
+		// Inserts the file "/etc/hostname" with the bootstrap machine name to the bootstrap ignition data
+		hostname := fmt.Sprintf("%s-bootstrap", clusterID.InfraID)
+		hostnameFile := igntypes.File{
+			Node: igntypes.Node{
+				Path:      "/etc/hostname",
+				Overwrite: ptr.To(true),
+			},
+			FileEmbedded1: igntypes.FileEmbedded1{
+				Mode: ptr.To(420),
+				Contents: igntypes.Resource{
+					Source: ptr.To(dataurl.EncodeBytes([]byte(hostname))),
+				},
+			},
+		}
+		a.Config.Storage.Files = append(a.Config.Storage.Files, hostnameFile)
+	}
 
 	return nil
 }

--- a/pkg/asset/machines/nutanix/capimachines.go
+++ b/pkg/asset/machines/nutanix/capimachines.go
@@ -61,7 +61,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			Spec: capv1.MachineSpec{
 				ClusterName: clusterID,
 				Bootstrap: capv1.Bootstrap{
-					DataSecretName: ptr.To(fmt.Sprintf("%s-%s", clusterID, role)),
+					DataSecretName: ptr.To(ntxMachine.Name),
 				},
 				InfrastructureRef: v1.ObjectReference{
 					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/stream-metadata-go/arch"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -791,7 +792,7 @@ func randomString(length int) string {
 
 // Ignition provisions the Azure container that holds the bootstrap ignition
 // file.
-func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
+func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]*corev1.Secret, error) {
 	session, err := in.InstallConfig.Azure.Session()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
@@ -865,5 +866,10 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("failed to create ignition shim: %w", err)
 	}
 
-	return ignShim, nil
+	ignSecrets := []*corev1.Secret{
+		clusterapi.IgnitionSecret(ignShim, in.InfraID, "bootstrap"),
+		clusterapi.IgnitionSecret(in.MasterIgnData, in.InfraID, "master"),
+	}
+
+	return ignSecrets, nil
 }

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -271,10 +271,12 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		logrus.Debugf("No infrastructure ready requirements for the %s provider", i.impl.Name())
 	}
 
+	masterIgnData := masterIgnAsset.Files()[0].Data
 	bootstrapIgnData, err := injectInstallInfo(bootstrapIgnAsset.Files()[0].Data)
 	if err != nil {
 		return fileList, fmt.Errorf("unable to inject installation info: %w", err)
 	}
+	ignitionSecrets := []*corev1.Secret{}
 
 	// The cloud-platform may need to override the default
 	// bootstrap ignition behavior.
@@ -282,22 +284,27 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		ignInput := IgnitionInput{
 			Client:           cl,
 			BootstrapIgnData: bootstrapIgnData,
+			MasterIgnData:    masterIgnData,
 			InfraID:          clusterID.InfraID,
 			InstallConfig:    installConfig,
 			TFVarsAsset:      tfvarsAsset,
 		}
 
 		timer.StartTimer(ignitionStage)
-		if bootstrapIgnData, err = p.Ignition(ctx, ignInput); err != nil {
+		if ignitionSecrets, err = p.Ignition(ctx, ignInput); err != nil {
 			return fileList, fmt.Errorf("failed preparing ignition data: %w", err)
 		}
 		timer.StopTimer(ignitionStage)
 	} else {
-		logrus.Debugf("No Ignition requirements for the %s provider", i.impl.Name())
+		logrus.Debugf("Using default ignition for the %s provider", i.impl.Name())
+		bootstrapIgnSecret := IgnitionSecret(bootstrapIgnData, clusterID.InfraID, "bootstrap")
+		masterIgnSecret := IgnitionSecret(masterIgnData, clusterID.InfraID, "master")
+		ignitionSecrets = append(ignitionSecrets, bootstrapIgnSecret, masterIgnSecret)
 	}
-	bootstrapIgnSecret := IgnitionSecret(bootstrapIgnData, clusterID.InfraID, "bootstrap")
-	masterIgnSecret := IgnitionSecret(masterIgnAsset.Files()[0].Data, clusterID.InfraID, "master")
-	machineManifests = append(machineManifests, bootstrapIgnSecret, masterIgnSecret)
+
+	for _, secret := range ignitionSecrets {
+		machineManifests = append(machineManifests, secret)
+	}
 
 	// Create the machine manifests.
 	timer.StartTimer(machineStage)

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
@@ -49,18 +50,20 @@ type PreProvisionInput struct {
 	WorkersAsset     *machines.Worker
 }
 
-// IgnitionProvider handles preconditions for bootstrap ignition and
-// generates ignition data for the CAPI bootstrap ignition secret.
+// IgnitionProvider handles preconditions for bootstrap ignition,
+// such as pushing to cloud storage. Returns bootstrap and master
+// ignition secrets.
 //
 // WARNING! Low-level primitive. Use only if absolutely necessary.
 type IgnitionProvider interface {
-	Ignition(ctx context.Context, in IgnitionInput) ([]byte, error)
+	Ignition(ctx context.Context, in IgnitionInput) ([]*corev1.Secret, error)
 }
 
 // IgnitionInput collects the args passed to the IgnitionProvider call.
 type IgnitionInput struct {
 	Client           client.Client
 	BootstrapIgnData []byte
+	MasterIgnData    []byte
 	InfraID          string
 	InstallConfig    *installconfig.InstallConfig
 	TFVarsAsset      *tfvars.TerraformVariables

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	capg "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -106,7 +107,7 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 // populate the metadata field of the bootstrap instance as the data can be too large. Instead, the data is
 // added to a bucket. A signed url is generated to point to the bucket and the ignition data will be
 // updated to point to the url. This is also allows for bootstrap data to be edited after its initial creation.
-func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
+func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]*corev1.Secret, error) {
 	// Create the bucket and presigned url. The url is generated using a known/expected name so that the
 	// url can be retrieved from the api by this name.
 	bucketName := gcp.GetBootstrapStorageName(in.InfraID)
@@ -134,6 +135,7 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("ignition failed to fill bucket: %w", err)
 	}
 
+	var ignShim string
 	for _, file := range in.TFVarsAsset.Files() {
 		if file.Filename == tfvars.TfPlatformVarsFileName {
 			var found bool
@@ -143,16 +145,19 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 				return nil, fmt.Errorf("failed to unmarshal %s to json: %w", tfvars.TfPlatformVarsFileName, err)
 			}
 
-			ignShim, found := tfvarsData["gcp_ignition_shim"].(string)
+			ignShim, found = tfvarsData["gcp_ignition_shim"].(string)
 			if !found {
 				return nil, fmt.Errorf("failed to find ignition shim")
 			}
-
-			return []byte(ignShim), nil
 		}
 	}
 
-	return nil, fmt.Errorf("failed to complete ignition process")
+	ignSecrets := []*corev1.Secret{
+		clusterapi.IgnitionSecret([]byte(ignShim), in.InfraID, "bootstrap"),
+		clusterapi.IgnitionSecret(in.MasterIgnData, in.InfraID, "master"),
+	}
+
+	return ignSecrets, nil
 }
 
 // InfraReady is called once cluster.Status.InfrastructureReady


### PR DESCRIPTION
To fix the 4.16 installer regression issue when installing a Nutanix OCP cluster with DHCP network. The issue was hit by the customer:
https://issues.redhat.com/browse/OCPBUGS-38118

The workaround fix is to add the file "/etc/hostname" with the Machine name to the master and bootstrap ignition data.

1. clusterapi: ignition interface returns secrets
    
        Updates the clusterapi ignition interface so that it returns
        all ignition secrets. Prior to this commit, the ignition interface
        returned the bootstrap ignition data, and the provision method
        turned this data into secrets. Updating the interface to return
        all secrets, gives greater flexibility to the platform to completely
        control the ignition secrets that are created for that platform.
    
        The motivation is that some platforms such as Nutanix may need
        to create per master ignition.
    
2. nutanix clusterapi: fix the regression bug OCPBUGS-38118 

Manual testing of the fix with DHCP network passed.