### PR TITLE
OCPBUGS-37506: Fix Azure storage account's public access

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -361,9 +361,9 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	logrus.Debugf("StorageAccount.ID=%s", *storageAccount.ID)
 
 	// Create blob storage container
-	publicAccess := armstorage.PublicAccessContainer
+	publicAccess := armstorage.PublicAccessNone
 	if platform.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessNone
+		publicAccess = armstorage.PublicAccessContainer
 	}
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{
 		SubscriptionID:       subscriptionID,
@@ -814,9 +814,9 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 	ignitionContainerName := "ignition"
 	blobName := "bootstrap.ign"
 	blobURL := fmt.Sprintf("%s/%s/%s", p.StorageURL, ignitionContainerName, blobName)
-	publicAccess := armstorage.PublicAccessContainer
+	publicAccess := armstorage.PublicAccessNone
 	if in.InstallConfig.Config.Azure.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessNone
+		publicAccess = armstorage.PublicAccessContainer
 	}
 	// Create ignition blob storage container
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{

--- a/pkg/infrastructure/azure/storage.go
+++ b/pkg/infrastructure/azure/storage.go
@@ -97,7 +97,7 @@ func CreateStorageAccount(ctx context.Context, in *CreateStorageAccountInput) (*
 		Location: to.Ptr(in.Region),
 		SKU:      &sku,
 		Properties: &armstorage.AccountPropertiesCreateParameters{
-			AllowBlobPublicAccess: to.Ptr(true),
+			AllowBlobPublicAccess: to.Ptr(false),
 			AllowSharedKeyAccess:  to.Ptr(allowSharedKeyAccess),
 			IsLocalUserEnabled:    to.Ptr(true),
 			LargeFileSharesState:  to.Ptr(armstorage.LargeFileSharesStateEnabled),
@@ -141,6 +141,7 @@ func CreateStorageAccount(ctx context.Context, in *CreateStorageAccountInput) (*
 		accountCreateParameters.Identity = &identity
 		accountCreateParameters.SKU = &sku
 		accountCreateParameters.Properties.Encryption = encryption
+		accountCreateParameters.Properties.AllowBlobPublicAccess = to.Ptr(true)
 	}
 
 	logrus.Debugf("Creating storage account")


### PR DESCRIPTION
While creating the Azure Storage account, give it public access only when CustomerManaged Key is present. Similarly, create Blob containers for Ignition and vhd with no public access by default unless CustomerManagedKey is present. 

See: https://github.com/openshift/installer/blob/d570c0561c0763f95b3eee6f80c7a84653db818a/data/data/azure/vnet/main.tf#L75 