### PR TITLE
AGENT-950: Implement Separate JWT Tokens for Different User Personas

### DIFF
--- a/cmd/node-joiner/testdata/add-nodes.txt
+++ b/cmd/node-joiner/testdata/add-nodes.txt
@@ -38,7 +38,7 @@ unqualified-search-registries = []
 CLUSTER_ID=c37c9544-4320-4380-9d8b-0753a4d9ea57
 CLUSTER_NAME=ostest
 CLUSTER_API_VIP_DNS_NAME=api.ostest.test.metalkube.org
-AGENT_AUTH_TOKEN_EXPIRY=.*
+AUTH_TOKEN_EXPIRY=.*
 -- expected/grub.cfg --
 .*fips=1.*
 -- expected/import-cluster-config.json --

--- a/data/data/agent/files/usr/local/bin/add-node.sh
+++ b/data/data/agent/files/usr/local/bin/add-node.sh
@@ -10,7 +10,7 @@ cluster_id=""
 while [[ "${cluster_id}" = "" ]]
 do
     # Get cluster id
-    cluster_id=$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN" | jq -r .[].id)
+    cluster_id=$(curl_assisted_service "/clusters" GET | jq -r .[].id)
     if [[ "${cluster_id}" = "" ]]; then
         sleep 2
     fi
@@ -24,7 +24,7 @@ status_issue="90_add-node"
 host_ready=false
 while [[ $host_ready == false ]]
 do
-    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r ".[].status")
+    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET | jq -r ".[].status")
     if [[ "${host_status}" != "known" ]]; then
         printf '\\e{yellow}Waiting for the host to be ready' | set_issue "${status_issue}"
         sleep 10
@@ -33,12 +33,12 @@ do
     fi
 done
 
-HOST_ID=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r '.[].id')
+HOST_ID=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET | jq -r '.[].id')
 printf '\nHost %s is ready for installation\n' "${HOST_ID}" 1>&2
 clear_issue "${status_issue}"
 
 # Add the current host to the cluster
-res=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install" POST "$USER_AUTH_TOKEN" -w "%{http_code}" -o /dev/null)
+res=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install" POST -w "%{http_code}" -o /dev/null)
 if [[ $res = "202" ]]; then 
     printf '\nHost installation started\n' 1>&2
 else

--- a/data/data/agent/files/usr/local/bin/add-node.sh
+++ b/data/data/agent/files/usr/local/bin/add-node.sh
@@ -10,7 +10,7 @@ cluster_id=""
 while [[ "${cluster_id}" = "" ]]
 do
     # Get cluster id
-    cluster_id=$(curl_assisted_service "/clusters" | jq -r .[].id)
+    cluster_id=$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN" | jq -r .[].id)
     if [[ "${cluster_id}" = "" ]]; then
         sleep 2
     fi
@@ -24,7 +24,7 @@ status_issue="90_add-node"
 host_ready=false
 while [[ $host_ready == false ]]
 do
-    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" | jq -r ".[].status")
+    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r ".[].status")
     if [[ "${host_status}" != "known" ]]; then
         printf '\\e{yellow}Waiting for the host to be ready' | set_issue "${status_issue}"
         sleep 10
@@ -33,12 +33,12 @@ do
     fi
 done
 
-HOST_ID=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" | jq -r '.[].id')
+HOST_ID=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r '.[].id')
 printf '\nHost %s is ready for installation\n' "${HOST_ID}" 1>&2
 clear_issue "${status_issue}"
 
 # Add the current host to the cluster
-res=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install" POST -w "%{http_code}" -o /dev/null)
+res=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/actions/install" POST "$USER_AUTH_TOKEN" -w "%{http_code}" -o /dev/null)
 if [[ $res = "202" ]]; then 
     printf '\nHost installation started\n' 1>&2
 else

--- a/data/data/agent/files/usr/local/bin/agent-auth-token-status.sh
+++ b/data/data/agent/files/usr/local/bin/agent-auth-token-status.sh
@@ -9,7 +9,7 @@ status_issue="65_token"
 
 export TZ=UTC
 check_token_expiry() {
-  expiry_epoch=$(date -d "${AGENT_AUTH_TOKEN_EXPIRY}" +%s)
+  expiry_epoch=$(date -d "${AUTH_TOKEN_EXPIRY}" +%s)
   current_epoch=$(date +%s)
 
   if [ "$current_epoch" -gt "$expiry_epoch" ]; then

--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -3,13 +3,14 @@
 curl_assisted_service() {
     local endpoint=$1
     local method=${2:-GET}
-    local additional_options=("${@:3}")  # Capture all arguments starting from the third one
+    local authz=${3:-}
+    local additional_options=("${@:4}")  # Capture all arguments starting from the fourth one
     local baseURL="${SERVICE_BASE_URL}api/assisted-install/v2"
 
     case "${method}" in
         "POST")
             curl -s -S -X POST "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${AGENT_AUTH_TOKEN}" \
+            -H "Authorization: ${authz}" \
             -H "accept: application/json" \
             -H "Content-Type: application/json" \
             ;;
@@ -21,8 +22,8 @@ curl_assisted_service() {
             ;;
         "GET")
             curl -s -S -X GET "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${AGENT_AUTH_TOKEN}" \
+            -H "Authorization: ${authz}" \
             -H "Accept: application/json"
             ;;
     esac
-}
+}   

--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -16,7 +16,7 @@ curl_assisted_service() {
             ;;
         "PATCH")
             curl -s -S -X PATCH "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${AGENT_AUTH_TOKEN}" \
+            -H "Authorization: ${authz}" \
             -H "accept: application/json" \
             -H "Content-Type: application/json" \
             ;;

--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -3,27 +3,17 @@
 curl_assisted_service() {
     local endpoint=$1
     local method=${2:-GET}
-    local authz=${3:-}
-    local additional_options=("${@:4}")  # Capture all arguments starting from the fourth one
+    local additional_options=("${@:3}")  # Capture all arguments starting from the third one
     local baseURL="${SERVICE_BASE_URL}api/assisted-install/v2"
 
-    case "${method}" in
-        "POST")
-            curl -s -S -X POST "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${authz}" \
-            -H "accept: application/json" \
-            -H "Content-Type: application/json" \
-            ;;
-        "PATCH")
-            curl -s -S -X PATCH "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${authz}" \
-            -H "accept: application/json" \
-            -H "Content-Type: application/json" \
-            ;;
-        "GET")
-            curl -s -S -X GET "${additional_options[@]}" "${baseURL}${endpoint}" \
-            -H "Authorization: ${authz}" \
-            -H "Accept: application/json"
-            ;;
-    esac
+    headers=(
+        -s -S
+        -H "Authorization: ${USER_AUTH_TOKEN}"
+        -H "accept: application/json"
+    )
+
+    [[ "$method" == "POST" || "$method" == "PATCH" ]] && headers+=(-H "Content-Type: application/json")
+
+    curl "${headers[@]}" -X "${method}" "${additional_options[@]}" "${baseURL}${endpoint}"
+
 }   

--- a/data/data/agent/files/usr/local/bin/start-agent.sh
+++ b/data/data/agent/files/usr/local/bin/start-agent.sh
@@ -8,7 +8,7 @@ INFRA_ENV_ID=""
 until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
     sleep 5
     >&2 echo "Querying assisted-service for infra-env-id..."
-    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET | jq -r .[0].id)
+    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET $USER_AUTH_TOKEN | jq -r '.[0].id')
 done
 echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
 

--- a/data/data/agent/files/usr/local/bin/start-agent.sh
+++ b/data/data/agent/files/usr/local/bin/start-agent.sh
@@ -8,7 +8,7 @@ INFRA_ENV_ID=""
 until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
     sleep 5
     >&2 echo "Querying assisted-service for infra-env-id..."
-    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET $USER_AUTH_TOKEN | jq -r '.[0].id')
+    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET "$USER_AUTH_TOKEN" | jq -r '.[0].id')
 done
 echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
 

--- a/data/data/agent/files/usr/local/bin/start-agent.sh
+++ b/data/data/agent/files/usr/local/bin/start-agent.sh
@@ -8,7 +8,7 @@ INFRA_ENV_ID=""
 until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
     sleep 5
     >&2 echo "Querying assisted-service for infra-env-id..."
-    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET "$USER_AUTH_TOKEN" | jq -r '.[0].id')
+    INFRA_ENV_ID=$(curl_assisted_service "/infra-envs" GET | jq -r '.[0].id')
 done
 echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
 

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
@@ -10,7 +10,7 @@ cluster_id=""
 while [[ "${cluster_id}" = "" ]]
 do
     # Get cluster id
-    cluster_id=$(curl_assisted_service "/clusters" GET $USER_AUTH_TOKEN | jq -r .[].id)
+    cluster_id=$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN" | jq -r .[].id)
     if [[ "${cluster_id}" = "" ]]; then
         sleep 2
     fi
@@ -28,7 +28,7 @@ status_issue="90_start-install"
 num_known_hosts() {
     local known_hosts=0
     local insufficient_hosts=0
-    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET $USER_AUTH_TOKEN | jq -r .[].status)
+    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r .[].status)
     if [[ -n ${host_status} ]]; then
         for status in ${host_status}; do
             if [[ "${status}" == "known" ]]; then
@@ -58,7 +58,7 @@ clear_issue "${status_issue}"
 while [[ "${cluster_status}" != "installed" ]]
 do
     sleep 5
-    cluster_info="$(curl_assisted_service "/clusters" GET $USER_AUTH_TOKEN)"
+    cluster_info="$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN")"
     cluster_status=$(printf '%s' "${cluster_info}" | jq -r .[].status)
     echo "Cluster status: ${cluster_status}" 1>&2
     # Start the cluster install, if it transitions back to Ready due to a failure,
@@ -66,7 +66,7 @@ do
     case "${cluster_status}" in
         "ready")
             echo "Starting cluster installation..." 1>&2
-            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST $USER_AUTH_TOKEN -w "%{http_code}" -o /dev/null)
+            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST "$USER_AUTH_TOKEN" -w "%{http_code}" -o /dev/null)
             if [[ $res = "202" ]]; then 
                 printf '\nCluster installation started\n' 1>&2
             fi

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
@@ -10,7 +10,7 @@ cluster_id=""
 while [[ "${cluster_id}" = "" ]]
 do
     # Get cluster id
-    cluster_id=$(curl_assisted_service "/clusters" GET | jq -r .[].id)
+    cluster_id=$(curl_assisted_service "/clusters" GET $USER_AUTH_TOKEN | jq -r .[].id)
     if [[ "${cluster_id}" = "" ]]; then
         sleep 2
     fi
@@ -28,7 +28,7 @@ status_issue="90_start-install"
 num_known_hosts() {
     local known_hosts=0
     local insufficient_hosts=0
-    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET | jq -r .[].status)
+    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET $USER_AUTH_TOKEN | jq -r .[].status)
     if [[ -n ${host_status} ]]; then
         for status in ${host_status}; do
             if [[ "${status}" == "known" ]]; then
@@ -58,7 +58,7 @@ clear_issue "${status_issue}"
 while [[ "${cluster_status}" != "installed" ]]
 do
     sleep 5
-    cluster_info="$(curl_assisted_service "/clusters" GET)"
+    cluster_info="$(curl_assisted_service "/clusters" GET $USER_AUTH_TOKEN)"
     cluster_status=$(printf '%s' "${cluster_info}" | jq -r .[].status)
     echo "Cluster status: ${cluster_status}" 1>&2
     # Start the cluster install, if it transitions back to Ready due to a failure,
@@ -66,7 +66,7 @@ do
     case "${cluster_status}" in
         "ready")
             echo "Starting cluster installation..." 1>&2
-            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST -w "%{http_code}" -o /dev/null)
+            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST $USER_AUTH_TOKEN -w "%{http_code}" -o /dev/null)
             if [[ $res = "202" ]]; then 
                 printf '\nCluster installation started\n' 1>&2
             fi

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh
@@ -10,7 +10,7 @@ cluster_id=""
 while [[ "${cluster_id}" = "" ]]
 do
     # Get cluster id
-    cluster_id=$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN" | jq -r .[].id)
+    cluster_id=$(curl_assisted_service "/clusters" GET | jq -r .[].id)
     if [[ "${cluster_id}" = "" ]]; then
         sleep 2
     fi
@@ -28,7 +28,7 @@ status_issue="90_start-install"
 num_known_hosts() {
     local known_hosts=0
     local insufficient_hosts=0
-    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET "$USER_AUTH_TOKEN" | jq -r .[].status)
+    host_status=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" GET | jq -r .[].status)
     if [[ -n ${host_status} ]]; then
         for status in ${host_status}; do
             if [[ "${status}" == "known" ]]; then
@@ -58,7 +58,7 @@ clear_issue "${status_issue}"
 while [[ "${cluster_status}" != "installed" ]]
 do
     sleep 5
-    cluster_info="$(curl_assisted_service "/clusters" GET "$USER_AUTH_TOKEN")"
+    cluster_info="$(curl_assisted_service "/clusters" GET)"
     cluster_status=$(printf '%s' "${cluster_info}" | jq -r .[].status)
     echo "Cluster status: ${cluster_status}" 1>&2
     # Start the cluster install, if it transitions back to Ready due to a failure,
@@ -66,7 +66,7 @@ do
     case "${cluster_status}" in
         "ready")
             echo "Starting cluster installation..." 1>&2
-            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST "$USER_AUTH_TOKEN" -w "%{http_code}" -o /dev/null)
+            res=$(curl_assisted_service "/clusters/${cluster_id}/actions/install" POST -w "%{http_code}" -o /dev/null)
             if [[ $res = "202" ]]; then 
                 printf '\nCluster installation started\n' 1>&2
             fi

--- a/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
+++ b/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
@@ -6,7 +6,7 @@ source "common.sh"
 
 echo "Waiting for assisted-service to be ready"
 
-until curl_assisted_service "/infra-envs" GET -o /dev/null --silent --fail; do
+until curl_assisted_service "/infra-envs" GET $USER_AUTH_TOKEN -o /dev/null --silent --fail; do
     printf '.'
     sleep 5
 done

--- a/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
+++ b/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
@@ -6,7 +6,7 @@ source "common.sh"
 
 echo "Waiting for assisted-service to be ready"
 
-until curl_assisted_service "/infra-envs" GET $USER_AUTH_TOKEN -o /dev/null --silent --fail; do
+until curl_assisted_service "/infra-envs" GET "$USER_AUTH_TOKEN" -o /dev/null --silent --fail; do
     printf '.'
     sleep 5
 done

--- a/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
+++ b/data/data/agent/files/usr/local/bin/wait-for-assisted-service.sh
@@ -6,7 +6,7 @@ source "common.sh"
 
 echo "Waiting for assisted-service to be ready"
 
-until curl_assisted_service "/infra-envs" GET "$USER_AUTH_TOKEN" -o /dev/null --silent --fail; do
+until curl_assisted_service "/infra-envs" GET -o /dev/null --silent --fail; do
     printf '.'
     sleep 5
 done

--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -20,4 +20,6 @@ OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
 STORAGE=filesystem
 INFRA_ENV_ID={{.InfraEnvID}}
 EC_PUBLIC_KEY_PEM={{.PublicKeyPEM}}
-AGENT_AUTH_TOKEN={{.Token}}
+AGENT_AUTH_TOKEN={{.AgentAuthToken}}
+USER_AUTH_TOKEN={{.UserAuthToken}}
+WATCHER_AUTH_TOKEN={{.WatcherAuthToken}}

--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -1,4 +1,4 @@
-AUTH_TYPE=none
+AUTH_TYPE=={{.AuthType}}
 DB_HOST=127.0.0.1
 DB_NAME=installer
 DB_PASS=admin

--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -20,6 +20,5 @@ OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
 STORAGE=filesystem
 INFRA_ENV_ID={{.InfraEnvID}}
 EC_PUBLIC_KEY_PEM={{.PublicKeyPEM}}
-AGENT_AUTH_TOKEN={{.AgentAuthToken}}
 USER_AUTH_TOKEN={{.UserAuthToken}}
 WATCHER_AUTH_TOKEN={{.WatcherAuthToken}}

--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -1,4 +1,4 @@
-AUTH_TYPE=={{.AuthType}}
+AUTH_TYPE={{.AuthType}}
 DB_HOST=127.0.0.1
 DB_NAME=installer
 DB_PASS=admin

--- a/data/data/agent/systemd/units/agent-auth-token-status.service
+++ b/data/data/agent/systemd/units/agent-auth-token-status.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=service that displays a message if agent auth token is expired.
+Description=service that displays a message if auth tokens are expired.
 Wants=network-online.target
 After=network-online.target agent-interactive-console.service
 ConditionPathExists=/etc/assisted/add-nodes.env

--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -16,7 +16,7 @@ EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 EnvironmentFile=/etc/assisted/add-nodes.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-import-cluster -v /etc/assisted/clusterconfig:/clusterconfig -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env CLUSTER_ID --env CLUSTER_NAME --env CLUSTER_API_VIP_DNS_NAME --env AGENT_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client importCluster
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-import-cluster -v /etc/assisted/clusterconfig:/clusterconfig -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env CLUSTER_ID --env CLUSTER_NAME --env CLUSTER_API_VIP_DNS_NAME --env USER_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client importCluster
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/agent-register-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-register-cluster.service.template
@@ -15,7 +15,7 @@ EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-register-cluster -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env AGENT_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client registerCluster
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-register-cluster -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests {{ if .HaveMirrorConfig }}-v /etc/containers:/etc/containers{{ end }} {{.CaBundleMount}} --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR --env USER_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client registerCluster
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -12,7 +12,7 @@ EnvironmentFile=/etc/assisted/rendezvous-host.env
 EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-register-infraenv -v /etc/assisted/manifests:/manifests --env SERVICE_BASE_URL --env IMAGE_TYPE_ISO --env AGENT_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client registerInfraEnv
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=agent-register-infraenv -v /etc/assisted/manifests:/manifests --env SERVICE_BASE_URL --env IMAGE_TYPE_ISO --env USER_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client registerInfraEnv
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/apply-host-config.service
+++ b/data/data/agent/systemd/units/apply-host-config.service
@@ -14,7 +14,7 @@ EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID --env WORKFLOW_TYPE --env AGENT_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID --env WORKFLOW_TYPE --env USER_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -69,17 +69,17 @@ func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, ssh
 	czero := &Cluster{}
 	capi := &clientSet{}
 
-	var authToken string
+	var watcherAuthToken string
 	var err error
 
 	switch workflowType {
 	case workflow.AgentWorkflowTypeInstall:
-		authToken, err = FindAuthTokenFromAssetStore(assetDir)
+		watcherAuthToken, err = FindAuthTokenFromAssetStore(assetDir)
 		if err != nil {
 			return nil, err
 		}
 	case workflow.AgentWorkflowTypeAddNodes:
-		authToken, err = gencrypto.GetAuthTokenFromCluster(ctx, kubeconfigPath)
+		watcherAuthToken, err = gencrypto.GetAuthTokenFromCluster(ctx, kubeconfigPath)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, ssh
 		return nil, fmt.Errorf("AgentWorkflowType value not supported: %s", workflowType)
 	}
 
-	restclient := NewNodeZeroRestClient(ctx, rendezvousIP, sshKey, authToken)
+	restclient := NewNodeZeroRestClient(ctx, rendezvousIP, sshKey, watcherAuthToken)
 
 	kubeclient, err := NewClusterKubeAPIClient(ctx, kubeconfigPath)
 	if err != nil {

--- a/pkg/agent/rest.go
+++ b/pkg/agent/rest.go
@@ -33,7 +33,7 @@ type NodeZeroRestClient struct {
 }
 
 // NewNodeZeroRestClient Initialize a new rest client to interact with the Agent Rest API on node zero.
-func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, token string) *NodeZeroRestClient {
+func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, watcherAuthToken string) *NodeZeroRestClient {
 	restClient := &NodeZeroRestClient{}
 
 	// Get SSH Keys which can be used to determine if Rest API failures are due to network connectivity issues
@@ -48,7 +48,7 @@ func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, token stri
 		Path:   client.DefaultBasePath,
 	}
 
-	config.AuthInfo = gencrypto.UserAuthHeaderWriter(token)
+	config.AuthInfo = gencrypto.WatcherAuthHeaderWriter(watcherAuthToken)
 
 	client := client.New(config)
 
@@ -137,7 +137,7 @@ func FindAuthTokenFromAssetStore(assetDir string) (string, error) {
 
 	var authToken string
 	if authConfig != nil {
-		authToken = authConfig.(*gencrypto.AuthConfig).AgentAuthToken
+		authToken = authConfig.(*gencrypto.AuthConfig).WatcherAuthToken
 	}
 
 	return authToken, nil

--- a/pkg/asset/agent/gencrypto/auth_utils.go
+++ b/pkg/asset/agent/gencrypto/auth_utils.go
@@ -29,7 +29,6 @@ func ParseToken(tokenString string) (jwt.MapClaims, error) {
 	return claims, nil
 }
 
-
 // ParseExpirationFromToken checks if the token is expired or not.
 func ParseExpirationFromToken(tokenString string) (time.Time, error) {
 	claims, err := ParseToken(tokenString)

--- a/pkg/asset/agent/gencrypto/auth_utils.go
+++ b/pkg/asset/agent/gencrypto/auth_utils.go
@@ -30,6 +30,8 @@ func ParseToken(tokenString string) (jwt.MapClaims, error) {
 }
 
 // ParseExpirationFromToken checks if the token is expired or not.
+// Returns zero time on error for consistent return type; caller should ignore time on error.
+// Otherwise returns the token expiry time.
 func ParseExpirationFromToken(tokenString string) (time.Time, error) {
 	claims, err := ParseToken(tokenString)
 	if err != nil {

--- a/pkg/asset/agent/gencrypto/auth_utils_test.go
+++ b/pkg/asset/agent/gencrypto/auth_utils_test.go
@@ -13,12 +13,12 @@ func TestParseExpirationFromToken(t *testing.T) {
 	assert.NotEmpty(t, privateKey)
 	assert.NoError(t, err)
 
-	tokenNoExp, err := generateToken(privateKey, nil)
+	tokenNoExp, err := generateToken("userAuth", privateKey, nil)
 	assert.NotEmpty(t, tokenNoExp)
 	assert.NoError(t, err)
 
 	expiry := time.Now().UTC().Add(30 * time.Second)
-	tokenWithExp, err := generateToken(privateKey, &expiry)
+	tokenWithExp, err := generateToken("userAuth", privateKey, &expiry)
 	assert.NotEmpty(t, tokenWithExp)
 	assert.NoError(t, err)
 

--- a/pkg/asset/agent/gencrypto/authconfig.go
+++ b/pkg/asset/agent/gencrypto/authconfig.go
@@ -35,9 +35,9 @@ var (
 
 // AuthType holds the authenticator type for agent based installer.
 const (
-	AuthType = "agent-installer-local"
-	agentPersona = "agentAuth"
-	userPersona = "userAuth"
+	AuthType       = "agent-installer-local"
+	agentPersona   = "agentAuth"
+	userPersona    = "userAuth"
 	watcherPersona = "watcherAuth"
 )
 
@@ -99,7 +99,7 @@ func (a *AuthConfig) Generate(_ context.Context, dependencies asset.Parents) err
 		// Auth tokens expires after 48 hours
 		expiry := time.Now().UTC().Add(48 * time.Hour)
 		a.AuthTokenExpiry = expiry.Format(time.RFC3339)
-		
+
 		agentAuthToken, err := generateToken(agentPersona, privateKey, &expiry)
 		if err != nil {
 			return err

--- a/pkg/asset/agent/gencrypto/authconfig.go
+++ b/pkg/asset/agent/gencrypto/authconfig.go
@@ -181,7 +181,7 @@ func keyPairPEM() (string, string, error) {
 func generateToken(userPersona string, privateKeyPem string, expiry *time.Time) (string, error) {
 	// Create the JWT claims
 	claims := jwt.MapClaims{
-		"sub": userPersona,
+		"auth_scheme": userPersona,
 	}
 	// Set the expiry time if provided
 	if expiry != nil {

--- a/pkg/asset/agent/gencrypto/authconfig.go
+++ b/pkg/asset/agent/gencrypto/authconfig.go
@@ -77,15 +77,11 @@ func (a *AuthConfig) Generate(_ context.Context, dependencies asset.Parents) err
 		watcherPersona: &a.WatcherAuthToken,
 	}
 
-	generateAndAssignToken := func(persona, privateKey string, expiry *time.Time) (string, error) {
-		return generateToken(persona, privateKey, expiry)
-	}
-
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		// Auth tokens do not expire
 		for persona, tokenField := range tokens {
-			token, err := generateAndAssignToken(persona, privateKey, nil)
+			token, err := generateToken(persona, privateKey, nil)
 			if err != nil {
 				return err
 			}
@@ -101,7 +97,7 @@ func (a *AuthConfig) Generate(_ context.Context, dependencies asset.Parents) err
 		a.AuthTokenExpiry = expiry.Format(time.RFC3339)
 
 		for persona, tokenField := range tokens {
-			token, err := generateAndAssignToken(persona, privateKey, &expiry)
+			token, err := generateToken(persona, privateKey, &expiry)
 			if err != nil {
 				return err
 			}

--- a/pkg/asset/agent/gencrypto/authconfig_test.go
+++ b/pkg/asset/agent/gencrypto/authconfig_test.go
@@ -38,21 +38,23 @@ func TestAuthConfig_Generate(t *testing.T) {
 			assert.NotEqual(t, authConfigAsset.UserAuthToken, authConfigAsset.WatcherAuthToken)
 
 			// verify each token is signed with correct persona
-			claims , err := ParseToken(authConfigAsset.AgentAuthToken)
+			claims, err := ParseToken(authConfigAsset.AgentAuthToken)
 			assert.NoError(t, err)
-			persona, _ := claims["sub"].(string)
+			persona, ok := claims["sub"].(string)
 			assert.Equal(t, persona, agentPersona)
+			assert.Equal(t, ok, true)
 
-			claims , err = ParseToken(authConfigAsset.UserAuthToken)
+			claims, err = ParseToken(authConfigAsset.UserAuthToken)
 			assert.NoError(t, err)
-			persona, _ = claims["sub"].(string)
+			persona, ok = claims["sub"].(string)
 			assert.Equal(t, persona, userPersona)
+			assert.Equal(t, ok, true)
 
-			claims , err = ParseToken(authConfigAsset.WatcherAuthToken)
+			claims, err = ParseToken(authConfigAsset.WatcherAuthToken)
 			assert.NoError(t, err)
-			persona, _ = claims["sub"].(string)
+			persona, ok = claims["sub"].(string)
 			assert.Equal(t, persona, watcherPersona)
-			
+			assert.Equal(t, ok, true)
 		})
 	}
 }

--- a/pkg/asset/agent/gencrypto/authconfig_test.go
+++ b/pkg/asset/agent/gencrypto/authconfig_test.go
@@ -31,6 +31,28 @@ func TestAuthConfig_Generate(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, authConfigAsset.PublicKey)
 			assert.NotEmpty(t, authConfigAsset.AgentAuthToken)
+
+			// All the 3 tokens should be unique
+			assert.NotEqual(t, authConfigAsset.AgentAuthToken, authConfigAsset.UserAuthToken)
+			assert.NotEqual(t, authConfigAsset.AgentAuthToken, authConfigAsset.WatcherAuthToken)
+			assert.NotEqual(t, authConfigAsset.UserAuthToken, authConfigAsset.WatcherAuthToken)
+
+			// verify each token is signed with correct persona
+			claims , err := ParseToken(authConfigAsset.AgentAuthToken)
+			assert.NoError(t, err)
+			persona, _ := claims["sub"].(string)
+			assert.Equal(t, persona, agentPersona)
+
+			claims , err = ParseToken(authConfigAsset.UserAuthToken)
+			assert.NoError(t, err)
+			persona, _ = claims["sub"].(string)
+			assert.Equal(t, persona, userPersona)
+
+			claims , err = ParseToken(authConfigAsset.WatcherAuthToken)
+			assert.NoError(t, err)
+			persona, _ = claims["sub"].(string)
+			assert.Equal(t, persona, watcherPersona)
+			
 		})
 	}
 }

--- a/pkg/asset/agent/gencrypto/authconfig_test.go
+++ b/pkg/asset/agent/gencrypto/authconfig_test.go
@@ -31,6 +31,8 @@ func TestAuthConfig_Generate(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, authConfigAsset.PublicKey)
 			assert.NotEmpty(t, authConfigAsset.AgentAuthToken)
+			assert.NotEmpty(t, authConfigAsset.UserAuthToken)
+			assert.NotEmpty(t, authConfigAsset.WatcherAuthToken)
 
 			// All the 3 tokens should be unique
 			assert.NotEqual(t, authConfigAsset.AgentAuthToken, authConfigAsset.UserAuthToken)

--- a/pkg/asset/agent/gencrypto/authconfig_test.go
+++ b/pkg/asset/agent/gencrypto/authconfig_test.go
@@ -40,19 +40,19 @@ func TestAuthConfig_Generate(t *testing.T) {
 			// verify each token is signed with correct persona
 			claims, err := ParseToken(authConfigAsset.AgentAuthToken)
 			assert.NoError(t, err)
-			persona, ok := claims["sub"].(string)
+			persona, ok := claims["auth_scheme"].(string)
 			assert.Equal(t, persona, agentPersona)
 			assert.Equal(t, ok, true)
 
 			claims, err = ParseToken(authConfigAsset.UserAuthToken)
 			assert.NoError(t, err)
-			persona, ok = claims["sub"].(string)
+			persona, ok = claims["auth_scheme"].(string)
 			assert.Equal(t, persona, userPersona)
 			assert.Equal(t, ok, true)
 
 			claims, err = ParseToken(authConfigAsset.WatcherAuthToken)
 			assert.NoError(t, err)
-			persona, ok = claims["sub"].(string)
+			persona, ok = claims["auth_scheme"].(string)
 			assert.Equal(t, persona, watcherPersona)
 			assert.Equal(t, ok, true)
 		})

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -80,7 +80,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 
 		a.platform = clusterInfo.PlatformType
 		a.isoFilename = agentAddNodesISOFilename
-		a.imageExpiresAt = authConfig.AgentAuthTokenExpiry
+		a.imageExpiresAt = authConfig.AuthTokenExpiry
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -474,7 +474,7 @@ func getAddNodesEnv(clusterInfo joiner.ClusterInfo, authTokenExpiry string) stri
 	return fmt.Sprintf(`CLUSTER_ID=%s
 CLUSTER_NAME=%s
 CLUSTER_API_VIP_DNS_NAME=%s
-AGENT_AUTH_TOKEN_EXPIRY=%s
+AUTH_TOKEN_EXPIRY=%s
 `, clusterInfo.ClusterID, clusterInfo.ClusterName, clusterInfo.APIDNSName, authTokenExpiry)
 }
 

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -78,7 +78,9 @@ type agentTemplateData struct {
 	ConfigImageFiles          string
 	ImageTypeISO              string
 	PublicKeyPEM              string
-	Token                     string
+	AgentAuthToken            string
+	UserAuthToken             string
+	WatcherAuthToken          string
 	TokenExpiry               string
 	AuthType                  string
 	CaBundleMount             string
@@ -205,7 +207,7 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 		// Enable add-nodes specific services
 		enabledServices = append(enabledServices, "agent-add-node.service")
 		// Generate add-nodes.env file
-		addNodesEnvFile := ignition.FileFromString(addNodesEnvPath, "root", 0644, getAddNodesEnv(*clusterInfo, authConfig.AgentAuthTokenExpiry))
+		addNodesEnvFile := ignition.FileFromString(addNodesEnvPath, "root", 0644, getAddNodesEnv(*clusterInfo, authConfig.AuthTokenExpiry))
 		config.Storage.Files = append(config.Storage.Files, addNodesEnvFile)
 
 		// Enable auth token service
@@ -283,7 +285,9 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 		authConfig.PublicKey,
 		authConfig.AuthType,
 		authConfig.AgentAuthToken,
-		authConfig.AgentAuthTokenExpiry,
+		authConfig.UserAuthToken,
+		authConfig.WatcherAuthToken,
+		authConfig.AuthTokenExpiry,
 		caBundleMount,
 		len(registriesConfig.MirrorConfig) > 0,
 		numMasters, numWorkers,
@@ -298,7 +302,7 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 
 	rendezvousHostFile := ignition.FileFromString(rendezvousHostEnvPath,
 		"root", 0644,
-		getRendezvousHostEnv(agentTemplateData.ServiceProtocol, a.RendezvousIP, authConfig.AgentAuthToken, agentWorkflow.Workflow))
+		getRendezvousHostEnv(agentTemplateData.ServiceProtocol, a.RendezvousIP, authConfig.AgentAuthToken, authConfig.UserAuthToken, agentWorkflow.Workflow))
 	config.Storage.Files = append(config.Storage.Files, rendezvousHostFile)
 
 	err = addBootstrapScripts(&config, agentManifests.ClusterImageSet.Spec.ReleaseImage)
@@ -404,7 +408,7 @@ func addBootstrapScripts(config *igntypes.Config, releaseImage string) (err erro
 }
 
 func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries,
-	imageTypeISO, infraEnvID, publicKey, authType, token, tokenExpiry, caBundleMount string,
+	imageTypeISO, infraEnvID, publicKey, authType, agentAuthToken, userAuthToken, watcherAuthToken, tokenExpiry, caBundleMount string,
 	haveMirrorConfig bool,
 	numMasters, numWorkers int,
 	osImage *models.OsImage,
@@ -426,13 +430,15 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseIm
 		ImageTypeISO:              imageTypeISO,
 		PublicKeyPEM:              publicKey,
 		AuthType:                  authType,
-		Token:                     token,
+		AgentAuthToken:            agentAuthToken,
+		UserAuthToken:             userAuthToken,
+		WatcherAuthToken:          watcherAuthToken,
 		TokenExpiry:               tokenExpiry,
 		CaBundleMount:             caBundleMount,
 	}
 }
 
-func getRendezvousHostEnv(serviceProtocol, nodeZeroIP, token string, workflowType workflow.AgentWorkflowType) string {
+func getRendezvousHostEnv(serviceProtocol, nodeZeroIP, agentAuthtoken, userAuthToken string, workflowType workflow.AgentWorkflowType) string {
 	serviceBaseURL := url.URL{
 		Scheme: serviceProtocol,
 		Host:   net.JoinHostPort(nodeZeroIP, "8090"),
@@ -443,8 +449,10 @@ func getRendezvousHostEnv(serviceProtocol, nodeZeroIP, token string, workflowTyp
 		Host:   net.JoinHostPort(nodeZeroIP, "8888"),
 		Path:   "/",
 	}
-	// AGENT_AUTH_TOKEN is required to authenticate API requests against agent-installer-local auth type.
-	// PULL_SECRET_TOKEN contains the same value as AGENT_AUTH_TOKEN. The name PULL_SECRET_TOKEN is used in
+	// USER_AUTH_TOKEN is required to authenticate API requests against agent-installer-local auth type
+	// and for the endpoints marked with userAuth security definition in assisted-service swagger.yaml.
+	// PULL_SECRET_TOKEN contains the AGENT_AUTH_TOKEN and is required for the endpoints marked with agentAuth security definition in assisted-service swagger.yaml.
+	// The name PULL_SECRET_TOKEN is used in
 	// assisted-installer-agent, which is responsible for authenticating API requests related to agents.
 	// Historically, PULL_SECRET_TOKEN was used solely to store the pull secrets.
 	// However, as the authentication mechanisms have evolved, PULL_SECRET_TOKEN now
@@ -456,10 +464,10 @@ func getRendezvousHostEnv(serviceProtocol, nodeZeroIP, token string, workflowTyp
 	return fmt.Sprintf(`NODE_ZERO_IP=%s
 SERVICE_BASE_URL=%s
 IMAGE_SERVICE_BASE_URL=%s
-AGENT_AUTH_TOKEN=%s
 PULL_SECRET_TOKEN=%s
+USER_AUTH_TOKEN=%s
 WORKFLOW_TYPE=%s
-`, nodeZeroIP, serviceBaseURL.String(), imageServiceBaseURL.String(), token, token, workflowType)
+`, nodeZeroIP, serviceBaseURL.String(), imageServiceBaseURL.String(), agentAuthtoken, userAuthToken, workflowType)
 }
 
 func getAddNodesEnv(clusterInfo joiner.ClusterInfo, authTokenExpiry string) string {

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -93,8 +93,10 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	clusterName := "test-agent-cluster-install.test"
 
 	publicKey := "-----BEGIN EC PUBLIC KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PUBLIC KEY-----\n"
-	token := "someToken"
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
+	agentAuthToken := "agentAuthToken"
+	userAuthToken := "userAuthToken"
+	watcherAuthToken := "watcherAuthToken"
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, agentAuthToken, userAuthToken, watcherAuthToken, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -110,16 +112,19 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, proxy, templateData.Proxy)
 	assert.Equal(t, publicKey, templateData.PublicKeyPEM)
 	assert.Equal(t, gencrypto.AuthType, templateData.AuthType)
-	assert.Equal(t, token, templateData.Token)
+	assert.Equal(t, agentAuthToken, templateData.AgentAuthToken)
+	assert.Equal(t, userAuthToken, templateData.UserAuthToken)
+	assert.Equal(t, watcherAuthToken, templateData.WatcherAuthToken)
 
 }
 
 func TestIgnition_getRendezvousHostEnv(t *testing.T) {
 	nodeZeroIP := "2001:db8::dead:beef"
-	token := "someToken"
-	rendezvousHostEnv := getRendezvousHostEnv("http", nodeZeroIP, token, workflow.AgentWorkflowTypeInstall)
+	agentAuthtoken := "agentAuthtoken"
+	userAuthToken := "userAuthToken"
+	rendezvousHostEnv := getRendezvousHostEnv("http", nodeZeroIP, agentAuthtoken, userAuthToken, workflow.AgentWorkflowTypeInstall)
 	assert.Equal(t,
-		"NODE_ZERO_IP="+nodeZeroIP+"\nSERVICE_BASE_URL=http://["+nodeZeroIP+"]:8090/\nIMAGE_SERVICE_BASE_URL=http://["+nodeZeroIP+"]:8888/\nAGENT_AUTH_TOKEN="+token+"\nPULL_SECRET_TOKEN="+token+"\nWORKFLOW_TYPE=install\n",
+		"NODE_ZERO_IP="+nodeZeroIP+"\nSERVICE_BASE_URL=http://["+nodeZeroIP+"]:8090/\nIMAGE_SERVICE_BASE_URL=http://["+nodeZeroIP+"]:8888/\nPULL_SECRET_TOKEN="+agentAuthtoken+"\nUSER_AUTH_TOKEN="+userAuthToken+"\nWORKFLOW_TYPE=install\n",
 		rendezvousHostEnv)
 }
 


### PR DESCRIPTION
- Create 3 seperate JWT tokens- AGENT_AUTH_TOKEN, USER_AUTH_TOKEN, WATCHER_AUTH_TOKEN 
- Update the claim to set 'auth_scheme' to identify the user persona 
-  Assisted service checks the `auth_scheme` to determine which user persona is allowed to access an endpoint
- WATCHER_AUTH_TOKEN is used with header `Watcher-Authorization` and is used by wait-for command ( watcher persona)
- USER_AUTH_TOKEN is used with header `Authorization` and is used by curl API requests, systemd services ( user persona)
- AGENT_AUTH_TOKEN is used with header `X-Secret-Key` and is used by agent service ( agent persona)
- Day2 monitor use case. Save WATCHER_AUTH_TOKEN in the secret
- Rename var to a common name AUTH_TOKEN_EXPIRY. All the 3 tokens expire at the same time.