### PR TITLE
OCPBUGS-41785: Validate MTU when controlPlanePort uses FixedIPs

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -380,11 +380,15 @@ func (ci *CloudInfo) getNetwork(ctx context.Context, controlPlanePort *openstack
 	networkName := controlPlanePort.Network.Name
 	networkID := controlPlanePort.Network.ID
 	if networkName == "" && networkID == "" {
-		return nil, nil
+		if len(ci.ControlPlanePortSubnets) > 0 && ci.ControlPlanePortSubnets[0].NetworkID != "" {
+			networkID = ci.ControlPlanePortSubnets[0].NetworkID
+		} else {
+			return nil, nil
+		}
 	}
 	opts := networks.ListOpts{}
 	if networkID != "" {
-		opts.ID = controlPlanePort.Network.ID
+		opts.ID = networkID
 	}
 	if networkName != "" {
 		opts.Name = controlPlanePort.Network.Name

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -97,9 +97,9 @@ func validateControlPlanePort(p *openstack.Platform, n *types.Networking, ci *Cl
 		} else if ci.ControlPlanePortNetwork.ID != networkID {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("controlPlanePort").Child("network"), networkDetail, "network must contain subnets"))
 		}
-		if hasIPv6Subnet && ci.ControlPlanePortNetwork.MTU < minimumMTUv6 {
-			allErrs = append(allErrs, field.InternalError(fldPath.Child("controlPlanePort").Child("network"), fmt.Errorf("network should have an MTU of at least %d", minimumMTUv6)))
-		}
+	}
+	if hasIPv6Subnet && ci.ControlPlanePortNetwork != nil && ci.ControlPlanePortNetwork.MTU < minimumMTUv6 {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("controlPlanePort").Child("network"), fmt.Errorf("network should have an MTU of at least %d", minimumMTUv6)))
 	}
 	return allErrs
 }


### PR DESCRIPTION
The minimum MTU for the IPv6 network was previously only enforced when the controlPlanePort used the Network filter. This commit change the validation to also work when using the Subnet filter from FixedIPs.

This commit does two things:
- populate the ControlPlanePortNetwork struct in CloudInfo even when using the Subnet filter and not the Network one.
- move the validation for MTU out of the branch for Network filter from the install-config.yaml