### PR TITLE
OSASINFRA-3614: OpenStack: remove creation of IPv4 rules on Single stack IPv6 cluster 

### DIFF
--- a/pkg/infrastructure/openstack/preprovision/securitygroups.go
+++ b/pkg/infrastructure/openstack/preprovision/securitygroups.go
@@ -168,7 +168,14 @@ func SecurityGroups(ctx context.Context, installConfig *installconfig.InstallCon
 
 		// In this loop: security groups with a catch-all remote IP
 		for ipVersion, anyIP := range map[rules.RuleEtherType][]string{
-			rules.EtherType4: {"0.0.0.0/0"},
+			rules.EtherType4: func() []string {
+				switch len(machineV4CIDRs) {
+				case 0:
+					return []string{}
+				default:
+					return []string{"0.0.0.0/0"}
+				}
+			}(),
 			rules.EtherType6: func() []string {
 				switch len(machineV6CIDRs) {
 				case 0:


### PR DESCRIPTION
When using single stack IPv6 there is no need to create IPv4 rules. This commit restricts the creation of IPv4 rules for when the IPv4 Machine Networks exists in the cluster.