### PR TITLE
OCPBUGS-38069: Remove firewall rules created by CAPG

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -267,6 +267,15 @@ func (p Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapD
 		return fmt.Errorf("failed to remove bootstrap firewall rules: %w", err)
 	}
 
+	if in.Metadata.GCP.NetworkProjectID == "" {
+		// Remove the overly permissive firewall rules created by CAPG that are redundant with those created by installer
+		// These are not created in a shared VPC installation
+		logrus.Infof("Removing firewall rules created by cluster-api-provider-gcp")
+		if err := removeCAPGFirewallRules(ctx, in.Metadata.InfraID, in.Metadata.GCP.ProjectID); err != nil {
+			return fmt.Errorf("failed to remove firewall rules created by cluster-api-provider-gcp: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/infrastructure/gcp/clusterapi/firewallrules.go
+++ b/pkg/infrastructure/gcp/clusterapi/firewallrules.go
@@ -349,3 +349,14 @@ func removeBootstrapFirewallRules(ctx context.Context, infraID, projectID string
 	firewallName := fmt.Sprintf("%s-bootstrap-in-ssh", infraID)
 	return deleteFirewallRule(ctx, firewallName, projectID)
 }
+
+// removeCAPGFirewallRules removes the overly permissive firewall rules created by cluster-api-provider-gcp.
+func removeCAPGFirewallRules(ctx context.Context, infraID, projectID string) error {
+	firewallName := fmt.Sprintf("allow-%s-cluster", infraID)
+	if err := deleteFirewallRule(ctx, firewallName, projectID); err != nil {
+		return err
+	}
+
+	firewallName = fmt.Sprintf("allow-%s-healthchecks", infraID)
+	return deleteFirewallRule(ctx, firewallName, projectID)
+}


### PR DESCRIPTION
Remove the overly permissive firewall rules created by cluster-api-provider-gcp.