### PR TITLE
OCPBUGS-39287: Fix var_files syntax to work on older version of ansible

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -1,11 +1,17 @@
 - hosts: localhost
   gather_facts: no
 
-  vars_files:
-  - metadata.json
-  - netid.json
+  vars:
+    var_files:
+    - metadata.json
+    - netid.json
 
   tasks:
+  - name: "Include external vars"
+    include_vars: "{{ item }}"
+    when: item is exists
+    loop: "{{ var_files|flatten(levels=1) }}"
+
   - name: "Check if metadata.json exists"
     ansible.builtin.stat:
       path: metadata.json


### PR DESCRIPTION
On ansible-core 2.14 and below, `var_files` chokes on missing file. This is no longer the case with ansible-core 2.15. We need a different strategy so that ansible ignores non-existent files.