### PR TITLE
OCPBUGS-36861: Updates GCP terraform worker role

### DIFF
--- a/data/data/gcp/cluster/iam/main.tf
+++ b/data/data/gcp/cluster/iam/main.tf
@@ -19,3 +19,9 @@ resource "google_project_iam_member" "worker-storage-admin" {
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
 }
+
+resource "google_project_iam_member" "worker-artifactregistry-reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
+}


### PR DESCRIPTION
This change updates the GCP terraform worker role to include permissions to pull from the artifact registry.

This ensures that new .pkg.dev images can be pulled and that once GCR is decomissioned, .gcr.io images can still be pulled.