### PR TITLE
[release-4.17] OCPBUGS-41542: Azure CAPI: Fix storage account and vhd container public access

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -360,9 +360,9 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	logrus.Debugf("StorageAccount.ID=%s", *storageAccount.ID)
 
 	// Create blob storage container
-	publicAccess := armstorage.PublicAccessContainer
+	publicAccess := armstorage.PublicAccessNone
 	if platform.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessNone
+		publicAccess = armstorage.PublicAccessContainer
 	}
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{
 		SubscriptionID:       subscriptionID,
@@ -813,9 +813,10 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 	ignitionContainerName := "ignition"
 	blobName := "bootstrap.ign"
 	blobURL := fmt.Sprintf("%s/%s/%s", p.StorageURL, ignitionContainerName, blobName)
-	publicAccess := armstorage.PublicAccessContainer
+
+	publicAccess := armstorage.PublicAccessNone
 	if in.InstallConfig.Config.Azure.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessNone
+		publicAccess = armstorage.PublicAccessContainer
 	}
 	// Create ignition blob storage container
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{

--- a/pkg/infrastructure/azure/storage.go
+++ b/pkg/infrastructure/azure/storage.go
@@ -90,7 +90,7 @@ func CreateStorageAccount(ctx context.Context, in *CreateStorageAccountInput) (*
 		Location: to.Ptr(in.Region),
 		SKU:      &sku,
 		Properties: &armstorage.AccountPropertiesCreateParameters{
-			AllowBlobPublicAccess: to.Ptr(true),
+			AllowBlobPublicAccess: to.Ptr(false),
 			AllowSharedKeyAccess:  to.Ptr(true),
 			IsLocalUserEnabled:    to.Ptr(true),
 			LargeFileSharesState:  to.Ptr(armstorage.LargeFileSharesStateEnabled),
@@ -134,6 +134,7 @@ func CreateStorageAccount(ctx context.Context, in *CreateStorageAccountInput) (*
 		accountCreateParameters.Identity = &identity
 		accountCreateParameters.SKU = &sku
 		accountCreateParameters.Properties.Encryption = encryption
+		accountCreateParameters.Properties.AllowBlobPublicAccess = to.Ptr(true)
 	}
 
 	logrus.Debugf("Creating storage account")


### PR DESCRIPTION
Setup the storage account and Blob containers for Ignition and vhd with no public access unless CustomerManagedKey is configured.

This is a manual backport of https://github.com/openshift/installer/pull/8944.