### PR TITLE
OCPBUGS-42637: Update RHCOS 4.18 bootimage metadata to 418.94.202410090804-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.16",
   "metadata": {
-    "last-modified": "2024-09-18T01:17:51Z",
-    "generator": "plume cosa2stream 7d7e544"
+    "last-modified": "2024-10-10T20:07:44Z",
+    "generator": "plume cosa2stream 7f06c1d"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-aws.aarch64.vmdk.gz",
-                "sha256": "55d83b008bfd3d0bcf0531f04935041917d486fb99edbc3bc21a1a7d9570f663",
-                "uncompressed-sha256": "766d42ba7ea66a927434c0a150ce195ce2d0cbfedb2347c8744568bf120076e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-aws.aarch64.vmdk.gz",
+                "sha256": "2ab1110b7e1517392d398f2a46074f2a5d197feeff8a63ccfc0b5421440d9e62",
+                "uncompressed-sha256": "bde56778bebb883fe3639904031f6d8fa875adf0f5e0888a4ed0c8ee3b55f447"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-azure.aarch64.vhd.gz",
-                "sha256": "5ca88fc60dba442997bddab36f20fb9293dd66b8babe3d760980449daa59fe28",
-                "uncompressed-sha256": "432ef5cd89d2478b46435d4c43767f84ccd742b8771b8eeecd605dd247ae87cd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-azure.aarch64.vhd.gz",
+                "sha256": "67a2eb665c5fefd39ea6443c95c6b4fbd3e315ac092dbe226bc7dcbc6c937c17",
+                "uncompressed-sha256": "4f472d52da7f9e7ab9414b0f167b980525b01a508d0b69c1eadc019d9cc7aa85"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-gcp.aarch64.tar.gz",
-                "sha256": "09aa2aad5cd43c2edf9ca1b9a02fa5ece00f361ca3988546d787406a3d7244e3",
-                "uncompressed-sha256": "37002a62c50ae9fb072888070bea5cc8d7d87bff7557bb022f6061e4a44f18d9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-gcp.aarch64.tar.gz",
+                "sha256": "f68a952553660016138dbf103f33fa815aa92976d4518f9e1cd5683691a646de",
+                "uncompressed-sha256": "9de4bdd989652079b0969495c1cb356e3103d09fbc61f23926bd4bb214d6c77e"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-metal4k.aarch64.raw.gz",
-                "sha256": "88cf426042887e21a3be4c533c89ac6ce9999c6c02cf8ad2ddc33f19623231b9",
-                "uncompressed-sha256": "dd197790cff3296992edb32a57b05f68755c494510a29a8589641dc3479c8d46"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-metal4k.aarch64.raw.gz",
+                "sha256": "f6544995606f1fc7c72a46527b27eb072801e55cf2e04578473d44282be7a2ee",
+                "uncompressed-sha256": "ccbac85731de5d9326dc6af0b65eaddf9050c97afa1792a7006d08d2c7635e95"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-live.aarch64.iso",
-                "sha256": "51930c99f25842c2a7819c198fa49f7134bacc4677a174cf5da5c65ec9071b06"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-live.aarch64.iso",
+                "sha256": "1a378c217c91a0e303efd61d714a868cb7015769da4e1c16c7b80130fd581962"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-live-kernel-aarch64",
-                "sha256": "89d249036fe1c7541673270a8a01e94e77f5867e1fc74d098ca2b41ac777f103"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-live-kernel-aarch64",
+                "sha256": "05f8420f17182ecc14f840350dcf3caf221acfda2aecf39430a0fdc40354f6a1"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-live-initramfs.aarch64.img",
-                "sha256": "5118861ae119a6cabbaa84a7cae1542d47a4780cf00c96a96442d48e229feef1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-live-initramfs.aarch64.img",
+                "sha256": "6ab9abb418384e7b6992bb00916e1e90274fcfdab3d3a14922f8865dac41918c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-live-rootfs.aarch64.img",
-                "sha256": "2340acc866f221b2d6518f16169a49576ff19518ffad49fa34c3294c911820fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-live-rootfs.aarch64.img",
+                "sha256": "c70ed6cdc2caae23cbbd4196c4e96910270397d82f2f1873cf4dc666ff87e555"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-metal.aarch64.raw.gz",
-                "sha256": "f5848da5d5edbd98529ca0e244a40be8a93f18297dd94a7b88c8300aaa888a0f",
-                "uncompressed-sha256": "7c9e8b141e8a31e6bb472127749d8f1ec72da0c0dd9d3ee47e485711d9eda7ed"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-metal.aarch64.raw.gz",
+                "sha256": "ab49c3b23c4e82df6df00ac10717d47a9e63169cc2fe7587b7f554daacf858aa",
+                "uncompressed-sha256": "cbd8a1431f6b2bf94fe345de3d4dedc448e1b2b955aeb02e5164d6060210d113"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-openstack.aarch64.qcow2.gz",
-                "sha256": "88bec58c68bc76a99d47b7e0b6631f01a160169559678db4e4b70625d84feae1",
-                "uncompressed-sha256": "94f3975540109f907ae7b93f34763b8817fc383a905d69e09a0e357dd3b42a5c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-openstack.aarch64.qcow2.gz",
+                "sha256": "e32f4c2f2db9b60e199097eaa7e094fff0f43f4cb0ad4198768375a0c3f6321c",
+                "uncompressed-sha256": "b52be43215ab7ba9cc9737d3f6efdb35f819d7e65f89f64beefb40b810ea7874"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/aarch64/rhcos-418.94.202409162337-0-qemu.aarch64.qcow2.gz",
-                "sha256": "61fe5660ceccc2b83535c839dd82fdda9c9e1ed41d5b36050dc882bbdc50fb48",
-                "uncompressed-sha256": "f1f5806f2072333832a93340bae0fc132ccf6859f360bb8524e5e493b57410a0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/aarch64/rhcos-418.94.202410090804-0-qemu.aarch64.qcow2.gz",
+                "sha256": "25a188165b915e42098cdf1789ba602befc6d18827b448b1d58175fb30db0682",
+                "uncompressed-sha256": "5720ac2a8e4fd648be36bd2a465df51f189e0a6edee5f50f46a4fa38802e509f"
               }
             }
           }
@@ -111,217 +111,217 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-05f70820e2984d99e"
+              "release": "418.94.202410090804-0",
+              "image": "ami-070f4ec6ce76bdbc0"
             },
             "ap-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0858d28fcdc1bfd1b"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0c5d9a9bc7598237c"
             },
             "ap-northeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0f5ef32dc42e02c18"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0190e8985602a7909"
             },
             "ap-northeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-02f7cff6cafbeb1d5"
+              "release": "418.94.202410090804-0",
+              "image": "ami-03f28e46b0234aecc"
             },
             "ap-northeast-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-083d0585e1024c2d6"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0ceb6988fc76750d9"
             },
             "ap-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0ba83282e56c91239"
+              "release": "418.94.202410090804-0",
+              "image": "ami-050d9cae6734894dc"
             },
             "ap-south-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0c66ce085d32ff624"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0eae45a775f68a625"
             },
             "ap-southeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-052688aa80c80d540"
+              "release": "418.94.202410090804-0",
+              "image": "ami-08ce044d7b5f816f5"
             },
             "ap-southeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0b61d2869f7a9d4e8"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0c490d65f0f6cd35f"
             },
             "ap-southeast-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-02e78bb1c8e2a7983"
+              "release": "418.94.202410090804-0",
+              "image": "ami-05f006d066dc6fffa"
             },
             "ap-southeast-4": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-01e6e52fa73579c50"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0e87dd4b210477c45"
             },
             "ca-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0df0b378346f97513"
+              "release": "418.94.202410090804-0",
+              "image": "ami-01aad326344f66e18"
             },
             "ca-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0ddce75508e6adcc9"
+              "release": "418.94.202410090804-0",
+              "image": "ami-038d561c5e6480af4"
             },
             "eu-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0faaec758e3641a2e"
+              "release": "418.94.202410090804-0",
+              "image": "ami-09c271a2dd40ce55f"
             },
             "eu-central-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-02a3f051f9a89b6cf"
+              "release": "418.94.202410090804-0",
+              "image": "ami-026d352b4b6627eea"
             },
             "eu-north-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-01671e4e2cc9a96c0"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0ad35f6fcb3264e69"
             },
             "eu-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-054ed05fcb3e93ce0"
+              "release": "418.94.202410090804-0",
+              "image": "ami-00ee3886856935aea"
             },
             "eu-south-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0fd14768eeb845c0e"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0026f8abd783e2e22"
             },
             "eu-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-04a267e4e3aea7c6a"
+              "release": "418.94.202410090804-0",
+              "image": "ami-03bde88286b9c8930"
             },
             "eu-west-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-00ce7fe8175c6ffa9"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0070940dc610cc3b3"
             },
             "eu-west-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0347b0a226536fe3f"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0e2221b535ce1c263"
             },
             "il-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-05603e105581caab5"
+              "release": "418.94.202410090804-0",
+              "image": "ami-01221d86ba6c548e3"
             },
             "me-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-02a4f26fb1a8ddab5"
+              "release": "418.94.202410090804-0",
+              "image": "ami-06e9861bbb87e64df"
             },
             "me-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0069995d2ea1cdc44"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0f3070ceaa1633924"
             },
             "sa-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-037efbc5f134a9ac8"
+              "release": "418.94.202410090804-0",
+              "image": "ami-084ffad549bbbefcd"
             },
             "us-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0f5a34ef733b181ce"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0463732df07ad9cec"
             },
             "us-east-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-069289ce3aa04a5ff"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0a275e9d7eac3eb8d"
             },
             "us-gov-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-044f77f2a9015836b"
+              "release": "418.94.202410090804-0",
+              "image": "ami-095777e92f1837478"
             },
             "us-gov-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-024863d163f3d1336"
+              "release": "418.94.202410090804-0",
+              "image": "ami-071b87d6ba7477629"
             },
             "us-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-00f57b0c464154fe2"
+              "release": "418.94.202410090804-0",
+              "image": "ami-02226c7facf2f7ac7"
             },
             "us-west-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0ec6175eb76cd3088"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0087877e0fff6cd55"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202409162337-0-gcp-aarch64"
+          "name": "rhcos-418-94-202410090804-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202409162337-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202409162337-0-azure.aarch64.vhd"
+          "release": "418.94.202410090804-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202410090804-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-metal4k.ppc64le.raw.gz",
-                "sha256": "885e099c5bcda486cd2d9f212b01b68d851b0cbd08c6d589ee9542d752dfeeaf",
-                "uncompressed-sha256": "7f53aa88b0628585621a5c77507be9956f772910430cf9d33b2b9a539dca816f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-metal4k.ppc64le.raw.gz",
+                "sha256": "a22ed3802bbe4cd504e85f93ed4f56e38b47c1ef8e49e68efabbcc53fabfe278",
+                "uncompressed-sha256": "132ab652aa14107a884eb696019cc0ef969c54b97ef7501a4fde1688622877df"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-live.ppc64le.iso",
-                "sha256": "105b28941b3ee539e09fbfea9ee0da1aecc84a03fd2d0f5ba720ed746a1d7703"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-live.ppc64le.iso",
+                "sha256": "ae4149ed4a3a149e943f4896b25068f16526cf3c13ca941b6484c327b7c379fa"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-live-kernel-ppc64le",
-                "sha256": "3ff871cdf3396cdc6dc7e5d20a1220baa6b275eea6e7af74f70d9a1debd25160"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-live-kernel-ppc64le",
+                "sha256": "e5326c2c246a61f9c13560999c296bce96adc82b3623e9e74a2358c17f6d28e3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-live-initramfs.ppc64le.img",
-                "sha256": "a80956f6239459aab2cf16fcc973fae4fc9d27e1d3e7f546d786e024ebb2f4ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-live-initramfs.ppc64le.img",
+                "sha256": "caad490fcfde9b37161f4d130c00ffbd53f183d137bbf1c17a09022c081bfcf2"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-live-rootfs.ppc64le.img",
-                "sha256": "81ee1a4d54f0db871ed3ce14015388ce2e53c65b0359361e4a4beb4821061203"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-live-rootfs.ppc64le.img",
+                "sha256": "a1d2f90fd1245b1d92801414ddd4972a1870bab39e7a9cae00b1e598885820c0"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-metal.ppc64le.raw.gz",
-                "sha256": "2f67106d669560c476e0242859a120072e9e16f660a572afe922d37f7304780d",
-                "uncompressed-sha256": "9dad56e4d63aad9e5f93f709cb31ad5a0535c4c68306ef544a80084c4cb9bd1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-metal.ppc64le.raw.gz",
+                "sha256": "ed994c23309aeb473f58d9ff9f1c6f1abba97c52980e2d824f07362978af273d",
+                "uncompressed-sha256": "3d4658f152c432ede8c7e3d2f92e9a9e905b754a4cfe700d7b07e2e1e1edf779"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "89429e7ce5603f6abf138cc3c46e64827229cf97393fc250d243e8f6cceffe6c",
-                "uncompressed-sha256": "5eebba195930a6430f066d45acfe9de714c3f2e8c6d607e1d6d59c461bfaac64"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "9afccf5513c61eb6665c0f3448cf4b0285589febb0594f8260fb36a4210b5d96",
+                "uncompressed-sha256": "8c517fb169805d127599448ca0dc25055bf27dfb3c44f4d8f38da51afbeef973"
               }
             }
           }
         },
         "powervs": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-powervs.ppc64le.ova.gz",
-                "sha256": "93a612aced32706437ed28002fee283dae9cb3e25099ab51b478af66395a9f37",
-                "uncompressed-sha256": "fd7d126496c884627094828d0e90a0f5b2dd0a331f4f6dd44f2957dda4315035"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-powervs.ppc64le.ova.gz",
+                "sha256": "0eb0d32d24f5673c913f41acdab46f30eb6b497182428633b0df5544b45cc4aa",
+                "uncompressed-sha256": "ab9cadf63855ac06a4c8ad63da09c2c6bf7835847f9bc17eb66f4a6351265836"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/ppc64le/rhcos-418.94.202409162337-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "c371cdc24f9c718fb41ab2f22cd80c8eab0d52c85fc7ee28112cb8b33c68e379",
-                "uncompressed-sha256": "a59472a9c51b0133f984f40837a534503b2a7a22e0eccaaa44913d2eb9757acc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/ppc64le/rhcos-418.94.202410090804-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "d54b55198ffdaae69a83ea2fa473b91abeee71e88c2bcfa3cae43489ed7d4c82",
+                "uncompressed-sha256": "2519644df0419f5ba318f42a8c5959346837a5b4947fbf9af5b5bdc6f8923078"
               }
             }
           }
@@ -331,64 +331,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "418.94.202409162337-0",
-              "object": "rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202410090804-0",
+              "object": "rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202409162337-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202410090804-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -397,88 +397,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "8aa310120fa2ba3b5346c06a3031bafcd770b9863314282b26ad8cd39f29f1ff",
-                "uncompressed-sha256": "d6693303b64042c7c01fbba974053e2b394a4165eb8a88d401c260b09d4e664f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "67dc76d6f9d8db3297be67ece6a685b143008319975958ae0dc4790f851f4844",
+                "uncompressed-sha256": "3fb4aba28bfdc568b4a6b35ce198b500294d63208d2963a4c74e2be54adc6b86"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-metal4k.s390x.raw.gz",
-                "sha256": "e1784611e0764cdf25638d9189385a13f481a7814c9d0474a0085fa0b01c23c0",
-                "uncompressed-sha256": "42cf9a2a2f4eefa98e8b188bfa037a0d291f41010b9b29f9861637b1087ddcf4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-metal4k.s390x.raw.gz",
+                "sha256": "0b8cc799c0a9f375a8c69c27adc03e281d148e07c43e2a1bc736fef37598c009",
+                "uncompressed-sha256": "16fe1d2eee30c00a5542f53da27926050c27a9d38a3b1581b106a78a69e814ba"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-live.s390x.iso",
-                "sha256": "1f86f12eea0711bcba1c8100ed3c70bc6ba9928d24ce38e5556e295a57e9dcb7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-live.s390x.iso",
+                "sha256": "2d3d9a150a9897e88e5093afe9c377ad71a40afed80da5bc09bed1ed622fd1de"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-live-kernel-s390x",
-                "sha256": "4e6912b73a21a593617435391d467e9327b6af0809f4a8625eda1148ed6e757d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-live-kernel-s390x",
+                "sha256": "a6c664197447e123b400286abae4673f05d3bf2574e0e1df01237feb6bc12ae5"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-live-initramfs.s390x.img",
-                "sha256": "a0983239381ccbd3ba39bd60d8a5555ddfb7352e5222b8ca4761eea54b9e43a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-live-initramfs.s390x.img",
+                "sha256": "335e2f43a8f7239ee8b51c8d1589ecc2ccc374daec75bded9b44ba42e3a6dc23"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-live-rootfs.s390x.img",
-                "sha256": "8ba8110e11249c694e955851dc8661b787de54d9817be7cfc6f0dec26ddbfa87"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-live-rootfs.s390x.img",
+                "sha256": "b95bc288a0d369017f626908caba387b77aed86edc06a031fbe6a27bb47e63df"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-metal.s390x.raw.gz",
-                "sha256": "cae065339f3ab4e30acbab6691713e30e22e87219706872d9eb5bbbf68ea2e05",
-                "uncompressed-sha256": "d8d3ccade8ceded2c4d70da66c497b02f36564f8fb0de6a4dc50125c6587703d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-metal.s390x.raw.gz",
+                "sha256": "d5d9f6ae68f7e2dcf3c989fd5875d5a2918c743a42c3eeba36c061c02e167764",
+                "uncompressed-sha256": "89e15c97b6e4d98ef957be2075dcf39de221ef7dc27f35999b1dfce85ea48891"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-openstack.s390x.qcow2.gz",
-                "sha256": "1298863fa1f254c2d15ac5f34d90fc25aa06ece7085e90420b02fbf2472a0ea8",
-                "uncompressed-sha256": "8ccacf0a1e7e8c48fb541bde62b74f7d5341b5ce6f45bc07af4d3181dea6004a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-openstack.s390x.qcow2.gz",
+                "sha256": "b4fec292200551f7ccb02635915107ee2dd1fac6761d1e6daac214de02b87808",
+                "uncompressed-sha256": "8cbb00ea9d257e5e892a2243b3989ffe17a131cd5725a935317dbc5353ab4439"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-qemu.s390x.qcow2.gz",
-                "sha256": "15c45fa750c273ce3c46baa71fbe08ba710323c39206261b967903e154a19efe",
-                "uncompressed-sha256": "bd2eb594e2a7c6caafad3593734d8062a52c2d76f24bca2fd17aef4c76a6bb5c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-qemu.s390x.qcow2.gz",
+                "sha256": "309b3f1662aaf2ecfd652b1e5c7114beca931674608f91ebe61323ce7abed8d4",
+                "uncompressed-sha256": "83c3179578df82cca5d72f133a02182364a944c337e679946ab1246783f01217"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/s390x/rhcos-418.94.202409162337-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "80408606b8c4dd5223b1e4e1ad1afccb5f3b2db5c0974c7323657971c76181e3",
-                "uncompressed-sha256": "9fd35041eb2ecb364ea19d4fb8f777d6a127aeca2b8bb08b7a2919a46fbe5e22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/s390x/rhcos-418.94.202410090804-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "0e492f2bba7b2cfc0f1e5abeede988dc02dff982b2976d89d56d67f9baf42bb5",
+                "uncompressed-sha256": "1e69056823056a290f0757d80c9442ddc5b45d44273e0bc85203b41d5311fc43"
               }
             }
           }
@@ -489,169 +489,169 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "528180635827c8f3d393880ccc4576ae1b150c35062431d9ba36484a163fc6f5",
-                "uncompressed-sha256": "62f036ef8e5c1958cda500ad6ef625daf7e8ff2a461cda511307ec621476553e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "e25866287a7c13f016a0594815092dfda832178ab1475a01cec6e62b57f96a91",
+                "uncompressed-sha256": "400ee235a0ec0d6f392b98813ed931c413d95c21153424c8199d35a89e38957f"
               }
             }
           }
         },
         "aws": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-aws.x86_64.vmdk.gz",
-                "sha256": "4a8153461d3ca685161966292d9cc36adb3ece97eee58e627215bff6e46c2767",
-                "uncompressed-sha256": "b12343e29128cae2e4eb7f18cc26f150a4f9f8c1078f31713c70f939af4a56e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-aws.x86_64.vmdk.gz",
+                "sha256": "abbb7e32378b12252cc2b3372bb9c1883d828c8a9a13e7dafc927b0ad2c1005a",
+                "uncompressed-sha256": "8ccb9c3192a7cc41f3a69b0c8b3f6b68b2d62f511383ef3446ee3b7842d48ca6"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-azure.x86_64.vhd.gz",
-                "sha256": "9ce37f36323520ab4cb8701f7c7cda203e99214ce0b56ef377e79b29aa656d18",
-                "uncompressed-sha256": "8d6be27ed6b9cf16cacce9b848cffdfee63004c3e6653a0767318f984c239ea7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-azure.x86_64.vhd.gz",
+                "sha256": "01bd305772c595772542d36920a4fe659a585179a643d1d8131ed6320286b5cd",
+                "uncompressed-sha256": "6df57a31fee994205e56f1172d672dbdc4d9e794a23675ef1093b684059897cc"
               }
             }
           }
         },
         "azurestack": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-azurestack.x86_64.vhd.gz",
-                "sha256": "e09f8992f9fb9d56499455ed8630a9af9654dc4c556c64f0437b48785c4a232f",
-                "uncompressed-sha256": "cf54e43aeb797f45e505a91e152fc8cdb27550d8fcbc00e18defdfbfeff77085"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-azurestack.x86_64.vhd.gz",
+                "sha256": "4311ca40fc522a53480638904748216e77068e5d04799e6801e0c95d30ac44e6",
+                "uncompressed-sha256": "46692830c65d22945c28178b9d1a862a3945664a24f9e99a0cee00f6182ccc8e"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-gcp.x86_64.tar.gz",
-                "sha256": "ce78d927bb2a621e614cee4ccb9bd212837e8a35d8c95724063bd24e9db8485b",
-                "uncompressed-sha256": "4ed1cd215938db3f7cc7ed04b443adb324b5631be76af5c5b6d11efdf64c67a4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-gcp.x86_64.tar.gz",
+                "sha256": "809593eedf39c10772e21e535fe7a5f51cb212443dda9d8b78ee0ed831fbd441",
+                "uncompressed-sha256": "f567db2e3a6244a7ca635b259a50fc750b75226de94f283492cb3c5afbf71091"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "1e9207e3335e5a88d7f2f9d4eb0a913a775f6a69aaa700ffacd3aa8ba4f89e01",
-                "uncompressed-sha256": "7c8f0d7d9b118c84a579d20ab347b132196dbc09c75086a1d778e518b3e3b0db"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "30527cdfec35ae4913a0e77df86dd06e450e796e937c4792f39fcf861df72a75",
+                "uncompressed-sha256": "9283f4767b2fb6ca68a2fa569a41b6d960190ed50a9542162886403bb10980e9"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-kubevirt.x86_64.ociarchive",
-                "sha256": "c974bcd79e3ad1fbe15d985a89e95e36a0a8705d74e263d39b0bcfa4178f977d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-kubevirt.x86_64.ociarchive",
+                "sha256": "6a63d16de656b637d151594b40da3e97508e9092ff6ac6ae7261ad0687b3b91b"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-metal4k.x86_64.raw.gz",
-                "sha256": "33f02d3e5a6675da6800285eab78861d2a719e231f2820a3ca5b4b688290580b",
-                "uncompressed-sha256": "5f51e80d488a483945f5e1cbe88e82f41c6aafc6ce1af8a45f99f8b11924b475"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-metal4k.x86_64.raw.gz",
+                "sha256": "ffdeb8c59467ee1783d0f144564dbdac676b26e7dc97d00bc30e0781a22eeb95",
+                "uncompressed-sha256": "3b18ce71c49f094381a4818837cbadc3d018555f5f23470f36496dd58c54877e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-live.x86_64.iso",
-                "sha256": "06377cc4f3bf9c2bb4deef400030d135de6806b0480cfc4aed10ee1e3adb5e45"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-live.x86_64.iso",
+                "sha256": "68800bd5763fd79fba156355fbc50270f3111d561569229de82336b8c847cc07"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-live-kernel-x86_64",
-                "sha256": "b56d4316a546a2bde98fb1bca5baa0f45ddbd32c5e8d5bd54396fea0b41bae01"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-live-kernel-x86_64",
+                "sha256": "b2034dda3e648b2daf5f17e50bb78df621100d7aa7ce9abdaad0676ada69ce9b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-live-initramfs.x86_64.img",
-                "sha256": "26915536a4577a1313fa2a24dd297ab8af77302584e2b0eef103907ecc9d0851"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-live-initramfs.x86_64.img",
+                "sha256": "46524515cf373fa40223b5631201792c8401660e9d57eaf11df0694cf5f6a2fd"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-live-rootfs.x86_64.img",
-                "sha256": "8587769ddadf227de81595cfac9e3d0d627d766357fdf5e4ed545590ec44fcf4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-live-rootfs.x86_64.img",
+                "sha256": "67f06f5cd995ed53877de5edb7a8dbb069e480088dd86b73d9d1ff7485e43242"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-metal.x86_64.raw.gz",
-                "sha256": "fe8e2aae9dea911cdbef174326bd4e65e3c5d6590830c98a038043fb05562536",
-                "uncompressed-sha256": "ea1f8c30eb067794a647535b1252d7bd34c063191b948ebdc535742e1fadb545"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-metal.x86_64.raw.gz",
+                "sha256": "82e94512d3dc3b29a967b827f3e5ea3ff81c3460fa3406ecee442f6825949d45",
+                "uncompressed-sha256": "427f3cd54aa536b41b79abd5ab99580c924a9b4ca21acfd5a2c1313660b0d11b"
               }
             }
           }
         },
         "nutanix": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-nutanix.x86_64.qcow2",
-                "sha256": "999c1db03ff4d965c7bea80d21ad2605ca929e54da5c2233d57c0960e5c8b98f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-nutanix.x86_64.qcow2",
+                "sha256": "f62bcdcb0fbe1f56353b7a44b745bba860ba40d05ef16f5075b46fce7eacfb24"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-openstack.x86_64.qcow2.gz",
-                "sha256": "975156390f170ea10ae0187165666367009551281a2cd2b477407009d39a44c7",
-                "uncompressed-sha256": "d437f9f33ea7382febc94cc45ed95be529166a52c95cf1ccac34bf77cc38df1e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-openstack.x86_64.qcow2.gz",
+                "sha256": "dd4679ea4d98c1b9e1c83fec2a9173d2504883ffdc6eadec0468f19104428ac5",
+                "uncompressed-sha256": "715d709404d6e87cf9da797d30c89f47bb1a0f90226a13995299791bc6675271"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-qemu.x86_64.qcow2.gz",
-                "sha256": "4f38d1ebbcfb0a36c2bb64eab1b629b8159c24c6fb727d95a85ed086af5eeb00",
-                "uncompressed-sha256": "49e0bd10cf71b321547110f6d9c89a7bc522239912374c50b0ba626eae59c9b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-qemu.x86_64.qcow2.gz",
+                "sha256": "4791d05318161aa0cf1005990da54788e99db725467058f76b0231d141cddf08",
+                "uncompressed-sha256": "1185ac4e6613f40e8a8b2037fce08c07a80d338e8866ddd8984b35c75512c451"
               }
             }
           }
         },
         "vmware": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202409162337-0/x86_64/rhcos-418.94.202409162337-0-vmware.x86_64.ova",
-                "sha256": "0b1a228c84af4cdc5fa86c67586495147a253de21c75fc9b59d17036c0e26dfe"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202410090804-0/x86_64/rhcos-418.94.202410090804-0-vmware.x86_64.ova",
+                "sha256": "209d23577512e1432e5f4e2f4be05ce910936b4532bb2426268c1c69f5b4b0a0"
               }
             }
           }
@@ -661,266 +661,266 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-6we2u7owe3ghu241z4zt"
+              "release": "418.94.202410090804-0",
+              "image": "m-6we0md6i54g9zcvsfuxv"
             },
             "ap-northeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "m-mj708w47j3vl6rx6q8sc"
+              "release": "418.94.202410090804-0",
+              "image": "m-mj7gp0pr1fboht811m7a"
             },
             "ap-southeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-t4nh55wj1j7whqnk3r4n"
+              "release": "418.94.202410090804-0",
+              "image": "m-t4ni4ujtp57fjvps2w5r"
             },
             "ap-southeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "m-p0wbpwiec2pecr1iavqt"
+              "release": "418.94.202410090804-0",
+              "image": "m-p0wf93nmrr83sfb2wg17"
             },
             "ap-southeast-3": {
-              "release": "418.94.202409162337-0",
-              "image": "m-8psi44j4o4yqkh105ypz"
+              "release": "418.94.202410090804-0",
+              "image": "m-8psbmde9zrd1ce37oqh9"
             },
             "ap-southeast-5": {
-              "release": "418.94.202409162337-0",
-              "image": "m-k1ag0esmuyqvn9hep89z"
+              "release": "418.94.202410090804-0",
+              "image": "m-k1a7paxmo63tb5l451g5"
             },
             "ap-southeast-6": {
-              "release": "418.94.202409162337-0",
-              "image": "m-5tsg6mix7tgjxhva24bx"
+              "release": "418.94.202410090804-0",
+              "image": "m-5ts0z21zf91ei6otlqi3"
             },
             "ap-southeast-7": {
-              "release": "418.94.202409162337-0",
-              "image": "m-0jo6ldnjt9cbuapz8u7a"
+              "release": "418.94.202410090804-0",
+              "image": "m-0joanid2hq60i3j4ylts"
             },
             "cn-beijing": {
-              "release": "418.94.202409162337-0",
-              "image": "m-2ze15o4r6crz0yd71djq"
+              "release": "418.94.202410090804-0",
+              "image": "m-2zeiwrr6gzo5o0xigbv3"
             },
             "cn-chengdu": {
-              "release": "418.94.202409162337-0",
-              "image": "m-2vca45g9yvisx1jj2w3m"
+              "release": "418.94.202410090804-0",
+              "image": "m-2vcdqd9aldemgft8f4xl"
             },
             "cn-fuzhou": {
-              "release": "418.94.202409162337-0",
-              "image": "m-gw07kuf4fzod9b9sbskr"
+              "release": "418.94.202410090804-0",
+              "image": "m-gw051qf5w1lq7y9har06"
             },
             "cn-guangzhou": {
-              "release": "418.94.202409162337-0",
-              "image": "m-7xvgkm9h2kvpslzeiu1n"
+              "release": "418.94.202410090804-0",
+              "image": "m-7xvfhsfrj6mx5dp3mlnm"
             },
             "cn-hangzhou": {
-              "release": "418.94.202409162337-0",
-              "image": "m-bp17nvn2d2slmoji55g2"
+              "release": "418.94.202410090804-0",
+              "image": "m-bp145jsikus6ptd9yac1"
             },
             "cn-heyuan": {
-              "release": "418.94.202409162337-0",
-              "image": "m-f8zi8y38wuhsqhmm36o8"
+              "release": "418.94.202410090804-0",
+              "image": "m-f8zc1sdlshbq2jkk2ofl"
             },
             "cn-hongkong": {
-              "release": "418.94.202409162337-0",
-              "image": "m-j6ch0fwqxl9lbxf4u1dt"
+              "release": "418.94.202410090804-0",
+              "image": "m-j6c7hpco21k6qhddkm7o"
             },
             "cn-huhehaote": {
-              "release": "418.94.202409162337-0",
-              "image": "m-hp31pxwk4uxsm3vubvfs"
+              "release": "418.94.202410090804-0",
+              "image": "m-hp36yxznixksrbpghy4s"
             },
             "cn-nanjing": {
-              "release": "418.94.202409162337-0",
-              "image": "m-gc725q6a7nhniqbwkqpi"
+              "release": "418.94.202410090804-0",
+              "image": "m-gc751qf5w1lq7y9har07"
             },
             "cn-qingdao": {
-              "release": "418.94.202409162337-0",
-              "image": "m-m5e7p2h2u3foz2gsbmwp"
+              "release": "418.94.202410090804-0",
+              "image": "m-m5eakckpgagriyc70quv"
             },
             "cn-shanghai": {
-              "release": "418.94.202409162337-0",
-              "image": "m-uf63f5m4nl7eoppjq3rs"
+              "release": "418.94.202410090804-0",
+              "image": "m-uf66lkocvbbsx0i1l8lb"
             },
             "cn-shenzhen": {
-              "release": "418.94.202409162337-0",
-              "image": "m-wz9btr0dqpv010m55nkh"
+              "release": "418.94.202410090804-0",
+              "image": "m-wz93k0q9m2c90l05wyvc"
             },
             "cn-wuhan-lr": {
-              "release": "418.94.202409162337-0",
-              "image": "m-n4a25q6a7nhniehpweut"
+              "release": "418.94.202410090804-0",
+              "image": "m-n4acc38qzsdylkosmxg5"
             },
             "cn-wulanchabu": {
-              "release": "418.94.202409162337-0",
-              "image": "m-0jl9ofgy4i099too3fmf"
+              "release": "418.94.202410090804-0",
+              "image": "m-0jle70b2b5841z402pea"
             },
             "cn-zhangjiakou": {
-              "release": "418.94.202409162337-0",
-              "image": "m-8vbdll7fvivooiuwlcil"
+              "release": "418.94.202410090804-0",
+              "image": "m-8vbhssycda7ctgbqaug6"
             },
             "eu-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-gw8cwvh1em6vw2yqc8vp"
+              "release": "418.94.202410090804-0",
+              "image": "m-gw8j8nb9lnm7mm6aorun"
             },
             "eu-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-d7ockpybnhm3078z5ggr"
+              "release": "418.94.202410090804-0",
+              "image": "m-d7o4q5nruqu5hwzc9ae8"
             },
             "me-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-l4vfxuweettaokz9gmqe"
+              "release": "418.94.202410090804-0",
+              "image": "m-l4v2i8t1fs8ccp523xwx"
             },
             "me-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-eb3dta27msz5kkexzeoo"
+              "release": "418.94.202410090804-0",
+              "image": "m-eb35klglw5kc866a83t9"
             },
             "us-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-0xia7311hb40lvgdsp70"
+              "release": "418.94.202410090804-0",
+              "image": "m-0xid0izus4z2h6bgsn7l"
             },
             "us-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "m-rj9ev0opi4l0uks86nhg"
+              "release": "418.94.202410090804-0",
+              "image": "m-rj92713qalrbf5gj10k5"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0c4e5325960f7e94d"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0eadb95fe9f1e937d"
             },
             "ap-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-098448ad00755f716"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0afa0e229cc7c8d38"
             },
             "ap-northeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-08f1db2a946805d46"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0958561c2c95e47be"
             },
             "ap-northeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0439403942791a076"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0da6eb6cb8628f656"
             },
             "ap-northeast-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-039611baaba93526f"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0cdb7384ea32dc485"
             },
             "ap-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0285627541cd613f8"
+              "release": "418.94.202410090804-0",
+              "image": "ami-060ad90a3a0654d43"
             },
             "ap-south-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-033c0e01bfdd4d929"
+              "release": "418.94.202410090804-0",
+              "image": "ami-00546805f758e9c8c"
             },
             "ap-southeast-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-09a1adf88a36aa0fb"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0c3a020ab34c4399d"
             },
             "ap-southeast-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-004792acb8992ca69"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0d646d6710564df04"
             },
             "ap-southeast-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0cc8d1b59813bd065"
+              "release": "418.94.202410090804-0",
+              "image": "ami-00a8336b584163221"
             },
             "ap-southeast-4": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-009b0dc90f91eadf9"
+              "release": "418.94.202410090804-0",
+              "image": "ami-090f8c246d757174b"
             },
             "ca-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0de5317801c1f7c6e"
+              "release": "418.94.202410090804-0",
+              "image": "ami-04fc5a83f18023ad4"
             },
             "ca-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-01b459909f692f7e6"
+              "release": "418.94.202410090804-0",
+              "image": "ami-088d00d214f1393f2"
             },
             "eu-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0f43d7eca560a0067"
+              "release": "418.94.202410090804-0",
+              "image": "ami-07c5073532ec09bb3"
             },
             "eu-central-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-01e76fb8a8c84ea99"
+              "release": "418.94.202410090804-0",
+              "image": "ami-01687155fae588cc5"
             },
             "eu-north-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0a32a8fdfa5bf0a91"
+              "release": "418.94.202410090804-0",
+              "image": "ami-02fa3363330261068"
             },
             "eu-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0c6d49b66b1e6c715"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0735332f740d9bb71"
             },
             "eu-south-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0d7345db674e4ee2a"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0c3964c0f26fe528e"
             },
             "eu-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-044c737e8dbbb47b0"
+              "release": "418.94.202410090804-0",
+              "image": "ami-037940e28ec72a9f3"
             },
             "eu-west-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0269a5ac5ce055338"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0b5316780ce53f90d"
             },
             "eu-west-3": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0ec9d49f34e8f0c0d"
+              "release": "418.94.202410090804-0",
+              "image": "ami-03fa30be1370942eb"
             },
             "il-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0c526fee6c947e890"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0607778725862fef1"
             },
             "me-central-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0ba0a8cfefc8f0ffc"
+              "release": "418.94.202410090804-0",
+              "image": "ami-04a1566d6cd693df6"
             },
             "me-south-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-08adb3151f8092d53"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0662443d9a27f6744"
             },
             "sa-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-00a80ef1ccf872a70"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0c4784f2637065d81"
             },
             "us-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-07ab46e92a8ec71c6"
+              "release": "418.94.202410090804-0",
+              "image": "ami-012d486b4a2bd1c08"
             },
             "us-east-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0289bd021cdc832e1"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0197c5c22c44c04f1"
             },
             "us-gov-east-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-03ab85fbe4661bccf"
+              "release": "418.94.202410090804-0",
+              "image": "ami-088e39428988506fb"
             },
             "us-gov-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-05e96fed81160e4dc"
+              "release": "418.94.202410090804-0",
+              "image": "ami-0aef5834d663b369d"
             },
             "us-west-1": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0e642003e3e0e0eb4"
+              "release": "418.94.202410090804-0",
+              "image": "ami-05b08344d0b094fdb"
             },
             "us-west-2": {
-              "release": "418.94.202409162337-0",
-              "image": "ami-0e3b9209c97d65864"
+              "release": "418.94.202410090804-0",
+              "image": "ami-06116ae2c019220a4"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202409162337-0-gcp-x86-64"
+          "name": "rhcos-418-94-202410090804-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "418.94.202409162337-0",
+          "release": "418.94.202410090804-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.18-9.4-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:78ad39da9bb3ec75a539824d669265be87c3fcd332b31db29b2d7df4549457ae"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:eecf2d7e3bff15aae65f85c99af769fc15b9a41ddc2f4e06581309eb404ef655"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202409162337-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202409162337-0-azure.x86_64.vhd"
+          "release": "418.94.202410090804-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202410090804-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
The changes done here will update the RHCOS 4.18 bootimage metadata

OCPBUGS-42637 - /boot/efi and /sysroot dir and subfiles are unlabeled_t

This change was generated using

```
 plume cosa2stream --target data/data/coreos/rhcos.json                    
  --distro rhcos --no-signatures --name 4.18-9.4                                        
  --url https://rhcos.mirror.openshift.com/art/storage/prod/streams   
  x86_64=418.94.202410090804-0                                                               
  aarch64=418.94.202410090804-0                                                              
  s390x=418.94.202410090804-0                                                                  
  ppc64le=418.94.202410090804-0 
```