### PR TITLE
OCPBUGS-39585: Add C4 instance validation

### DIFF
--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -36,6 +36,7 @@ var (
 		"c2d": {PDStandard, PDSSD, PDBalanced},
 		"c3":  {PDSSD, PDBalanced, HyperDiskBalanced},
 		"c3d": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"c4":  {HyperDiskBalanced},
 		"e2":  {PDStandard, PDSSD, PDBalanced},
 		"m1":  {PDSSD, PDBalanced, HyperDiskBalanced},
 		"n1":  {PDStandard, PDSSD, PDBalanced},


### PR DESCRIPTION
** Allow Users to select C4 instance types. These instances are only valid with hyperdisk-balanced disk types.