### PR TITLE
OCPBUGS-38551: only allow a single network in failure domain topology

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -183,6 +183,10 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path, isLegacyUp
 			}
 		}
 
+		if len(failureDomain.Topology.Networks) > 1 {
+			allErrs = append(allErrs, field.Required(topologyFld.Child("networks"), "must specify a single network"))
+		}
+
 		// Folder in failuredomain is optional
 		if len(failureDomain.Topology.Folder) != 0 {
 			folderPathRegexp := regexp.MustCompile(`^/(.*?)/vm/(.*?)$`)


### PR DESCRIPTION
Description:
If multiple networks are configured, the installer will progress but fail very early in bootstrap due to API validation.

Test of this PR with multiple NICs:
```
$ ./bin/openshift-install create cluster --dir inst
ERROR failed to fetch Metadata: failed to load asset "Install Config": failed to create install config: invalid "install-config.yaml" file: platform.vsphere.failureDomains.topology.networks: Required value: must specify a single network
```