### PR TITLE
OCPBUGS-43768: Log correct hostname for validation status

### DIFF
--- a/pkg/agent/validations.go
+++ b/pkg/agent/validations.go
@@ -34,7 +34,7 @@ type validationResultHistory struct {
 	previousMessage string
 }
 
-func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger, hostLogPrefix string) error {
+func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger, logPrefix string) error {
 	clusterLogPrefix := "Cluster validation: "
 	updatedClusterValidationHistory, err := updateValidationResultHistory(clusterLogPrefix, cluster.ValidationsInfo, validationResults.ClusterValidationHistory, log)
 	if err != nil {
@@ -43,6 +43,7 @@ func checkValidations(cluster *models.Cluster, validationResults *validationResu
 	validationResults.ClusterValidationHistory = updatedClusterValidationHistory
 
 	for _, h := range cluster.Hosts {
+		hostLogPrefix := logPrefix
 		if hostLogPrefix == "" {
 			hostLogPrefix = "Host " + h.RequestedHostname + " validation: "
 		}


### PR DESCRIPTION
The log prefix was getting set the first time through the host loop and not getting modified for subsequent hosts. We need to calculate it anew for each host.