### PR TITLE
OCPBUGS-42544: support additionalNTPSources in node-joiner tool

### DIFF
--- a/cmd/node-joiner/testdata/add-nodes-chrony-conf.txt
+++ b/cmd/node-joiner/testdata/add-nodes-chrony-conf.txt
@@ -1,0 +1,38 @@
+
+# Verify that the /etc/chrony.conf is added to the image containing the same content of
+# the machineconfig `50-workers-chrony-configuration` (if present in the cluster).
+
+exec node-joiner add-nodes --kubeconfig=$WORK/kubeconfig --log-level=debug --dir=$WORK
+
+grep '^0$' $WORK/exit_code
+exists $WORK/node.x86_64.iso
+isoCmp node.x86_64.iso /etc/chrony.conf expected/chrony.conf
+
+-- nodes-config.yaml --
+hosts:
+    - hostname: extra-worker-0
+      interfaces:
+        - name: eth0
+          macAddress: 00:f4:3d:a0:0e:2b
+          
+-- setup/0050-workers-chrony-configuration-mc.yaml --
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-workers-chrony-configuration
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,c2VydmVyIGZvby5udHAuc2VydmVyIGlidXJzdAo=
+        mode: 420
+        overwrite: true
+        path: /etc/chrony.conf
+
+-- expected/chrony.conf --
+server foo.ntp.server iburst

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -212,6 +212,11 @@ func (a *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 		if err := addDay2IgnitionEndpoints(&config, *clusterInfo); err != nil {
 			return err
 		}
+		// Configure the live environment with the chrony configuration provided by the
+		// cluster, to allow using the same NTP servers.
+		if clusterInfo.ChronyConf != nil {
+			config.Storage.Files = append(config.Storage.Files, *clusterInfo.ChronyConf)
+		}
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)


### PR DESCRIPTION
This patch fixes the issue of adding a new node with an inaccurate date/time by reusing for the installation the same NTP servers applied by the machine config operator, found in the target cluster.

(note: no additional configuration is required by the user in nodes-config.yaml)