### PR TITLE
OCPBUGS-38152: Add roles needed for shared VPC

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -68,6 +68,16 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 		if err = AddServiceAccountRoles(ctx, projectID, masterSA, GetMasterRoles()); err != nil {
 			return fmt.Errorf("failed to add master roles: %w", err)
 		}
+
+		// Add additional roles for shared VPC
+		if len(in.InstallConfig.Config.Platform.GCP.NetworkProjectID) > 0 {
+			projID := in.InstallConfig.Config.Platform.GCP.NetworkProjectID
+			// Add roles needed for creating firewalls
+			roles := GetSharedVPCRoles()
+			if err = AddServiceAccountRoles(ctx, projID, masterSA, roles); err != nil {
+				return fmt.Errorf("failed to add roles for shared VPC: %w", err)
+			}
+		}
 	}
 
 	createSA := false

--- a/pkg/infrastructure/gcp/clusterapi/iam.go
+++ b/pkg/infrastructure/gcp/clusterapi/iam.go
@@ -48,6 +48,14 @@ func GetWorkerRoles() []string {
 	}
 }
 
+// GetSharedVPCRoles returns the pre-defined roles for a shared VPC installation.
+func GetSharedVPCRoles() []string {
+	return []string{
+		"roles/compute.networkAdmin",
+		"roles/compute.securityAdmin",
+	}
+}
+
 // CreateServiceAccount is used to create a service account for a compute instance.
 func CreateServiceAccount(ctx context.Context, infraID, projectID, role string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)


### PR DESCRIPTION
Add additional role needed for shared VPC to the network project to allow creation of firewalls.