### PR TITLE
OCPBUGS-33308: IngressController subnet selection in AWS

### DIFF
--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -226,6 +226,9 @@ func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, s
 	if err != nil {
 		return append(allErrs, field.Invalid(fldPath, subnets, err.Error()))
 	}
+	if publish == types.InternalPublishingStrategy && len(publicSubnets) > 0 {
+		logrus.Warnf("Public subnets should not be provided when publish is set to %s", types.InternalPublishingStrategy)
+	}
 	publicSubnetsIdx := map[string]int{}
 	for idx, id := range subnets {
 		if _, ok := publicSubnets[id]; ok {


### PR DESCRIPTION
Add a warning that public subnets can not be set when publish is set to
internal