### PR TITLE
CORS-3741: [Nutanix] support multiple subnets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.3-0.20240416171357-98239ba02cb2
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.35.1
-	github.com/openshift/api v0.0.0-20241109205306-a2817b89f7e0
+	github.com/openshift/api v0.0.0-20241118215836-09b63162bb15
 	github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift/api v0.0.0-20241109205306-a2817b89f7e0 h1:l4VHxObu73EoMGtdgxNXo+MeYCjQyvN/PCvSfV/SkCU=
-github.com/openshift/api v0.0.0-20241109205306-a2817b89f7e0/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
+github.com/openshift/api v0.0.0-20241118215836-09b63162bb15 h1:5bt8CBbXv1iSmBNCBXugsIT04NgHFCSkM1mOyuE8s2Q=
+github.com/openshift/api v0.0.0-20241118215836-09b63162bb15/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6 h1:U6ve+dnHlHhAELoxX+rdFOHVhoaYl0l9qtxwYtsO6C0=
 github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6/go.mod h1:o2H5VwQhUD8P6XsK6dRmKpCCJqVvv12KJQZBXmcCXCU=
 github.com/openshift/assisted-service v1.0.10-0.20230830164851-6573b5d7021d h1:CKw2Y4EdaFsMoqAdr2Tq0nlYTaaXmCRdP0gOu7pN64U=

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -147,7 +148,27 @@ func TestValidatePlatform(t *testing.T) {
 				p.SubnetUUIDs[0] = ""
 				return p
 			}(),
-			expectedError: `^test-path\.subnet: Required value: must specify the subnet$`,
+			expectedError: `^test-path\.subnetUUIDs: Required value: must specify at least one subnet$`,
+		},
+		{
+			name: "too many subnet items",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				for i := 1; i <= 32; i++ {
+					p.SubnetUUIDs = append(p.SubnetUUIDs, fmt.Sprintf("subnet-%v", i))
+				}
+				return p
+			}(),
+			expectedError: `^test-path\.subnetUUIDs: Too many: 33: must have at most 32 items$`,
+		},
+		{
+			name: "duplicate subnet item",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.SubnetUUIDs = append(p.SubnetUUIDs, p.SubnetUUIDs[0])
+				return p
+			}(),
+			expectedError: `^test-path\.subnetUUIDs: Invalid value: "b06179c8-dea3-4f8e-818a-b2e88fbc2201": should not configure duplicate value$`,
 		},
 		{
 			name: "Capital letters in Prism Central",

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -1739,6 +1739,7 @@ type NutanixPlatformSpec struct {
 	// failureDomains configures failure domains information for the Nutanix platform.
 	// When set, the failure domains defined here may be used to spread Machines across
 	// prism element clusters to improve fault tolerance of the cluster.
+	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=NutanixMultiSubnets,maxItems=32
 	// +listType=map
 	// +listMapKey=name
 	// +optional
@@ -1765,13 +1766,15 @@ type NutanixFailureDomain struct {
 	Cluster NutanixResourceIdentifier `json:"cluster"`
 
 	// subnets holds a list of identifiers (one or more) of the cluster's network subnets
+	// If the feature gate NutanixMultiSubnets is enabled, up to 32 subnets may be configured.
 	// for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be
 	// obtained from the Prism Central console or using the prism_central API.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=1
-	// +listType=map
-	// +listMapKey=type
+	// +openshift:validation:FeatureGateAwareMaxItems:featureGate="",maxItems=1
+	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=NutanixMultiSubnets,maxItems=32
+	// +openshift:validation:FeatureGateAwareXValidation:featureGate=NutanixMultiSubnets,rule="self.all(x, self.exists_one(y, x == y))",message="each subnet must be unique"
+	// +listType=atomic
 	Subnets []NutanixResourceIdentifier `json:"subnets"`
 }
 

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -314,6 +314,7 @@ infrastructures.config.openshift.io:
   - BareMetalLoadBalancer
   - GCPClusterHostedDNS
   - GCPLabelsTags
+  - NutanixMultiSubnets
   - VSphereControlPlaneMachineSet
   - VSphereMultiNetworks
   - VSphereMultiVCenters

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -1519,7 +1519,7 @@ var map_NutanixFailureDomain = map[string]string{
 	"":        "NutanixFailureDomain configures failure domain information for the Nutanix platform.",
 	"name":    "name defines the unique name of a failure domain. Name is required and must be at most 64 characters in length. It must consist of only lower case alphanumeric characters and hyphens (-). It must start and end with an alphanumeric character. This value is arbitrary and is used to identify the failure domain within the platform.",
 	"cluster": "cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
-	"subnets": "subnets holds a list of identifiers (one or more) of the cluster's network subnets for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
+	"subnets": "subnets holds a list of identifiers (one or more) of the cluster's network subnets If the feature gate NutanixMultiSubnets is enabled, up to 32 subnets may be configured. for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
 }
 
 func (NutanixFailureDomain) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -678,4 +678,12 @@ var (
 						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1697").
 						mustRegister()
+
+	FeatureGateNutanixMultiSubnets = newFeatureGate("NutanixMultiSubnets").
+					reportProblemsToJiraComponent("Cloud Compute / Nutanix Provider").
+					contactPerson("yanhli").
+					productScope(ocpSpecific).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1711").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
 )

--- a/vendor/github.com/openshift/api/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -32,6 +32,7 @@ controllerconfigs.machineconfiguration.openshift.io:
   - BareMetalLoadBalancer
   - GCPClusterHostedDNS
   - GCPLabelsTags
+  - NutanixMultiSubnets
   - VSphereControlPlaneMachineSet
   - VSphereMultiNetworks
   - VSphereMultiVCenters

--- a/vendor/github.com/openshift/api/operator/v1/register.go
+++ b/vendor/github.com/openshift/api/operator/v1/register.go
@@ -62,6 +62,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&OpenShiftAPIServerList{},
 		&OpenShiftControllerManager{},
 		&OpenShiftControllerManagerList{},
+		&OLM{},
+		&OLMList{},
 		&ServiceCA{},
 		&ServiceCAList{},
 		&ServiceCatalogAPIServer{},

--- a/vendor/github.com/openshift/api/operator/v1/types_olm.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_olm.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1504
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=operator-lifecycle-manager,operatorOrdering=01
 // +openshift:enable:FeatureGate=NewOLM
+// +openshift:capability=OperatorLifecycleManagerV1
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'cluster'",message="olm is a singleton, .metadata.name must be 'cluster'"
 type OLM struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -350,7 +350,7 @@ olms.operator.openshift.io:
   Annotations: {}
   ApprovedPRNumber: https://github.com/openshift/api/pull/1504
   CRDName: olms.operator.openshift.io
-  Capability: ""
+  Capability: OperatorLifecycleManagerV1
   Category: ""
   FeatureGates:
   - NewOLM

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1092,7 +1092,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runtime-spec v1.2.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/openshift/api v0.0.0-20241109205306-a2817b89f7e0
+# github.com/openshift/api v0.0.0-20241118215836-09b63162bb15
 ## explicit; go 1.22.0
 github.com/openshift/api/annotations
 github.com/openshift/api/config/v1


### PR DESCRIPTION
[CORS-3741](https://issues.redhat.com//browse/CORS-3741)
Allow users to configure multiple subnets via platform.nutanix.subnetUUIDs in the install-config.yaml.

Depends on https://github.com/openshift/api/pull/2077