### PR TITLE
OCPBUGS-42012:  Systemd Fails to Parse Multiline EC Keys

### DIFF
--- a/pkg/asset/agent/gencrypto/authconfig.go
+++ b/pkg/asset/agent/gencrypto/authconfig.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -16,7 +17,7 @@ import (
 
 // AuthConfig is an asset that generates ECDSA public/private keys, JWT token.
 type AuthConfig struct {
-	PublicKey, PrivateKey, Token string
+	PublicKey, Token string
 }
 
 // LocalJWTKeyType suggests the key type to be used for the token.
@@ -44,10 +45,12 @@ func (a *AuthConfig) Generate(dependencies asset.Parents) error {
 	if err != nil {
 		return err
 	}
-	a.PublicKey = PublicKey
-	a.PrivateKey = PrivateKey
+	// Encode to Base64 (Standard encoding)
+	encodedPubKeyPEM := base64.StdEncoding.EncodeToString([]byte(PublicKey))
 
-	token, err := localJWTForKey(infraEnvID.ID, a.PrivateKey)
+	a.PublicKey = encodedPubKeyPEM
+
+	token, err := localJWTForKey(infraEnvID.ID, PrivateKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/gencrypto/authconfig_test.go
+++ b/pkg/asset/agent/gencrypto/authconfig_test.go
@@ -14,7 +14,7 @@ func TestAuthConfig_Generate(t *testing.T) {
 		name string
 	}{
 		{
-			name: "generate-public-private-keys",
+			name: "generate-public-key-and-token",
 		},
 	}
 	for _, tc := range cases {
@@ -27,8 +27,7 @@ func TestAuthConfig_Generate(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			assert.Contains(t, authConfigAsset.PrivateKey, "BEGIN EC PRIVATE KEY")
-			assert.Contains(t, authConfigAsset.PublicKey, "BEGIN EC PUBLIC KEY")
+			assert.NotEmpty(t, authConfigAsset.PublicKey)
 			assert.NotEmpty(t, authConfigAsset.Token)
 		})
 	}

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -255,7 +255,6 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		osImage,
 		infraEnv.Spec.Proxy,
 		imageTypeISO,
-		keyPairAsset.PrivateKey,
 		keyPairAsset.PublicKey,
 		caBundleMount)
 
@@ -373,7 +372,7 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 	osImage *models.OsImage,
 	proxy *v1beta1.Proxy,
 	imageTypeISO,
-	privateKey, publicKey string,
+	publicKey string,
 	caBundleMount string) *agentTemplateData {
 	return &agentTemplateData{
 		ServiceProtocol:           "http",
@@ -390,7 +389,6 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage,
 		OSImage:                   osImage,
 		Proxy:                     proxy,
 		ImageTypeISO:              imageTypeISO,
-		PrivateKeyPEM:             privateKey,
 		PublicKeyPEM:              publicKey,
 		CaBundleMount:             caBundleMount,
 	}

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -90,10 +90,9 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	}
 	clusterName := "test-agent-cluster-install.test"
 
-	privateKey := "-----BEGIN EC PUBLIC KEY-----\nMFkwEwYHKoAiDHV4tg==\n-----END EC PUBLIC KEY-----\n"
 	publicKey := "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PRIVATE KEY-----\n"
 
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", privateKey, publicKey, "")
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, infraEnvID, osImage, proxy, "minimal-iso", publicKey, "")
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -107,7 +106,6 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, infraEnvID, templateData.InfraEnvID)
 	assert.Equal(t, osImage, templateData.OSImage)
 	assert.Equal(t, proxy, templateData.Proxy)
-	assert.Equal(t, privateKey, templateData.PrivateKeyPEM)
 	assert.Equal(t, publicKey, templateData.PublicKeyPEM)
 }
 


### PR DESCRIPTION
Base64 encode public key to fix systemd parsing issues; remove unused field