### PR TITLE
CORS-3706: allow to install an OCP Nutanix cluster using PC's existing RHCOS image

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4168,6 +4168,11 @@ spec:
                         - message: type is immutable once set
                           rule: oldSelf == '' || self == oldSelf
                     type: object
+                  preloadedOSImageName:
+                    description: PreloadedOSImageName uses the named preloaded RHCOS
+                      image from PC/PE, instead of create and upload a new image for
+                      each cluster.
+                    type: string
                   prismCentral:
                     description: PrismCentral is the endpoint (address and port) and
                       credentials to connect to the Prism Central. This serves as

--- a/pkg/asset/installconfig/nutanix/validation.go
+++ b/pkg/asset/installconfig/nutanix/validation.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
+	nutanixclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 )
@@ -60,6 +64,14 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 		}
 	}
 
+	// validate PreloadedOSImageName if configured
+	if p.PreloadedOSImageName != "" {
+		err = validatePreloadedImage(ctx, nc, p)
+		if err != nil {
+			errList = append(errList, field.Invalid(parentPath.Child("preloadedOSImageName"), p.PreloadedOSImageName, fmt.Sprintf("fail to validate the preloaded rhcos image: %v", err)))
+		}
+	}
+
 	// validate each FailureDomain configuration
 	for _, fd := range p.FailureDomains {
 		// validate whether the prism element with the UUID exists
@@ -100,4 +112,62 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 	}
 
 	return errList.ToAggregate()
+}
+
+func validatePreloadedImage(ctx context.Context, nc *nutanixclientv3.Client, p *nutanixtypes.Platform) error {
+	// retrieve the rhcos release version
+	rhcosStream, err := rhcos.FetchCoreOSBuild(ctx)
+	if err != nil {
+		return err
+	}
+
+	arch, ok := rhcosStream.Architectures["x86_64"]
+	if !ok {
+		return fmt.Errorf("unable to find the x86_64 rhcos architecture")
+	}
+	artifacts, ok := arch.Artifacts["nutanix"]
+	if !ok {
+		return fmt.Errorf("unable to find the x86_64 nutanix rhcos artifacts")
+	}
+	rhcosReleaseVersion := artifacts.Release
+
+	// retrieve the rhcos version number from rhcosReleaseVersion
+	rhcosVerNum, err := strconv.Atoi(strings.Split(rhcosReleaseVersion, ".")[0])
+	if err != nil {
+		return fmt.Errorf("failed to get the rhcos image version number from the version string %s: %w", rhcosReleaseVersion, err)
+	}
+
+	// retrieve the rhcos version number from the preloaded image object
+	imgUUID, err := nutanixtypes.FindImageUUIDByName(ctx, nc, p.PreloadedOSImageName)
+	if err != nil {
+		return err
+	}
+	imgResp, err := nc.V3.GetImage(ctx, *imgUUID)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve the rhcos image with uuid %s: %w", *imgUUID, err)
+	}
+	imgSource := *imgResp.Status.Resources.SourceURI
+
+	si := strings.LastIndex(imgSource, "/rhcos-")
+	if si < 0 {
+		return fmt.Errorf("failed to get the rhcos image version from the preloaded image %s object's source_uri %s", p.PreloadedOSImageName, imgSource)
+	}
+	verStr := strings.Split(imgSource[si+7:], ".")[0]
+	imgVerNum, err := strconv.Atoi(verStr)
+	if err != nil {
+		return fmt.Errorf("failed to get the rhcos image version number from the version string %s: %w", verStr, err)
+	}
+
+	// verify that the image version numbers are compactible
+	versionDiff := rhcosVerNum - imgVerNum
+	switch {
+	case versionDiff < 0:
+		return fmt.Errorf("the preloaded image's rhcos version: %v is too many revisions ahead the installer bundled rhcos version: %v", imgVerNum, rhcosVerNum)
+	case versionDiff >= 2:
+		return fmt.Errorf("the preloaded image's rhcos version: %v is too many revisions behind the installer bundled rhcos version: %v", imgVerNum, rhcosVerNum)
+	case versionDiff == 1:
+		logrus.Warnf("the preloaded image's rhcos version: %v is behind the installer bundled rhcos version: %v, installation may fail", imgVerNum, rhcosVerNum)
+	}
+
+	return nil
 }

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -452,7 +452,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			return fmt.Errorf("failed to generate Cluster API machine manifests for control-plane: %w", err)
 		}
 		pool.Platform.Nutanix = &mpool
-		templateName := nutanixtypes.RHCOSImageName(clusterID.InfraID)
+		templateName := nutanixtypes.RHCOSImageName(ic.Platform.Nutanix, clusterID.InfraID)
 
 		c.FileList, err = nutanixcapi.GenerateMachines(clusterID.InfraID, ic, &pool, templateName, "master")
 		if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -502,7 +502,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
 		pool.Platform.Nutanix = &mpool
-		templateName := nutanixtypes.RHCOSImageName(clusterID.InfraID)
+		templateName := nutanixtypes.RHCOSImageName(ic.Platform.Nutanix, clusterID.InfraID)
 
 		machines, controlPlaneMachineSet, err = nutanix.Machines(clusterID.InfraID, ic, &pool, templateName, "master", masterUserDataSecretName)
 		if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -652,7 +652,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
 			pool.Platform.Nutanix = &mpool
-			imageName := nutanixtypes.RHCOSImageName(clusterID.InfraID)
+			imageName := nutanixtypes.RHCOSImageName(ic.Platform.Nutanix, clusterID.InfraID)
 
 			sets, err := nutanix.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", workerUserDataSecretName)
 			if err != nil {

--- a/pkg/types/nutanix/helpers.go
+++ b/pkg/types/nutanix/helpers.go
@@ -190,8 +190,13 @@ func getTaskStatus(clientV3 nutanixclientv3.Service, taskUUID string) (string, e
 }
 
 // RHCOSImageName is the unique image name for a given cluster.
-func RHCOSImageName(infraID string) string {
-	return fmt.Sprintf("%s-rhcos", infraID)
+func RHCOSImageName(p *Platform, infraID string) string {
+	imgName := p.PreloadedOSImageName
+	if imgName == "" {
+		imgName = fmt.Sprintf("%s-rhcos", infraID)
+	}
+
+	return imgName
 }
 
 // CategoryKey returns the cluster specific category key name.

--- a/pkg/types/nutanix/platform.go
+++ b/pkg/types/nutanix/platform.go
@@ -28,6 +28,12 @@ type Platform struct {
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
 
+	// PreloadedOSImageName uses the named preloaded RHCOS image from PC/PE,
+	// instead of create and upload a new image for each cluster.
+	//
+	// +optional
+	PreloadedOSImageName string `json:"preloadedOSImageName,omitempty"`
+
 	// DeprecatedAPIVIP is the virtual IP address for the api endpoint
 	// Deprecated: use APIVIPs
 	//


### PR DESCRIPTION
[CORS-3706](https://issues.redhat.com//browse/CORS-3706): 
Allow users to optionally use an existing RHCOS image from Prism-Central to install an OCP Nutanix cluster. This feature is requested by customer, for the use-case of creating a large number of OCP clusters with a Nutanix PC. Instead of creating an RHCOS image object for each OCP cluster, these clusters can share a preloaded RHCOS image object in PC, so as to save network bandwidth and PC storage.