### PR TITLE
CORS-3696: Add AWS User Provisioned DNS option to install config

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openshift/installer/pkg/gather/service"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/vsphere"
 	baremetalutils "github.com/openshift/installer/pkg/utils/baremetal"
@@ -891,7 +892,7 @@ func handleUnreachableAPIServer(ctx context.Context, config *rest.Config) error 
 	}
 	switch installConfig.Config.Platform.Name() { //nolint:gocritic
 	case gcp.Name:
-		if installConfig.Config.GCP.UserProvisionedDNS != gcp.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
 			return nil
 		}
 	default:

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -49,6 +49,7 @@ import (
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
 	"github.com/openshift/installer/pkg/gather/service"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
+	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
@@ -891,6 +892,10 @@ func handleUnreachableAPIServer(ctx context.Context, config *rest.Config) error 
 		return fmt.Errorf("failed to fetch %s: %w", installConfig.Name(), err)
 	}
 	switch installConfig.Config.Platform.Name() { //nolint:gocritic
+	case aws.Name:
+		if installConfig.Config.AWS.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
+			return nil
+		}
 	case gcp.Name:
 		if installConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
 			return nil

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2687,6 +2687,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  userProvisionedDNS:
+                    default: Disabled
+                    description: UserProvisionedDNS indicates if the customer is providing
+                      their own DNS solution in place of the default provisioned by
+                      the Installer.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   userTags:
                     additionalProperties:
                       type: string

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.3-0.20240416171357-98239ba02cb2
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.34.1
-	github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f
+	github.com/openshift/api v0.0.0-20241007111039-82e082220d91
 	github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f h1:ya1OmyZm3LIIxI3U9VE9Nyx3ehCHgBwxyFUPflYPWls=
-github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
+github.com/openshift/api v0.0.0-20241007111039-82e082220d91 h1:Hog3EODKZHpsOmmVec/ndxrNT0L65Aimd5eh5cQBbBQ=
+github.com/openshift/api v0.0.0-20241007111039-82e082220d91/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6 h1:U6ve+dnHlHhAELoxX+rdFOHVhoaYl0l9qtxwYtsO6C0=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service/api v0.0.0-20230831114549-1922eda29cf8 h1:+fZLKbycDo4JeLwPGVSAgf2XPaJGLM341l9ZfrrlxG0=

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -52,6 +52,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
@@ -503,7 +504,7 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 		publicZoneName := ""
 		privateZoneName := ""
 
-		if installConfig.Config.GCP.UserProvisionedDNS != gcp.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
 			if installConfig.Config.Publish == types.ExternalPublishingStrategy {
 				publicZone, err := client.GetDNSZone(ctx, installConfig.Config.GCP.ProjectID, installConfig.Config.BaseDomain, true)
 				if err != nil {
@@ -554,7 +555,7 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 				PrivateZoneName:     privateZoneName,
 				PublishStrategy:     installConfig.Config.Publish,
 				InfrastructureName:  clusterID.InfraID,
-				UserProvisionedDNS:  installConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
+				UserProvisionedDNS:  installConfig.Config.GCP.UserProvisionedDNS == dns.UserProvisionedDNSEnabled,
 				UserTags:            tags,
 				IgnitionShim:        string(shim),
 				PresignedURL:        url,

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/dns"
 )
 
 type resourceRequirements struct {
@@ -573,6 +574,11 @@ var requiredServices = []string{
 // ValidateForProvisioning validates if the install config is valid for provisioning the cluster.
 func ValidateForProvisioning(client API, ic *types.InstallConfig, metadata *Metadata) error {
 	if ic.Publish == types.InternalPublishingStrategy && ic.AWS.HostedZone == "" {
+		return nil
+	}
+
+	if ic.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
+		logrus.Debug("User Provisioned DNS enabled, skipping zone validation")
 		return nil
 	}
 

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/validate"
 	mapiutil "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
@@ -376,7 +377,7 @@ func checkRecordSets(client API, ic *types.InstallConfig, zone *dns.ManagedZone,
 
 // ValidateForProvisioning validates that the install config is valid for provisioning the cluster.
 func ValidateForProvisioning(ic *types.InstallConfig) error {
-	if ic.Platform.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled {
+	if ic.Platform.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 		return nil
 	}
 

--- a/pkg/asset/lbconfig/lbconfig.go
+++ b/pkg/asset/lbconfig/lbconfig.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,13 +143,14 @@ func (i *Config) ParseDNSDataFromConfig(loadBalancerType LoadBalancerCategory) (
 
 	if internalData, ok := lbData["data"]; ok {
 		if lbStoredData, ok := internalData.(map[string]interface{})[string(loadBalancerType)]; ok {
-			// TODO: make this parse a comma separated string
-			parsedIP := net.ParseIP(lbStoredData.(string))
-			if parsedIP != nil {
-				ipAddresses = append(ipAddresses, parsedIP)
-			} else {
-				// assume the data is a dns entry
-				dnsNames = append(dnsNames, lbStoredData.(string))
+			candidates := strings.Split(lbStoredData.(string), ",")
+			for _, candidate := range candidates {
+				if parsedIP := net.ParseIP(candidate); parsedIP != nil {
+					ipAddresses = append(ipAddresses, parsedIP)
+				} else {
+					// assume the data is a dns entry
+					dnsNames = append(dnsNames, candidate)
+				}
 			}
 		}
 	}

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -21,6 +21,7 @@ import (
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	dnstypes "github.com/openshift/installer/pkg/types/dns"
 	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
@@ -136,7 +137,7 @@ func (d *DNS) Generate(ctx context.Context, dependencies asset.Parents) error {
 	case gcptypes.Name:
 		// We donot want to configure cloud DNS when `UserProvisionedDNS` is enabled.
 		// So, do not set PrivateZone and PublicZone fields in the DNS manifest.
-		if installConfig.Config.GCP.UserProvisionedDNS == gcptypes.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 			config.Spec.PublicZone = &configv1.DNSZone{ID: ""}
 			config.Spec.PrivateZone = &configv1.DNSZone{ID: ""}
 			break

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -129,6 +129,15 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 					config.Status.PlatformStatus.AWS.ServiceEndpoints[j].Name
 			})
 		}
+		// If the user has requested the use of a DNS provisioned by them, then OpenShift needs to
+		// start an in-cluster DNS for the installation to succeed. The user can then configure their
+		// DNS post-install.
+		config.Status.PlatformStatus.AWS.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{
+			DNSType: configv1.PlatformDefaultDNSType,
+		}
+		if installConfig.Config.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
+			config.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
+		}
 	case azure.Name:
 		config.Spec.PlatformSpec.Type = configv1.AzurePlatformType
 
@@ -197,8 +206,9 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 		// If the user has requested the use of a DNS provisioned by them, then OpenShift needs to
 		// start an in-cluster DNS for the installation to succeed. The user can then configure their
 		// DNS post-install.
-		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{}
-		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.PlatformDefaultDNSType
+		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{
+			DNSType: configv1.PlatformDefaultDNSType,
+		}
 		if installConfig.Config.GCP.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
 			config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
 		}

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
@@ -198,7 +199,7 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 		// DNS post-install.
 		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{}
 		config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.PlatformDefaultDNSType
-		if installConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled {
+		if installConfig.Config.GCP.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
 			config.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
 		}
 	case ibmcloud.Name:

--- a/pkg/asset/manifests/infrastructure_test.go
+++ b/pkg/asset/manifests/infrastructure_test.go
@@ -75,7 +75,31 @@ func TestGenerateInfrastructure(t *testing.T) {
 			infraBuild.withGCPClusterHostedDNS("Enabled"),
 		),
 		expectedFilesGenerated: 2,
-	}}
+	},
+		{
+			name:          "default AWS custom DNS",
+			installConfig: icBuild.build(icBuild.forAWS()),
+			expectedInfrastructure: infraBuild.build(
+				infraBuild.forPlatform(configv1.AWSPlatformType),
+				infraBuild.withAWSClusterHostedDNS("Disabled"),
+				infraBuild.withAWSPlatformSpec(),
+				infraBuild.withAWSPlatformStatus(),
+			),
+			expectedFilesGenerated: 1,
+		}, {
+			name: "AWS custom DNS",
+			installConfig: icBuild.build(
+				icBuild.forAWS(),
+				icBuild.withAWSUserProvisionedDNS("Enabled"),
+			),
+			expectedInfrastructure: infraBuild.build(
+				infraBuild.forPlatform(configv1.AWSPlatformType),
+				infraBuild.withAWSClusterHostedDNS("Enabled"),
+				infraBuild.withAWSPlatformSpec(),
+				infraBuild.withAWSPlatformStatus(),
+			),
+			expectedFilesGenerated: 1,
+		}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			parents := asset.Parents{}
@@ -185,6 +209,16 @@ func (b icBuildNamespace) withGCPUserProvisionedDNS(enabled string) icOption {
 	}
 }
 
+func (b icBuildNamespace) withAWSUserProvisionedDNS(enabled string) icOption {
+	return func(ic *types.InstallConfig) {
+		b.forAWS()(ic)
+		if enabled == "Enabled" {
+			ic.Platform.AWS.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
+			ic.FeatureGates = []string{"AWSClusterHostedDNS=true"}
+		}
+	}
+}
+
 type infraOption func(*configv1.Infrastructure)
 
 type infraBuildNamespace struct{}
@@ -242,6 +276,9 @@ func (b infraBuildNamespace) withAWSPlatformStatus() infraOption {
 			return
 		}
 		infra.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{}
+		infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{
+			DNSType: configv1.PlatformDefaultDNSType,
+		}
 	}
 }
 
@@ -306,6 +343,18 @@ func (b infraBuildNamespace) withGCPClusterHostedDNS(enabled string) infraOption
 		infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.PlatformDefaultDNSType
 		if enabled == "Enabled" {
 			infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
+		}
+	}
+}
+
+func (b infraBuildNamespace) withAWSClusterHostedDNS(enabled string) infraOption {
+	return func(infra *configv1.Infrastructure) {
+		b.withAWSPlatformStatus()(infra)
+		infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig = &configv1.CloudLoadBalancerConfig{
+			DNSType: configv1.PlatformDefaultDNSType,
+		}
+		if enabled == "Enabled" {
+			infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
 		}
 	}
 }

--- a/pkg/asset/manifests/infrastructure_test.go
+++ b/pkg/asset/manifests/infrastructure_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/dns"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	nonetypes "github.com/openshift/installer/pkg/types/none"
 )
@@ -178,7 +179,7 @@ func (b icBuildNamespace) withGCPUserProvisionedDNS(enabled string) icOption {
 	return func(ic *types.InstallConfig) {
 		b.forGCP()(ic)
 		if enabled == "Enabled" {
-			ic.Platform.GCP.UserProvisionedDNS = gcptypes.UserProvisionedDNSEnabled
+			ic.Platform.GCP.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
 			ic.FeatureGates = []string{"GCPClusterHostedDNS=true"}
 		}
 	}

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -191,6 +191,11 @@ func Test_PrintFields(t *testing.T) {
     subnets <[]string>
       Subnets specifies existing subnets (by ID) where cluster resources will be created.  Leave unset to have the installer create subnets in a new VPC on your behalf.
 
+    userProvisionedDNS <string>
+      Default: "Disabled"
+      Valid Values: "Enabled","Disabled"
+      UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default provisioned by the Installer.
+
     userTags <object>
       UserTags additional keys and values that the installer will add as tags to all resources that it creates. Resources created by the cluster itself may not include these tags.`,
 	}, {

--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/openshift/installer/pkg/types/dns"
 	"strings"
 	"time"
 
@@ -115,6 +116,13 @@ func (*Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput) 
 	}
 
 	client := awsconfig.NewClient(awsSession)
+
+	// The user has selected to provision their own DNS solution. Skip the creation of the
+	// Hosted Zone(s) and the records for those zones.
+	if in.InstallConfig.Config.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
+		logrus.Debugf("User Provisioned DNS enabled, skipping dns record creation")
+		return nil
+	}
 
 	logrus.Infoln("Creating Route53 records for control plane load balancer")
 

--- a/pkg/infrastructure/aws/clusterapi/ignition.go
+++ b/pkg/infrastructure/aws/clusterapi/ignition.go
@@ -1,0 +1,72 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/sirupsen/logrus"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/dns"
+)
+
+func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
+	if in.InstallConfig.Config.AWS.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
+		return in.BootstrapIgnData, nil
+	}
+
+	awsCluster := &capa.AWSCluster{}
+	key := k8sClient.ObjectKey{
+		Name:      in.InfraID,
+		Namespace: capiutils.Namespace,
+	}
+	if err := in.Client.Get(ctx, key, awsCluster); err != nil {
+		return nil, fmt.Errorf("failed to get AWSCluster: %w", err)
+	}
+
+	awsSession, err := in.InstallConfig.AWS.Session(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get aws session: %w", err)
+	}
+
+	// There is no direct access to load balancer IP addresses, so the security groups
+	// are used here to find the network interfaces that correspond to the load balancers.
+	securityGroupIDs := make([]*string, 0, len(awsCluster.Status.Network.SecurityGroups))
+	for _, securityGroup := range awsCluster.Status.Network.SecurityGroups {
+		securityGroupIDs = append(securityGroupIDs, aws.String(securityGroup.ID))
+	}
+	nicInput := ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: securityGroupIDs,
+			},
+		},
+	}
+	nicOutput, err := ec2.New(awsSession).DescribeNetworkInterfacesWithContext(ctx, &nicInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe network interfaces: %w", err)
+	}
+
+	// The only network interfaces existing at this stage are those from the load balancers.
+	// If this stage is executed after control plane nodes are provisioned, there may be
+	// other network interfaces available.
+	publicIPAddresses := []string{}
+	privateIPAddresses := []string{}
+	for _, nic := range nicOutput.NetworkInterfaces {
+		if nic.Association != nil && nic.Association.PublicIp != nil {
+			logrus.Debugf("found public IP address %s associated with %s", *nic.Association.PublicIp, *nic.Description)
+			publicIPAddresses = append(publicIPAddresses, *nic.Association.PublicIp)
+		} else if nic.PrivateIpAddress != nil {
+			logrus.Debugf("found private IP address %s associated with %s", *nic.PrivateIpAddress, *nic.Description)
+			privateIPAddresses = append(privateIPAddresses, *nic.PrivateIpAddress)
+		}
+	}
+	return clusterapi.EditIgnition(in, awstypes.Name, publicIPAddresses, privateIPAddresses)
+}

--- a/pkg/infrastructure/clusterapi/ignition.go
+++ b/pkg/infrastructure/clusterapi/ignition.go
@@ -1,0 +1,125 @@
+package clusterapi
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"sigs.k8s.io/yaml"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/cmd/openshift-install/command"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/lbconfig"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
+)
+
+const (
+	infrastructureFilepath = "/opt/openshift/manifests/cluster-infrastructure-02-config.yml"
+
+	// replaceable is the string that precedes the encoded data in the ignition data.
+	// The data must be replaced before decoding the string, and the string must be
+	// prepended to the encoded data.
+	replaceable = "data:text/plain;charset=utf-8;base64,"
+)
+
+// EditIgnition attempts to edit the contents of the bootstrap ignition when the user has selected
+// a custom DNS configuration. Find the public and private load balancer addresses and fill in the
+// infrastructure file within the ignition struct.
+func EditIgnition(in IgnitionInput, platform string, publicIPAddresses, privateIPAddresses []string) ([]byte, error) {
+	ignData := &igntypes.Config{}
+	err := json.Unmarshal(in.BootstrapIgnData, ignData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bootstrap ignition: %w", err)
+	}
+
+	err = AddLoadBalancersToInfra(platform, ignData, publicIPAddresses, privateIPAddresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add load balancers to ignition config: %w", err)
+	}
+
+	publicIPsSingleStr := strings.Join(publicIPAddresses, ",")
+	privateIPsSingleStr := strings.Join(privateIPAddresses, ",")
+
+	lbConfig, err := lbconfig.GenerateLBConfigOverride(privateIPsSingleStr, publicIPsSingleStr)
+	if err != nil {
+		return nil, err
+	}
+	if err := asset.NewDefaultFileWriter(lbConfig).PersistToFile(command.RootOpts.Dir); err != nil {
+		return nil, fmt.Errorf("failed to save %s to state file: %w", lbConfig.Name(), err)
+	}
+
+	editedIgnBytes, err := json.Marshal(ignData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ignition data to json: %w", err)
+	}
+
+	return editedIgnBytes, nil
+}
+
+// AddLoadBalancersToInfra will load the public and private load balancer information into
+// the infrastructure CR. This will occur after the data has already been inserted into the
+// ignition file.
+func AddLoadBalancersToInfra(platform string, config *igntypes.Config, publicLBs []string, privateLBs []string) error {
+	for i, fileData := range config.Storage.Files {
+		// update the contents of this file
+		if fileData.Path == infrastructureFilepath {
+			contents := config.Storage.Files[i].Contents.Source
+			replaced := strings.Replace(*contents, replaceable, "", 1)
+
+			rawDecodedText, err := base64.StdEncoding.DecodeString(replaced)
+			if err != nil {
+				return fmt.Errorf("failed to decode contents of ignition file: %w", err)
+			}
+
+			infra := &configv1.Infrastructure{}
+			if err := yaml.Unmarshal(rawDecodedText, infra); err != nil {
+				return fmt.Errorf("failed to unmarshal infrastructure: %w", err)
+			}
+
+			// convert the list of strings to a list of IPs
+			apiIntLbs := []configv1.IP{}
+			for _, ip := range privateLBs {
+				apiIntLbs = append(apiIntLbs, configv1.IP(ip))
+			}
+			apiLbs := []configv1.IP{}
+			for _, ip := range publicLBs {
+				apiLbs = append(apiLbs, configv1.IP(ip))
+			}
+			cloudLBInfo := configv1.CloudLoadBalancerIPs{
+				APIIntLoadBalancerIPs: apiIntLbs,
+				APILoadBalancerIPs:    apiLbs,
+			}
+
+			switch platform {
+			case gcptypes.Name:
+				if infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType == configv1.ClusterHostedDNSType {
+					infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted = &cloudLBInfo
+				}
+			case awstypes.Name:
+				if infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.DNSType == configv1.ClusterHostedDNSType {
+					infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.ClusterHosted = &cloudLBInfo
+				}
+			default:
+				return fmt.Errorf("invalid platform %s", platform)
+			}
+
+			// convert the infrastructure back to an encoded string
+			infraContents, err := yaml.Marshal(infra)
+			if err != nil {
+				return fmt.Errorf("failed to marshal infrastructure: %w", err)
+			}
+
+			encoded := fmt.Sprintf("%s%s", replaceable, base64.StdEncoding.EncodeToString(infraContents))
+			// replace the contents with the edited information
+			config.Storage.Files[i].Contents.Source = &encoded
+
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
@@ -224,7 +225,7 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 		return fmt.Errorf("failed to add firewall rules: %w", err)
 	}
 
-	if in.InstallConfig.Config.GCP.UserProvisionedDNS != gcptypes.UserProvisionedDNSEnabled {
+	if in.InstallConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
 		// Get the network from the GCP Cluster. The network is used to create the private managed zone.
 		if gcpCluster.Status.Network.SelfLink == nil {
 			return fmt.Errorf("failed to get GCP network: %w", err)

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -122,14 +122,9 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("failed to create bucket %s: %w", bucketName, err)
 	}
 
-	editedIgnitionBytes, err := EditIgnition(ctx, in)
+	ignitionBytes, err := editIgnition(ctx, in)
 	if err != nil {
 		return nil, fmt.Errorf("failed to edit bootstrap ignition: %w", err)
-	}
-
-	ignitionBytes := in.BootstrapIgnData
-	if editedIgnitionBytes != nil {
-		ignitionBytes = editedIgnitionBytes
 	}
 
 	if err := gcp.FillBucket(ctx, bucketHandle, string(ignitionBytes)); err != nil {

--- a/pkg/infrastructure/gcp/clusterapi/ignition.go
+++ b/pkg/infrastructure/gcp/clusterapi/ignition.go
@@ -2,21 +2,12 @@ package clusterapi
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
-	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	capg "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/installer/cmd/openshift-install/command"
-	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/lbconfig"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	"github.com/openshift/installer/pkg/types"
@@ -24,141 +15,51 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
-const (
-	infrastructureFilepath = "/opt/openshift/manifests/cluster-infrastructure-02-config.yml"
-
-	// replaceable is the string that precedes the encoded data in the ignition data.
-	// The data must be replaced before decoding the string, and the string must be
-	// prepended to the encoded data.
-	replaceable = "data:text/plain;charset=utf-8;base64,"
-)
-
-// EditIgnition attempts to edit the contents of the bootstrap ignition when the user has selected
+// editIgnition attempts to edit the contents of the bootstrap ignition when the user has selected
 // a custom DNS configuration. Find the public and private load balancer addresses and fill in the
 // infrastructure file within the ignition struct.
-func EditIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
-	defer cancel()
-
-	if in.InstallConfig.Config.GCP.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
-		gcpCluster := &capg.GCPCluster{}
-		key := client.ObjectKey{
-			Name:      in.InfraID,
-			Namespace: capiutils.Namespace,
-		}
-		if err := in.Client.Get(ctx, key, gcpCluster); err != nil {
-			return nil, fmt.Errorf("failed to get GCP cluster: %w", err)
-		}
-
-		svc, err := NewComputeService()
-		if err != nil {
-			return nil, err
-		}
-
-		project := in.InstallConfig.Config.GCP.ProjectID
-		if in.InstallConfig.Config.GCP.NetworkProjectID != "" {
-			project = in.InstallConfig.Config.GCP.NetworkProjectID
-		}
-
-		computeAddress := ""
-		if in.InstallConfig.Config.Publish == types.ExternalPublishingStrategy {
-			apiIPAddress := *gcpCluster.Status.Network.APIServerAddress
-			addressCut := apiIPAddress[strings.LastIndex(apiIPAddress, "/")+1:]
-			computeAddressObj, err := svc.GlobalAddresses.Get(project, addressCut).Context(ctx).Do()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get global compute address: %w", err)
-			}
-			computeAddress = computeAddressObj.Address
-		}
-
-		apiIntIPAddress := *gcpCluster.Status.Network.APIInternalAddress
-		addressIntCut := apiIntIPAddress[strings.LastIndex(apiIntIPAddress, "/")+1:]
-		computeIntAddress, err := svc.Addresses.Get(project, in.InstallConfig.Config.GCP.Region, addressIntCut).Context(ctx).Do()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get compute address: %w", err)
-		}
-
-		ignData := &igntypes.Config{}
-		err = json.Unmarshal(in.BootstrapIgnData, ignData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal bootstrap ignition: %w", err)
-		}
-
-		err = addLoadBalancersToInfra(gcp.Name, ignData, []string{computeAddress}, []string{computeIntAddress.Address})
-		if err != nil {
-			return nil, fmt.Errorf("failed to add load balancers to ignition config: %w", err)
-		}
-
-		lbConfig, err := lbconfig.GenerateLBConfigOverride(computeIntAddress.Address, computeAddress)
-		if err != nil {
-			return nil, err
-		}
-		if err := asset.NewDefaultFileWriter(lbConfig).PersistToFile(command.RootOpts.Dir); err != nil {
-			return nil, fmt.Errorf("failed to save %s to state file: %w", lbConfig.Name(), err)
-		}
-
-		editedIgnBytes, err := json.Marshal(ignData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert ignition data to json: %w", err)
-		}
-
-		return editedIgnBytes, nil
+func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, error) {
+	if in.InstallConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
+		return in.BootstrapIgnData, nil
 	}
 
-	return nil, nil
-}
-
-// addLoadBalancersToInfra will load the public and private load balancer information into
-// the infrastructure CR. This will occur after the data has already been inserted into the
-// ignition file.
-func addLoadBalancersToInfra(platform string, config *igntypes.Config, publicLBs []string, privateLBs []string) error {
-	for i, fileData := range config.Storage.Files {
-		// update the contents of this file
-		if fileData.Path == infrastructureFilepath {
-			contents := config.Storage.Files[i].Contents.Source
-			replaced := strings.Replace(*contents, replaceable, "", 1)
-
-			rawDecodedText, err := base64.StdEncoding.DecodeString(replaced)
-			if err != nil {
-				return fmt.Errorf("failed to decode contents of ignition file: %w", err)
-			}
-
-			infra := &configv1.Infrastructure{}
-			if err := yaml.Unmarshal(rawDecodedText, infra); err != nil {
-				return fmt.Errorf("failed to unmarshal infrastructure: %w", err)
-			}
-
-			// convert the list of strings to a list of IPs
-			apiIntLbs := []configv1.IP{}
-			for _, ip := range privateLBs {
-				apiIntLbs = append(apiIntLbs, configv1.IP(ip))
-			}
-			apiLbs := []configv1.IP{}
-			for _, ip := range publicLBs {
-				apiLbs = append(apiLbs, configv1.IP(ip))
-			}
-			cloudLBInfo := configv1.CloudLoadBalancerIPs{
-				APIIntLoadBalancerIPs: apiIntLbs,
-				APILoadBalancerIPs:    apiLbs,
-			}
-
-			if infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType == configv1.ClusterHostedDNSType {
-				infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted = &cloudLBInfo
-			}
-
-			// convert the infrastructure back to an encoded string
-			infraContents, err := yaml.Marshal(infra)
-			if err != nil {
-				return fmt.Errorf("failed to marshal infrastructure: %w", err)
-			}
-
-			encoded := fmt.Sprintf("%s%s", replaceable, base64.StdEncoding.EncodeToString(infraContents))
-			// replace the contents with the edited information
-			config.Storage.Files[i].Contents.Source = &encoded
-
-			break
-		}
+	gcpCluster := &capg.GCPCluster{}
+	key := client.ObjectKey{
+		Name:      in.InfraID,
+		Namespace: capiutils.Namespace,
+	}
+	if err := in.Client.Get(ctx, key, gcpCluster); err != nil {
+		return nil, fmt.Errorf("failed to get GCP cluster: %w", err)
 	}
 
-	return nil
+	svc, err := NewComputeService()
+	if err != nil {
+		return nil, err
+	}
+
+	project := in.InstallConfig.Config.GCP.ProjectID
+	if in.InstallConfig.Config.GCP.NetworkProjectID != "" {
+		project = in.InstallConfig.Config.GCP.NetworkProjectID
+	}
+
+	computeAddress := ""
+	if in.InstallConfig.Config.Publish == types.ExternalPublishingStrategy {
+		apiIPAddress := *gcpCluster.Status.Network.APIServerAddress
+		addressCut := apiIPAddress[strings.LastIndex(apiIPAddress, "/")+1:]
+		computeAddressObj, err := svc.GlobalAddresses.Get(project, addressCut).Context(ctx).Do()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get global compute address: %w", err)
+		}
+
+		computeAddress = computeAddressObj.Address
+	}
+
+	apiIntIPAddress := *gcpCluster.Status.Network.APIInternalAddress
+	addressIntCut := apiIntIPAddress[strings.LastIndex(apiIntIPAddress, "/")+1:]
+	computeIntAddress, err := svc.Addresses.Get(project, in.InstallConfig.Config.GCP.Region, addressIntCut).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get compute address: %w", err)
+	}
+
+	return clusterapi.EditIgnition(in, gcp.Name, []string{computeAddress}, []string{computeIntAddress.Address})
 }

--- a/pkg/infrastructure/gcp/clusterapi/ignition.go
+++ b/pkg/infrastructure/gcp/clusterapi/ignition.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
@@ -39,7 +40,7 @@ func EditIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, err
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
-	if in.InstallConfig.Config.GCP.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled {
+	if in.InstallConfig.Config.GCP.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
 		gcpCluster := &capg.GCPCluster{}
 		key := client.ObjectKey{
 			Name:      in.InfraID,

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/types/dns"
 )
 
 const (
@@ -119,6 +120,13 @@ type Platform struct {
 	// Public IPv4 address that you bring to your AWS account with BYOIP.
 	// +optional
 	PublicIpv4Pool string `json:"publicIpv4Pool,omitempty"`
+
+	// UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default
+	// provisioned by the Installer.
+	// +kubebuilder:default:="Disabled"
+	// +default="Disabled"
+	// +kubebuilder:validation:Enum="Enabled";"Disabled"
+	UserProvisionedDNS dns.UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
 }
 
 // ServiceEndpoint store the configuration for services to

--- a/pkg/types/aws/validation/featuregates.go
+++ b/pkg/types/aws/validation/featuregates.go
@@ -1,0 +1,22 @@
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	features "github.com/openshift/api/features"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
+	"github.com/openshift/installer/pkg/types/featuregates"
+)
+
+// GatedFeatures determines all of the install config fields that should
+// be validated to ensure that the proper featuregate is enabled when the field is used.
+func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
+	return []featuregates.GatedInstallConfigFeature{
+		{
+			FeatureGateName: features.FeatureGateAWSClusterHostedDNS,
+			Condition:       c.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled,
+			Field:           field.NewPath("platform", "aws", "userProvisionedDNS"),
+		},
+	}
+}

--- a/pkg/types/dns/dns.go
+++ b/pkg/types/dns/dns.go
@@ -1,0 +1,12 @@
+package dns
+
+// UserProvisionedDNS indicates whether the DNS solution is provisioned by the Installer or the user.
+type UserProvisionedDNS string
+
+const (
+	// UserProvisionedDNSEnabled indicates that the DNS solution is provisioned and provided by the user.
+	UserProvisionedDNSEnabled UserProvisionedDNS = "Enabled"
+
+	// UserProvisionedDNSDisabled indicates that the DNS solution is provisioned by the Installer.
+	UserProvisionedDNSDisabled UserProvisionedDNS = "Disabled"
+)

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -2,17 +2,8 @@ package gcp
 
 import (
 	"fmt"
-)
 
-// UserProvisionedDNS indicates whether the DNS solution is provisioned by the Installer or the user.
-type UserProvisionedDNS string
-
-const (
-	// UserProvisionedDNSEnabled indicates that the DNS solution is provisioned and provided by the user.
-	UserProvisionedDNSEnabled UserProvisionedDNS = "Enabled"
-
-	// UserProvisionedDNSDisabled indicates that the DNS solution is provisioned by the Installer.
-	UserProvisionedDNSDisabled UserProvisionedDNS = "Disabled"
+	"github.com/openshift/installer/pkg/types/dns"
 )
 
 // Platform stores all the global configuration that all machinesets
@@ -66,7 +57,7 @@ type Platform struct {
 	// +kubebuilder:default:="Disabled"
 	// +default="Disabled"
 	// +kubebuilder:validation:Enum="Enabled";"Disabled"
-	UserProvisionedDNS UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
+	UserProvisionedDNS dns.UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
 }
 
 // UserLabel is a label to apply to GCP resources created for the cluster.

--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -5,8 +5,8 @@ import (
 
 	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/featuregates"
-	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 // GatedFeatures determines all of the install config fields that should
@@ -16,7 +16,7 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 	return []featuregates.GatedInstallConfigFeature{
 		{
 			FeatureGateName: features.FeatureGateGCPClusterHostedDNS,
-			Condition:       g.UserProvisionedDNS == gcp.UserProvisionedDNSEnabled,
+			Condition:       g.UserProvisionedDNS == dns.UserProvisionedDNSEnabled,
 			Field:           field.NewPath("platform", "gcp", "userProvisionedDNS"),
 		},
 	}

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -7,7 +7,7 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -22,7 +22,7 @@ func TestFeatureGates(t *testing.T) {
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.GCP = validGCPPlatform()
-				c.GCP.UserProvisionedDNS = gcp.UserProvisionedDNSEnabled
+				c.GCP.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
 				return c
 			}(),
 			expected: `^platform.gcp.userProvisionedDNS: Forbidden: this field is protected by the GCPClusterHostedDNS feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -28,6 +28,16 @@ func TestFeatureGates(t *testing.T) {
 			expected: `^platform.gcp.userProvisionedDNS: Forbidden: this field is protected by the GCPClusterHostedDNS feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
+			name: "AWS UserProvisionedDNS is not allowed without Feature Gates",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.AWS = validAWSPlatform()
+				c.AWS.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
+				return c
+			}(),
+			expected: `^platform.aws.userProvisionedDNS: Forbidden: this field is protected by the AWSClusterHostedDNS feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
+		},
+		{
 			name: "vSphere hosts is allowed with Feature Gates enabled",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1290,6 +1290,8 @@ func validateGatedFeatures(c *types.InstallConfig) field.ErrorList {
 		gatedFeatures = append(gatedFeatures, gcpvalidation.GatedFeatures(c)...)
 	case c.VSphere != nil:
 		gatedFeatures = append(gatedFeatures, vspherevalidation.GatedFeatures(c)...)
+	case c.AWS != nil:
+		gatedFeatures = append(gatedFeatures, awsvalidation.GatedFeatures(c)...)
 	}
 
 	fg := c.EnabledFeatureGates()

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -507,6 +507,20 @@ type AWSPlatformStatus struct {
 	// +listType=atomic
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+
+	// cloudLoadBalancerConfig holds configuration related to DNS and cloud
+	// load balancers. It allows configuration of in-cluster DNS as an alternative
+	// to the platform default DNS implementation.
+	// When using the ClusterHosted DNS type, Load Balancer IP addresses
+	// must be provided for the API and internal API load balancers as well as the
+	// ingress load balancer.
+	//
+	// +default={"dnsType": "PlatformDefault"}
+	// +kubebuilder:default={"dnsType": "PlatformDefault"}
+	// +openshift:enable:FeatureGate=AWSClusterHostedDNS
+	// +optional
+	// +nullable
+	CloudLoadBalancerConfig *CloudLoadBalancerConfig `json:"cloudLoadBalancerConfig,omitempty"`
 }
 
 // AWSResourceTag is a tag to apply to AWS resources created for the cluster.
@@ -647,12 +661,12 @@ type GCPPlatformStatus struct {
 	// Tombstone the field as a reminder.
 	// ClusterHostedDNS ClusterHostedDNS `json:"clusterHostedDNS,omitempty"`
 
-	// cloudLoadBalancerConfig is a union that contains the IP addresses of API,
-	// API-Int and Ingress Load Balancers created on the cloud platform. These
-	// values would not be populated on on-prem platforms. These Load Balancer
-	// IPs are used to configure the in-cluster DNS instances for API, API-Int
-	// and Ingress services. `dnsType` is expected to be set to `ClusterHosted`
-	// when these Load Balancer IP addresses are populated and used.
+	// cloudLoadBalancerConfig holds configuration related to DNS and cloud
+	// load balancers. It allows configuration of in-cluster DNS as an alternative
+	// to the platform default DNS implementation.
+	// When using the ClusterHosted DNS type, Load Balancer IP addresses
+	// must be provided for the API and internal API load balancers as well as the
+	// ingress load balancer.
 	//
 	// +default={"dnsType": "PlatformDefault"}
 	// +kubebuilder:default={"dnsType": "PlatformDefault"}

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
@@ -245,6 +245,11 @@ func (in *AWSPlatformStatus) DeepCopyInto(out *AWSPlatformStatus) {
 		*out = make([]AWSResourceTag, len(*in))
 		copy(*out, *in)
 	}
+	if in.CloudLoadBalancerConfig != nil {
+		in, out := &in.CloudLoadBalancerConfig, &out.CloudLoadBalancerConfig
+		*out = new(CloudLoadBalancerConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -310,6 +310,7 @@ infrastructures.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
+  - AWSClusterHostedDNS
   - BareMetalLoadBalancer
   - GCPClusterHostedDNS
   - GCPLabelsTags

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -1184,10 +1184,11 @@ func (AWSPlatformSpec) SwaggerDoc() map[string]string {
 }
 
 var map_AWSPlatformStatus = map[string]string{
-	"":                 "AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.",
-	"region":           "region holds the default AWS region for new AWS resources created by the cluster.",
-	"serviceEndpoints": "ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
-	"resourceTags":     "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+	"":                        "AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.",
+	"region":                  "region holds the default AWS region for new AWS resources created by the cluster.",
+	"serviceEndpoints":        "ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
+	"resourceTags":            "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+	"cloudLoadBalancerConfig": "cloudLoadBalancerConfig holds configuration related to DNS and cloud load balancers. It allows configuration of in-cluster DNS as an alternative to the platform default DNS implementation. When using the ClusterHosted DNS type, Load Balancer IP addresses must be provided for the API and internal API load balancers as well as the ingress load balancer.",
 }
 
 func (AWSPlatformStatus) SwaggerDoc() map[string]string {
@@ -1389,7 +1390,7 @@ var map_GCPPlatformStatus = map[string]string{
 	"region":                  "region holds the region for new GCP resources created for the cluster.",
 	"resourceLabels":          "resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.",
 	"resourceTags":            "resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.",
-	"cloudLoadBalancerConfig": "cloudLoadBalancerConfig is a union that contains the IP addresses of API, API-Int and Ingress Load Balancers created on the cloud platform. These values would not be populated on on-prem platforms. These Load Balancer IPs are used to configure the in-cluster DNS instances for API, API-Int and Ingress services. `dnsType` is expected to be set to `ClusterHosted` when these Load Balancer IP addresses are populated and used.",
+	"cloudLoadBalancerConfig": "cloudLoadBalancerConfig holds configuration related to DNS and cloud load balancers. It allows configuration of in-cluster DNS as an alternative to the platform default DNS implementation. When using the ClusterHosted DNS type, Load Balancer IP addresses must be provided for the API and internal API load balancers as well as the ingress load balancer.",
 }
 
 func (GCPPlatformStatus) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -313,6 +313,13 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
+	FeatureGateAWSClusterHostedDNS = newFeatureGate("AWSClusterHostedDNS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("barbacbd").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
 	FeatureGateMixedCPUsAllocation = newFeatureGate("MixedCPUsAllocation").
 					reportProblemsToJiraComponent("NodeTuningOperator").
 					contactPerson("titzhak").

--- a/vendor/github.com/openshift/api/machineconfiguration/v1/types.go
+++ b/vendor/github.com/openshift/api/machineconfiguration/v1/types.go
@@ -196,7 +196,8 @@ type ControllerConfigStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// conditions represents the latest available observations of current state.
-	// +listType=atomic
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []ControllerConfigStatusCondition `json:"conditions"`
 

--- a/vendor/github.com/openshift/api/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -28,6 +28,7 @@ controllerconfigs.machineconfiguration.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
+  - AWSClusterHostedDNS
   - BareMetalLoadBalancer
   - GCPClusterHostedDNS
   - GCPLabelsTags

--- a/vendor/github.com/openshift/api/operator/v1/types.go
+++ b/vendor/github.com/openshift/api/operator/v1/types.go
@@ -178,12 +178,34 @@ var (
 
 // OperatorCondition is just the standard condition fields.
 type OperatorCondition struct {
+	// type of condition in CamelCase or in foo.example.com/CamelCase.
+	// ---
+	// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+	// useful (see .node.status.conditions), the ability to deconflict is important.
+	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// +required
 	// +kubebuilder:validation:Required
-	Type               string          `json:"type"`
-	Status             ConditionStatus `json:"status"`
-	LastTransitionTime metav1.Time     `json:"lastTransitionTime,omitempty"`
-	Reason             string          `json:"reason,omitempty"`
-	Message            string          `json:"message,omitempty"`
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+	// +kubebuilder:validation:MaxLength=316
+	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
+
+	// status of the condition, one of True, False, Unknown.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	Status ConditionStatus `json:"status"`
+
+	// lastTransitionTime is the last time the condition transitioned from one status to another.
+	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+
+	Reason string `json:"reason,omitempty"`
+
+	Message string `json:"message,omitempty"`
 }
 
 type ConditionStatus string

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -52,7 +52,10 @@ func (NodeStatus) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorCondition = map[string]string{
-	"": "OperatorCondition is just the standard condition fields.",
+	"":                   "OperatorCondition is just the standard condition fields.",
+	"type":               "type of condition in CamelCase or in foo.example.com/CamelCase.",
+	"status":             "status of the condition, one of True, False, Unknown.",
+	"lastTransitionTime": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
 }
 
 func (OperatorCondition) SwaggerDoc() map[string]string {
@@ -1122,8 +1125,8 @@ func (NodePortStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_OpenStackLoadBalancerParameters = map[string]string{
-	"":               "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
-	"loadBalancerIP": "loadBalancerIP specifies the floating IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. This value must be a valid IPv4 or IPv6 address. ",
+	"":           "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
+	"floatingIP": "floatingIP specifies the IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. When specified, the floating IP has to be pre-created.  If the specified value is not a floating IP or is already claimed, the OpenStack cloud provider won't be able to provision the load balancer. This field may only be used if the IngressController has External scope. This value must be a valid IPv4 or IPv6 address. ",
 }
 
 func (OpenStackLoadBalancerParameters) SwaggerDoc() map[string]string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1031,7 +1031,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runtime-spec v1.2.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f
+# github.com/openshift/api v0.0.0-20241007111039-82e082220d91
 ## explicit; go 1.22.0
 github.com/openshift/api/annotations
 github.com/openshift/api/config/v1


### PR DESCRIPTION
** The AWS platform will now include the userProvisionedDNS option. The user can Enable the feature with "Enabled". The default value is "Disabled".
** Added the AWSClusterHostedDNS Featureset from API.