### PR TITLE
OCPBUGS-38436: PowerVS: Fix mad system pool

### DIFF
--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -51,7 +51,7 @@ var Regions = map[string]Region{
 		VPCRegion:   "eu-es",
 		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones:       []string{"mad02", "mad04"},
-		SysTypes:    []string{"s1022"},
+		SysTypes:    []string{"e980", "s1022"},
 		VPCZones:    []string{"eu-es-1", "eu-es-2"},
 	},
 	"osa": {


### PR DESCRIPTION
Add system type e980 to the list of allowed system types for the Madrid region.