### PR TITLE
OCPBUGS-43425: Power VS: Only delete TG connections created by the installer

### DIFF
--- a/pkg/destroy/powervs/cloud-transit-gateways.go
+++ b/pkg/destroy/powervs/cloud-transit-gateways.go
@@ -312,7 +312,7 @@ func (o *ClusterUninstaller) listTransitConnections(item cloudResource) (cloudRe
 			return nil, err
 		}
 		for _, transitConnection = range transitConnectionCollections.Connections {
-			if *transitConnection.TransitGateway.ID != item.id {
+			if *transitConnection.TransitGateway.ID != item.id || !(strings.Contains(*transitConnection.Name, o.InfraID)) {
 				o.Logger.Debugf("listTransitConnections: SKIP: %s, %s, %s", *transitConnection.ID, *transitConnection.Name, *transitConnection.TransitGateway.Name)
 				continue
 			}


### PR DESCRIPTION
Don't delete Power VS side connections that are not created by the installer when reusing an existing Transit Gateway.