### PR TITLE
OCPBUGS-43561: add zsh completion

### DIFF
--- a/cmd/openshift-install/completions.go
+++ b/cmd/openshift-install/completions.go
@@ -57,16 +57,15 @@ func newCompletionCmd() *cobra.Command {
 	}
 	completionCmd.AddCommand(bashCompletionCmd)
 
-	// The zsh completions didn't work for crawford, so commenting them out
-	//zshCompletionCmd := &cobra.Command{
-	//Use:     "zsh",
-	//Short:   "Outputs the zsh shell completions",
-	//Example: completionExampleZsh,
-	//RunE: func(cmd *cobra.Command, _ []string) error {
-	//return cmd.Root().GenZshCompletion(os.Stdout)
-	//},
-	//}
-	//completionCmd.AddCommand(zshCompletionCmd)
+	zshCompletionCmd := &cobra.Command{
+		Use:     "zsh",
+		Short:   "Outputs the zsh shell completions",
+		Example: completionExampleZsh,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		},
+	}
+	completionCmd.AddCommand(zshCompletionCmd)
 
 	return completionCmd
 }


### PR DESCRIPTION
[openshift-install-completion-zsh.txt](https://github.com/user-attachments/files/17437686/openshift-install-completion-zsh.txt)

Fixes #9115 

Seems to work
```zsh
~/git/installer zshcompletion*
❯ openshift-install create i
completions
ignition-configs  -- Generates the Ignition Config asset
install-config    -- Generates the Install Config asset
```

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
