### PR TITLE
OCPBUGS-43088: GCP Validate Disk and Instance Type

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -80,6 +80,9 @@ func validateInstanceAndDiskType(fldPath *field.Path, diskType, instanceType, ar
 	}
 
 	family, _, _ := strings.Cut(instanceType, "-")
+	if family == "custom" {
+		family = gcp.DefaultCustomInstanceType
+	}
 	diskTypes, ok := gcp.InstanceTypeToDiskTypeMap[family]
 	if !ok {
 		return field.NotFound(fldPath.Child("type"), family)

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -111,14 +111,16 @@ var (
 	invalidateXpnSA          = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.GCP.ServiceAccount = invalidXpnSA }
 
 	machineTypeAPIResult = map[string]*compute.MachineType{
-		"n1-standard-1":  {GuestCpus: 1, MemoryMb: 3840},
-		"n1-standard-2":  {GuestCpus: 2, MemoryMb: 7680},
-		"n1-standard-4":  {GuestCpus: 4, MemoryMb: 15360},
-		"n2-standard-1":  {GuestCpus: 1, MemoryMb: 8192},
-		"n2-standard-2":  {GuestCpus: 2, MemoryMb: 16384},
-		"n2-standard-4":  {GuestCpus: 4, MemoryMb: 32768},
-		"n4-standard-4":  {GuestCpus: 4, MemoryMb: 32768},
-		"t2a-standard-4": {GuestCpus: 4, MemoryMb: 16384},
+		"n1-standard-1":     {GuestCpus: 1, MemoryMb: 3840},
+		"n1-standard-2":     {GuestCpus: 2, MemoryMb: 7680},
+		"n1-standard-4":     {GuestCpus: 4, MemoryMb: 15360},
+		"n2-standard-1":     {GuestCpus: 1, MemoryMb: 8192},
+		"n2-standard-2":     {GuestCpus: 2, MemoryMb: 16384},
+		"n2-standard-4":     {GuestCpus: 4, MemoryMb: 32768},
+		"n4-standard-4":     {GuestCpus: 4, MemoryMb: 32768},
+		"t2a-standard-4":    {GuestCpus: 4, MemoryMb: 16384},
+		"n4-custom-4-16384": {GuestCpus: 4, MemoryMb: 16384}, // custom machine type
+		"custom-4-16384":    {GuestCpus: 4, MemoryMb: 16384}, // custom machine type - default type
 	}
 
 	subnetAPIResult = []*compute.Subnetwork{
@@ -862,6 +864,38 @@ func TestValidateInstanceType(t *testing.T) {
 			diskType:       "hyperdisk-balanced",
 			expectedError:  true,
 			expectedErrMsg: `^\[instance.diskType: Invalid value: "hyperdisk\-balanced": n2\-standard\-4 instance requires one of the following disk types: \[pd\-standard pd\-ssd pd\-balanced\]\]$`,
+		},
+		{
+			name:           "Valid custom instance type",
+			zones:          []string{"a"},
+			instanceType:   "n4-custom-4-16384",
+			diskType:       "hyperdisk-balanced",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Valid custom instance type invalid disk type",
+			zones:          []string{"a"},
+			instanceType:   "n4-custom-4-16384",
+			diskType:       "pd-ssd",
+			expectedError:  true,
+			expectedErrMsg: `^\[instance.diskType: Invalid value: "pd\-ssd": n4\-custom\-4\-16384 instance requires one of the following disk types: \[hyperdisk\-balanced\]\]$`,
+		},
+		{
+			name:           "Valid custom default instance type",
+			zones:          []string{"a"},
+			instanceType:   "custom-4-16384",
+			diskType:       "pd-ssd",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Invalid disk type custom default instance type",
+			zones:          []string{"a"},
+			instanceType:   "custom-4-16384",
+			diskType:       "hyperdisk-balanced",
+			expectedError:  true,
+			expectedErrMsg: `^\[instance.diskType: Invalid value: "hyperdisk\-balanced": custom\-4\-16384 instance requires one of the following disk types: \[pd\-standard pd\-ssd pd\-balanced\]\]$`,
 		},
 	}
 

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -27,6 +27,10 @@ var (
 	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
 	ComputeSupportedDisks = sets.New(HyperDiskBalanced, PDBalanced, PDSSD, PDStandard)
 
+	// DefaultCustomInstanceType is the default instance type on the GCP server side. The default custom
+	// instance type can be changed on the client side with gcloud.
+	DefaultCustomInstanceType = "n1"
+
 	// InstanceTypeToDiskTypeMap contains a map where the key is the Instance Type, and the
 	// values are a list of disk types that are supported by the installer and correlate to the Instance Type.
 	InstanceTypeToDiskTypeMap = map[string][]string{

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -27,13 +27,23 @@ var (
 	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
 	ComputeSupportedDisks = sets.New(HyperDiskBalanced, PDBalanced, PDSSD, PDStandard)
 
-	// DiskTypeToInstanceTypeMap contains a map where the key is the Disk Type, and the values are a list of
-	// instance types that are supported by the installer and correlate to the Disk Type.
-	DiskTypeToInstanceTypeMap = map[string][]string{
-		PDStandard:        {"a2", "e2", "n1", "n2", "n2d", "t2a", "t2d"},
-		PDSSD:             {"a2", "a3", "c3", "c3d", "e2", "m1", "n1", "n2", "n2d", "t2a", "t2d"},
-		PDBalanced:        {"a2", "a3", "c3", "c3d", "e2", "m1", "n1", "n2", "n2d", "t2a", "t2d"},
-		HyperDiskBalanced: {"c3", "c3d", "m1", "n4"},
+	// InstanceTypeToDiskTypeMap contains a map where the key is the Instance Type, and the
+	// values are a list of disk types that are supported by the installer and correlate to the Instance Type.
+	InstanceTypeToDiskTypeMap = map[string][]string{
+		"a2":  {PDStandard, PDSSD, PDBalanced},
+		"a3":  {PDSSD, PDBalanced},
+		"c2":  {PDStandard, PDSSD, PDBalanced},
+		"c2d": {PDStandard, PDSSD, PDBalanced},
+		"c3":  {PDSSD, PDBalanced, HyperDiskBalanced},
+		"c3d": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"e2":  {PDStandard, PDSSD, PDBalanced},
+		"m1":  {PDSSD, PDBalanced, HyperDiskBalanced},
+		"n1":  {PDStandard, PDSSD, PDBalanced},
+		"n2":  {PDStandard, PDSSD, PDBalanced},
+		"n2d": {PDStandard, PDSSD, PDBalanced},
+		"n4":  {HyperDiskBalanced},
+		"t2a": {PDStandard, PDSSD, PDBalanced},
+		"t2d": {PDStandard, PDSSD, PDBalanced},
 	}
 )
 


### PR DESCRIPTION
** Update the error text and the way that disks and instances are validated. Before, the error message was backwards on indicating if the instance type or the disk type was the problem. Now, the disk type is validated against the instance type (rather than the opposite).