### PR TITLE
AGENT-988: fix node-joiner integration tests

### DIFF
--- a/hack/go-integration-test-nodejoiner.sh
+++ b/hack/go-integration-test-nodejoiner.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Example:  ./hack/go-integration-test-nodejoiner.sh
 
-go install -mod=mod sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+go install -mod=mod sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 # shellcheck disable=SC2086
 KUBEBUILDER_ASSETS="$($GOPATH/bin/setup-envtest use 1.31.0 -p path --bin-dir /tmp)" go test -timeout 0 -run .Integration ./cmd/node-joiner/... "${@}"
 


### PR DESCRIPTION
This patch pins the setup-envtest version to v0.19. Previous usage of  `@latest` required go 1.23+, resulting then in broken CI jobs, since the CI environment is currently running with `go 1.22.7` and `GOTOOLCHAIN=local`