### PR TITLE
clusterapi: ignition interface returns secrets

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/stream-metadata-go/arch"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -791,7 +792,7 @@ func randomString(length int) string {
 
 // Ignition provisions the Azure container that holds the bootstrap ignition
 // file.
-func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
+func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]*corev1.Secret, error) {
 	session, err := in.InstallConfig.Azure.Session()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
@@ -865,5 +866,10 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("failed to create ignition shim: %w", err)
 	}
 
-	return ignShim, nil
+	ignSecrets := []*corev1.Secret{
+		clusterapi.IgnitionSecret(ignShim, in.InfraID, "bootstrap"),
+		clusterapi.IgnitionSecret(in.MasterIgnData, in.InfraID, "master"),
+	}
+
+	return ignSecrets, nil
 }

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -271,10 +271,12 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		logrus.Debugf("No infrastructure ready requirements for the %s provider", i.impl.Name())
 	}
 
+	masterIgnData := masterIgnAsset.Files()[0].Data
 	bootstrapIgnData, err := injectInstallInfo(bootstrapIgnAsset.Files()[0].Data)
 	if err != nil {
 		return fileList, fmt.Errorf("unable to inject installation info: %w", err)
 	}
+	ignitionSecrets := []*corev1.Secret{}
 
 	// The cloud-platform may need to override the default
 	// bootstrap ignition behavior.
@@ -282,22 +284,27 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		ignInput := IgnitionInput{
 			Client:           cl,
 			BootstrapIgnData: bootstrapIgnData,
+			MasterIgnData:    masterIgnData,
 			InfraID:          clusterID.InfraID,
 			InstallConfig:    installConfig,
 			TFVarsAsset:      tfvarsAsset,
 		}
 
 		timer.StartTimer(ignitionStage)
-		if bootstrapIgnData, err = p.Ignition(ctx, ignInput); err != nil {
+		if ignitionSecrets, err = p.Ignition(ctx, ignInput); err != nil {
 			return fileList, fmt.Errorf("failed preparing ignition data: %w", err)
 		}
 		timer.StopTimer(ignitionStage)
 	} else {
-		logrus.Debugf("No Ignition requirements for the %s provider", i.impl.Name())
+		logrus.Debugf("Using default ignition for the %s provider", i.impl.Name())
+		bootstrapIgnSecret := IgnitionSecret(bootstrapIgnData, clusterID.InfraID, "bootstrap")
+		masterIgnSecret := IgnitionSecret(masterIgnData, clusterID.InfraID, "master")
+		ignitionSecrets = append(ignitionSecrets, bootstrapIgnSecret, masterIgnSecret)
 	}
-	bootstrapIgnSecret := IgnitionSecret(bootstrapIgnData, clusterID.InfraID, "bootstrap")
-	masterIgnSecret := IgnitionSecret(masterIgnAsset.Files()[0].Data, clusterID.InfraID, "master")
-	machineManifests = append(machineManifests, bootstrapIgnSecret, masterIgnSecret)
+
+	for _, secret := range ignitionSecrets {
+		machineManifests = append(machineManifests, secret)
+	}
 
 	// Create the machine manifests.
 	timer.StartTimer(machineStage)

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
@@ -49,18 +50,20 @@ type PreProvisionInput struct {
 	WorkersAsset     *machines.Worker
 }
 
-// IgnitionProvider handles preconditions for bootstrap ignition and
-// generates ignition data for the CAPI bootstrap ignition secret.
+// IgnitionProvider handles preconditions for bootstrap ignition,
+// such as pushing to cloud storage. Returns bootstrap and master
+// ignition secrets.
 //
 // WARNING! Low-level primitive. Use only if absolutely necessary.
 type IgnitionProvider interface {
-	Ignition(ctx context.Context, in IgnitionInput) ([]byte, error)
+	Ignition(ctx context.Context, in IgnitionInput) ([]*corev1.Secret, error)
 }
 
 // IgnitionInput collects the args passed to the IgnitionProvider call.
 type IgnitionInput struct {
 	Client           client.Client
 	BootstrapIgnData []byte
+	MasterIgnData    []byte
 	InfraID          string
 	InstallConfig    *installconfig.InstallConfig
 	TFVarsAsset      *tfvars.TerraformVariables


### PR DESCRIPTION
Updates the clusterapi ignition interface so that it returns all ignition secrets. Prior to this commit, the ignition interface returned the bootstrap ignition data, and the provision method turned this data into secrets. Updating the interface to return all secrets, gives greater flexibility to the platform to completely control the ignition secrets that are created for that platform.

The motivation is that some platforms such as Nutanix may need to create per master ignition.