### PR TITLE
AGENT-1023: support patch in curl_assisted_service

### DIFF
--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -13,6 +13,12 @@ curl_assisted_service() {
             -H "accept: application/json" \
             -H "Content-Type: application/json" \
             ;;
+        "PATCH")
+            curl -s -S -X PATCH "${additional_options[@]}" "${baseURL}${endpoint}" \
+            -H "Authorization: ${AGENT_AUTH_TOKEN}" \
+            -H "accept: application/json" \
+            -H "Content-Type: application/json" \
+            ;;
         "GET")
             curl -s -S -X GET "${additional_options[@]}" "${baseURL}${endpoint}" \
             -H "Authorization: ${AGENT_AUTH_TOKEN}" \


### PR DESCRIPTION
Added support for PATCH in curl_assisted_service func.
Needed for the appliance flow: https://github.com/openshift/appliance/blob/1c405b5cc722b29edcf4bb6bbe14e44d21a4c066/data/scripts/bin/update-hosts.sh.template#L29-L30