### PR TITLE
OCPBUGS-36861: Updates GCP CAPI worker role

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/iam.go
+++ b/pkg/infrastructure/gcp/clusterapi/iam.go
@@ -45,6 +45,7 @@ func GetWorkerRoles() []string {
 	return []string{
 		"roles/compute.viewer",
 		"roles/storage.admin",
+		"roles/artifactregistry.reader",
 	}
 }
 


### PR DESCRIPTION
This change updates the GCP CAPI worker role to include permissions to pull from the artifact registry.

This ensures that new `.pkg.dev` images can be pulled and that once GCR is decomissioned, `.gcr.io` images can still be pulled.