### PR TITLE
OCPBUGS-38599: incorrect folder gen, workaround govmomi vm folder path bug

### DIFF
--- a/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
@@ -39,12 +39,10 @@ func initializeFoldersAndTemplates(ctx context.Context, cachedImage string, fail
 	if err != nil {
 		return err
 	}
-	dcFolders, err := dc.Folders(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to get datacenter folder: %w", err)
-	}
 
-	folderPath := path.Join(dcFolders.VmFolder.InventoryPath, clusterID)
+	// Upstream govmomi bug, workaround
+	// https://github.com/vmware/govmomi/issues/3523
+	folderPath := path.Join(dc.InventoryPath, "vm", clusterID)
 
 	// we must set the Folder to the infraId somewhere, we will need to remove that.
 	// if we are overwriting folderPath it needs to have a slash (path)

--- a/pkg/infrastructure/vsphere/clusterapi/folder.go
+++ b/pkg/infrastructure/vsphere/clusterapi/folder.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
@@ -47,6 +48,7 @@ func createFolder(ctx context.Context, fullpath string, session *session.Session
 	}
 
 	if folder != nil && err == nil {
+		logrus.Debugf("creating folder %s in vcenter", base)
 		return folder.CreateFolder(ctx, base)
 	}
 	return folder, err


### PR DESCRIPTION
This PR resolves an issue when `folder` is undefined and datacenter exists as a child of a datacenter folder. instead of using DatacenterFolders.VmFolder we
replace that with a path.Join of the datacenter InventoryPath, vm and the clusterID. This will provide the entire correct path to the hidden `/vm/` folder in vCenter.