### PR TITLE
CORS-3709: GCP: Update Master pointer Ignition with API-Int IP

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/quota"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/clusterapi"
 	infra "github.com/openshift/installer/pkg/infrastructure/platform"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
@@ -76,6 +77,7 @@ func (c *Cluster) Dependencies() []asset.Asset {
 		&machines.ClusterAPI{},
 		new(rhcos.Image),
 		&manifests.Manifests{},
+		&tls.RootCA{},
 	}
 }
 

--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -91,14 +91,14 @@ func (*Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInp
 // infrastructure CR. The infrastructure CR is updated and added to the ignition files. CAPA creates a
 // bucket for ignition, and this ignition data will be placed in the bucket.
 func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]*corev1.Secret, error) {
-	ignBytes, err := editIgnition(ctx, in)
+	editedBootstrapIgn, editedMasterIgn, err := editIgnition(ctx, in)
 	if err != nil {
 		return nil, fmt.Errorf("failed to edit bootstrap ignition: %w", err)
 	}
 
 	ignSecrets := []*corev1.Secret{
-		clusterapi.IgnitionSecret(ignBytes, in.InfraID, "bootstrap"),
-		clusterapi.IgnitionSecret(in.MasterIgnData, in.InfraID, "master"),
+		clusterapi.IgnitionSecret(editedBootstrapIgn, in.InfraID, "bootstrap"),
+		clusterapi.IgnitionSecret(editedMasterIgn, in.InfraID, "master"),
 	}
 	return ignSecrets, nil
 }

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	capimanifests "github.com/openshift/installer/pkg/asset/manifests/clusterapi"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/clusterapi"
 	"github.com/openshift/installer/pkg/infrastructure"
 	"github.com/openshift/installer/pkg/metrics/timer"
@@ -82,6 +83,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	bootstrapIgnAsset := &bootstrap.Bootstrap{}
 	masterIgnAsset := &machine.Master{}
 	tfvarsAsset := &tfvars.TerraformVariables{}
+	rootCA := &tls.RootCA{}
 	parents.Get(
 		manifestsAsset,
 		workersAsset,
@@ -94,6 +96,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		masterIgnAsset,
 		capiMachinesAsset,
 		tfvarsAsset,
+		rootCA,
 	)
 
 	var clusterIDs []string
@@ -288,6 +291,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 			InfraID:          clusterID.InfraID,
 			InstallConfig:    installConfig,
 			TFVarsAsset:      tfvarsAsset,
+			RootCA:           rootCA,
 		}
 
 		timer.StartTimer(ignitionStage)

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
 )
 
@@ -67,6 +68,7 @@ type IgnitionInput struct {
 	InfraID          string
 	InstallConfig    *installconfig.InstallConfig
 	TFVarsAsset      *tfvars.TerraformVariables
+	RootCA           *tls.RootCA
 }
 
 // InfraReadyProvider defines the InfraReady hook, which is

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -122,12 +122,12 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("failed to create bucket %s: %w", bucketName, err)
 	}
 
-	ignitionBytes, err := editIgnition(ctx, in)
+	editedBootstrapIgn, editedMasterIgn, err := editIgnition(ctx, in)
 	if err != nil {
 		return nil, fmt.Errorf("failed to edit bootstrap ignition: %w", err)
 	}
 
-	if err := gcp.FillBucket(ctx, bucketHandle, string(ignitionBytes)); err != nil {
+	if err := gcp.FillBucket(ctx, bucketHandle, string(editedBootstrapIgn)); err != nil {
 		return nil, fmt.Errorf("ignition failed to fill bucket: %w", err)
 	}
 
@@ -150,7 +150,7 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 
 	ignSecrets := []*corev1.Secret{
 		clusterapi.IgnitionSecret([]byte(ignShim), in.InfraID, "bootstrap"),
-		clusterapi.IgnitionSecret(in.MasterIgnData, in.InfraID, "master"),
+		clusterapi.IgnitionSecret(editedMasterIgn, in.InfraID, "master"),
 	}
 
 	return ignSecrets, nil


### PR DESCRIPTION
When userProvisionedDNS(custom-dns) is configured, the Master Pointer Ignition is updated with the API-INT IP in place of the API-Int URL because at this stage, the in-cluster DNS is not running yet.

Also, for control plane nodes to be able to pull ignition from the machine-config-server, its tls cert is updated to accept the LB IPs and not just the API-Int URL.