### PR TITLE
OCPBUGS-36869: Prevent race with provisioning-interface service

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
@@ -4,4 +4,6 @@ set -eu
 
 CID_FILE="$1"
 
-podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/
+while ! podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/; do
+    sleep 5
+done

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/extract-machine-os.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+CID_FILE="$1"
+
+podman run --rm --name machine-os-extractor --cidfile="${CID_FILE}" --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS="${PROVISIONING_IP_OPTIONS}" -v systemd-ironic:/shared:z "${MACHINE_OS_IMAGES_IMAGE}" /bin/copy-metal --all /shared/html/images/

--- a/data/data/bootstrap/baremetal/systemd/units/build-metal3-env.service.template
+++ b/data/data/bootstrap/baremetal/systemd/units/build-metal3-env.service.template
@@ -3,6 +3,8 @@ Description=Build Metal3 environment
 Requires=release-image.service
 Wants=network-online.target crio.service
 After=network-online.target crio.service release-image.service
+# Do not restart network interface while running
+After=provisioning-interface.service
 
 [Service]
 ExecStart=/usr/local/bin/build-metal3-env.sh

--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -13,7 +13,7 @@ Before=ironic-httpd.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/ironic.env
-ExecStart=/usr/bin/podman run --rm --name machine-os-extractor --cidfile=%t/%N.cid --cgroups=no-conmon --log-driver=passthrough --env IP_OPTIONS=${PROVISIONING_IP_OPTIONS} -v systemd-ironic:/shared:z $MACHINE_OS_IMAGES_IMAGE /bin/copy-metal --all /shared/html/images/
+ExecStart=/usr/local/bin/extract-machine-os.sh %t/%N.cid
 TimeoutStartSec=20m
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%N.cid
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile=%t/%N.cid

--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -4,6 +4,8 @@ BindsTo=ironic-volume.service
 Requires=build-ironic-env.service
 Wants=crio.service
 After=crio.service build-ironic-env.service ironic-volume.service
+# Do not restart network interface while running
+After=provisioning-interface.service
 # The rootfs file must be created before the httpd container is started
 # otherwise the kernel params in inspector.ipxe will not be set correctly
 Before=ironic-httpd.service


### PR DESCRIPTION
Normally in baremetal IPI the bootstrap VM's provisioning-interface service operates on the provisioning interface. However, in the case that the provisioning network is disabled but a `bootstrapProvisioningIP` is still specified, it will operate on the external network interface. Since this service involves restarting the interface, if it runs at the same time as other services it disrupts the network connectivity for those services, which can cause them to fail. This typically causes the whole installation to fail, as other units that Require the failed ones are never started by systemd (even after a successful retry of the failure).

This change adds ordering dependencies to prevent other services from running in parallel.