### PR TITLE
OCPBUGS-43674: ABI cluster installation fails for external OCI platform

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/external_with_bootArtifactsBaseURL_minimal_iso.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/external_with_bootArtifactsBaseURL_minimal_iso.txt
@@ -10,6 +10,8 @@ exists $WORK/boot-artifacts/agent.x86_64-rootfs.img
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
 
+isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
+
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
@@ -45,3 +47,41 @@ metadata:
   namespace: cluster0
 rendezvousIP: 192.168.111.20
 bootArtifactsBaseURL: http://user-specified-infra.com
+
+-- expected/agent-cluster-install.yaml --
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"external":{"platformName":"oci","cloudControllerManager":"External"}}}'
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  clusterDeploymentRef:
+    name: ostest
+  external:
+    cloudControllerManager: External
+    platformName: oci
+  imageSetRef:
+    name: openshift-was not built correctly
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    machineNetwork:
+    - cidr: 192.168.111.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - 172.30.0.0/16
+    userManagedNetworking: true
+  platformType: External
+  provisionRequirements:
+    controlPlaneAgents: 3
+  sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  debugInfo:
+    eventsURL: ""
+    logsURL: ""
+  progress:
+    totalPercentage: 0

--- a/cmd/openshift-install/testdata/agent/image/configurations/external_without_bootArtifactsBaseURL_minimal_iso.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/external_without_bootArtifactsBaseURL_minimal_iso.txt
@@ -9,6 +9,8 @@ exists $WORK/agent.x86_64.iso
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
 
+isocmp agent.x86_64.iso /etc/assisted/manifests/agent-cluster-install.yaml expected/agent-cluster-install.yaml
+
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
@@ -43,3 +45,41 @@ metadata:
   name: ostest
   namespace: cluster0
 rendezvousIP: 192.168.111.20
+
+-- expected/agent-cluster-install.yaml --
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"platform":{"external":{"platformName":"oci","cloudControllerManager":"External"}}}'
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  clusterDeploymentRef:
+    name: ostest
+  external:
+    cloudControllerManager: External
+    platformName: oci
+  imageSetRef:
+    name: openshift-was not built correctly
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    machineNetwork:
+    - cidr: 192.168.111.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - 172.30.0.0/16
+    userManagedNetworking: true
+  platformType: External
+  provisionRequirements:
+    controlPlaneAgents: 3
+  sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  debugInfo:
+    eventsURL: ""
+    logsURL: ""
+  progress:
+    totalPercentage: 0

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -214,6 +214,9 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 				PlatformName: installConfig.Config.Platform.External.PlatformName,
 			}
 		}
+		if installConfig.Config.Platform.Name() == external.Name && installConfig.Config.Platform.External.PlatformName == agent.ExternalPlatformNameOci {
+			agentClusterInstall.Spec.ExternalPlatformSpec.CloudControllerManager = external.CloudControllerManagerTypeExternal
+		}
 
 		if installConfig.Config.Platform.Name() == none.Name || installConfig.Config.Platform.Name() == external.Name {
 			logrus.Debugf("Setting UserManagedNetworking to true for %s platform", installConfig.Config.Platform.Name())

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -117,7 +117,8 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodExternalOCIPlatformACI.Spec.Networking.UserManagedNetworking = &val
 	goodExternalOCIPlatformACI.Spec.PlatformType = hiveext.ExternalPlatformType
 	goodExternalOCIPlatformACI.Spec.ExternalPlatformSpec = &hiveext.ExternalPlatformSpec{
-		PlatformName: agent.ExternalPlatformNameOci,
+		PlatformName:           agent.ExternalPlatformNameOci,
+		CloudControllerManager: externaltype.CloudControllerManagerTypeExternal,
 	}
 	goodExternalOCIPlatformACI.SetAnnotations(map[string]string{
 		installConfigOverrides: `{"platform":{"external":{"platformName":"oci","cloudControllerManager":"External"}}}`,


### PR DESCRIPTION
- Correctly maps agentClusterInstall with cloudControllerManager value 
- Updated integrations tests