### PR TITLE
NO-JIRA: ignition/bootstrap/common: account for templated files when setting mode

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -399,6 +399,7 @@ func AddStorageFiles(config *igntypes.Config, base string, uri string, templateD
 	}
 
 	filename := path.Base(uri)
+	filename = strings.TrimSuffix(filename, ".template")
 	parentDir := path.Base(path.Dir(uri))
 
 	var mode int

--- a/pkg/asset/imagebased/image/ignition.go
+++ b/pkg/asset/imagebased/image/ignition.go
@@ -130,7 +130,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 	}
 
 	if ibiConfig.IgnitionConfigOverride != "" {
-		if err := setIngnitionConfigOverride(config, ibiConfig.IgnitionConfigOverride); err != nil {
+		if err := setIgnitionConfigOverride(config, ibiConfig.IgnitionConfigOverride); err != nil {
 			return fmt.Errorf("failed to override ignition config: %w", err)
 		}
 	}
@@ -152,7 +152,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 	return nil
 }
 
-func setIngnitionConfigOverride(config *igntypes.Config, override string) error {
+func setIgnitionConfigOverride(config *igntypes.Config, override string) error {
 	ignitionConfigOverride, _, err := v3_2.Parse([]byte(override))
 	if err != nil {
 		return fmt.Errorf("failed to parse ignition config override: %w", err)


### PR DESCRIPTION
The if chain just after this expects the final filename and not the
possibly templated version. Strip the suffix in case it's a templated
file.

This notably fixes the mode for `registries.conf`, which became a
templated file and so went from 0644 to 0600. This patch brings it back
to 0644.

