### PR TITLE
OCPBUGS-39402: Fix IPv6 security group rule for schedulable master

### DIFF
--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -367,7 +367,7 @@
         security_group: "{{ os_sg_master }}"
         ethertype: IPv6
         protocol: tcp
-        remote_ip_prefix: "{{ os_subnet_range }}"
+        remote_ip_prefix: "{{ os_subnet6_range }}"
         port_range_min: 1936
         port_range_max: 1936
       when: os_master_schedulable is defined and os_master_schedulable


### PR DESCRIPTION
There was a typo and we were trying to match an IPv6 network for remote IP prefix instead of an IPv6 one.