### PR TITLE
OCPBUGS-37770: data/bootstrap/files/usr/local/bin/bootkube: Pass CVO render --feature-gate-manifest-path

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -163,7 +163,8 @@ then
 		"${RELEASE_IMAGE_DIGEST}" \
 		render \
 			--output-dir=/assets/cvo-bootstrap \
-			--release-image="${RELEASE_IMAGE_DIGEST}"
+			--release-image="${RELEASE_IMAGE_DIGEST}" \
+			--feature-gate-manifest-path=/assets/manifests/99_feature-gate.yaml
 
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/
 	cp cvo-bootstrap/manifests/* manifests/


### PR DESCRIPTION
Populating the new option from openshift/cluster-version-operator#1078 with [the manifest we generate in `pkg/asset/manifests/featuregate.go`][1].  This allows the cluster-version operator to  render manifests appropriate to the configured feature set.

/hold until the CVO pull merges

[1]: https://github.com/openshift/installer/blob/fe126cafe857fa5e4e7f88a2134a19ae2f089b85/pkg/asset/manifests/featuregate.go#L17