### PR TITLE
OCPBUGS-38235: upi/aws: update lambda runtime python version

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -294,7 +294,7 @@ Resources:
               elb.register_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
             responseData = {}
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp'])
-      Runtime: "python3.8"
+      Runtime: "python3.11"
       Timeout: 120
 
   RegisterSubnetTagsLambdaIamRole:
@@ -354,7 +354,7 @@ Resources:
                 ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'], 'Value': 'shared'}]);
             responseData = {}
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
-      Runtime: "python3.8"
+      Runtime: "python3.11"
       Timeout: 120
 
   RegisterPublicSubnetTags:


### PR DESCRIPTION
The usage of python3.8 in lambda runtimes is being deprecated soon (Oct 14, 2024) [1]. This change updates it to python3.9 which is the default version in RHEL 9.

[1] https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html