### PR TITLE
OSASINFRA-3571: openstack: refactor ConfigDrive & add it for workers

### DIFF
--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -34,6 +34,9 @@ func MachineSets(ctx context.Context, clusterID string, config *types.InstallCon
 	}
 	mpool := pool.Platform.OpenStack
 
+	// Only enable config drive when using single stack IPv6
+	configDrive := isSingleStackIPv6(config.MachineNetwork)
+
 	// In installer CLI code paths, the replica number is set to 3 by default
 	// when install-config does not have any Compute machine-pool, or when the
 	// Compute machine-pool does not have the `replicas` property.
@@ -68,6 +71,7 @@ func MachineSets(ctx context.Context, clusterID string, config *types.InstallCon
 			role,
 			userDataSecret,
 			failureDomains[idx],
+			&configDrive,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/asset/machines/openstack/openstackmachines_test.go
+++ b/pkg/asset/machines/openstack/openstackmachines_test.go
@@ -1,0 +1,82 @@
+package openstack
+
+import (
+	"net"
+	"testing"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestIsSingleStackIPv6(t *testing.T) {
+	tests := []struct {
+		name           string
+		machineNetwork []types.MachineNetworkEntry
+		expected       bool
+	}{
+		{
+			name: "single IPv6 CIDR",
+			machineNetwork: []types.MachineNetworkEntry{
+				{
+					CIDR: ipnet.IPNet{
+						IPNet: net.IPNet{
+							IP:   net.ParseIP("2001:db8::"),
+							Mask: net.CIDRMask(32, 128),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "single IPv4 CIDR",
+			machineNetwork: []types.MachineNetworkEntry{
+				{
+					CIDR: ipnet.IPNet{
+						IPNet: net.IPNet{
+							IP:   net.ParseIP("192.168.1.0"),
+							Mask: net.CIDRMask(24, 32),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple CIDRs",
+			machineNetwork: []types.MachineNetworkEntry{
+				{
+					CIDR: ipnet.IPNet{
+						IPNet: net.IPNet{
+							IP:   net.ParseIP("2001:db8::"),
+							Mask: net.CIDRMask(32, 128),
+						},
+					},
+				},
+				{
+					CIDR: ipnet.IPNet{
+						IPNet: net.IPNet{
+							IP:   net.ParseIP("192.168.1.0"),
+							Mask: net.CIDRMask(24, 32),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:           "empty machine network",
+			machineNetwork: []types.MachineNetworkEntry{},
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSingleStackIPv6(tt.machineNetwork)
+			if result != tt.expected {
+				t.Errorf("isSingleStackIPv6() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Create a function to figure out whether IPv6 single stack is enabled
  and that will activate ConfigDrive.
* Enable ConfigDrive for workers as well, not just masters.
