### PR TITLE
OCPBUGS-37506: Azure CAPI: Update publicAccess for Blob Containers

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -362,9 +362,6 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 
 	// Create blob storage container
 	publicAccess := armstorage.PublicAccessNone
-	if platform.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessContainer
-	}
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{
 		SubscriptionID:       subscriptionID,
 		ResourceGroupName:    resourceGroupName,
@@ -824,9 +821,6 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 	blobName := "bootstrap.ign"
 	blobURL := fmt.Sprintf("%s/%s/%s", p.StorageURL, ignitionContainerName, blobName)
 	publicAccess := armstorage.PublicAccessNone
-	if in.InstallConfig.Config.Azure.CustomerManagedKey != nil {
-		publicAccess = armstorage.PublicAccessContainer
-	}
 	// Create ignition blob storage container
 	createBlobContainerOutput, err := CreateBlobContainer(ctx, &CreateBlobContainerInput{
 		ContainerName:        ignitionContainerName,


### PR DESCRIPTION
Always set public access to Blob containers to `PublicAccessNone` even when Customer Managed Keys are configured.