### PR TITLE
OCPBUGS-30292: For agent installer, add RendezvousIP to NO_PROXY

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
@@ -7,10 +7,15 @@ stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
 exists $WORK/agent.x86_64.iso
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
+isocmp agent.x86_64.iso /etc/systemd/system.conf.d/10-default-env.conf expected/10-default-env.conf
 
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
+proxy:
+  httpProxy: http://192.168.111.1:8215
+  httpsProxy: http://192.168.111.1:8215
+  noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
 controlPlane: 
   name: master
   replicas: 3
@@ -44,3 +49,9 @@ metadata:
   name: ostest
   namespace: cluster0
 rendezvousIP: 192.168.111.20
+
+-- expected/10-default-env.conf --
+[Manager]
+DefaultEnvironment=HTTP_PROXY="http://192.168.111.1:8215"
+DefaultEnvironment=HTTPS_PROXY="http://192.168.111.1:8215"
+DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20"

--- a/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -7,6 +7,8 @@ DefaultEnvironment=HTTP_PROXY="{{replace .Proxy.HTTPProxy "%" "%%"}}"
 DefaultEnvironment=HTTPS_PROXY="{{replace .Proxy.HTTPSProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.NoProxy -}}
-DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}},{{.RendezvousIP}}"
+{{else -}}
+DefaultEnvironment=NO_PROXY="{{.RendezvousIP}}"
 {{end -}}
 {{end -}}

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -79,6 +79,7 @@ type agentTemplateData struct {
 	TokenExpiry               string
 	AuthType                  string
 	CaBundleMount             string
+	RendezvousIP              string
 }
 
 // Name returns the human-friendly name of the asset.
@@ -272,6 +273,7 @@ func (a *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 		numMasters, numWorkers,
 		osImage,
 		infraEnv.Spec.Proxy,
+		a.RendezvousIP,
 	)
 
 	err = bootstrap.AddStorageFiles(&config, "/", "agent/files", agentTemplateData)
@@ -386,7 +388,7 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseIm
 	haveMirrorConfig bool,
 	numMasters, numWorkers int,
 	osImage *models.OsImage,
-	proxy *v1beta1.Proxy) *agentTemplateData {
+	proxy *v1beta1.Proxy, rendezvousIP string) *agentTemplateData {
 	return &agentTemplateData{
 		ServiceProtocol:           "http",
 		PullSecret:                pullSecret,
@@ -407,6 +409,7 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseIm
 		Token:                     token,
 		TokenExpiry:               tokenExpiry,
 		CaBundleMount:             caBundleMount,
+		RendezvousIP:              rendezvousIP,
 	}
 }
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -93,7 +93,8 @@ func TestIgnition_getTemplateData(t *testing.T) {
 
 	publicKey := "-----BEGIN EC PUBLIC KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PUBLIC KEY-----\n"
 	token := "someToken"
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
+	rendezvousIP := "192.168.111.80"
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy, rendezvousIP)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -110,6 +111,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, publicKey, templateData.PublicKeyPEM)
 	assert.Equal(t, gencrypto.AuthType, templateData.AuthType)
 	assert.Equal(t, token, templateData.Token)
+	assert.Equal(t, rendezvousIP, templateData.RendezvousIP)
 
 }
 


### PR DESCRIPTION
If a proxy is configured, ensure that the RendezvousIP is included in NO_PROXY setting in assisted. Not setting this value can result in hard to debug issues.