### PR TITLE
OCPBUGS-38177: install-status reflects day 2 services

### DIFF
--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -4,7 +4,14 @@
 source "issue_status.sh"
 
 inactive_services() {
-    local services="assisted-service.service agent-register-cluster.service agent-register-infraenv.service apply-host-config.service start-cluster-installation.service"
+    local services="assisted-service.service agent-register-infraenv.service apply-host-config.service"
+    if [ ! -e "/etc/assisted/add-nodes.env" ]; then
+        # install workflow
+        services+=" agent-register-cluster.service start-cluster-installation.service"
+    else
+        # add nodes workflow
+        services+=" agent-import-cluster.service agent-add-node.service"
+    fi
     for s in ${services}; do
         if ! systemctl is-active "${s}" >/dev/null; then
             printf "%s " "${s}"


### PR DESCRIPTION
Updated install-status.sh to check agent-import-cluster.service and agent-add-node.service for day 2 add nodes workflow.

agent-register-cluster.service and start-cluster-installation.service are classified as install workflow only services.