### PR TITLE
MGMT-19191: Provide a way to add coreos installer params for installation phase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/thedevsaddam/retry v0.0.0-20200324223450-9769a859cc6d
+	github.com/thoas/go-funk v0.9.3
 	github.com/ulikunitz/xz v0.5.12
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/vmware/govmomi v0.43.0
@@ -261,7 +262,6 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
-	github.com/thoas/go-funk v0.9.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/pkg/asset/imagebased/image/ignition.go
+++ b/pkg/asset/imagebased/image/ignition.go
@@ -43,14 +43,15 @@ func (i *Ignition) Dependencies() []asset.Asset {
 }
 
 type ibiConfigurationFile struct {
-	ExtraPartitionLabel  string `json:"extraPartitionLabel,omitempty"`
-	ExtraPartitionNumber uint   `json:"extraPartitionNumber,omitempty"`
-	ExtraPartitionStart  string `json:"extraPartitionStart,omitempty"`
-	InstallationDisk     string `json:"installationDisk"`
-	SeedImage            string `json:"seedImage"`
-	SeedVersion          string `json:"seedVersion"`
-	Shutdown             bool   `json:"shutdown,omitempty"`
-	SkipDiskCleanup      bool   `json:"skipDiskCleanup,omitempty"`
+	ExtraPartitionLabel  string   `json:"extraPartitionLabel,omitempty"`
+	ExtraPartitionNumber uint     `json:"extraPartitionNumber,omitempty"`
+	ExtraPartitionStart  string   `json:"extraPartitionStart,omitempty"`
+	InstallationDisk     string   `json:"installationDisk"`
+	SeedImage            string   `json:"seedImage"`
+	SeedVersion          string   `json:"seedVersion"`
+	Shutdown             bool     `json:"shutdown,omitempty"`
+	SkipDiskCleanup      bool     `json:"skipDiskCleanup,omitempty"`
+	CoreosInstallerArgs  []string `json:"coreosInstallerArgs,omitempty"`
 }
 
 type ibiTemplateData struct {
@@ -99,6 +100,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 		SeedImage:            ibiConfig.SeedImage,
 		Shutdown:             ibiConfig.Shutdown,
 		SkipDiskCleanup:      ibiConfig.SkipDiskCleanup,
+		CoreosInstallerArgs:  ibiConfig.CoreosInstallerArgs,
 	}
 	ibiConfigJSON, err := json.Marshal(ibiConfigFile)
 	if err != nil {

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -308,6 +308,42 @@ proxy:
 			expectedFound: false,
 			expectedError: "invalid Image-based Installation ISO Config: proxy.httpsProxy: Unsupported value: \"invalidscheme\": supported values: \"http\", \"https\"",
 		},
+		{
+			name: "invalid-coreosInstallerArgs arg - not allowed arg",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+coreosInstallerArgs:
+- "--test"
+- "3"
+`,
+
+			expectedFound: false,
+			expectedError: "found unexpected flag --test for coreosInstallerArgs - allowed flags are [--append-karg --delete-karg --save-partlabel --save-partindex",
+		},
+		{
+			name: "valid-coreosInstallerArgs arg",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+coreosInstallerArgs:
+- "--save-partindex"
+- "5"
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/imagebased/imagebased_config_types.go
+++ b/pkg/types/imagebased/imagebased_config_types.go
@@ -124,4 +124,12 @@ type InstallationConfig struct {
 
 	// SSHKey is the public Secure Shell (SSH) key to provide access to instances.
 	SSHKey string `json:"sshKey,omitempty"`
+
+	// CoreosInstallerParams additional parameters for coreos-install command that will be used while writing os to disk
+	// Example: in order not to override earlier created installation disk partition, you can provide
+	// coreosInstallerArgs: []{"--save-partindex=6"} - this will save previously created partition number 6
+	// Allowed flags: "--append-karg", "--delete-karg", "--save-partlabel", "--save-partindex"
+	//
+	// +optional
+	CoreosInstallerArgs []string `json:"coreosInstallerArgs,omitempty"`
 }


### PR DESCRIPTION
[MGMT-19191](https://issues.redhat.com//browse/MGMT-19191): Provide a way to add coreos installer params for installation phase
Adding new field CoreosInstallerParams to image based install command to customize coreos installer command in lca cli