### PR TITLE
OCPBUGS-39081: Bump extract-machine-os timout to 20m

### DIFF
--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -12,7 +12,7 @@ Before=ironic-httpd.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/ironic.env
 ExecStart=/usr/bin/podman run --rm --name machine-os-extractor --cidfile=%t/%N.cid --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS=${PROVISIONING_IP_OPTIONS} -v systemd-ironic:/shared:z $MACHINE_OS_IMAGES_IMAGE /bin/copy-metal --all /shared/html/images/
-TimeoutStartSec=180
+TimeoutStartSec=20m
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%N.cid
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile=%t/%N.cid
 ExecStopPost=-/bin/rm -f %t/%N.cid


### PR DESCRIPTION
This service has to download a large container image,
bump update the timout to allow for a slow download rate.
