### PR TITLE
Removes instances of deprecated experimentalPropagateUserTags

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2600,12 +2600,6 @@ spec:
                           type: string
                         type: array
                     type: object
-                  experimentalPropagateUserTags:
-                    description: The field is deprecated. ExperimentalPropagateUserTags
-                      is an experimental flag that directs in-cluster operators to
-                      include the specified user tags in the tags of the AWS resources
-                      that the operators create.
-                    type: boolean
                   hostedZone:
                     description: HostedZone is the ID of an existing hosted zone into
                       which to add DNS records for the cluster's internal API. An

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -297,69 +297,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			},
 		},
 		{
-			name: "experimentalPropagateUserTags takes precedence",
-			data: `
-apiVersion: v1
-metadata:
-  name: test-cluster
-baseDomain: test-domain
-platform:
-  aws:
-    region: us-east-1
-    experimentalPropagateUserTags: false
-    propagateUserTags: true
-pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
-`,
-			expectedFound: true,
-			expectedConfig: &types.InstallConfig{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: types.InstallConfigVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
-				},
-				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
-				BaseDomain:                  "test-domain",
-				Networking: &types.Networking{
-					MachineNetwork: []types.MachineNetworkEntry{
-						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
-					},
-					NetworkType:    "OVNKubernetes",
-					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
-					ClusterNetwork: []types.ClusterNetworkEntry{
-						{
-							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
-							HostPrefix: 23,
-						},
-					},
-				},
-				ControlPlane: &types.MachinePool{
-					Name:           "master",
-					Replicas:       pointer.Int64Ptr(3),
-					Hyperthreading: types.HyperthreadingEnabled,
-					Architecture:   types.ArchitectureAMD64,
-				},
-				Compute: []types.MachinePool{
-					{
-						Name:           "worker",
-						Replicas:       pointer.Int64Ptr(3),
-						Hyperthreading: types.HyperthreadingEnabled,
-						Architecture:   types.ArchitectureAMD64,
-					},
-				},
-				Platform: types.Platform{
-					AWS: &aws.Platform{
-						Region:                       "us-east-1",
-						ExperimentalPropagateUserTag: pointer.BoolPtr(false),
-						PropagateUserTag:             false,
-					},
-				},
-				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
-				Publish:    types.ExternalPublishingStrategy,
-			},
-		},
-		{
-			name: "missing experimentalPropagateUserTags",
+			name: "set propagateUserTags to true",
 			data: `
 apiVersion: v1
 metadata:
@@ -410,9 +348,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				},
 				Platform: types.Platform{
 					AWS: &aws.Platform{
-						Region:                       "us-east-1",
-						ExperimentalPropagateUserTag: nil,
-						PropagateUserTag:             true,
+						Region:           "us-east-1",
+						PropagateUserTag: true,
 					},
 				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
@@ -420,7 +357,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			},
 		},
 		{
-			name: "support only experimental - backport test",
+			name: "set propagateUserTags to false",
 			data: `
 apiVersion: v1
 metadata:
@@ -429,7 +366,7 @@ baseDomain: test-domain
 platform:
   aws:
     region: us-east-1
-    experimentalPropagateUsertags: true
+    propagateUserTags: false
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: true,
@@ -471,9 +408,67 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				},
 				Platform: types.Platform{
 					AWS: &aws.Platform{
-						Region:                       "us-east-1",
-						ExperimentalPropagateUserTag: pointer.BoolPtr(true),
-						PropagateUserTag:             true,
+						Region:           "us-east-1",
+						PropagateUserTag: false,
+					},
+				},
+				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
+			},
+		},
+		{
+			name: "missing propagateUserTags sets the field to false",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+platform:
+  aws:
+    region: us-east-1
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: true,
+			expectedConfig: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
+				Networking: &types.Networking{
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
+					NetworkType:    "OVNKubernetes",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+							HostPrefix: 23,
+						},
+					},
+				},
+				ControlPlane: &types.MachinePool{
+					Name:           "master",
+					Replicas:       pointer.Int64Ptr(3),
+					Hyperthreading: types.HyperthreadingEnabled,
+					Architecture:   types.ArchitectureAMD64,
+				},
+				Compute: []types.MachinePool{
+					{
+						Name:           "worker",
+						Replicas:       pointer.Int64Ptr(3),
+						Hyperthreading: types.HyperthreadingEnabled,
+						Architecture:   types.ArchitectureAMD64,
+					},
+				},
+				Platform: types.Platform{
+					AWS: &aws.Platform{
+						Region:           "us-east-1",
+						PropagateUserTag: false,
 					},
 				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -156,9 +156,6 @@ func Test_PrintFields(t *testing.T) {
     defaultMachinePlatform <object>
       DefaultMachinePlatform is the default configuration used when installing on AWS for machine pools which do not define their own platform configuration.
 
-    experimentalPropagateUserTags <boolean>
-      The field is deprecated. ExperimentalPropagateUserTags is an experimental flag that directs in-cluster operators to include the specified user tags in the tags of the AWS resources that the operators create.
-
     hostedZone <string>
       HostedZone is the ID of an existing hosted zone into which to add DNS records for the cluster's internal API. An existing hosted zone can only be used when also using existing subnets. The hosted zone must be associated with the VPC containing the subnets. Leave the hosted zone unset to have the installer create the hosted zone on your behalf.
 

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -71,12 +71,6 @@ type Platform struct {
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 
-	// The field is deprecated. ExperimentalPropagateUserTags is an experimental
-	// flag that directs in-cluster operators to include the specified
-	// user tags in the tags of the AWS resources that the operators create.
-	// +optional
-	ExperimentalPropagateUserTag *bool `json:"experimentalPropagateUserTags,omitempty"`
-
 	// PropagateUserTags is a flag that directs in-cluster operators
 	// to include the specified user tags in the tags of the
 	// AWS resources that the operators create.

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -281,10 +281,6 @@ func upconvertVIP(newVIPValues *[]string, oldVIPValue, newFieldName, oldFieldNam
 
 // convertAWS upconverts deprecated fields in the AWS platform.
 func convertAWS(config *types.InstallConfig) error {
-	// Deprecated ExperimentalPropagateUserTag takes precedence when set
-	if config.Platform.AWS.ExperimentalPropagateUserTag != nil {
-		config.Platform.AWS.PropagateUserTag = *config.Platform.AWS.ExperimentalPropagateUserTag
-	}
 	// BestEffortDeleteIgnition takes precedence when set
 	if !config.AWS.BestEffortDeleteIgnition {
 		config.AWS.BestEffortDeleteIgnition = config.AWS.PreserveBootstrapIgnition


### PR DESCRIPTION
The PR intends to remove the instance and usage of deprecated experimentalPropagateUserTags field. It also updated unit testcases accordingly. The corresponding updates to enhancements are added in https://github.com/openshift/enhancements/pull/1669.