### PR TITLE
OCPBUGS-33370: Improve baremetal gather error message

### DIFF
--- a/pkg/infrastructure/baremetal/variables.go
+++ b/pkg/infrastructure/baremetal/variables.go
@@ -88,7 +88,7 @@ func getMasterAddresses(dir string) ([]string, error) {
 
 	data, err := os.ReadFile(filepath.Join(dir, MastersFileName))
 	if err != nil {
-		return masters, err
+		return masters, fmt.Errorf("failed to read masters.json (this can happen when bootstrap didn't run): %w", err)
 	}
 
 	hosts := map[string]baremetalhost.BareMetalHost{}


### PR DESCRIPTION
masters.json is only written when bootstrap runs.  Provide a hint that if the file is missing, perhaps there were errors that prevented bootstrap from starting.