### PR TITLE
OCPBUGS-43279: Allow custom machine types

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -80,6 +80,9 @@ func validateInstanceAndDiskType(fldPath *field.Path, diskType, instanceType, ar
 	}
 
 	family, _, _ := strings.Cut(instanceType, "-")
+	if family == "custom" {
+		family = gcp.DefaultCustomInstanceType
+	}
 	diskTypes, ok := gcp.InstanceTypeToDiskTypeMap[family]
 	if !ok {
 		return field.NotFound(fldPath.Child("type"), family)

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -111,14 +111,16 @@ var (
 	invalidateXpnSA          = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.GCP.ServiceAccount = invalidXpnSA }
 
 	machineTypeAPIResult = map[string]*compute.MachineType{
-		"n1-standard-1":  {GuestCpus: 1, MemoryMb: 3840},
-		"n1-standard-2":  {GuestCpus: 2, MemoryMb: 7680},
-		"n1-standard-4":  {GuestCpus: 4, MemoryMb: 15360},
-		"n2-standard-1":  {GuestCpus: 1, MemoryMb: 8192},
-		"n2-standard-2":  {GuestCpus: 2, MemoryMb: 16384},
-		"n2-standard-4":  {GuestCpus: 4, MemoryMb: 32768},
-		"n4-standard-4":  {GuestCpus: 4, MemoryMb: 32768},
-		"t2a-standard-4": {GuestCpus: 4, MemoryMb: 16384},
+		"n1-standard-1":     {GuestCpus: 1, MemoryMb: 3840},
+		"n1-standard-2":     {GuestCpus: 2, MemoryMb: 7680},
+		"n1-standard-4":     {GuestCpus: 4, MemoryMb: 15360},
+		"n2-standard-1":     {GuestCpus: 1, MemoryMb: 8192},
+		"n2-standard-2":     {GuestCpus: 2, MemoryMb: 16384},
+		"n2-standard-4":     {GuestCpus: 4, MemoryMb: 32768},
+		"n4-standard-4":     {GuestCpus: 4, MemoryMb: 32768},
+		"t2a-standard-4":    {GuestCpus: 4, MemoryMb: 16384},
+		"n4-custom-4-16384": {GuestCpus: 4, MemoryMb: 16384}, // custom machine type
+		"custom-4-16384":    {GuestCpus: 4, MemoryMb: 16384}, // custom machine type - default type
 	}
 
 	subnetAPIResult = []*compute.Subnetwork{
@@ -862,6 +864,38 @@ func TestValidateInstanceType(t *testing.T) {
 			diskType:       "hyperdisk-balanced",
 			expectedError:  true,
 			expectedErrMsg: `^\[instance.diskType: Invalid value: "hyperdisk\-balanced": n2\-standard\-4 instance requires one of the following disk types: \[pd\-standard pd\-ssd pd\-balanced\]\]$`,
+		},
+		{
+			name:           "Valid custom instance type",
+			zones:          []string{"a"},
+			instanceType:   "n4-custom-4-16384",
+			diskType:       "hyperdisk-balanced",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Valid custom instance type invalid disk type",
+			zones:          []string{"a"},
+			instanceType:   "n4-custom-4-16384",
+			diskType:       "pd-ssd",
+			expectedError:  true,
+			expectedErrMsg: `^\[instance.diskType: Invalid value: "pd\-ssd": n4\-custom\-4\-16384 instance requires one of the following disk types: \[hyperdisk\-balanced\]\]$`,
+		},
+		{
+			name:           "Valid custom default instance type",
+			zones:          []string{"a"},
+			instanceType:   "custom-4-16384",
+			diskType:       "pd-ssd",
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Invalid disk type custom default instance type",
+			zones:          []string{"a"},
+			instanceType:   "custom-4-16384",
+			diskType:       "hyperdisk-balanced",
+			expectedError:  true,
+			expectedErrMsg: `^\[instance.diskType: Invalid value: "hyperdisk\-balanced": custom\-4\-16384 instance requires one of the following disk types: \[pd\-standard pd\-ssd pd\-balanced\]\]$`,
 		},
 	}
 

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -27,6 +27,10 @@ var (
 	// ComputeSupportedDisks contains the supported disk types for control plane nodes.
 	ComputeSupportedDisks = sets.New(HyperDiskBalanced, PDBalanced, PDSSD, PDStandard)
 
+	// DefaultCustomInstanceType is the default instance type on the GCP server side. The default custom
+	// instance type can be changed on the client side with gcloud.
+	DefaultCustomInstanceType = "n1"
+
 	// InstanceTypeToDiskTypeMap contains a map where the key is the Instance Type, and the
 	// values are a list of disk types that are supported by the installer and correlate to the Instance Type.
 	InstanceTypeToDiskTypeMap = map[string][]string{


### PR DESCRIPTION
** Validation for gcp machine types (and disk types) did not allow custom machine types. GCP adds "custom" to the machine type when custom machine types are created, search for the word custom in the machine type. This skips the validation of disk type to instance type correlation, but this does not skip the validation of minimum requirements.