### PR TITLE
OCPBUGS-41184: GCP Validate Disk and Instance Type

### DIFF
--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -27,13 +27,23 @@ var (
 	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
 	ComputeSupportedDisks = sets.New(HyperDiskBalanced, PDBalanced, PDSSD, PDStandard)
 
-	// DiskTypeToInstanceTypeMap contains a map where the key is the Disk Type, and the values are a list of
-	// instance types that are supported by the installer and correlate to the Disk Type.
-	DiskTypeToInstanceTypeMap = map[string][]string{
-		PDStandard:        {"a2", "e2", "n1", "n2", "n2d", "t2a", "t2d"},
-		PDSSD:             {"a2", "a3", "c3", "c3d", "e2", "m1", "n1", "n2", "n2d", "t2a", "t2d"},
-		PDBalanced:        {"a2", "a3", "c3", "c3d", "e2", "m1", "n1", "n2", "n2d", "t2a", "t2d"},
-		HyperDiskBalanced: {"c3", "c3d", "m1", "n4"},
+	// InstanceTypeToDiskTypeMap contains a map where the key is the Instance Type, and the
+	// values are a list of disk types that are supported by the installer and correlate to the Instance Type.
+	InstanceTypeToDiskTypeMap = map[string][]string{
+		"a2":  {PDStandard, PDSSD, PDBalanced},
+		"a3":  {PDSSD, PDBalanced},
+		"c2":  {PDStandard, PDSSD, PDBalanced},
+		"c2d": {PDStandard, PDSSD, PDBalanced},
+		"c3":  {PDSSD, PDBalanced, HyperDiskBalanced},
+		"c3d": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"e2":  {PDStandard, PDSSD, PDBalanced},
+		"m1":  {PDSSD, PDBalanced, HyperDiskBalanced},
+		"n1":  {PDStandard, PDSSD, PDBalanced},
+		"n2":  {PDStandard, PDSSD, PDBalanced},
+		"n2d": {PDStandard, PDSSD, PDBalanced},
+		"n4":  {HyperDiskBalanced},
+		"t2a": {PDStandard, PDSSD, PDBalanced},
+		"t2d": {PDStandard, PDSSD, PDBalanced},
 	}
 )
 


### PR DESCRIPTION
** Update the error text and the way that disks and instances are validated. Before, the error message was backwards on indicating if the instance type or the disk type was the problem. Now, the disk type is validated against the instance type (rather than the opposite).