### PR TITLE
OCPBUGS-43567: pkg/asset/installconfig/azure: send full certifcate chain

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -313,6 +313,7 @@ func newTokenCredentialFromCertificates(credentials *Credentials, cloudConfig cl
 		ClientOptions: azcore.ClientOptions{
 			Cloud: cloudConfig,
 		},
+		SendCertificateChain: true,
 	}
 
 	data, err := os.ReadFile(credentials.ClientCertificatePath)


### PR DESCRIPTION
- Send full certificate chain when using certificates for credentials

https://issues.redhat.com/browse/OCPBUGS-43567