### PR TITLE
OCPBUGS-37442: azure: Pick the next available IP address for internal LB

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -57,7 +57,7 @@ func (c *Client) GetVirtualNetwork(ctx context.Context, resourceGroupName, virtu
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
-	vnetClient, err := c.getVirtualNetworksClient(ctx)
+	vnetClient, err := c.GetVirtualNetworksClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (c *Client) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, v
 }
 
 // getVnetsClient sets up a new client to retrieve vnets
-func (c *Client) getVirtualNetworksClient(ctx context.Context) (*aznetwork.VirtualNetworksClient, error) {
+func (c *Client) GetVirtualNetworksClient(ctx context.Context) (*aznetwork.VirtualNetworksClient, error) {
 	vnetsClient := aznetwork.NewVirtualNetworksClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	vnetsClient.Authorizer = c.ssn.Authorizer
 	return &vnetsClient, nil

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/pkg/errors"
@@ -48,14 +49,6 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	computeSubnet := installConfig.Config.Platform.Azure.ComputeSubnetName(clusterID.InfraID)
 	networkSecurityGroup := installConfig.Config.Platform.Azure.NetworkSecurityGroupName(clusterID.InfraID)
 
-	controlPlaneOutboundLB := &capz.LoadBalancerSpec{
-		Name:             clusterID.InfraID,
-		FrontendIPsCount: to.Ptr(int32(1)),
-	}
-	if installConfig.Config.Platform.Azure.OutboundType == azure.UserDefinedRoutingOutboundType {
-		controlPlaneOutboundLB = nil
-	}
-
 	source := "*"
 	if installConfig.Config.Publish == types.InternalPublishingStrategy {
 		source = mainCIDR.String()
@@ -92,19 +85,48 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		nodeSubnetID = "UNKNOWN"
 	}
 
+	apiServerLB := capz.LoadBalancerSpec{
+		Name: fmt.Sprintf("%s-internal", clusterID.InfraID),
+		BackendPool: capz.BackendPool{
+			Name: fmt.Sprintf("%s-internal", clusterID.InfraID),
+		},
+		LoadBalancerClassSpec: capz.LoadBalancerClassSpec{
+			Type: capz.Internal,
+		},
+	}
+
+	controlPlaneOutboundLB := &capz.LoadBalancerSpec{
+		Name:             clusterID.InfraID,
+		FrontendIPsCount: to.Ptr(int32(1)),
+	}
+	if installConfig.Config.Platform.Azure.OutboundType == azure.UserDefinedRoutingOutboundType {
+		controlPlaneOutboundLB = nil
+	}
+
 	virtualNetworkID := ""
 	if installConfig.Config.Azure.VirtualNetwork != "" {
 		client, err := installConfig.Azure.Client()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get azure client: %w", err)
 		}
-
-		virtualNetwork, err := client.GetVirtualNetwork(context.TODO(), installConfig.Config.Azure.NetworkResourceGroupName, installConfig.Config.Azure.VirtualNetwork)
+		ctx := context.TODO()
+		virtualNetwork, err := client.GetVirtualNetwork(ctx, installConfig.Config.Azure.NetworkResourceGroupName, installConfig.Config.Azure.VirtualNetwork)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get azure virtual network: %w", err)
 		}
 		if virtualNetwork != nil {
 			virtualNetworkID = *virtualNetwork.ID
+		}
+		lbip, err := getNextAvailableIP(ctx, installConfig)
+		if err != nil {
+			return nil, err
+		}
+		apiServerLB.FrontendIPs = []capz.FrontendIP{{
+			Name: fmt.Sprintf("%s-internal-frontEnd", clusterID.InfraID),
+			FrontendIPClass: capz.FrontendIPClass{
+				PrivateIPAddress: lbip,
+			},
+		},
 		}
 	}
 
@@ -145,15 +167,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 						},
 					},
 				},
-				APIServerLB: capz.LoadBalancerSpec{
-					Name: fmt.Sprintf("%s-internal", clusterID.InfraID),
-					BackendPool: capz.BackendPool{
-						Name: fmt.Sprintf("%s-internal", clusterID.InfraID),
-					},
-					LoadBalancerClassSpec: capz.LoadBalancerClassSpec{
-						Type: capz.Internal,
-					},
-				},
+				APIServerLB:            apiServerLB,
 				ControlPlaneOutboundLB: controlPlaneOutboundLB,
 				Subnets: capz.Subnets{
 					{
@@ -239,4 +253,48 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			},
 		},
 	}, nil
+}
+
+func getNextAvailableIP(ctx context.Context, installConfig *installconfig.InstallConfig) (string, error) {
+	lbip := capz.DefaultInternalLBIPAddress
+	machineCidr := installConfig.Config.MachineNetwork
+	client, err := installConfig.Azure.Client()
+	if err != nil {
+		return "", fmt.Errorf("failed to get azure client: %w", err)
+	}
+	vClient, err := client.GetVirtualNetworksClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get azure virtual network client: %w", err)
+	}
+
+	availableIP, err := vClient.CheckIPAddressAvailability(ctx, installConfig.Config.Azure.NetworkResourceGroupName, installConfig.Config.Azure.VirtualNetwork, lbip)
+	if err != nil {
+		return "", fmt.Errorf("failed to get azure ip availability: %w", err)
+	}
+	if *availableIP.Available {
+		for _, cidrRange := range machineCidr {
+			_, ipnet, err := net.ParseCIDR(cidrRange.CIDR.String())
+			if err != nil {
+				return "", fmt.Errorf("failed to get machine network CIDR: %w", err)
+			}
+			if ipnet.Contains(net.ParseIP(lbip)) {
+				return lbip, nil
+			}
+		}
+	}
+	if *availableIP.AvailableIPAddresses == nil || len(*availableIP.AvailableIPAddresses) == 0 {
+		return "", fmt.Errorf("failed to get an available IP in given virtual network for LB: %w", err)
+	}
+	for _, ip := range *availableIP.AvailableIPAddresses {
+		for _, cidrRange := range machineCidr {
+			_, ipnet, err := net.ParseCIDR(cidrRange.CIDR.String())
+			if err != nil {
+				return "", fmt.Errorf("failed to get machine network CIDR: %w", err)
+			}
+			if ipnet.Contains(net.ParseIP(ip)) {
+				return ip, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to get available IP in given machine network: %w", err)
 }


### PR DESCRIPTION
If a cluster is installed in an existing vnet, since CAPI hardcodes
the internal LB IP to 10.0.0.100, there is a chance of conflict
if there was a cluster already installed. Added a check to see
if the default internal LB is available, else pick the next
available IP.

Also added a field in the install config "InternalLBIP" that the
users can set for the internal LB to use.