### PR TITLE
OCPBUGS-39416: OpenStack: Install CI dependencies from rpm

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -93,23 +93,12 @@ The requirements for UPI are broadly similar to the [ones for OpenStack IPI][ipi
 
 This repository contains [Ansible playbooks][ansible-upi] to deploy OpenShift on OpenStack.
 
-They can be downloaded from Github with this script:
+They can be downloaded from Github with this script, using the `curl` and `jq` tools:
 
 ```sh
-RELEASE="release-4.14"; xargs -n 1 curl -O <<< "
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/bootstrap.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/common.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/compute-nodes.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/control-plane.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-bootstrap.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-compute-nodes.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-control-plane.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-network.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-security-groups.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/down-containers.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/inventory.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/network.yaml
-        https://raw.githubusercontent.com/openshift/installer/${RELEASE}/upi/openstack/security-groups.yaml"
+RELEASE="release-4.14"; curl -L "https://api.github.com/repos/openshift/installer/contents/upi/openstack?ref=$RELEASE" | \
+    jq -r '.[]|select(.download_url | endswith("yaml")).download_url'| \
+    xargs -n 1 curl -O
 ```
 
 For installing a different version, change the branch (`release-4.14`)

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -22,8 +22,6 @@ of this method of installation.
   - [Table of Contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
   - [Install Ansible](#install-ansible)
-    - [RHEL](#rhel)
-    - [Fedora](#fedora)
   - [OpenShift Configuration Directory](#openshift-configuration-directory)
   - [Red Hat Enterprise Linux CoreOS (RHCOS)](#red-hat-enterprise-linux-coreos-rhcos)
   - [API and Ingress Floating IP Addresses](#api-and-ingress-floating-ip-addresses)
@@ -106,64 +104,44 @@ accordingly (e.g. `release-4.12`).
 
 **Requirements:**
 
-* Python (>=3.8 for ansible-core, currently tested by CI or lower if using Ansible 2.9)
-* Ansible (>=2.10 is currently tested by CI, 2.9 is EOL soon)
+* Python
+* Ansible
 * Python modules required in the playbooks. Namely:
   * openstackclient
   * openstacksdk
   * netaddr
 * Ansible collections required in the playbooks. Namely:
   * openstack.cloud
-  * ansible.utils
   * community.general
 
-### RHEL
-
-From a RHEL box, make sure that the repository origins are all set:
+From a RHEL-9 box, make sure that the repository origins are all set:
 
 ```sh
 sudo subscription-manager register # if not done already
 sudo subscription-manager attach --pool=$YOUR_POOLID # if not done already
 sudo subscription-manager repos --disable=* # if not done already
 sudo subscription-manager repos \
-  --enable=rhel-8-for-x86_64-baseos-rpms \ # change RHEL version if needed
-  --enable=rhel-8-for-x86_64-appstream-rpms # change RHEL version if needed
+  --enable=rhel-9-for-x86_64-appstream-rpms \
+  --enable=rhel-9-for-x86_64-baseos-rpms \
+  --enable=openstack-17.1-for-rhel-9-x86_64-rpms
 ```
 
 Then install the package:
 ```sh
-sudo dnf install ansible-core
+sudo dnf install ansible-collection-ansible-netcommon \
+    ansible-collection-community-general \
+    ansible-collections-openstack \
+    python3-netaddr \
+    python3-openstackclient \
+    python3-pip
 ```
 
-Make sure that `python` points to Python3:
+Followed by:
 ```sh
-sudo alternatives --set python /usr/bin/python3
-```
-
-To avoid packages not found or mismatches, we use pip to install the dependencies:
-```sh
-python3 -m pip install --upgrade pip
-python3 -m pip install yq openstackclient openstacksdk netaddr
-```
-
-### Fedora
-
-This command installs all required dependencies on Fedora:
-
-```sh
-sudo dnf install python3-openstackclient ansible-core python3-openstacksdk python3-netaddr
+python -m pip install yq
 ```
 
 [ansible-upi]: ../../../upi/openstack "Ansible Playbooks for Openstack UPI"
-
-## Ansible Collections
-
-The Ansible Collections are not packaged (yet) on recent versions of OSP and RHEL when `ansible-core` is
-installed instead of Ansible 2.9. So the collections need to be installed from `ansible-galaxy`.
-
-```sh
-ansible-galaxy collection install openstack.cloud ansible.utils community.general
-```
 
 ## OpenShift Configuration Directory
 

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -22,6 +22,8 @@ of this method of installation.
   - [Table of Contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
   - [Install Ansible](#install-ansible)
+    - [RHEL8](#rhel8)
+    - [RHEL9](#rhel9)
   - [OpenShift Configuration Directory](#openshift-configuration-directory)
   - [Red Hat Enterprise Linux CoreOS (RHCOS)](#red-hat-enterprise-linux-coreos-rhcos)
   - [API and Ingress Floating IP Addresses](#api-and-ingress-floating-ip-addresses)
@@ -113,6 +115,36 @@ accordingly (e.g. `release-4.12`).
 * Ansible collections required in the playbooks. Namely:
   * openstack.cloud
   * community.general
+
+### RHEL8
+
+From a RHEL-8 box, make sure that the repository origins are all set:
+
+```sh
+sudo subscription-manager register # if not done already
+sudo subscription-manager attach --pool=$YOUR_POOLID # if not done already
+sudo subscription-manager repos --disable=* # if not done already
+sudo subscription-manager repos \
+  --enable=rhel-8-for-x86_64-appstream-rpms \
+  --enable=rhel-8-for-x86_64-baseos-rpms \
+  --enable=openstack-16-for-rhel-8-x86_64-rpms
+```
+
+Then install the package:
+```sh
+sudo dnf install ansible-collections-openstack \
+    python3-netaddr \
+    python3-openstackclient \
+    python3-openstacksdk \
+    python3-pip
+```
+
+Followed by:
+```sh
+python -m pip install yq
+```
+
+### RHEL9
 
 From a RHEL-9 box, make sure that the repository origins are all set:
 

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -2,7 +2,7 @@
 # It builds an image containing the openshift-install command as well as the openstack cli.
 FROM registry.ci.openshift.org/ocp/4.15:installer-terraform-providers as providers
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -21,21 +21,18 @@ COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-m
 # Install Dependendencies for tests
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    ansible-collection-ansible-netcommon \
-    ansible-collection-community-general \
     ansible-collections-openstack \
     gettext \
     git \
     glibc-locale-source \
-    gzip \
     jq \
     make \
     nmap \
     python3-netaddr \
     python3-openstackclient \
+    python3-openstacksdk \
     python3-pip \
-    unzip \
-    util-linux && \
+    unzip && \
     yum clean all && rm -rf /var/cache/yum/* && \
     localedef -c -f UTF-8 -i en_US en_US.UTF-8 && \
     git config --system user.name test && \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -19,7 +19,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/docs/user/openstack /
 COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-manifests.sh /go/src/github.com/openshift/installer/scripts/openstack/manifest-tests /var/lib/openshift-install/manifest-tests
 
 # Install Dependendencies for tests
-# https://github.com/openshift/origin/blob/6114cbc507bf18890f009f16ee424a62007bc390/images/tests/Dockerfile.rhel
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     ansible-collection-ansible-netcommon \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -20,30 +20,30 @@ COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-m
 
 # Install Dependendencies for tests
 # https://github.com/openshift/origin/blob/6114cbc507bf18890f009f16ee424a62007bc390/images/tests/Dockerfile.rhel
-RUN yum install --setopt=tsflags=nodocs -y gettext make git gzip util-linux glibc-locale-source && \
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y \
+    ansible-collection-ansible-utils \
+    ansible-collection-community-general \
+    ansible-collections-openstack \
+    gettext \
+    git \
+    glibc-locale-source \
+    gzip \
+    jq \
+    make \
+    nmap \
+    python3-netaddr \
+    python3-openstackclient \
+    python3-pip \
+    unzip \
+    util-linux && \
     yum clean all && rm -rf /var/cache/yum/* && \
     localedef -c -f UTF-8 -i en_US en_US.UTF-8 && \
     git config --system user.name test && \
     git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
-RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y \
-    python38 unzip jq nmap && \
-    yum erase -y python36 && \
-    yum clean all && rm -rf /var/cache/yum/*
-
-RUN python3 -m pip install --upgrade pip
-
-# ansible 2.9 is EOL in September 2023, so we need to install ansible-core and get the collections from source
-# until we have a package available.
-RUN python3 -m pip install ansible-core
-RUN ansible-galaxy collection install openstack.cloud ansible.utils community.general && \
-    mkdir -p /usr/share/ansible/collections/ansible_collections && \
-    cp -r /root/.ansible/collections/ansible_collections/* /usr/share/ansible/collections/ansible_collections/
-
-# ansible-core comes with python3.8 but openstacksdk comes with python3.6 so let's install them from pip.
-RUN python3 -m pip install yq openstackclient openstacksdk netaddr
+RUN python3 -m pip install yq
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -22,7 +22,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-m
 # https://github.com/openshift/origin/blob/6114cbc507bf18890f009f16ee424a62007bc390/images/tests/Dockerfile.rhel
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    ansible-collection-ansible-utils \
+    ansible-collection-ansible-netcommon \
     ansible-collection-community-general \
     ansible-collections-openstack \
     gettext \

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -54,13 +54,13 @@ all:
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
       # This value will be overwritten by the network.yaml playbook.
-      os_apiVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(5) }}"
+      os_apiVIP: "{{ os_subnet_range | next_nth_usable(5) }}"
 
       # An IPv4 address that will be assigned to the ingress VIP.
       # Be aware that the 10 and 11 of the machineNetwork will
       # be taken by neutron dhcp by default, and wont be available.
       # This value will be overwritten by the network.yaml playbook.
-      os_ingressVIP: "{{ os_subnet_range | ansible.utils.next_nth_usable(7) }}"
+      os_ingressVIP: "{{ os_subnet_range | next_nth_usable(7) }}"
 
       # Set control-plane nodes to schedule workloads when number of compute
       # nodes is zero

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -20,8 +20,8 @@
       name: "{{ os_subnet }}"
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
-      allocation_pool_start: "{{ os_subnet_range | ansible.utils.next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range | ansible.utils.ipaddr('last_usable') }}"
+      allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
+      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
       dns_nameservers: "{{ os_external_dns }}"
 
   - name: 'Create the cluster IPv6 subnet'
@@ -110,8 +110,8 @@
     shell: |
       python -c 'import yaml
       path = "inventory.yaml"
-      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
-      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
+      ipv4 = "{{ item.ip_address|ipv4 }}"
+      ipv6 = "{{ item.ip_address|ipv6 }}"
       if ipv4 != "False":
         key = "os_apiVIP"
         ip = ipv4
@@ -129,8 +129,8 @@
     shell: |
       python -c 'import yaml
       path = "inventory.yaml"
-      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
-      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
+      ipv4 = "{{ item.ip_address|ipv4 }}"
+      ipv6 = "{{ item.ip_address|ipv6 }}"
       if ipv4 != "False":
         key = "os_ingressVIP"
         ip = ipv4


### PR DESCRIPTION
Prefer RPM over dependencies coming from pip or ansible galaxy.

Manual cherry-pick of https://github.com/openshift/installer/pull/8830.