### PR TITLE
[release-4.17] OCPBUGS-41539: Pick the next available IP address for internal LB

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -57,7 +57,7 @@ func (c *Client) GetVirtualNetwork(ctx context.Context, resourceGroupName, virtu
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
-	vnetClient, err := c.getVirtualNetworksClient(ctx)
+	vnetClient, err := c.GetVirtualNetworksClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (c *Client) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, v
 }
 
 // getVnetsClient sets up a new client to retrieve vnets
-func (c *Client) getVirtualNetworksClient(ctx context.Context) (*aznetwork.VirtualNetworksClient, error) {
+func (c *Client) GetVirtualNetworksClient(ctx context.Context) (*aznetwork.VirtualNetworksClient, error) {
 	vnetsClient := aznetwork.NewVirtualNetworksClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	vnetsClient.Authorizer = c.ssn.Authorizer
 	return &vnetsClient, nil


### PR DESCRIPTION
If a cluster is installed in an existing vnet, since CAPI hardcodes the internal LB IP to 10.0.0.100, there is a chance of conflict if there was a cluster already installed. Added a check to see if the default internal LB is available, else pick the next available IP.