### PR TITLE
AGENT-972, AGENT-973: Agent minimal ISO support for all platforms

### DIFF
--- a/cmd/openshift-install/testdata/agent/agentconfigtemplate/agent-config-template.txt
+++ b/cmd/openshift-install/testdata/agent/agentconfigtemplate/agent-config-template.txt
@@ -22,6 +22,7 @@ metadata:
 # All fields are optional
 rendezvousIP: your-node0-ip
 bootArtifactsBaseURL: http://user-specified-infra.com
+minimalISO: false
 additionalNTPSources:
 - 0.rhel.pool.ntp.org
 - 1.rhel.pool.ntp.org

--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -57,6 +57,7 @@ metadata:
 # All fields are optional
 rendezvousIP: your-node0-ip
 bootArtifactsBaseURL: http://user-specified-infra.com
+minimalISO: false
 additionalNTPSources:
 - 0.rhel.pool.ntp.org
 - 1.rhel.pool.ntp.org

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -162,9 +162,10 @@ func (a *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 		}
 		a.RendezvousIP = nodeZeroIP
 		logrus.Infof("The rendezvous host IP (node0 IP) is %s", a.RendezvousIP)
-		// Define cluster name and image type.
+		// Define cluster name
 		clusterName = fmt.Sprintf("%s.%s", agentManifests.ClusterDeployment.Spec.ClusterName, agentManifests.ClusterDeployment.Spec.BaseDomain)
-		if agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType {
+		if (agentConfigAsset.Config != nil && agentConfigAsset.Config.MinimalISO) ||
+			(agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType) {
 			imageTypeISO = "minimal-iso"
 		}
 		// Fetch the required number of master and worker nodes.

--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -27,6 +27,9 @@ type Config struct {
 	RendezvousIP         string `json:"rendezvousIP,omitempty"`
 	BootArtifactsBaseURL string `json:"bootArtifactsBaseURL,omitempty"`
 	Hosts                []Host `json:"hosts,omitempty"`
+	// When MinimalISO is set to true, a minimal ISO that does not contain the rootfs will be generated.
+	// By default a full ISO will be created, unless the platform is External, which generates a minimal ISO.
+	MinimalISO bool `json:"minimalISO,omitempty"`
 }
 
 // Host defines per host configurations


### PR DESCRIPTION
Add the ability to enable minimal ISO support for all platform types, not just External. Adds a new flag to the 'agent create image' command.
