### PR TITLE
OCPBUGS-36196: pkg/infrastructure/azure: set correct cloud for BYO vnet

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -234,7 +234,15 @@ func (p *Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionI
 
 	// Creating a dummy nsg for existing vnets installation to appease the ingress operator.
 	if in.InstallConfig.Config.Azure.VirtualNetwork != "" {
-		networkClientFactory, err := armnetwork.NewClientFactory(subscriptionID, tokenCredential, nil)
+		networkClientFactory, err := armnetwork.NewClientFactory(
+			subscriptionID,
+			tokenCredential,
+			&arm.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Cloud: cloudConfiguration,
+				},
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create azure network factory: %w", err)
 		}


### PR DESCRIPTION
Cloud configuration wasn't being set when an existing vnet was set. 