### PR TITLE
OCPBUGS-36670: Update SecurityType for Image used by ConfidentialVMs

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -896,6 +896,17 @@ func getMachinePoolSecurityType(in clusterapi.InfraReadyInput) (string, error) {
 			securityType = pool.Settings.SecurityType
 		}
 	}
+	if securityType == "" && in.InstallConfig.Config.Compute != nil {
+		for _, compute := range in.InstallConfig.Config.Compute {
+			if compute.Platform.Azure != nil {
+				pool := compute.Platform.Azure
+				if pool.Settings != nil {
+					securityType = pool.Settings.SecurityType
+					break
+				}
+			}
+		}
+	}
 	if securityType == "" && in.InstallConfig.Config.Platform.Azure.DefaultMachinePlatform != nil {
 		pool := in.InstallConfig.Config.Platform.Azure.DefaultMachinePlatform
 		if pool.Settings != nil {

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -40,8 +40,8 @@ import (
 const (
 	retryTime        = 10 * time.Second
 	retryCount       = 6
-	confidentialVMST = "ConfidentialVM"
-	trustedLaunchST  = "TrustedLaunch"
+	confidentialVMST = "ConfidentialVMSupported"
+	trustedLaunchST  = "TrustedLaunchsupported"
 )
 
 // Provider implements Azure CAPI installation.
@@ -411,7 +411,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 		computeClientFactory := createImageGalleryOutput.ComputeClientFactory
 
 		// Create gallery images
-		basicImage, err := CreateGalleryImage(ctx, &CreateGalleryImageInput{
+		_, err = CreateGalleryImage(ctx, &CreateGalleryImageInput{
 			ResourceGroupName:    resourceGroupName,
 			GalleryName:          galleryName,
 			GalleryImageName:     galleryImageName,
@@ -440,8 +440,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 			return err
 		}
 
-		var galleryImageID *string
-		gen2Image, err := CreateGalleryImage(ctx, &CreateGalleryImageInput{
+		_, err = CreateGalleryImage(ctx, &CreateGalleryImageInput{
 			ResourceGroupName:    resourceGroupName,
 			GalleryName:          galleryName,
 			GalleryImageName:     galleryGen2ImageName,
@@ -463,16 +462,12 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 			return err
 		}
 
-		if securityType == confidentialVMST {
-			galleryImageID = basicImage.GalleryImage.ID
-		}
 		// Create gallery image versions
 		_, err = CreateGalleryImageVersion(ctx, &CreateGalleryImageVersionInput{
 			ResourceGroupName:       resourceGroupName,
 			StorageAccountID:        *storageAccount.ID,
 			GalleryName:             galleryName,
 			GalleryImageName:        galleryImageName,
-			GalleryImageID:          galleryImageID,
 			GalleryImageVersionName: galleryImageVersionName,
 			Region:                  platform.Region,
 			BlobURL:                 blobURL,
@@ -483,15 +478,11 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 			return err
 		}
 
-		if securityType == confidentialVMST {
-			galleryImageID = gen2Image.GalleryImage.ID
-		}
 		_, err = CreateGalleryImageVersion(ctx, &CreateGalleryImageVersionInput{
 			ResourceGroupName:       resourceGroupName,
 			StorageAccountID:        *storageAccount.ID,
 			GalleryName:             galleryName,
 			GalleryImageName:        galleryGen2ImageName,
-			GalleryImageID:          galleryImageID,
 			GalleryImageVersionName: galleryGen2ImageVersionName,
 			Region:                  platform.Region,
 			BlobURL:                 blobURL,

--- a/pkg/infrastructure/azure/compute.go
+++ b/pkg/infrastructure/azure/compute.go
@@ -170,7 +170,6 @@ type CreateGalleryImageVersionInput struct {
 	ResourceGroupName       string
 	GalleryName             string
 	GalleryImageName        string
-	GalleryImageID          *string
 	GalleryImageVersionName string
 	Region                  string
 	StorageAccountID        string
@@ -208,11 +207,6 @@ func CreateGalleryImageVersion(ctx context.Context, in *CreateGalleryImageVersio
 				},
 			},
 		},
-	}
-
-	// GalleryImageID needs to be passed in only when securityType is set to "ConfidentialVM"
-	if in.GalleryImageID != nil {
-		galleryImageVersionProperties.StorageProfile.OSDiskImage.Source.ID = in.GalleryImageID
 	}
 
 	galleryImageVersionPoller, err := galleryImageVersionsClient.BeginCreateOrUpdate(


### PR DESCRIPTION
Information for creating Gen 2 images with support for `TrustedLaunch` and `ConfidentalVM` was obtained from:
1.  Trusted launch - https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch-portal?tabs=portal%2Cportal3%2Cportal2#trusted-launch-vm-supported-images
2. ConfidentialVM - https://learn.microsoft.com/en-us/azure/confidential-computing/create-confidential-vm-from-compute-gallery#confidential-vm-supported-images