### PR TITLE
OCPBUGS-41834: Add agent installer checks for hosts interface table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0
+	github.com/go-openapi/validate v0.24.0
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/mock v1.7.0-rc.1
@@ -185,7 +186,6 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
-	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/gobuffalo/flect v1.0.2 // indirect

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -284,6 +284,30 @@ func TestNMStateConfig_Generate(t *testing.T) {
 			expectedConfig:     nil,
 			expectedError:      "failed to validate network yaml",
 		},
+		{
+			name: "invalid networkConfig, no interfaces in interface table",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.ClusterInfo{},
+				getAgentHostsConfigNoInterfaces(),
+				getValidOptionalInstallConfig(),
+			},
+			requiresNmstatectl: true,
+			expectedConfig:     nil,
+			expectedError:      "at least one interface for host 0 must be provided",
+		},
+		{
+			name: "invalid networkConfig, invalid mac in interface table",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.ClusterInfo{},
+				getAgentHostsConfigInvalidMac(),
+				getValidOptionalInstallConfig(),
+			},
+			requiresNmstatectl: true,
+			expectedConfig:     nil,
+			expectedError:      "MAC address 98-af-65-a5-8d-02 for host 0 is incorrectly formatted, use XX:XX:XX:XX:XX:XX format",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -450,6 +450,39 @@ func getAgentHostsWithBMCConfig() *agentconfig.AgentHosts {
 	}
 }
 
+func getAgentHostsConfigNoInterfaces() *agentconfig.AgentHosts {
+	return &agentconfig.AgentHosts{
+		Hosts: []agenttypes.Host{
+			{
+				Hostname:   "control-0.example.org",
+				Interfaces: []*v1beta1.Interface{},
+				NetworkConfig: v1beta1.NetConfig{
+					Raw: unmarshalJSON([]byte(rawNMStateConfig)),
+				},
+			},
+		},
+	}
+}
+
+func getAgentHostsConfigInvalidMac() *agentconfig.AgentHosts {
+	return &agentconfig.AgentHosts{
+		Hosts: []agenttypes.Host{
+			{
+				Hostname: "control-0.example.org",
+				Interfaces: []*v1beta1.Interface{
+					{
+						Name:       "enp2s0",
+						MacAddress: "98-af-65-a5-8d-02",
+					},
+				},
+				NetworkConfig: v1beta1.NetConfig{
+					Raw: unmarshalJSON([]byte(rawNMStateConfig)),
+				},
+			},
+		},
+	}
+}
+
 func getGoodACI() *hiveext.AgentClusterInstall {
 	goodACI := &hiveext.AgentClusterInstall{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Add checks for the host interface table to validate:
- at least one entry is defined in the interface table when using network configuration
- the MAC addresses in the interface table are using the expected format