### PR TITLE
OCPBUGS-39081: Handle retry of extract-machine-os

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+CID_FILE="$1"
+
+podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --sdnotify=ignore --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
@@ -4,4 +4,6 @@ set -eu
 
 CID_FILE="$1"
 
-podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --sdnotify=ignore --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/
+podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --cgroups=no-conmon --sdnotify=ignore --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/
+
+systemd-notify --ready

--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -17,7 +17,8 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%N.cid
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile=%t/%N.cid
 ExecStopPost=-/bin/rm -f %t/%N.cid
 KillMode=none
-Type=oneshot
+Type=notify
+NotifyAccess=all
 RemainAfterExit=true
 Restart=on-failure
 RestartSec=10

--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -11,7 +11,7 @@ Before=ironic-httpd.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/ironic.env
-ExecStart=/usr/bin/podman run --rm --name machine-os-extractor --cidfile=%t/%N.cid --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS=${PROVISIONING_IP_OPTIONS} -v systemd-ironic:/shared:z $MACHINE_OS_IMAGES_IMAGE /bin/copy-metal --all /shared/html/images/
+ExecStart=/usr/local/bin/extract-machine-os.sh %t/%N.cid
 TimeoutStartSec=180
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%N.cid
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile=%t/%N.cid

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -34,7 +34,8 @@ done
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in approve-csr bootkube crio crio-configure image-customization ironic ironic-dnsmasq ironic-httpd ironic-ramdisk-logs \
+for service in approve-csr bootkube crio crio-configure \
+    extract-machine-os image-customization ironic ironic-dnsmasq ironic-httpd ironic-ramdisk-logs \
     kubelet master-bmh-update metal3-baremetal-operator release-image release-image-download sssd
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"


### PR DESCRIPTION
If a oneshot service fails, it will retry but services that depend on it will not be restarted. Instead, convert extract-machine-os to a notify script so that it will be retried until it succeeds.

This trick first seen at https://github.com/openshift/installer/pull/8742/files#r1681857649