### PR TITLE
[DNM] Testing user data secret labelling

### DIFF
--- a/pkg/asset/machines/userdata.go
+++ b/pkg/asset/machines/userdata.go
@@ -13,6 +13,8 @@ kind: Secret
 metadata:
   name: {{.name}}
   namespace: openshift-machine-api
+  labels:
+    "machineconfiguration.openshift.io/contains-managed-ca-bundle": ""
 type: Opaque
 data:
   disableTemplating: "dHJ1ZQo="


### PR DESCRIPTION
This adds a label to the `($POOL_NAME)-user-data` secret created at install time. This would help MCO identify the secrets used in MCS cert management