### PR TITLE
OCPBUGS-38034: destroy/aws: remove gov cloud tagging endpoint workaround

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -145,10 +145,7 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	case endpoints.UsIsoEast1RegionID, endpoints.UsIsoWest1RegionID, endpoints.UsIsobEast1RegionID:
 		break
 	case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
-		if o.Region != endpoints.UsGovWest1RegionID {
-			tagClients = append(tagClients,
-				resourcegroupstaggingapi.New(awsSession, aws.NewConfig().WithRegion(endpoints.UsGovWest1RegionID)))
-		}
+		break
 	default:
 		if o.Region != endpoints.UsEast1RegionID {
 			tagClients = append(tagClients,


### PR DESCRIPTION
In previous versions of the AWS SDK, us-gov-east region didn't have a tagging endpoint and tagging operations were done via the us-gov-west endpoint [1]. That seems to have changed and both regions have their own tagging endpoint now [2].

If we don't remove the cross-region tagging endpoint client from the destroy code, we get an error like:
```
INFO error while finding resources to delete       error=get tagged resources: InvalidSignatureException: Credential should be scoped to a valid region.
	status code: 400, request id: 7151f2ae-dccf-4ef6-baa4-320c14d8dba2
```

[1] https://github.com/openshift/installer/pull/4042
[2] https://docs.aws.amazon.com/general/latest/gr/arg.html