### PR TITLE
OCPBUGS-38722: aws: validate public-only subnets configs

### DIFF
--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -136,7 +135,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		availabilityZones[*az.ZoneName] = az
 	}
 
-	publicOnlySubnets := os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY") != ""
+	publicOnlySubnets := typesaws.IsPublicOnlySubnetsEnabled()
 
 	for _, id := range ids {
 		meta, ok := metas[id]

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -49,6 +50,13 @@ func Validate(ctx context.Context, meta *Metadata, config *types.InstallConfig) 
 	allErrs = append(allErrs, validateAMI(ctx, config)...)
 	allErrs = append(allErrs, validatePublicIpv4Pool(ctx, meta, field.NewPath("platform", "aws", "publicIpv4PoolId"), config)...)
 	allErrs = append(allErrs, validatePlatform(ctx, meta, field.NewPath("platform", "aws"), config.Platform.AWS, config.Networking, config.Publish)...)
+
+	if awstypes.IsPublicOnlySubnetsEnabled() {
+		logrus.Warnln("Public-only subnets install. Please be warned this is not supported")
+		if config.Publish == types.InternalPublishingStrategy {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("publish"), config.Publish, "cluster cannot be private with public subnets"))
+		}
+	}
 
 	if config.ControlPlane != nil {
 		arch := string(config.ControlPlane.Architecture)
@@ -101,6 +109,8 @@ func validatePlatform(ctx context.Context, meta *Metadata, fldPath *field.Path, 
 
 	if len(platform.Subnets) > 0 {
 		allErrs = append(allErrs, validateSubnets(ctx, meta, fldPath.Child("subnets"), platform.Subnets, networking, publish)...)
+	} else if awstypes.IsPublicOnlySubnetsEnabled() {
+		allErrs = append(allErrs, field.Required(fldPath.Child("subnets"), "subnets must be specified for public-only subnets clusters"))
 	}
 	if platform.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, validateMachinePool(ctx, meta, fldPath.Child("defaultMachinePlatform"), platform, platform.DefaultMachinePlatform, controlPlaneReq, "", "")...)
@@ -221,6 +231,9 @@ func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, s
 		if _, ok := publicSubnets[id]; ok {
 			publicSubnetsIdx[id] = idx
 		}
+	}
+	if len(publicSubnets) == 0 && awstypes.IsPublicOnlySubnetsEnabled() {
+		allErrs = append(allErrs, field.Required(fldPath, "public subnets are required for a public-only subnets cluster"))
 	}
 
 	edgeSubnets, err := meta.EdgeSubnets(ctx)

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -267,6 +267,7 @@ func TestValidate(t *testing.T) {
 		edgeSubnets    Subnets
 		instanceTypes  map[string]InstanceType
 		proxy          string
+		publicOnly     string
 		expectErr      string
 	}{{
 		name: "valid no byo",
@@ -854,6 +855,42 @@ func TestValidate(t *testing.T) {
 		}(),
 		availZones: validAvailZones(),
 		expectErr:  `^platform.aws.publicIpv4PoolId: Invalid value: "ipv4pool-ec2-123": publish strategy Internal can't be used with custom Public IPv4 Pools$`,
+	}, {
+		name: "invalid publish method for public-only subnets install",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfig()
+			c.Publish = types.InternalPublishingStrategy
+			return c
+		}(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		publicOnly:     "true",
+		expectErr:      `^publish: Invalid value: \"Internal\": cluster cannot be private with public subnets$`,
+	}, {
+		name: "no subnets specified for public-only subnets cluster",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfig()
+			c.Platform.AWS.Subnets = []string{}
+			return c
+		}(),
+		privateSubnets: validPrivateSubnets(),
+		availZones:     validAvailZones(),
+		publicOnly:     "true",
+		expectErr:      `^platform\.aws\.subnets: Required value: subnets must be specified for public-only subnets clusters$`,
+	}, {
+		name:           "no public subnets specified for public-only subnets cluster",
+		installConfig:  validInstallConfig(),
+		privateSubnets: validPrivateSubnets(),
+		availZones:     validAvailZones(),
+		publicOnly:     "true",
+		expectErr:      `platform\.aws\.subnets: Required value: public subnets are required for a public-only subnets cluster`,
+	}, {
+		name:           "valid public-only subnets install config",
+		installConfig:  validInstallConfig(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		availZones:     validAvailZones(),
+		publicOnly:     "true",
 	}}
 
 	for _, test := range tests {
@@ -870,6 +907,11 @@ func TestValidate(t *testing.T) {
 				os.Setenv("HTTP_PROXY", test.proxy)
 			} else {
 				os.Unsetenv("HTTP_PROXY")
+			}
+			if test.publicOnly != "" {
+				os.Setenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY", test.publicOnly)
+			} else {
+				os.Unsetenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY")
 			}
 			err := Validate(context.TODO(), meta, test.installConfig)
 			if test.expectErr == "" {

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -167,7 +166,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			return fmt.Errorf("failed to create CAPA tags from UserTags: %w", err)
 		}
 
-		publicOnlySubnets := os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY") != ""
+		publicOnlySubnets := awstypes.IsPublicOnlySubnetsEnabled()
 
 		pool.Platform.AWS = &mpool
 		awsMachines, err := aws.GenerateMachines(clusterID.InfraID, &aws.MachineInput{

--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
 // BootstrapSSHDescription is the description for the
@@ -253,7 +253,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 		}
 	}
 
-	if len(os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY")) > 0 {
+	if awstypes.IsPublicOnlySubnetsEnabled() {
 		// If we don't set the subnets for the internal LB, CAPA will try to use private subnets but there aren't any in
 		// public-only mode.
 		awsCluster.Spec.ControlPlaneLoadBalancer.Subnets = awsCluster.Spec.NetworkSpec.Subnets.IDs()

--- a/pkg/asset/manifests/aws/zones.go
+++ b/pkg/asset/manifests/aws/zones.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -14,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	utilscidr "github.com/openshift/installer/pkg/asset/manifests/capiutils/cidr"
 	"github.com/openshift/installer/pkg/types"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
 // subnetsInput handles subnets information gathered from metadata.
@@ -166,7 +166,7 @@ func setSubnetsBYOVPC(in *zonesInput) error {
 	// Skip adding private subnets if this is a public-only subnets install.
 	// We need to skip because the Installer is tricked into thinking the public subnets are also private and we would
 	// end up adding public subnets twice to the cluster manifest, causing a duplicate error.
-	if len(os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY")) == 0 {
+	if !awstypes.IsPublicOnlySubnetsEnabled() {
 		for _, subnet := range in.Subnets.privateSubnets {
 			in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
 				ID:               subnet.ID,

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -145,4 +147,11 @@ func IsSecretRegion(region string) bool {
 		return true
 	}
 	return false
+}
+
+// IsPublicOnlySubnetsEnabled returns whether the public-only subnets feature has been enabled via env var.
+func IsPublicOnlySubnetsEnabled() bool {
+	// Even though this looks too simple for a function, it's better than having to update the logic everywhere it's
+	// used in case we decide to check for specific values set in the env var.
+	return os.Getenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY") != ""
 }


### PR DESCRIPTION
A public-only subnets cluster install requires:

1. publish method to not be "Internal"
2. a BYO VPC with public subnets