### PR TITLE
NO-JIRA: Print the "export KUBECONFIG=..." command on its own line for easier cut-and-paste

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -773,7 +773,7 @@ func logComplete(directory, consoleURL string) error {
 		return err
 	}
 	logrus.Info("Install complete!")
-	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", kubeconfig)
+	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run\n    export KUBECONFIG=%s", kubeconfig)
 	if consoleURL != "" {
 		logrus.Infof("Access the OpenShift web-console here: %s", consoleURL)
 		if skipPasswordPrintFlag {


### PR DESCRIPTION
A long time ago I submitted a PR (#6018) to change the installer output from

```
INFO To access the cluster as the system:admin user when using 'oc',
run 'export KUBECONFIG=/path/to/installer/auth/kubeconfig'
```

to

```
INFO To access the cluster as the system:admin user when using 'oc', run
    export KUBECONFIG=/path/to/installer/auth/kubeconfig
```

for ease of cut-and-pasting, but then a few months later it accidentally got reverted due to a badly-resolved merge conflict in #5336.

This just puts it back to how it was in #6018 (which, FTR, is how README.md still claims it prints it).