### PR TITLE
OCPBUGS-41785: Validate MTU for custom network

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -15,6 +15,13 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
+const (
+	// MTU of 1280 is the minimum allowed for IPv6 + 100 for the
+	// OVN-Kubernetes encapsulation overhead
+	// https://issues.redhat.com/browse/OCPBUGS-2921
+	minimumMTUv6 = 1380
+)
+
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo) field.ErrorList {
 	var allErrs field.ErrorList
@@ -89,6 +96,9 @@ func validateControlPlanePort(p *openstack.Platform, n *types.Networking, ci *Cl
 			allErrs = append(allErrs, field.NotFound(fldPath.Child("controlPlanePort").Child("network"), networkDetail))
 		} else if ci.ControlPlanePortNetwork.ID != networkID {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("controlPlanePort").Child("network"), networkDetail, "network must contain subnets"))
+		}
+		if hasIPv6Subnet && ci.ControlPlanePortNetwork.MTU < minimumMTUv6 {
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("controlPlanePort").Child("network"), fmt.Errorf("network should have an MTU of at least %d", minimumMTUv6)))
 		}
 	}
 	return allErrs

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	"github.com/stretchr/testify/assert"
@@ -55,17 +56,21 @@ func withControlPlanePortSubnets(subnetCIDR, allocationPoolStart, allocationPool
 			},
 			IPVersion: 4,
 		}
-		Allsubnets := []*subnets.Subnet{&subnet}
-		ci.ControlPlanePortSubnets = Allsubnets
+		allSubnets := []*subnets.Subnet{&subnet}
+		ci.ControlPlanePortSubnets = allSubnets
 	}
 }
+
 func validPlatformCloudInfo(options ...func(*CloudInfo)) *CloudInfo {
 	ci := CloudInfo{
-		ExternalNetwork: &networks.Network{
-			ID:           "71b97520-69af-4c35-8153-cdf827z96e60",
-			Name:         validExternalNetwork,
-			AdminStateUp: true,
-			Status:       "ACTIVE",
+		ExternalNetwork: &Network{
+			networks.Network{
+				ID:           "71b97520-69af-4c35-8153-cdf827z96e60",
+				Name:         validExternalNetwork,
+				AdminStateUp: true,
+				Status:       "ACTIVE",
+			},
+			mtu.NetworkMTUExt{},
 		},
 		APIFIP: &floatingips.FloatingIP{
 			ID:     validFIP1,
@@ -413,8 +418,8 @@ func TestMachineSubnet(t *testing.T) {
 				subnet := subnets.Subnet{
 					ID: "00000000-5a89-4465-8d54-3517ec2bad48",
 				}
-				Allsubnets := []*subnets.Subnet{&subnet}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnet}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking:     validNetworking(),
@@ -435,9 +440,11 @@ func TestMachineSubnet(t *testing.T) {
 					NetworkID: "00000000-1a11-4465-8d54-3517ec2bad48",
 					CIDR:      "172.0.0.1/24",
 				}
-				Allsubnets := []*subnets.Subnet{&subnet}
-				ci.ControlPlanePortSubnets = Allsubnets
-				ci.ControlPlanePortNetwork = &networks.Network{ID: "00000000-2a22-4465-8d54-3517ec2bad48"}
+				allSubnets := []*subnets.Subnet{&subnet}
+				ci.ControlPlanePortSubnets = allSubnets
+				network := Network{}
+				network.ID = "00000000-2a22-4465-8d54-3517ec2bad48"
+				ci.ControlPlanePortNetwork = &network
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -463,8 +470,8 @@ func TestMachineSubnet(t *testing.T) {
 					ID:   validSubnetID,
 					CIDR: "172.0.0.1/16",
 				}
-				Allsubnets := []*subnets.Subnet{&subnet}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnet}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -506,8 +513,8 @@ func TestMachineSubnet(t *testing.T) {
 					CIDR:      "2001:db8::/64",
 					IPVersion: 6,
 				}
-				Allsubnets := []*subnets.Subnet{&subnet, &subnetv6}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnet, &subnetv6}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -536,8 +543,8 @@ func TestMachineSubnet(t *testing.T) {
 					ID:   validSubnetID,
 					CIDR: "172.0.0.1/16",
 				}
-				Allsubnets := []*subnets.Subnet{&subnet}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnet}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -577,8 +584,8 @@ func TestMachineSubnet(t *testing.T) {
 					CIDR:      "10.0.0.0/16",
 					IPVersion: 4,
 				}
-				Allsubnets := []*subnets.Subnet{&subnet, &subnetv6}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnet, &subnetv6}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -610,8 +617,8 @@ func TestMachineSubnet(t *testing.T) {
 					CIDR:      "2001:db8::/64",
 					IPVersion: 6,
 				}
-				Allsubnets := []*subnets.Subnet{&subnetv6}
-				ci.ControlPlanePortSubnets = Allsubnets
+				allSubnets := []*subnets.Subnet{&subnetv6}
+				ci.ControlPlanePortSubnets = allSubnets
 				return ci
 			}(),
 			networking: func() *types.Networking {
@@ -623,6 +630,53 @@ func TestMachineSubnet(t *testing.T) {
 				return n
 			}(),
 			expectedErrMsg: "",
+		},
+		{
+			name: "MTU too low",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				fixedIPv6 := openstack.FixedIP{
+					Subnet: openstack.SubnetFilter{ID: "00000000-1111-4465-8d54-3517ec2bad48"},
+				}
+				p.ControlPlanePort = &openstack.PortTarget{
+					FixedIPs: []openstack.FixedIP{fixedIPv6},
+					Network:  openstack.NetworkFilter{ID: "71b97520-69af-4c35-8153-cdf827z96e60"},
+				}
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				subnetv6 := subnets.Subnet{
+					ID:        "00000000-1111-4465-8d54-3517ec2bad48",
+					CIDR:      "2001:db8::/64",
+					IPVersion: 6,
+					NetworkID: "71b97520-69af-4c35-8153-cdf827z96e60",
+				}
+				allSubnets := []*subnets.Subnet{&subnetv6}
+				ci.ControlPlanePortSubnets = allSubnets
+
+				network := Network{
+					networks.Network{
+						ID:           "71b97520-69af-4c35-8153-cdf827z96e60",
+						Name:         "too-low",
+						AdminStateUp: true,
+						Status:       "ACTIVE",
+						Subnets:      []string{"00000000-1111-4465-8d54-3517ec2bad48"},
+					},
+					mtu.NetworkMTUExt{MTU: 1200},
+				}
+				ci.ControlPlanePortNetwork = &network
+				return ci
+			}(),
+			networking: func() *types.Networking {
+				n := validNetworking()
+				machineNetworkEntry := &types.MachineNetworkEntry{
+					CIDR: *ipnet.MustParseCIDR("2001:db8::/64"),
+				}
+				n.MachineNetwork = []types.MachineNetworkEntry{*machineNetworkEntry}
+				return n
+			}(),
+			expectedErrMsg: "platform.openstack.controlPlanePort.network: Internal error: network should have an MTU of at least 1380",
 		},
 	}
 

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu/requests.go
@@ -1,0 +1,87 @@
+package mtu
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
+)
+
+// ListOptsExt adds an MTU option to the base ListOpts.
+type ListOptsExt struct {
+	networks.ListOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `q:"mtu"`
+}
+
+// ToNetworkListQuery adds the router:external option to the base network
+// list options.
+func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts.ListOptsBuilder)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	if opts.MTU > 0 {
+		params.Add("mtu", fmt.Sprintf("%d", opts.MTU))
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
+
+// CreateOptsExt adds an MTU option to the base Network CreateOpts.
+type CreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu,omitempty"`
+}
+
+// ToNetworkCreateMap adds an MTU to the base network creation options.
+func (opts CreateOptsExt) ToNetworkCreateMap() (map[string]any, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.MTU == 0 {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]any)
+	networkMap["mtu"] = opts.MTU
+
+	return base, nil
+}
+
+// CreateOptsExt adds an MTU option to the base Network UpdateOpts.
+type UpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu,omitempty"`
+}
+
+// ToNetworkUpdateMap adds an MTU to the base network uptade options.
+func (opts UpdateOptsExt) ToNetworkUpdateMap() (map[string]any, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.MTU == 0 {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]any)
+	networkMap["mtu"] = opts.MTU
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu/results.go
@@ -1,0 +1,8 @@
+package mtu
+
+// NetworkMTUExt represents an extended form of a Network with additional MTU field.
+type NetworkMTUExt struct {
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -730,6 +730,7 @@ github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attribu
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/external
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers
+github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/quotas
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules


### PR DESCRIPTION
Set the minimum MTU to 1380 when deploying on IPv6. This value
corresponds to the minimum MTU for IPv6, which is 1280, and the
ovn-kubernetes overhead, which is 100.