### PR TITLE
OCPBUGS-39002: Add new disk types GCP Control Plane nodes

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -514,7 +514,8 @@ spec:
                               type: integer
                             diskType:
                               description: DiskType defines the type of disk. For
-                                control plane nodes, the valid value is pd-ssd.
+                                control plane nodes, the valid values are pd-balanced,
+                                pd-ssd, and hyperdisk-balanced.
                               enum:
                               - pd-balanced
                               - pd-ssd
@@ -1594,7 +1595,8 @@ spec:
                             type: integer
                           diskType:
                             description: DiskType defines the type of disk. For control
-                              plane nodes, the valid value is pd-ssd.
+                              plane nodes, the valid values are pd-balanced, pd-ssd,
+                              and hyperdisk-balanced.
                             enum:
                             - pd-balanced
                             - pd-ssd
@@ -3396,7 +3398,8 @@ spec:
                             type: integer
                           diskType:
                             description: DiskType defines the type of disk. For control
-                              plane nodes, the valid value is pd-ssd.
+                              plane nodes, the valid values are pd-balanced, pd-ssd,
+                              and hyperdisk-balanced.
                             enum:
                             - pd-balanced
                             - pd-ssd

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -181,6 +181,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	zones := defaultZones
 	instanceType := defaultInstanceType
 	arch := types.ArchitectureAMD64
+	cpDiskType := ""
 	if ic.ControlPlane != nil {
 		arch = string(ic.ControlPlane.Architecture)
 		if instanceType == "" {
@@ -193,6 +194,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			if len(ic.ControlPlane.Platform.GCP.Zones) > 0 {
 				zones = ic.ControlPlane.Platform.GCP.Zones
 			}
+			cpDiskType = ic.ControlPlane.Platform.GCP.DiskType
 		}
 	}
 	allErrs = append(allErrs,
@@ -202,7 +204,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			ic.GCP.ProjectID,
 			ic.GCP.Region,
 			zones,
-			"", // the control plane nodes only support one disk type currently
+			cpDiskType,
 			instanceType,
 			controlPlaneReq,
 			arch,

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -1,11 +1,21 @@
 package gcp
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 // FeatureSwitch indicates whether the feature is enabled or disabled.
 type FeatureSwitch string
 
 // OnHostMaintenanceType indicates the setting for the OnHostMaintenance feature, but this is only
 // applicable when ConfidentialCompute is Enabled.
 type OnHostMaintenanceType string
+
+var (
+	// ControlPlaneSupportedDisks contains the supported disk types for control plane nodes.
+	ControlPlaneSupportedDisks = sets.New("hyperdisk-balanced", "pd-balanced", "pd-ssd")
+
+	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
+	ComputeSupportedDisks = sets.New("hyperdisk-balanced", "pd-balanced", "pd-ssd", "pd-standard")
+)
 
 const (
 	// EnabledFeature indicates that the feature is configured as enabled.
@@ -85,7 +95,7 @@ type MachinePool struct {
 // OSDisk defines the disk for machines on GCP.
 type OSDisk struct {
 	// DiskType defines the type of disk.
-	// For control plane nodes, the valid value is pd-ssd.
+	// For control plane nodes, the valid values are pd-balanced, pd-ssd, and hyperdisk-balanced.
 	// +optional
 	// +kubebuilder:validation:Enum=pd-balanced;pd-ssd;pd-standard;hyperdisk-balanced
 	DiskType string `json:"diskType"`

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -29,11 +29,8 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 		}
 	}
 
-	if p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-balanced")
-		if !diskTypes.Has(p.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
-		}
+	if diskType := p.OSDisk.DiskType; diskType != "" && !gcp.ComputeSupportedDisks.Has(diskType) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), diskType, sets.List(gcp.ComputeSupportedDisks)))
 	}
 
 	if p.ConfidentialCompute == string(gcp.EnabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
@@ -64,9 +61,8 @@ func ValidateServiceAccount(platform *gcp.Platform, p *types.MachinePool, fldPat
 func ValidateMasterDiskType(p *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if p.Name == "master" && p.Platform.GCP.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-ssd")
-		if !diskTypes.Has(p.Platform.GCP.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, diskTypes.List()))
+		if !gcp.ControlPlaneSupportedDisks.Has(p.Platform.GCP.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, sets.List(gcp.ControlPlaneSupportedDisks)))
 		}
 	}
 	return allErrs
@@ -77,10 +73,8 @@ func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	if p != nil && p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-ssd")
-
-		if !diskTypes.Has(p.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
+		if !gcp.ControlPlaneSupportedDisks.Has(p.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, sets.List(gcp.ControlPlaneSupportedDisks)))
 		}
 	}
 

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -179,6 +179,34 @@ func TestValidateMachinePool(t *testing.T) {
 			valid: false,
 		},
 		{
+			name:     "valid GCP disk type master",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "hyperdisk-balanced"
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name:     "invalid GCP disk type master",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "pd-standard"
+				return p
+			}(),
+			valid: false,
+		},
+		{
 			name:     "valid GCP service account use",
 			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1", NetworkProjectID: "ExampleNetworkProject"}},
 			pool: func() *types.MachinePool {


### PR DESCRIPTION
** GCP Control Plane Nodes should now be allowed to use pd-balanced and hyperdisk-balanced. The IOPS rating is sufficient for both disk types to be used for control plane nodes, but pd-standard still falls short.

** Update installer explain to provide the correct information