### PR TITLE
OCPBUGS-38114:  aws: add support for clusters with public-only subnets

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -166,13 +167,15 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			return fmt.Errorf("failed to create CAPA tags from UserTags: %w", err)
 		}
 
+		publicOnlySubnets := os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY") != ""
+
 		pool.Platform.AWS = &mpool
 		awsMachines, err := aws.GenerateMachines(clusterID.InfraID, &aws.MachineInput{
 			Role:     "master",
 			Pool:     &pool,
 			Subnets:  subnets,
 			Tags:     tags,
-			PublicIP: false,
+			PublicIP: publicOnlySubnets,
 			Ignition: &v1beta2.Ignition{
 				Version: "3.2",
 				// master machines should get ignition from the MCS on the bootstrap node
@@ -199,7 +202,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			Subnets:        bootstrapSubnets,
 			Pool:           &pool,
 			Tags:           tags,
-			PublicIP:       installConfig.Config.Publish == types.ExternalPublishingStrategy,
+			PublicIP:       publicOnlySubnets || (installConfig.Config.Publish == types.ExternalPublishingStrategy),
 			PublicIpv4Pool: ic.Platform.AWS.PublicIpv4Pool,
 			Ignition:       ignition,
 		})

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -250,6 +251,12 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 			PublicIpv4Pool:              ptr.To(ic.Config.Platform.AWS.PublicIpv4Pool),
 			PublicIpv4PoolFallBackOrder: ptr.To(capa.PublicIpv4PoolFallbackOrderAmazonPool),
 		}
+	}
+
+	if len(os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY")) > 0 {
+		// If we don't set the subnets for the internal LB, CAPA will try to use private subnets but there aren't any in
+		// public-only mode.
+		awsCluster.Spec.ControlPlaneLoadBalancer.Subnets = awsCluster.Spec.NetworkSpec.Subnets.IDs()
 	}
 
 	manifests = append(manifests, &asset.RuntimeFile{


### PR DESCRIPTION
We lost support to this internal feature when we move from terraform to CAPI. Although it's still possible to get a cluster with public-only subnets by editing the AWSCluster manifest before install, it's more convenient to have a fully automated process to be used in CI.