### PR TITLE
NO-ISSUE: imagebasedinstaller:  support json files in extramanifests directory

### DIFF
--- a/cmd/openshift-install/testdata/imagebased/configimage/manifests/extra_manifests.txt
+++ b/cmd/openshift-install/testdata/imagebased/configimage/manifests/extra_manifests.txt
@@ -1,0 +1,66 @@
+# Verify that the extra-manifests directory populates with the appropriate files
+
+exec openshift-install image-based create config-image --dir $WORK
+
+exists $WORK/imagebasedconfig.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+isoContains imagebasedconfig.iso /cluster-configuration/manifest.json
+isoContains imagebasedconfig.iso /extra-manifests/test.yaml
+isoContains imagebasedconfig.iso /extra-manifests/test.yml
+isoContains imagebasedconfig.iso /extra-manifests/test.json
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 1
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- image-based-config.yaml --
+apiVersion: v1beta1
+kind: ImageBasedConfig
+metadata:
+  name: ostest
+  namespace: cluster0
+hostname: ostest
+
+-- extra-manifests/test.yaml --
+apiVersion: v1beta1
+kind: DummyData
+metadata:
+  name: test.yaml
+
+-- extra-manifests/test.yml --
+apiVersion: v1beta1
+kind: DummyData
+metadata:
+  name: test.yml
+
+-- extra-manifests/test.json --
+{
+  "apiVersion": "v1beta1",
+  "kind": "DummyData",
+  "metadata": {
+    "name": "test.json"
+  }
+}

--- a/cmd/openshift-install/testdata/imagebased/configimage/manifests/extra_manifests.txt
+++ b/cmd/openshift-install/testdata/imagebased/configimage/manifests/extra_manifests.txt
@@ -3,10 +3,7 @@
 exec openshift-install image-based create config-image --dir $WORK
 
 exists $WORK/imagebasedconfig.iso
-exists $WORK/auth/kubeconfig
-exists $WORK/auth/kubeadmin-password
 
-isoContains imagebasedconfig.iso /cluster-configuration/manifest.json
 isoContains imagebasedconfig.iso /extra-manifests/test.yaml
 isoContains imagebasedconfig.iso /extra-manifests/test.yml
 isoContains imagebasedconfig.iso /extra-manifests/test.json

--- a/pkg/asset/imagebased/configimage/extramanifests.go
+++ b/pkg/asset/imagebased/configimage/extramanifests.go
@@ -48,9 +48,14 @@ func (em *ExtraManifests) Load(f asset.FileFetcher) (found bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to load *.yml files: %w", err)
 	}
+	jsonFileList, err := f.FetchByPattern(filepath.Join(extraManifestsDir, "*.json"))
+	if err != nil {
+		return false, fmt.Errorf("failed to load *.json files: %w", err)
+	}
 
 	em.FileList = append(em.FileList, yamlFileList...)
 	em.FileList = append(em.FileList, ymlFileList...)
+	em.FileList = append(em.FileList, jsonFileList...)
 	asset.SortFiles(em.FileList)
 
 	return len(em.FileList) > 0, nil

--- a/pkg/asset/imagebased/configimage/extramanifests_test.go
+++ b/pkg/asset/imagebased/configimage/extramanifests_test.go
@@ -88,6 +88,10 @@ func TestExtraManifests_Load(t *testing.T) {
 		},
 	}
 
+	yamlPattern := "extra-manifests/*.yaml"
+	ymlPattern := "extra-manifests/*.yml"
+	jsonPattern := "extra-manifests/*.json"
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			yamlFiles := []*asset.File{}
@@ -115,33 +119,22 @@ func TestExtraManifests_Load(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			fileFetcher := mock.NewMockFileFetcher(mockCtrl)
+
 			if tc.yamlFetchError != nil {
-				fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yaml").Return(
-					[]*asset.File{},
-					tc.yamlFetchError,
-				)
-			} else if tc.ymlFetchError != nil {
-				fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yaml").Return(yamlFiles, nil)
+				fileFetcher.EXPECT().FetchByPattern(yamlPattern).Return([]*asset.File{}, tc.yamlFetchError)
+			} else {
+				fileFetcher.EXPECT().FetchByPattern(yamlPattern).Return(yamlFiles, nil)
 
 				if tc.ymlFetchError != nil {
-					fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yml").Return(
-						[]*asset.File{},
-						tc.ymlFetchError,
-					)
+					fileFetcher.EXPECT().FetchByPattern(ymlPattern).Return([]*asset.File{}, tc.ymlFetchError)
 				} else {
-					fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yml").Return(ymlFiles, nil)
-				}
-			} else {
-				fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yaml").Return(yamlFiles, nil)
-				fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.yml").Return(ymlFiles, nil)
+					fileFetcher.EXPECT().FetchByPattern(ymlPattern).Return(ymlFiles, nil)
 
-				if tc.jsonFetchError != nil {
-					fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.json").Return(
-						[]*asset.File{},
-						tc.jsonFetchError,
-					)
-				} else {
-					fileFetcher.EXPECT().FetchByPattern("extra-manifests/*.json").Return(jsonFiles, nil)
+					if tc.jsonFetchError != nil {
+						fileFetcher.EXPECT().FetchByPattern(jsonPattern).Return([]*asset.File{}, tc.jsonFetchError)
+					} else {
+						fileFetcher.EXPECT().FetchByPattern(jsonPattern).Return(jsonFiles, nil)
+					}
 				}
 			}
 


### PR DESCRIPTION
Added support for `.json` files in the extra-manifests directory when creating a config-image using the "image-based" installer. Updated test cases as well to test added functionality.

Fixes #9134