### PR TITLE
OCPBUGS-39339: gather: simplify service regex for analyze

### DIFF
--- a/pkg/gather/service/analyze.go
+++ b/pkg/gather/service/analyze.go
@@ -19,7 +19,7 @@ import (
 // then the name of the service is "release-image".
 // In case the log-bundle is from bootstrap-in-place installation the file name is:
 // "log-bundle-20210329190553/log-bundle-bootstrap/bootstrap/services/release-image.json"
-var serviceEntriesFilePathRegex = regexp.MustCompile(`^[^\/]+(?:\/log-bundle-bootstrap)?\/bootstrap\/services\/([^.]+)\.json$`)
+var serviceEntriesFilePathRegex = regexp.MustCompile(`\/bootstrap\/services\/([^.]+)\.json$`)
 
 // AnalyzeGatherBundle will analyze the bootstrap gather bundle at the specified path.
 // Analysis will be logged.


### PR DESCRIPTION
By running `openshift-install gather bootstrap --dir path/to/workdir` outside of the `workdir`, the logs from the bootstrap VM are saved with `log-bundle-XXXX/` prefix path but compared against the full path `path/to/workdir` during path substitution for the final log bundle archive:
```
DEBUG Log bundle written to /var/home/core/log-bundle-20241004145703.tar.gz
DEBUG combinedDirectory: c/log-bundle-20241004145703
[...]
DEBUG oldHeaderName: log-bundle-20241004145703/bootstrap/services/approve-csr.json
DEBUG replacing '/c/cluster-log-bundle-20241004145703/' by '' in log-bundle-20241004145703/bootstrap/services/approve-csr.json
DEBUG newHeaderName: log-bundle-20241004145703/bootstrap/services/approve-csr.json
DEBUG no log-bundle-XXXX prefix, adding: c/log-bundle-20241004145703/log-bundle-20241004145703/bootstrap/services/approve-csr.json
```
This causes the service regex from the analyze command to not match any service files and we get the error
```
ERROR Invalid log bundle or the bootstrap machine could not be reached and bootstrap logs were not collected.
```
even though the bootstrap logs were successfully collected.

There are 3 possible fixes for this issue:
1. Change the collector script to save bootstrap logs in the bootstrap VM using the same path as specified to the `gather bootstrap` command;
2. When pulling the logs from the bootstrap VM, rename/move all the files to the path specified to `gather bootstrap`;
3. Change the service regex to ignore the path prefix.

I have opted to implement 3, since it involves the fewest changes and it's unlikely to introduce serious regressions: at worst it will make the analyze fail but the log collection won't be affected.