### PR TITLE
[release-4.16] OCPBUGS-39468: Enable TLS for virtual media in initial ironic deployment

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-httpd.container.template
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic-httpd.container.template
@@ -17,10 +17,14 @@ Network=host
 # podman (rather than systemd) redirect the logs to journald.
 PodmanArgs=--log-driver=journald
 Volume=ironic.volume:/shared:z
+{{ if not .PlatformData.BareMetal.DisableIronicVirtualMediaTLS }}
+Volume=/opt/openshift/tls/ironic/:/certs/vmedia/:z
+{{ end }}
 Environment="IRONIC_RAMDISK_SSH_KEY=${IRONIC_RAMDISK_SSH_KEY}"
 Environment="PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE}"
 Environment="HTTP_PORT=${HTTP_PORT}"
 Environment="USE_IRONIC_INSPECTOR=false"
+Environment="VMEDIA_TLS_PORT=6183"
 
 [Service]
 EnvironmentFile=/etc/ironic.env

--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic.container.template
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/ironic.container.template
@@ -18,6 +18,9 @@ Exec=/bin/runironic
 Network=host
 Volume=${AUTH_DIR}:/auth:z,ro
 Volume=ironic.volume:/shared:z
+{{ if not .PlatformData.BareMetal.DisableIronicVirtualMediaTLS }}
+Volume=/opt/openshift/tls/ironic/:/certs/vmedia/:z
+{{ end }}
 Environment="IRONIC_RAMDISK_SSH_KEY=${IRONIC_RAMDISK_SSH_KEY}"
 Environment="PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE}"
 Environment="OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120"
@@ -26,6 +29,7 @@ Environment="IRONIC_KERNEL_PARAMS=${IRONIC_KERNEL_PARAMS}"
 Environment="HTTP_PORT=${HTTP_PORT}"
 Environment="OS_DEFAULT__FORCE_RAW_IMAGES=False"
 Environment="USE_IRONIC_INSPECTOR=false"
+Environment="VMEDIA_TLS_PORT=6183"
 
 [Service]
 EnvironmentFile=/etc/ironic.env

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -5,8 +5,12 @@ import (
 	"net"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 	utilsnet "k8s.io/utils/net"
 
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 )
@@ -79,13 +83,16 @@ type TemplateData struct {
 
 	// ExternalURLv6 is a callback URL for the node if the node and the BMC use different network families
 	ExternalURLv6 string
+
+	// DisableIronicVirtualMediaTLS enables or disables TLS in ironic virtual media deployments
+	DisableIronicVirtualMediaTLS bool
 }
 
-func externalURLs(apiVIPs []string) (externalURLv4 string, externalURLv6 string) {
+func externalURLs(apiVIPs []string, protocol string) (externalURLv4 string, externalURLv6 string) {
 	if len(apiVIPs) > 1 {
 		// IPv6 BMCs may not be able to reach IPv4 servers, use the right callback URL for them.
 		// Warning: when backporting to 4.12 or earlier, change the port to 80!
-		externalURL := fmt.Sprintf("http://%s/", net.JoinHostPort(apiVIPs[1], "6180"))
+		externalURL := fmt.Sprintf("%s://%s/", protocol, net.JoinHostPort(apiVIPs[1], "6180"))
 		if utilsnet.IsIPv6String(apiVIPs[1]) {
 			externalURLv6 = externalURL
 		}
@@ -98,7 +105,7 @@ func externalURLs(apiVIPs []string) (externalURLv4 string, externalURLv6 string)
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
-func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, controlPlaneReplicaCount int64, ironicUsername, ironicPassword string) *TemplateData {
+func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, controlPlaneReplicaCount int64, ironicUsername, ironicPassword string, dependencies asset.Parents) *TemplateData {
 	var templateData TemplateData
 
 	templateData.Hosts = config.Hosts
@@ -111,8 +118,42 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	templateData.ExternalStaticDNS = config.BootstrapExternalStaticDNS
 	templateData.ExternalMACAddress = config.ExternalMACAddress
 
-	_, externalURLv6 := externalURLs(config.APIVIPs)
+	// If the user has manually set disableVirtualMediaTLS to False in the Provisioning CR, then enable TLS in ironic.
+	// The default value of 'true' is temporary (for backporting to older releases), which will be changed to 'false' in the future.
+	templateData.DisableIronicVirtualMediaTLS = true
+	protocol := "http"
 
+	type provisioningCRTemplate struct {
+		Spec struct {
+			DisableVirtualMediaTLS *bool `yaml:"disableVirtualMediaTLS"`
+		} `yaml:"spec"`
+	}
+	provisioningCR := &provisioningCRTemplate{}
+	openshiftManifests := &manifests.Openshift{}
+	dependencies.Get(openshiftManifests)
+	var provisioningCRBytes []byte
+	for _, file := range openshiftManifests.Files() {
+		if strings.Contains(file.Filename, "99_baremetal-provisioning-config.yaml") {
+			provisioningCRBytes = file.Data
+			break
+		}
+	}
+	if provisioningCRBytes != nil {
+		err := yaml.Unmarshal(provisioningCRBytes, provisioningCR)
+		if err != nil {
+			logrus.Errorf("Error in unmarshalling Provisioning CR while generating TLS certificate for ironic virtual media: %s", err)
+		}
+	} else {
+		logrus.Errorf("No Provisioning CR data found while generating TLS certificate for ironic virtual media")
+	}
+	if provisioningCR.Spec.DisableVirtualMediaTLS != nil {
+		templateData.DisableIronicVirtualMediaTLS = *provisioningCR.Spec.DisableVirtualMediaTLS
+		if !*provisioningCR.Spec.DisableVirtualMediaTLS {
+			logrus.Debugf("TLS is enabled for ironic virtual media")
+			protocol = "https"
+		}
+	}
+	_, externalURLv6 := externalURLs(config.APIVIPs, protocol)
 	templateData.ExternalURLv6 = externalURLv6
 
 	if len(config.APIVIPs) > 0 {

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/baremetal"
 )
@@ -35,7 +37,12 @@ func TestTemplatingIPv4(t *testing.T) {
 		},
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
+	openshiftDependency := []asset.Asset{
+		&manifests.Openshift{},
+	}
+	dependencies := asset.Parents{}
+	dependencies.Add(openshiftDependency...)
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd", dependencies)
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100,24")
 	assert.Equal(t, result.ProvisioningCIDR, 24)
@@ -53,8 +60,13 @@ func TestTemplatingManagedIPv6(t *testing.T) {
 		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",
 		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
 	}
+	openshiftDependency := []asset.Asset{
+		&manifests.Openshift{},
+	}
+	dependencies := asset.Parents{}
+	dependencies.Add(openshiftDependency...)
 
-	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd", dependencies)
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff,80")
 	assert.Equal(t, result.ProvisioningCIDR, 80)
@@ -70,8 +82,13 @@ func TestTemplatingUnmanagedIPv6(t *testing.T) {
 		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",
 		ProvisioningNetwork:     baremetal.UnmanagedProvisioningNetwork,
 	}
+	openshiftDependency := []asset.Asset{
+		&manifests.Openshift{},
+	}
+	dependencies := asset.Parents{}
+	dependencies.Add(openshiftDependency...)
 
-	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd")
+	result := GetTemplateData(&bareMetalConfig, nil, 3, "bootstrap-ironic-user", "passw0rd", dependencies)
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "")
 	assert.Equal(t, result.ProvisioningCIDR, 64)

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -158,6 +158,7 @@ func (a *Common) Dependencies() []asset.Asset {
 		&tls.MCSCertKey{},
 		&tls.RootCA{},
 		&tls.ServiceAccountKeyPair{},
+		&tls.IronicTLSCert{},
 		&releaseimage.Image{},
 		new(rhcos.Image),
 	}
@@ -289,6 +290,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 			*installConfig.Config.ControlPlane.Replicas,
 			ironicCreds.Username,
 			ironicCreds.Password,
+			dependencies,
 		)
 	case vspheretypes.Name:
 		platformData.VSphere = vsphere.GetTemplateData(installConfig.Config.Platform.VSphere)
@@ -612,6 +614,7 @@ func (a *Common) addParentFiles(dependencies asset.Parents) {
 		&tls.MCSCertKey{},
 		&tls.ServiceAccountKeyPair{},
 		&tls.JournalCertKey{},
+		&tls.IronicTLSCert{},
 	} {
 		dependencies.Get(asset)
 

--- a/pkg/asset/tls/ironictls.go
+++ b/pkg/asset/tls/ironictls.go
@@ -1,0 +1,64 @@
+package tls
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+)
+
+// IronicTLSCert is the asset that generates the key/cert pair that is used for
+// enabling TLS for virtual media in ironic.
+type IronicTLSCert struct {
+	SelfSignedCertKey
+}
+
+var _ asset.WritableAsset = (*IronicTLSCert)(nil)
+
+// Dependencies returns the dependency of the the cert/key pair, which includes
+// the parent CA, and install config if it depends on the install config for
+// DNS names, etc.
+func (a *IronicTLSCert) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the cert/key pair based on its dependencies.
+func (a *IronicTLSCert) Generate(dependencies asset.Parents) error {
+	installConfig := &installconfig.InstallConfig{}
+	dependencies.Get(installConfig)
+	if installConfig.Config.Platform.BareMetal == nil {
+		return nil
+	}
+
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "ironic", OrganizationalUnit: []string{"openshift"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Validity:     ValidityOneDay,
+	}
+
+	vips := installConfig.Config.BareMetal.APIVIPs
+	if installConfig.Config.BareMetal.BootstrapProvisioningIP != "" {
+		vips = append(vips, installConfig.Config.BareMetal.BootstrapProvisioningIP)
+	}
+	cfg.IPAddresses = []net.IP{}
+	for _, vip := range vips {
+		cfg.IPAddresses = append(cfg.IPAddresses, net.ParseIP(vip))
+	}
+	hostname := internalAPIAddress(installConfig.Config)
+	cfg.DNSNames = []string{hostname}
+
+	logrus.Debugf("Generating TLS certificate for ironic (virtual media)")
+	return a.SelfSignedCertKey.Generate(cfg, "ironic/tls")
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *IronicTLSCert) Name() string {
+	return "Certificate (ironic virtual media TLS)"
+}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/installer/pull/8819