### PR TITLE
AGENT-859: Support for PXE files in day 2

### DIFF
--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -22,30 +22,26 @@ func main() {
 func nodeJoiner() error {
 	nodesAddCmd := &cobra.Command{
 		Use:   "add-nodes",
-		Short: "Generates an ISO that could be used to boot the configured nodes to let them join an existing cluster",
+		Short: "Generates an ISO that can be used to boot the configured nodes to let them join an existing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeConfig, err := cmd.Flags().GetString("kubeconfig")
+			dir, kubeConfig, err := getCommonFlags(cmd)
 			if err != nil {
 				return err
 			}
-			dir, err := cmd.Flags().GetString("dir")
+			generatePXE, err := cmd.Flags().GetBool("pxe")
 			if err != nil {
 				return err
 			}
-			return nodejoiner.NewAddNodesCommand(dir, kubeConfig)
+			return nodejoiner.NewAddNodesCommand(dir, kubeConfig, &generatePXE)
 		},
 	}
+	nodesAddCmd.Flags().BoolP("pxe", "p", false, "Instead of an ISO, generates PXE artifacts that can be used to boot the configured nodes to let them join an existing cluster")
 
 	nodesMonitorCmd := &cobra.Command{
 		Use:   "monitor-add-nodes",
 		Short: "Monitors the configured nodes while they are joining an existing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := cmd.Flags().GetString("dir")
-			if err != nil {
-				return err
-			}
-
-			kubeConfig, err := cmd.Flags().GetString("kubeconfig")
+			dir, kubeConfig, err := getCommonFlags(cmd)
 			if err != nil {
 				return err
 			}
@@ -71,6 +67,18 @@ func nodeJoiner() error {
 	rootCmd.AddCommand(nodesMonitorCmd)
 
 	return rootCmd.Execute()
+}
+
+func getCommonFlags(cmd *cobra.Command) (string, string, error) {
+	kubeConfig, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return "", "", err
+	}
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return "", "", err
+	}
+	return dir, kubeConfig, nil
 }
 
 func runRootCmd(cmd *cobra.Command, args []string) {

--- a/cmd/node-joiner/testdata/add-nodes-pxe.txt
+++ b/cmd/node-joiner/testdata/add-nodes-pxe.txt
@@ -1,0 +1,21 @@
+
+# Verify that the add-nodes command generates PXE files
+
+exec node-joiner add-nodes --pxe --kubeconfig=$WORK/kubeconfig --log-level=debug --dir=$WORK
+
+exists $WORK/boot-artifacts/agent.x86_64-initrd.img
+exists $WORK/boot-artifacts/agent.x86_64-rootfs.img
+exists $WORK/boot-artifacts/agent.x86_64-vmlinuz
+exists $WORK/boot-artifacts/agent.x86_64.ipxe
+
+grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img' $WORK/boot-artifacts/agent.x86_64.ipxe
+grep 'kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img  fips=1' $WORK/boot-artifacts/agent.x86_64.ipxe
+! grep 'coreos.liveiso=' $WORK/boot-artifacts/agent.x86_64.ipxe
+
+-- nodes-config.yaml --
+bootArtifactsBaseURL: http://user-specified-pxe-infra.com
+hosts:
+    - hostname: extra-worker-0
+      interfaces:
+        - name: eth0
+          macAddress: 00:f4:3d:a0:0e:2b

--- a/internal/tshelpers/fakeregistry.go
+++ b/internal/tshelpers/fakeregistry.go
@@ -156,6 +156,8 @@ func (fr *FakeOCPRegistry) makeMinimalISO() ([]byte, error) {
 	files := map[string][]byte{
 		"iso/images/ignition.img":       []byte("ignitionimg"),
 		"iso/images/pxeboot/initrd.img": []byte("initrdimg"),
+		"iso/images/pxeboot/rootfs.img": []byte("rootfsimg"),
+		"iso/images/pxeboot/vmlinuz":    []byte("vmlinuz"),
 		"iso/images/efiboot.img":        []byte("efibootimg"),
 		"iso/boot.catalog":              []byte("bootcatalog"),
 		// The following files are required to allow the correct embedding of

--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -15,8 +15,10 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
 	config "github.com/openshift/installer/pkg/asset/agent/agentconfig"
+	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
 	"github.com/openshift/installer/pkg/asset/agent/mirror"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
 
 const (
@@ -49,6 +51,8 @@ func (a *AgentArtifacts) Dependencies() []asset.Asset {
 		&manifests.AgentClusterInstall{},
 		&mirror.RegistriesConf{},
 		&config.AgentConfig{},
+		&workflow.AgentWorkflow{},
+		&joiner.ClusterInfo{},
 	}
 }
 
@@ -61,8 +65,8 @@ func (a *AgentArtifacts) Generate(_ context.Context, dependencies asset.Parents)
 	agentClusterInstall := &manifests.AgentClusterInstall{}
 	registriesConf := &mirror.RegistriesConf{}
 	agentconfig := &config.AgentConfig{}
-
-	dependencies.Get(ignition, kargs, baseIso, agentManifests, agentClusterInstall, registriesConf, agentconfig)
+	agentWorkflow := &workflow.AgentWorkflow{}
+	dependencies.Get(ignition, kargs, baseIso, agentManifests, agentClusterInstall, registriesConf, agentconfig, agentWorkflow)
 
 	ignitionByte, err := json.Marshal(ignition.Config)
 	if err != nil {
@@ -75,15 +79,26 @@ func (a *AgentArtifacts) Generate(_ context.Context, dependencies asset.Parents)
 	a.ISOPath = baseIso.File.Filename
 	a.Kargs = kargs.KernelCmdLine()
 
-	if agentconfig.Config != nil {
-		a.BootArtifactsBaseURL = strings.Trim(agentconfig.Config.BootArtifactsBaseURL, "/")
-		// External platform will always create a minimal ISO
-		a.MinimalISO = agentconfig.Config.MinimalISO || agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType
-		if agentconfig.Config.MinimalISO {
-			logrus.Infof("Minimal ISO will be created based on configuration")
-		} else if agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType {
-			logrus.Infof("Minimal ISO will be created for External platform")
+	switch agentWorkflow.Workflow {
+	case workflow.AgentWorkflowTypeInstall:
+		if agentconfig.Config != nil {
+			a.BootArtifactsBaseURL = strings.Trim(agentconfig.Config.BootArtifactsBaseURL, "/")
+			// External platform will always create a minimal ISO
+			a.MinimalISO = agentconfig.Config.MinimalISO || agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType
+			if agentconfig.Config.MinimalISO {
+				logrus.Infof("Minimal ISO will be created based on configuration")
+			} else if agentManifests.AgentClusterInstall.Spec.PlatformType == hiveext.ExternalPlatformType {
+				logrus.Infof("Minimal ISO will be created for External platform")
+			}
 		}
+	case workflow.AgentWorkflowTypeAddNodes:
+		clusterInfo := &joiner.ClusterInfo{}
+		dependencies.Get(clusterInfo)
+		if clusterInfo.BootArtifactsBaseURL != "" {
+			a.BootArtifactsBaseURL = strings.Trim(clusterInfo.BootArtifactsBaseURL, "/")
+		}
+	default:
+		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
 	}
 
 	var agentTuiFiles []string

--- a/pkg/asset/agent/joiner/addnodesconfig.go
+++ b/pkg/asset/agent/joiner/addnodesconfig.go
@@ -36,14 +36,16 @@ type Config struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	CPUArchitecture string       `json:"cpuArchitecture,omitempty"`
-	SSHKey          string       `json:"sshKey,omitempty"`
-	Hosts           []agent.Host `json:"hosts,omitempty"`
+	CPUArchitecture      string       `json:"cpuArchitecture,omitempty"`
+	SSHKey               string       `json:"sshKey,omitempty"`
+	BootArtifactsBaseURL string       `json:"bootArtifactsBaseURL,omitempty"`
+	Hosts                []agent.Host `json:"hosts,omitempty"`
 }
 
 // Params is used to store the command line parameters.
 type Params struct {
-	Kubeconfig string `json:"kubeconfig,omitempty"`
+	Kubeconfig  string `json:"kubeconfig,omitempty"`
+	GeneratePXE bool   `json:"generatePXE,omitempty"`
 }
 
 // Save stores the current parameters on disk.

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -73,6 +73,7 @@ type ClusterInfo struct {
 	FIPS                          bool
 	Nodes                         *corev1.NodeList
 	ChronyConf                    *igntypes.File
+	BootArtifactsBaseURL          string
 }
 
 var _ asset.WritableAsset = (*ClusterInfo)(nil)
@@ -121,6 +122,7 @@ func (ci *ClusterInfo) Generate(_ context.Context, dependencies asset.Parents) e
 		ci.retrieveSSHKey,
 		ci.retrieveFIPS,
 		ci.retrieveWorkerChronyConfig,
+		ci.retrieveBootArtifactsBaseURL,
 		ci.retrieveNamespace,
 	} {
 		if err := f(); err != nil {
@@ -297,6 +299,13 @@ func (ci *ClusterInfo) retrieveWorkerChronyConfig() error {
 		chronyConf := f
 		ci.ChronyConf = &chronyConf
 		break
+	}
+	return nil
+}
+
+func (ci *ClusterInfo) retrieveBootArtifactsBaseURL() error {
+	if ci.addNodesConfig.Config.BootArtifactsBaseURL != "" {
+		ci.BootArtifactsBaseURL = ci.addNodesConfig.Config.BootArtifactsBaseURL
 	}
 	return nil
 }

--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -18,18 +18,24 @@ const (
 )
 
 // NewAddNodesCommand creates a new command for add nodes.
-func NewAddNodesCommand(directory string, kubeConfig string) error {
-	err := saveParams(directory, kubeConfig)
+func NewAddNodesCommand(directory string, kubeConfig string, generatePXE *bool) error {
+	err := saveParams(directory, kubeConfig, generatePXE)
 	if err != nil {
 		return err
 	}
 
-	fetcher := store.NewAssetsFetcher(directory)
-	err = fetcher.FetchAndPersist(context.Background(), []asset.WritableAsset{
+	assets := []asset.WritableAsset{
 		&workflow.AgentWorkflowAddNodes{},
-		&image.AgentImage{},
-		&configimage.ConfigImage{},
-	})
+	}
+	if *generatePXE {
+		assets = append(assets, &image.AgentPXEFiles{})
+	} else {
+		assets = append(assets, &image.AgentImage{})
+		assets = append(assets, &configimage.ConfigImage{})
+	}
+
+	fetcher := store.NewAssetsFetcher(directory)
+	err = fetcher.FetchAndPersist(context.Background(), assets)
 
 	// Save the exit code result
 	exitCode := "0"
@@ -43,11 +49,16 @@ func NewAddNodesCommand(directory string, kubeConfig string) error {
 	return err
 }
 
-func saveParams(directory, kubeConfig string) error {
+func saveParams(directory, kubeConfig string, generatePXE *bool) error {
 	// Store the current parameters into the assets folder, so
 	// that they could be retrieved later by the assets
+	genPXE := false
+	if generatePXE != nil {
+		genPXE = *generatePXE
+	}
 	params := joiner.Params{
-		Kubeconfig: kubeConfig,
+		Kubeconfig:  kubeConfig,
+		GeneratePXE: genPXE,
 	}
 	return params.Save(directory)
 }

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -9,7 +9,7 @@ import (
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
-	err := saveParams(directory, kubeconfigPath)
+	err := saveParams(directory, kubeconfigPath, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding --pxe flag to "node-joiner add-nodes" generates PXE boot artificats instead of an ISO.