### PR TITLE
OCPBUGS-38198: Remove timed context for gcp client

### DIFF
--- a/pkg/asset/ignition/bootstrap/gcp/storage.go
+++ b/pkg/asset/ignition/bootstrap/gcp/storage.go
@@ -34,17 +34,6 @@ func NewStorageClient(ctx context.Context) (*storage.Client, error) {
 	return client, nil
 }
 
-// CreateBucketHandle will create the bucket handle that can be used as a reference for other storage resources.
-func CreateBucketHandle(ctx context.Context, bucketName string) (*storage.BucketHandle, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
-	defer cancel()
-	client, err := NewStorageClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create storage client: %w", err)
-	}
-	return client.Bucket(bucketName), nil
-}
-
 // CreateStorage creates the gcp bucket/storage. The storage bucket does Not include the bucket object. The
 // bucket object is created as a separate process/function, so that the two are not tied together, and
 // the data stored inside the object can be set at a later time.
@@ -72,9 +61,10 @@ func CreateStorage(ctx context.Context, ic *installconfig.InstallConfig, bucketH
 // CreateSignedURL creates a signed url and correlates the signed url with a storage bucket.
 func CreateSignedURL(clusterID string) (string, error) {
 	bucketName := GetBootstrapStorageName(clusterID)
-	handle, err := CreateBucketHandle(context.Background(), bucketName)
+
+	client, err := NewStorageClient(context.TODO())
 	if err != nil {
-		return "", fmt.Errorf("creating presigned url, failed to create bucket handle: %w", err)
+		return "", fmt.Errorf("failed to create storage client: %w", err)
 	}
 
 	// Signing a URL requires credentials authorized to sign a URL. You can pass
@@ -88,7 +78,7 @@ func CreateSignedURL(clusterID string) (string, error) {
 
 	// The object has not been created yet. This is ok, it is expected to be created after this call.
 	// However, if the object is never created this could cause major issues.
-	url, err := handle.SignedURL(bootstrapIgnitionBucketObjName, &opts)
+	url, err := client.Bucket(bucketName).SignedURL(bootstrapIgnitionBucketObjName, &opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to create a signed url: %w", err)
 	}
@@ -115,14 +105,17 @@ func FillBucket(ctx context.Context, bucketHandle *storage.BucketHandle, content
 
 // DestroyStorage Destroy the bucket and the bucket objects that are associated with the bucket.
 func DestroyStorage(ctx context.Context, clusterID string) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
-	defer cancel()
-
 	client, err := NewStorageClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create storage client: %w", err)
 	}
 	bucketName := GetBootstrapStorageName(clusterID)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
+	defer cancel()
+	if err := client.Bucket(bucketName).Object(bootstrapIgnitionBucketObjName).Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete bucket object %s: %w", bootstrapIgnitionBucketObjName, err)
+	}
 
 	// Deleting a bucket will delete the managed folders and bucket objects.
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {


### PR DESCRIPTION
** removing the timeout for a client that is causing failures when we return from the function that creates a signed url.