### PR TITLE
OCPBUGS-38657: upstream capv bug causes session timeout

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -276,6 +276,7 @@ func (c *system) Run(ctx context.Context) error {
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
 					"--leader-elect=false",
+					"--enable-keep-alive=false",
 				},
 				map[string]string{
 					"EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION": "true",


### PR DESCRIPTION
Until we can bump capv to the latest version
disable session keep alive that causes session
timeout and deadlocks as described in the links
attached to the bug.