### PR TITLE
CFE-1105: Remove featureGate checks on GCP userLabels and userTags configs

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3514,8 +3514,7 @@ spec:
                     description: userLabels has additional keys and values that the
                       installer will add as labels to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
-                      these labels. GCPLabelsTags featureGate is defined for managing
-                      this feature and is enabled by default.
+                      these labels.
                     items:
                       description: UserLabel is a label to apply to GCP resources
                         created for the cluster.
@@ -3552,8 +3551,7 @@ spec:
                       installer will add as tags to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
                       these tags. Tag key and tag value should be the shortnames of
-                      the tag key and tag value resource. GCPLabelsTags featureGate
-                      is defined for managing this feature and is enabled by default.
+                      the tag key and tag value resource.
                     items:
                       description: UserTag is a tag to apply to GCP resources created
                         for the cluster.

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -52,15 +52,13 @@ type Platform struct {
 
 	// userLabels has additional keys and values that the installer will add as
 	// labels to all resources that it creates on GCP. Resources created by the
-	// cluster itself may not include these labels. GCPLabelsTags featureGate is
-	// defined for managing this feature and is enabled by default.
+	// cluster itself may not include these labels.
 	UserLabels []UserLabel `json:"userLabels,omitempty"`
 
 	// userTags has additional keys and values that the installer will add as
 	// tags to all resources that it creates on GCP. Resources created by the
 	// cluster itself may not include these tags. Tag key and tag value should
-	// be the shortnames of the tag key and tag value resource. GCPLabelsTags featureGate
-	// is defined for managing this feature and is enabled by default.
+	// be the shortnames of the tag key and tag value resource.
 	UserTags []UserTag `json:"userTags,omitempty"`
 
 	// UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default

--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -15,16 +15,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 	g := c.GCP
 	return []featuregates.GatedInstallConfigFeature{
 		{
-			FeatureGateName: features.FeatureGateGCPLabelsTags,
-			Condition:       len(g.UserLabels) > 0,
-			Field:           field.NewPath("platform", "gcp", "userLabels"),
-		},
-		{
-			FeatureGateName: features.FeatureGateGCPLabelsTags,
-			Condition:       len(g.UserTags) > 0,
-			Field:           field.NewPath("platform", "gcp", "userTags"),
-		},
-		{
 			FeatureGateName: features.FeatureGateGCPClusterHostedDNS,
 			Condition:       g.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
 			Field:           field.NewPath("platform", "gcp", "userProvisionedDNS"),

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -18,50 +18,6 @@ func TestFeatureGates(t *testing.T) {
 		expected      string
 	}{
 		{
-			name: "GCP UserTags is allowed with default enabled Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.Default
-				c.GCP = validGCPPlatform()
-				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
-				return c
-			}(),
-		},
-		{
-			name: "GCP UserTags is not allowed when GCPLabelsTags Feature Gate is disabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"GCPLabelsTags=false"}
-				c.GCP = validGCPPlatform()
-				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
-				return c
-			}(),
-			expected: `^platform.gcp.userTags: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
-		{
-			name: "GCP UserLabels is allowed with default enabled Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.Default
-				c.GCP = validGCPPlatform()
-				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
-				return c
-			}(),
-		},
-		{
-			name: "GCP UserLabels is not allowed when GCPLabelsTags Feature Gate is disabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"GCPLabelsTags=false"}
-				c.GCP = validGCPPlatform()
-				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
-				return c
-			}(),
-			expected: `^platform.gcp.userLabels: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
-		{
 			name: "GCP UserProvisionedDNS is not allowed without Feature Gates",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
`GCPLabelsTags` feature gate was enabled by default in 4.17 release. In 4.18 the feature gate and the checks will be removed.