### PR TITLE
OCPBUGS-39231: add chrony.conf file when additional NTP sources are configured

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/assets/with_additional_ntp_sources.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/with_additional_ntp_sources.txt
@@ -1,0 +1,82 @@
+# Verify that the most relevant assets are properly generated in the ISO
+
+exec openshift-install agent create image --dir $WORK
+
+exists $WORK/agent.x86_64.iso
+
+isocmp agent.x86_64.iso /etc/chrony.conf expected/chrony.conf
+isocmp agent.x86_64.iso /etc/assisted/manifests/infraenv.yaml expected/infraenv.yaml
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 1
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+additionalNTPSources:
+- 0.clock.ntp.org
+- 1.clock.ntp.org
+
+-- expected/chrony.conf --
+server 0.clock.ntp.org iburst
+server 1.clock.ntp.org iburst
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony
+-- expected/infraenv.yaml --
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  additionalNTPSources:
+  - 0.clock.ntp.org
+  - 1.clock.ntp.org
+  clusterRef:
+    name: ostest
+    namespace: cluster0
+  cpuArchitecture: x86_64
+  ipxeScriptType: ""
+  nmStateConfigLabelSelector:
+    matchLabels:
+      infraenvs.agent-install.openshift.io: ostest
+  pullSecretRef:
+    name: ostest-pull-secret
+  sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  agentLabelSelector: {}
+  bootArtifacts:
+    initrd: ""
+    ipxeScript: ""
+    kernel: ""
+    rootfs: ""
+  debugInfo:
+    eventsURL: ""

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"net"
 	"net/url"
 	"path"
@@ -48,6 +49,7 @@ const extraManifestPath = "/etc/assisted/extra-manifests"
 const registriesConfPath = "/etc/containers/registries.conf"
 const registryCABundlePath = "/etc/pki/ca-trust/source/anchors/domain.crt"
 const clusterConfigPath = "/etc/assisted/clusterconfig"
+const chronyConfPath = "/etc/chrony.conf"
 
 // Ignition is an asset that generates the agent installer ignition file.
 type Ignition struct {
@@ -330,6 +332,11 @@ func (a *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 	}
 
 	err = addExtraManifests(&config, extraManifests)
+	if err != nil {
+		return err
+	}
+
+	err = addNTPSources(&config, infraEnv)
 	if err != nil {
 		return err
 	}
@@ -706,4 +713,29 @@ func getPublicContainerRegistries(registriesConfig *mirror.RegistriesConf) strin
 	}
 
 	return "quay.io"
+}
+
+func addNTPSources(config *igntypes.Config, infraEnv *v1beta1.InfraEnv) error {
+	if len(infraEnv.Spec.AdditionalNTPSources) == 0 {
+		return nil
+	}
+
+	chronyConfTemplate := `{{ range . }}server {{ . }} iburst
+{{ end }}makestep 1.0 3
+rtcsync
+logdir /var/log/chrony
+`
+	tmpl, err := template.New("chronyConf").Parse(chronyConfTemplate)
+	if err != nil {
+		return fmt.Errorf("error while parsing template for %s file: %w", chronyConfPath, err)
+	}
+
+	var sb strings.Builder
+	err = tmpl.Execute(&sb, infraEnv.Spec.AdditionalNTPSources)
+	if err != nil {
+		return fmt.Errorf("error while generating %s file: %w", chronyConfPath, err)
+	}
+
+	config.Storage.Files = append(config.Storage.Files, ignition.FileFromString(chronyConfPath, "root", 0644, sb.String()))
+	return nil
 }

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -410,45 +411,44 @@ func TestIgnition_Generate(t *testing.T) {
 	err = os.Chdir(path.Join(workingDirectory, "../../../../data"))
 	assert.NoError(t, err)
 
-	secretDataBytes, err := base64.StdEncoding.DecodeString("c3VwZXItc2VjcmV0Cg==")
-	assert.NoError(t, err)
-
 	cases := []struct {
 		name                string
-		overrideDeps        []asset.Asset
+		overrideAssets      map[reflect.Type]func(t *testing.T, dep asset.Asset) asset.Asset
 		expectedError       string
 		expectedFiles       []string
 		expectedFileContent map[string]string
 		serviceEnabledMap   map[string]bool
 	}{
 		{
-			name: "no-extra-manifests",
+			name: "default",
 			serviceEnabledMap: map[string]bool{
 				"pre-network-manager-config.service": true,
 				"agent-check-config-image.service":   false},
 			expectedFiles: generatedFiles(),
 		},
 		{
-			name: "default",
-			overrideDeps: []asset.Asset{
-				&manifests.ExtraManifests{
-					FileList: []*asset.File{
-						{
-							Filename: "openshift/test-configmap.yaml",
-							Data: []byte(`
+			name: "with extra manifests",
+			overrideAssets: map[reflect.Type]func(t *testing.T, dep asset.Asset) asset.Asset{
+				reflect.TypeOf(manifests.ExtraManifests{}): func(t *testing.T, dep asset.Asset) asset.Asset {
+					t.Helper()
+					return &manifests.ExtraManifests{
+						FileList: []*asset.File{
+							{
+								Filename: "openshift/test-configmap.yaml",
+								Data: []byte(`
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agent-test-1
-
+    name: agent-test-1
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agent-test-2`),
+    name: agent-test-2`),
+							},
 						},
-					},
+					}
 				},
 			},
 			expectedFiles: generatedFiles("/etc/assisted/extra-manifests/test-configmap-0.yaml", "/etc/assisted/extra-manifests/test-configmap-1.yaml"),
@@ -469,49 +469,54 @@ metadata:
 		},
 		{
 			name: "no nmstateconfigs defined, pre-network-manager-config.service should not be enabled",
-			overrideDeps: []asset.Asset{
-				&manifests.AgentManifests{
-					InfraEnv: &aiv1beta1.InfraEnv{
-						Spec: aiv1beta1.InfraEnvSpec{
-							SSHAuthorizedKey: "my-ssh-key",
-						},
-					},
-					ClusterImageSet: &hivev1.ClusterImageSet{
-						Spec: hivev1.ClusterImageSetSpec{
-							ReleaseImage: "registry.ci.openshift.org/origin/release:4.11",
-						},
-					},
-					ClusterDeployment: &hivev1.ClusterDeployment{
-						Spec: hivev1.ClusterDeploymentSpec{
-							ClusterName: "ostest",
-							BaseDomain:  "ostest",
-						},
-					},
-					PullSecret: &v1.Secret{
-						Data: map[string][]byte{
-							".dockerconfigjson": secretDataBytes,
-						},
-					},
-					AgentClusterInstall: &hiveext.AgentClusterInstall{
-						Spec: hiveext.AgentClusterInstallSpec{
-							APIVIP: "192.168.111.5",
-							ProvisionRequirements: hiveext.ProvisionRequirements{
-								ControlPlaneAgents: 3,
-								WorkerAgents:       5,
-							},
-						},
-					},
+			overrideAssets: map[reflect.Type]func(t *testing.T, dep asset.Asset) asset.Asset{
+				reflect.TypeOf(manifests.AgentManifests{}): func(t *testing.T, dep asset.Asset) asset.Asset {
+					t.Helper()
+					am, ok := dep.(*manifests.AgentManifests)
+					assert.True(t, ok)
+					// remove nmstate configuration
+					am.NMStateConfigs = []*aiv1beta1.NMStateConfig{}
+					am.StaticNetworkConfigs = []*models.HostStaticNetworkConfig{}
+					return am
 				},
 			},
 			serviceEnabledMap: map[string]bool{
 				"pre-network-manager-config.service": false},
+		},
+		{
+			name: "with additional ntp sources",
+			overrideAssets: map[reflect.Type]func(t *testing.T, dep asset.Asset) asset.Asset{
+				reflect.TypeOf(manifests.AgentManifests{}): func(t *testing.T, dep asset.Asset) asset.Asset {
+					t.Helper()
+					am, ok := dep.(*manifests.AgentManifests)
+					assert.True(t, ok)
+					am.InfraEnv.Spec.AdditionalNTPSources = []string{"0.clock.ntp.org", "1.clock.ntp.org"}
+					return am
+				},
+			},
+			expectedFiles: generatedFiles("/etc/chrony.conf"),
+			expectedFileContent: map[string]string{
+				"/etc/chrony.conf": `server 0.clock.ntp.org iburst
+server 1.clock.ntp.org iburst
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony`,
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			deps := buildIgnitionAssetDefaultDependencies(t)
 
-			overrideDeps(deps, tc.overrideDeps)
+			if tc.overrideAssets != nil {
+				for i, dep := range deps {
+					overrideFunc, found := tc.overrideAssets[reflect.TypeOf(dep).Elem()]
+					if !found {
+						continue
+					}
+					deps[i] = overrideFunc(t, dep)
+				}
+			}
 
 			parents := asset.Parents{}
 			parents.Add(deps...)


### PR DESCRIPTION
This patch introduces the support of `additionalNTPSources` also for the ABI bootstrap ephemeral environment, required to properly sync'up the time of the current instance