### PR TITLE
MGMT-19151: Add ingress CN to cluster configuration for image-based installer

### DIFF
--- a/pkg/asset/imagebased/configimage/ingressoperatorsigner.go
+++ b/pkg/asset/imagebased/configimage/ingressoperatorsigner.go
@@ -2,9 +2,19 @@ package configimage
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint: gosec
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"time"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -34,13 +44,21 @@ func (a *IngressOperatorSignerCertKey) Generate(ctx context.Context, dependencie
 	signerName := fmt.Sprintf("%s@%d", "ingress-operator", time.Now().Unix())
 
 	cfg := &tls.CertCfg{
-		Subject:   pkix.Name{CommonName: signerName, OrganizationalUnit: []string{"openshift"}},
+		Subject:   pkix.Name{CommonName: signerName},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		Validity:  tls.ValidityOneYear * 2,
 		IsCA:      true,
 	}
 
-	return a.SelfSignedCertKey.Generate(ctx, cfg, "ingress-operator-signer")
+	key, crt, err := generateSelfSignedCertificate(cfg)
+	if err != nil {
+		return err
+	}
+
+	a.KeyRaw = tls.PrivateKeyToPem(key)
+	a.CertRaw = tls.CertToPem(crt)
+
+	return nil
 }
 
 // IngressOperatorCABundle is the asset the generates the ingress-operator-signer-ca-bundle,
@@ -71,4 +89,82 @@ func (a *IngressOperatorCABundle) Generate(ctx context.Context, deps asset.Paren
 // Name returns the human-friendly name of the asset.
 func (a *IngressOperatorCABundle) Name() string {
 	return "Certificate (ingress-operator-ca-bundle)"
+}
+
+// selfSignedCertificate creates a self signed certificate.
+//
+// TODO: this is a modified tls.SelfSignedCertificate function to allow the
+// certificate's Subject.OU to be empty. We should revisit this by sharing as
+// much code as possible with the tls package.
+//
+// https://github.com/openshift/installer/blob/6723dfd18056a6d002f792afce5547fc24874908/pkg/asset/tls/tls.go
+func selfSignedCertificate(cfg *tls.CertCfg, key *rsa.PrivateKey) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	cert := x509.Certificate{
+		BasicConstraintsValid: true,
+		IsCA:                  cfg.IsCA,
+		KeyUsage:              cfg.KeyUsages,
+		NotAfter:              time.Now().Add(cfg.Validity),
+		NotBefore:             time.Now(),
+		SerialNumber:          serial,
+		Subject:               cfg.Subject,
+	}
+	// verifies that the CN for the cert is set
+	if len(cfg.Subject.CommonName) == 0 {
+		return nil, errors.New("certification's subject is not set, or invalid")
+	}
+	pub := key.Public()
+	cert.SubjectKeyId, err = generateSubjectKeyID(pub)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set subject key identifier: %w", err)
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &cert, &cert, key.Public(), key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+	return x509.ParseCertificate(certBytes)
+}
+
+// generateSelfSignedCertificate generates a key/cert pair defined by CertCfg.
+func generateSelfSignedCertificate(cfg *tls.CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
+	key, err := tls.PrivateKey()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	crt, err := selfSignedCertificate(cfg, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create self-signed certificate: %w", err)
+	}
+	return key, crt, nil
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}
+
+// generateSubjectKeyID generates a SHA-1 hash of the subject public key.
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	var publicKeyBytes []byte
+	var err error
+
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{N: pub.N, E: pub.E})
+		if err != nil {
+			return nil, fmt.Errorf("failed to Marshal ans1 public key: %w", err)
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y) //nolint: staticcheck
+	default:
+		return nil, errors.New("only RSA and ECDSA public keys supported")
+	}
+
+	hash := sha1.Sum(publicKeyBytes) //nolint: gosec
+	return hash[:], nil
 }

--- a/pkg/types/imagebased/seedreconfiguration.go
+++ b/pkg/types/imagebased/seedreconfiguration.go
@@ -106,13 +106,13 @@ type KubeAPICrypto struct {
 // ServingCrypto contains the kubernetes API private keys that are used to
 // generate the cluster's certificates.
 type ServingCrypto struct {
-	// LocalhostSignerPrivateKey is a PEM-encoded X.509 key.
+	// LocalhostSignerPrivateKey is a PEM-encoded private key.
 	LocalhostSignerPrivateKey string `json:"localhost_signer_private_key,omitempty"`
 
-	// ServiceNetworkSignerPrivateKey is a PEM-encoded X.509 key.
+	// ServiceNetworkSignerPrivateKey is a PEM-encoded private key.
 	ServiceNetworkSignerPrivateKey string `json:"service_network_signer_private_key,omitempty"`
 
-	// LoadbalancerSignerPrivateKey is a PEM-encoded X.509 key.
+	// LoadbalancerSignerPrivateKey is a PEM-encoded private key.
 	LoadbalancerSignerPrivateKey string `json:"loadbalancer_external_signer_private_key,omitempty"`
 }
 
@@ -125,8 +125,11 @@ type ClientAuthCrypto struct {
 
 // IngresssCrypto contains the ingrees CA certificate.
 type IngresssCrypto struct {
-	// IngressCA is a PEM-encoded X.509 certificate.
-	IngressCA string `json:"ingress_ca,omitempty"`
+	// IngressCAPrivateKey is a PEM-encoded private key.
+	IngressCAPrivateKey string `json:"ingress_ca,omitempty"`
+
+	// IngressCertificateCN is the Subject.CN of the ingress CA certificate.
+	IngressCertificateCN string `json:"ingress_certificate_cn,omitempty"`
 }
 
 // AdditionalTrustBundle represents the PEM-encoded X.509 certificate bundle


### PR DESCRIPTION
This PR adds the ingress CA certificate `Subject.CN` to the cluster configuration manifest included in the image-based configuration ISO, in addition to the respective ingress CA private key. This CN will be used by recert during an IBI configuration to replace the seed's CN with this one, in order for the kubeconfig certificate-authority-data ingress CA to match the one in the newly created cluster.