### PR TITLE
AGENT-998: allow node-joiner hack script to run in the CI

### DIFF
--- a/hack/go-integration-test-nodejoiner.sh
+++ b/hack/go-integration-test-nodejoiner.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Example:  ./hack/go-integration-test-nodejoiner.sh
 
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+go install -mod=mod sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 # shellcheck disable=SC2086
 KUBEBUILDER_ASSETS="$($GOPATH/bin/setup-envtest use 1.31.0 -p path --bin-dir /tmp)" go test -timeout 0 -run .Integration ./cmd/node-joiner/... "${@}"
 


### PR DESCRIPTION
By default in the CI the `-mod=vendor` is set, preventing the script to install (donwload) the `setup-envtest` tool, which is required to download the apiserver and etcd binaries used by [envtest](https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest#where-does-it-put-all-those-binaries) 