### PR TITLE
OCPBUGS-39206: Update GCP Disk Types 4.16

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -507,7 +507,8 @@ spec:
                               type: integer
                             diskType:
                               description: DiskType defines the type of disk. For
-                                control plane nodes, the valid value is pd-ssd.
+                                control plane nodes, the valid values are pd-balanced,
+                                pd-ssd, and hyperdisk-balanced.
                               enum:
                               - pd-balanced
                               - pd-ssd
@@ -1416,7 +1417,8 @@ spec:
                             type: integer
                           diskType:
                             description: DiskType defines the type of disk. For control
-                              plane nodes, the valid value is pd-ssd.
+                              plane nodes, the valid values are pd-balanced, pd-ssd,
+                              and hyperdisk-balanced.
                             enum:
                             - pd-balanced
                             - pd-ssd
@@ -3049,7 +3051,8 @@ spec:
                             type: integer
                           diskType:
                             description: DiskType defines the type of disk. For control
-                              plane nodes, the valid value is pd-ssd.
+                              plane nodes, the valid values are pd-balanced, pd-ssd,
+                              and hyperdisk-balanced.
                             enum:
                             - pd-balanced
                             - pd-ssd

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -512,6 +512,7 @@ spec:
                               - pd-balanced
                               - pd-ssd
                               - pd-standard
+                              - hyperdisk-balanced
                               type: string
                             encryptionKey:
                               description: EncryptionKey defines the KMS key to be
@@ -1420,6 +1421,7 @@ spec:
                             - pd-balanced
                             - pd-ssd
                             - pd-standard
+                            - hyperdisk-balanced
                             type: string
                           encryptionKey:
                             description: EncryptionKey defines the KMS key to be used
@@ -3052,6 +3054,7 @@ spec:
                             - pd-balanced
                             - pd-ssd
                             - pd-standard
+                            - hyperdisk-balanced
                             type: string
                           encryptionKey:
                             description: EncryptionKey defines the KMS key to be used

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -181,6 +181,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	zones := defaultZones
 	instanceType := defaultInstanceType
 	arch := types.ArchitectureAMD64
+	cpDiskType := ""
 	if ic.ControlPlane != nil {
 		arch = string(ic.ControlPlane.Architecture)
 		if instanceType == "" {
@@ -193,6 +194,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			if len(ic.ControlPlane.Platform.GCP.Zones) > 0 {
 				zones = ic.ControlPlane.Platform.GCP.Zones
 			}
+			cpDiskType = ic.ControlPlane.Platform.GCP.DiskType
 		}
 	}
 	allErrs = append(allErrs,
@@ -202,7 +204,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			ic.GCP.ProjectID,
 			ic.GCP.Region,
 			zones,
-			"", // the control plane nodes only support one disk type currently
+			cpDiskType,
 			instanceType,
 			controlPlaneReq,
 			arch,

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -74,7 +74,7 @@ func Validate(client API, ic *types.InstallConfig) error {
 }
 
 // ValidateInstanceType ensures the instance type has sufficient Vcpu and Memory.
-func ValidateInstanceType(client API, fieldPath *field.Path, project, region string, zones []string, instanceType string, req resourceRequirements, arch string) field.ErrorList {
+func ValidateInstanceType(client API, fieldPath *field.Path, project, region string, zones []string, diskType string, instanceType string, req resourceRequirements, arch string) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	typeMeta, typeZones, err := client.GetMachineTypeWithZones(context.TODO(), project, region, instanceType)
@@ -83,6 +83,14 @@ func ValidateInstanceType(client API, fieldPath *field.Path, project, region str
 			return append(allErrs, field.Invalid(fieldPath.Child("type"), instanceType, err.Error()))
 		}
 		return append(allErrs, field.InternalError(nil, err))
+	}
+
+	if diskType == "hyperdisk-balanced" {
+		family, _, _ := strings.Cut(instanceType, "-")
+		families := sets.NewString("c3", "c3d", "m1", "n4")
+		if !families.Has(family) {
+			allErrs = append(allErrs, field.NotSupported(fieldPath.Child("diskType"), family, families.List()))
+		}
 	}
 
 	userZones := sets.New(zones...)
@@ -153,6 +161,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	if ic.GCP.DefaultMachinePlatform != nil {
 		defaultZones = ic.GCP.DefaultMachinePlatform.Zones
 		defaultInstanceType = ic.GCP.DefaultMachinePlatform.InstanceType
+
 		if ic.GCP.DefaultMachinePlatform.InstanceType != "" {
 			allErrs = append(allErrs,
 				ValidateInstanceType(
@@ -161,6 +170,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 					ic.GCP.ProjectID,
 					ic.GCP.Region,
 					ic.GCP.DefaultMachinePlatform.Zones,
+					ic.GCP.DefaultMachinePlatform.DiskType,
 					ic.GCP.DefaultMachinePlatform.InstanceType,
 					defaultInstanceReq,
 					unknownArchitecture,
@@ -192,6 +202,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			ic.GCP.ProjectID,
 			ic.GCP.Region,
 			zones,
+			"", // the control plane nodes only support one disk type currently
 			instanceType,
 			controlPlaneReq,
 			arch,
@@ -213,6 +224,12 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 				zones = compute.Platform.GCP.Zones
 			}
 		}
+
+		diskType := ""
+		if compute.Platform.GCP != nil && compute.Platform.GCP.DiskType != "" {
+			diskType = compute.Platform.GCP.DiskType
+		}
+
 		allErrs = append(allErrs,
 			ValidateInstanceType(
 				client,
@@ -220,6 +237,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 				ic.GCP.ProjectID,
 				ic.GCP.Region,
 				zones,
+				diskType,
 				instanceType,
 				computeReq,
 				string(arch),

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -233,7 +233,7 @@ func getRegionFromZone(zoneName string) string {
 // projects/project/zones/zone/diskTypes/pd-standard -> "ssd_total_storage"
 func getDiskLimit(typeURL string) string {
 	switch getNameFromURL("diskTypes", typeURL) {
-	case "pd-balanced", "pd-ssd":
+	case "pd-balanced", "pd-ssd", "hyperdisk-balanced":
 		return "ssd_total_storage"
 	case "pd-standard":
 		return "disks_total_storage"

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -1,11 +1,21 @@
 package gcp
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 // FeatureSwitch indicates whether the feature is enabled or disabled.
 type FeatureSwitch string
 
 // OnHostMaintenanceType indicates the setting for the OnHostMaintenance feature, but this is only
 // applicable when ConfidentialCompute is Enabled.
 type OnHostMaintenanceType string
+
+var (
+	// ControlPlaneSupportedDisks contains the supported disk types for control plane nodes.
+	ControlPlaneSupportedDisks = sets.New("hyperdisk-balanced", "pd-balanced", "pd-ssd")
+
+	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
+	ComputeSupportedDisks = sets.New("hyperdisk-balanced", "pd-balanced", "pd-ssd", "pd-standard")
+)
 
 const (
 	// EnabledFeature indicates that the feature is configured as enabled.
@@ -86,7 +96,7 @@ type MachinePool struct {
 // OSDisk defines the disk for machines on GCP.
 type OSDisk struct {
 	// DiskType defines the type of disk.
-	// For control plane nodes, the valid value is pd-ssd.
+	// For control plane nodes, the valid values are pd-balanced, pd-ssd, and hyperdisk-balanced.
 	// +optional
 	// +kubebuilder:validation:Enum=pd-balanced;pd-ssd;pd-standard;hyperdisk-balanced
 	DiskType string `json:"diskType"`

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -88,7 +88,7 @@ type OSDisk struct {
 	// DiskType defines the type of disk.
 	// For control plane nodes, the valid value is pd-ssd.
 	// +optional
-	// +kubebuilder:validation:Enum=pd-balanced;pd-ssd;pd-standard
+	// +kubebuilder:validation:Enum=pd-balanced;pd-ssd;pd-standard;hyperdisk-balanced
 	DiskType string `json:"diskType"`
 
 	// DiskSizeGB defines the size of disk in GB.

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -29,11 +29,8 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 		}
 	}
 
-	if p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-balanced")
-		if !diskTypes.Has(p.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
-		}
+	if diskType := p.OSDisk.DiskType; diskType != "" && !gcp.ComputeSupportedDisks.Has(diskType) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), diskType, sets.List(gcp.ComputeSupportedDisks)))
 	}
 
 	if p.ConfidentialCompute == string(gcp.EnabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
@@ -74,9 +71,8 @@ func ValidateServiceAccount(platform *gcp.Platform, p *types.MachinePool, fldPat
 func ValidateMasterDiskType(p *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if p.Name == "master" && p.Platform.GCP.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-ssd")
-		if !diskTypes.Has(p.Platform.GCP.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, diskTypes.List()))
+		if !gcp.ControlPlaneSupportedDisks.Has(p.Platform.GCP.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, sets.List(gcp.ControlPlaneSupportedDisks)))
 		}
 	}
 	return allErrs
@@ -87,10 +83,8 @@ func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	if p != nil && p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-ssd")
-
-		if !diskTypes.Has(p.OSDisk.DiskType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
+		if !gcp.ControlPlaneSupportedDisks.Has(p.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, sets.List(gcp.ControlPlaneSupportedDisks)))
 		}
 	}
 

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -30,7 +30,7 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	}
 
 	if p.OSDisk.DiskType != "" {
-		diskTypes := sets.NewString("pd-balanced", "pd-ssd", "pd-standard")
+		diskTypes := sets.NewString("pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-balanced")
 		if !diskTypes.Has(p.OSDisk.DiskType) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
 		}

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -48,7 +48,7 @@ func TestValidateMachinePool(t *testing.T) {
 					DiskType: "pd-",
 				},
 			},
-			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-balanced", "pd-ssd", "pd-standard"$`,
+			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "hyperdisk-balanced", "pd-balanced", "pd-ssd", "pd-standard"$`,
 		},
 		{
 			name: "valid disk size",

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -179,6 +179,34 @@ func TestValidateMachinePool(t *testing.T) {
 			valid: false,
 		},
 		{
+			name:     "valid GCP disk type master",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "hyperdisk-balanced"
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name:     "invalid GCP disk type master",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "pd-standard"
+				return p
+			}(),
+			valid: false,
+		},
+		{
 			name:     "valid GCP service account use",
 			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1", NetworkProjectID: "ExampleNetworkProject"}},
 			pool: func() *types.MachinePool {


### PR DESCRIPTION
** Update the enumeration for GCP disks to include hyperdisk-balanced.
** Update the allowed disk types of compute nodes for gcp. This will now include hyperdisk-balanced.
** GCP Control Plane Nodes should now be allowed to use pd-balanced and
    hyperdisk-balanced. The IOPS rating is sufficient for both disk types
    to be used for control plane nodes, but pd-standard still falls short.
    
** Update installer explain to provide the correct information