### PR TITLE
OCPBUGS-43041: fix slice init length

### DIFF
--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -56,7 +56,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 	var vpcFromSubnet string
 	client := ec2.New(session, aws.NewConfig().WithRegion(region))
 
-	idPointers := make([]*string, len(ids))
+	idPointers := make([]*string, 0, len(ids))
 	for _, id := range ids {
 		idPointers = append(idPointers, aws.String(id))
 	}

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -367,7 +367,7 @@ func (c *Client) GetRegions(ctx context.Context, project string) ([]string, erro
 		return nil, errors.Wrapf(err, "failed to get regions for project")
 	}
 
-	computeRegions := make([]string, len(gcpRegionsList.Items))
+	computeRegions := make([]string, 0, len(gcpRegionsList.Items))
 	for _, region := range gcpRegionsList.Items {
 		computeRegions = append(computeRegions, region.Name)
 	}

--- a/pkg/destroy/aws/ec2helpers.go
+++ b/pkg/destroy/aws/ec2helpers.go
@@ -843,7 +843,7 @@ func deleteEC2VPCEndpointService(ctx context.Context, client *ec2.EC2, id string
 		logger.Warn("Unable to get the list of VPC endpoint connections connected to service: ", err)
 		logger.Warn("Attempting to delete the VPC Endpoint Service")
 	} else {
-		endpointList := make([]*string, len(output.VpcEndpointConnections))
+		endpointList := make([]*string, 0, len(output.VpcEndpointConnections))
 		for _, endpoint := range output.VpcEndpointConnections {
 			if aws.StringValue(endpoint.VpcEndpointState) != "rejected" {
 				endpointList = append(endpointList, endpoint.VpcEndpointId)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW