### PR TITLE
CORS-3855: Remove ARO build flag from installer

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -17,7 +17,6 @@ import (
 	azstorage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 )
 
 //go:generate mockgen -source=./client.go -destination=mock/azureclient_generated.go -package=mock
@@ -44,11 +43,7 @@ type API interface {
 	GetAvailabilityZones(ctx context.Context, region string, instanceType string) ([]string, error)
 	GetLocationInfo(ctx context.Context, region string, instanceType string) (*azenc.ResourceSkuLocationInfo, error)
 	CheckIfExistsStorageAccount(ctx context.Context, resourceGroup, storageAccountName, region string) error
-	CheckIfARO(ctx context.Context, groupName string) (bool, error)
 }
-
-var aro *bool
-var aroTag = "installer-aro"
 
 // Client makes calls to the Azure API.
 type Client struct {
@@ -246,30 +241,6 @@ func (c *Client) GetGroup(ctx context.Context, groupName string) (*azres.Group, 
 		return nil, fmt.Errorf("failed to get resource group: %w", err)
 	}
 	return &res, nil
-}
-
-// CheckIfARO checks the existing resource group provided for specific tag
-// to see if the value set is to ARO. If set, the installer will ignore multiple
-// checks/validations and perform ARO specific tasks.
-func (c *Client) CheckIfARO(ctx context.Context, groupName string) (bool, error) {
-	if aro != nil {
-		return *aro, nil
-	}
-	if groupName == "" {
-		return false, nil
-	}
-	group, err := c.GetGroup(ctx, groupName)
-	if err != nil {
-		return false, err
-	}
-	rgTags := group.Tags
-	aro = ptr.To(false)
-	if value, ok := rgTags[aroTag]; ok {
-		if value != nil && *value == "owned" {
-			aro = ptr.To(true)
-		}
-	}
-	return *aro, nil
 }
 
 // ListResourceIDsByGroup returns a list of resource IDs for resource group groupName.

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -635,10 +635,6 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 
 	azureClient.EXPECT().CheckIfExistsStorageAccount(gomock.Any(), validBootDiagnosticsResourceGroup, validBootDiagnosticsStorageAccount, validRegion).Return(nil)
 
-	// ARO specific code
-	azureClient.EXPECT().CheckIfARO(gomock.Any(), gomock.Not("valid-resource-group-with-resources-aro")).Return(false, nil).AnyTimes()
-	azureClient.EXPECT().CheckIfARO(gomock.Any(), "valid-resource-group-with-resources-aro").Return(true, nil).AnyTimes()
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			editedInstallConfig := validInstallConfig()

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -180,11 +180,6 @@ func (a *InstallConfig) finish(ctx context.Context, filename string) error {
 // that have already been checked by validation.ValidateInstallConfig().
 func (a *InstallConfig) platformValidation(ctx context.Context) error {
 	if a.Config.Platform.Azure != nil {
-		if a.Config.Platform.Azure.IsARO() {
-			// ARO performs platform validation in the Resource Provider before
-			// the Installer is called
-			return nil
-		}
 		client, err := a.Azure.Client()
 		if err != nil {
 			return err

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -152,7 +152,6 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 			VirtualNetworkName:       vnet,
 			SubnetName:               subnet,
 			ResourceManagerEndpoint:  installConfig.Config.Azure.ARMEndpoint,
-			ARO:                      installConfig.Config.Azure.IsARO(),
 		}.JSON()
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -279,46 +279,6 @@ func (o *Openshift) Generate(ctx context.Context, dependencies asset.Parents) er
 		}
 		assetData["99_baremetal-provisioning-config.yaml"] = applyTemplateData(baremetalConfig.Files()[0].Data, bmTemplateData)
 	}
-	if platform == azuretypes.Name {
-		var aro bool
-		client, err := installConfig.Azure.Client()
-		if err == nil {
-			isAro, err := client.CheckIfARO(context.TODO(), installConfig.Config.Azure.ResourceGroupName)
-			if err == nil {
-				aro = isAro
-			}
-		}
-		if aro && installConfig.Config.CredentialsMode != types.ManualCredentialsMode {
-			// config is used to created compatible secret to trigger azure cloud
-			// controller config merge behaviour
-			// https://github.com/openshift/origin/blob/90c050f5afb4c52ace82b15e126efe98fa798d88/vendor/k8s.io/legacy-cloud-providers/azure/azure_config.go#L83
-			session, err := installConfig.Azure.Session()
-			if err != nil {
-				return err
-			}
-			config := struct {
-				AADClientID     string `json:"aadClientId" yaml:"aadClientId"`
-				AADClientSecret string `json:"aadClientSecret" yaml:"aadClientSecret"`
-			}{
-				AADClientID:     session.Credentials.ClientID,
-				AADClientSecret: session.Credentials.ClientSecret,
-			}
-
-			b, err := yaml.Marshal(config)
-			if err != nil {
-				return err
-			}
-
-			azureCloudProviderSecret := &openshift.AzureCloudProviderSecret{}
-			dependencies.Get(azureCloudProviderSecret)
-			for _, f := range azureCloudProviderSecret.Files() {
-				name := strings.TrimSuffix(filepath.Base(f.Filename), ".template")
-				assetData[name] = applyTemplateData(f.Data, map[string]string{
-					"CloudConfig": string(b),
-				})
-			}
-		}
-	}
 
 	o.FileList = []*asset.File{}
 	for name, data := range assetData {

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -279,35 +279,44 @@ func (o *Openshift) Generate(ctx context.Context, dependencies asset.Parents) er
 		}
 		assetData["99_baremetal-provisioning-config.yaml"] = applyTemplateData(baremetalConfig.Files()[0].Data, bmTemplateData)
 	}
-
-	if platform == azuretypes.Name && installConfig.Config.Azure.IsARO() && installConfig.Config.CredentialsMode != types.ManualCredentialsMode {
-		// config is used to created compatible secret to trigger azure cloud
-		// controller config merge behaviour
-		// https://github.com/openshift/origin/blob/90c050f5afb4c52ace82b15e126efe98fa798d88/vendor/k8s.io/legacy-cloud-providers/azure/azure_config.go#L83
-		session, err := installConfig.Azure.Session()
-		if err != nil {
-			return err
+	if platform == azuretypes.Name {
+		var aro bool
+		client, err := installConfig.Azure.Client()
+		if err == nil {
+			isAro, err := client.CheckIfARO(context.TODO(), installConfig.Config.Azure.ResourceGroupName)
+			if err == nil {
+				aro = isAro
+			}
 		}
-		config := struct {
-			AADClientID     string `json:"aadClientId" yaml:"aadClientId"`
-			AADClientSecret string `json:"aadClientSecret" yaml:"aadClientSecret"`
-		}{
-			AADClientID:     session.Credentials.ClientID,
-			AADClientSecret: session.Credentials.ClientSecret,
-		}
+		if aro && installConfig.Config.CredentialsMode != types.ManualCredentialsMode {
+			// config is used to created compatible secret to trigger azure cloud
+			// controller config merge behaviour
+			// https://github.com/openshift/origin/blob/90c050f5afb4c52ace82b15e126efe98fa798d88/vendor/k8s.io/legacy-cloud-providers/azure/azure_config.go#L83
+			session, err := installConfig.Azure.Session()
+			if err != nil {
+				return err
+			}
+			config := struct {
+				AADClientID     string `json:"aadClientId" yaml:"aadClientId"`
+				AADClientSecret string `json:"aadClientSecret" yaml:"aadClientSecret"`
+			}{
+				AADClientID:     session.Credentials.ClientID,
+				AADClientSecret: session.Credentials.ClientSecret,
+			}
 
-		b, err := yaml.Marshal(config)
-		if err != nil {
-			return err
-		}
+			b, err := yaml.Marshal(config)
+			if err != nil {
+				return err
+			}
 
-		azureCloudProviderSecret := &openshift.AzureCloudProviderSecret{}
-		dependencies.Get(azureCloudProviderSecret)
-		for _, f := range azureCloudProviderSecret.Files() {
-			name := strings.TrimSuffix(filepath.Base(f.Filename), ".template")
-			assetData[name] = applyTemplateData(f.Data, map[string]string{
-				"CloudConfig": string(b),
-			})
+			azureCloudProviderSecret := &openshift.AzureCloudProviderSecret{}
+			dependencies.Get(azureCloudProviderSecret)
+			for _, f := range azureCloudProviderSecret.Files() {
+				name := strings.TrimSuffix(filepath.Base(f.Filename), ".template")
+				assetData[name] = applyTemplateData(f.Data, map[string]string{
+					"CloudConfig": string(b),
+				})
+			}
 		}
 	}
 

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -193,11 +193,6 @@ func (p *Platform) NetworkSecurityGroupName(infraID string) string {
 	return fmt.Sprintf("%s-nsg", infraID)
 }
 
-// IsARO returns true if ARO-only modifications are enabled
-func (p *Platform) IsARO() bool {
-	return aro
-}
-
 // GetStorageAccountName takes an infraID and generates a
 // storage account name, which can't be more than 24 characters.
 func GetStorageAccountName(infraID string) string {

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -61,7 +61,7 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region should be set to one of the supported Azure regions"))
 	}
-	if !p.IsARO() && publish != types.InternalPublishingStrategy {
+	if publish != types.InternalPublishingStrategy {
 		if p.BaseDomainResourceGroupName == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("baseDomainResourceGroupName"), "baseDomainResourceGroupName is the resource group name where the azure dns zone is deployed"))
 		}

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -58,30 +58,12 @@ func TestValidatePlatform(t *testing.T) {
 		},
 		{
 			name: "invalid baseDomainResourceGroupName",
-			wantSkip: func(p *azure.Platform) bool {
-				// This test case doesn't apply to ARO
-				// so we want to skip it when run tests for ARO build
-				return p.IsARO()
-			},
 			platform: func() *azure.Platform {
 				p := validPlatform()
 				p.BaseDomainResourceGroupName = ""
 				return p
 			}(),
 			expected: `^test-path\.baseDomainResourceGroupName: Required value: baseDomainResourceGroupName is the resource group name where the azure dns zone is deployed$`,
-		},
-		{
-			name: "do not require baseDomainResourceGroupName on ARO",
-			wantSkip: func(p *azure.Platform) bool {
-				// This is a ARO-specific test case
-				// so want to skip when running non-ARO builds
-				return !p.IsARO()
-			},
-			platform: func() *azure.Platform {
-				p := validPlatform()
-				p.BaseDomainResourceGroupName = ""
-				return p
-			}(),
 		},
 		{
 			name:     "minimal",


### PR DESCRIPTION
Removing the ARO build flag from the installer to achieve the goal of moving ARO installs closer to the installer. Ideally, these ARO specific changes to the installs/installer need to be done either in the wrapper or hive.