### PR TITLE
OCPBUGS-42563: machines: don't sort mpool zones

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -3,7 +3,6 @@ package azure
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -82,11 +81,11 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		*machineSetProvider = *provider
 		machines = append(machines, machine)
 	}
-	replicas := int32(total)
 
+	replicas := int32(total)
 	failureDomains := []machinev1.AzureFailureDomain{}
+
 	if len(mpool.Zones) > 1 {
-		sort.Strings(mpool.Zones)
 		for _, zone := range mpool.Zones {
 			domain := machinev1.AzureFailureDomain{
 				Zone: zone,

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -3,7 +3,6 @@ package gcp
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -70,7 +69,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	}
 	replicas := int32(total)
 	failureDomains := []machinev1.GCPFailureDomain{}
-	sort.Strings(mpool.Zones)
+
 	for _, zone := range mpool.Zones {
 		domain := machinev1.GCPFailureDomain{
 			Zone: zone,
@@ -78,6 +77,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		failureDomains = append(failureDomains, domain)
 	}
 	machineSetProvider.Zone = ""
+
 	controlPlaneMachineSet := &machinev1.ControlPlaneMachineSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1",
@@ -229,6 +229,7 @@ func ConfigMasters(machines []machineapi.Machine, controlPlane *machinev1.Contro
 	providerSpec.TargetPools = targetPools
 	return nil
 }
+
 func getNetworks(platform *gcp.Platform, clusterID, role string) (string, string, error) {
 	if platform.Network == "" {
 		return fmt.Sprintf("%s-network", clusterID), fmt.Sprintf("%s-%s-subnet", clusterID, role), nil


### PR DESCRIPTION
When sorting the availability zones before creating the CPMS manifest, we are inadvertently changing the backing array that is used by the MAPI machine manifests for controlPlane nodes, thus creating a discrepancy between which zones capi creates the machines in and where they are assigned to in the mapi manifests.

The CPMS operator sorts the failure domains before using them [1], so there is no reason for the installer to do that.

[1] https://github.com/openshift/cluster-control-plane-machine-set-operator/blob/611636f48fc87bb09c95121d228697cee72fc118/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go#L114-L122