### PR TITLE
OCPBUGS-38070: Azure CAPI: Add check for APIServer OperatorPublishingStrategy

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -512,7 +512,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 
 	var lbBap *armnetwork.BackendAddressPool
 	var extLBFQDN string
-	if in.InstallConfig.Config.Publish == types.ExternalPublishingStrategy {
+	if in.InstallConfig.Config.PublicAPI() {
 		publicIP, err := createPublicIP(ctx, &pipInput{
 			name:          fmt.Sprintf("%s-pip-v4", in.InfraID),
 			infraID:       in.InfraID,
@@ -574,7 +574,7 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 	subscriptionID := ssn.Credentials.SubscriptionID
 	cloudConfiguration := ssn.CloudConfig
 
-	if in.InstallConfig.Config.Publish == types.ExternalPublishingStrategy {
+	if in.InstallConfig.Config.PublicAPI() {
 		vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, ssn.TokenCreds,
 			&arm.ClientOptions{
 				ClientOptions: policy.ClientOptions{

--- a/pkg/infrastructure/azure/dns.go
+++ b/pkg/infrastructure/azure/dns.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
-	"github.com/openshift/installer/pkg/types"
 )
 
 type recordListType string
@@ -39,7 +38,6 @@ type recordPrivateList struct {
 
 // Create DNS entries for azure.
 func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBFQDN string, resourceGroup string) error {
-	private := in.InstallConfig.Config.Publish == types.InternalPublishingStrategy
 	baseDomainResourceGroup := in.InstallConfig.Config.Azure.BaseDomainResourceGroupName
 	zone := in.InstallConfig.Config.BaseDomain
 	privatezone := in.InstallConfig.Config.ClusterDomain()
@@ -111,7 +109,7 @@ func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBF
 
 	// Create the records for api and api-int in the private zone and api.<clustername> for public zone.
 	// CAPI currently creates a record called "apiserver" instead of "api" so creating "api" for the installer in the private zone.
-	if !private {
+	if in.InstallConfig.Config.PublicAPI() {
 		cnameRecordName := apiExternalName
 		// apiExternalNameV6 := fmt.Sprintf("v6-api.%s", infraID)
 		// if useIPv6 {


### PR DESCRIPTION
While creating the DNS and External LB for APIServer, add check to make sure APIServer's OperatorPublishingStrategy is `External` when publishing strategy is `Mixed`. This is to
augment the existing check that looked at only the `PublishingStrategy`.