### PR TITLE
AGENT-944: Enable assisted-service debug logging

### DIFF
--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -12,6 +12,7 @@ EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR=/opt/agent/tls
 HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]
 INSTALL_INVOKER=agent-installer
 IPV6_SUPPORT=true
+LOG_LEVEL=debug
 NTP_DEFAULT_SERVER=
 PUBLIC_CONTAINER_REGISTRIES={{.PublicContainerRegistries}}
 RELEASE_IMAGES={{.ReleaseImages}}


### PR DESCRIPTION
Since the assisted-service API will be more difficult for users to access with the API authentication changes, enable debug logging so additional messages will be available in the assisted-service logs.