### PR TITLE
[release-4.16] OCPBUGS-41885: vSphere - If template is defined skip downloading

### DIFF
--- a/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/vsphere/clusterapi/clusterapi.go
@@ -86,13 +86,17 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 	 * one folder per datacenter
 	 * one template per region/zone aka failuredomain
 	 */
+
 	installConfig := in.InstallConfig
 	clusterID := &installconfig.ClusterID{InfraID: in.InfraID}
-	var tagID string
+	var tagID, cachedImage string
+	var err error
 
-	cachedImage, err := cache.DownloadImageFile(string(*in.RhcosImage), cache.InstallerApplicationName)
-	if err != nil {
-		return fmt.Errorf("failed to use cached vsphere image: %w", err)
+	if downloadImage(installConfig) {
+		cachedImage, err = cache.DownloadImageFile(string(*in.RhcosImage), cache.InstallerApplicationName)
+		if err != nil {
+			return fmt.Errorf("failed to use cached vsphere image: %w", err)
+		}
 	}
 
 	for _, vcenter := range installConfig.Config.VSphere.VCenters {
@@ -128,4 +132,15 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 	}
 
 	return nil
+}
+
+// downloadImage if any failure domains don't have a defined template, this function
+// returns true.
+func downloadImage(installConfig *installconfig.InstallConfig) bool {
+	for _, fd := range installConfig.Config.VSphere.FailureDomains {
+		if fd.Topology.Template == "" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This is a backport of #8926 

Description:
In the event that all defined failure domains specify a template, the ova does not need to be downloaded. If any failure domain fails to specify a template, an attempt will be made to download the template.

This is a continuation of work started in https://github.com/openshift/installer/pull/8729