### PR TITLE
OCPBUGS-30292: If agent proxy defined, add MachineNetwork to noProxy

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
@@ -54,4 +54,4 @@ rendezvousIP: 192.168.111.20
 [Manager]
 DefaultEnvironment=HTTP_PROXY="http://192.168.111.1:8215"
 DefaultEnvironment=HTTPS_PROXY="http://192.168.111.1:8215"
-DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20"
+DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24"

--- a/cmd/openshift-install/testdata/agent/image/configurations/control-plane-4-replicas.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/control-plane-4-replicas.txt
@@ -55,7 +55,7 @@ rendezvousIP: 192.168.111.20
 [Manager]
 DefaultEnvironment=HTTP_PROXY="http://192.168.111.1:8215"
 DefaultEnvironment=HTTPS_PROXY="http://192.168.111.1:8215"
-DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20"
+DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24"
 -- expected/agent-cluster-install.yaml --
 apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
@@ -90,7 +90,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:

--- a/cmd/openshift-install/testdata/agent/image/configurations/control-plane-5-replicas.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/control-plane-5-replicas.txt
@@ -55,7 +55,7 @@ rendezvousIP: 192.168.111.20
 [Manager]
 DefaultEnvironment=HTTP_PROXY="http://192.168.111.1:8215"
 DefaultEnvironment=HTTPS_PROXY="http://192.168.111.1:8215"
-DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20"
+DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24"
 -- expected/agent-cluster-install.yaml --
 apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
@@ -90,7 +90,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -76,7 +76,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:
@@ -135,7 +135,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   pullSecretRef:
     name: ostest-pull-secret
   sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -14,6 +14,10 @@ isoIgnitionContains agent.x86_64.iso /etc/assisted/manifests/pull-secret.yaml
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
+proxy:
+  httpProxy: http://192.168.111.1:8215
+  httpsProxy: http://192.168.111.1:8215
+  noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
 controlPlane: 
   name: master
   replicas: 1
@@ -69,6 +73,10 @@ spec:
   platformType: None
   provisionRequirements:
     controlPlaneAgents: 1
+  proxy:
+    httpProxy: http://192.168.111.1:8215
+    httpsProxy: http://192.168.111.1:8215
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:
@@ -124,6 +132,10 @@ spec:
   nmStateConfigLabelSelector:
     matchLabels:
       infraenvs.agent-install.openshift.io: ostest
+  proxy:
+    httpProxy: http://192.168.111.1:8215
+    httpsProxy: http://192.168.111.1:8215
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
   pullSecretRef:
     name: ostest-pull-secret
   sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=

--- a/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -7,8 +7,6 @@ DefaultEnvironment=HTTP_PROXY="{{replace .Proxy.HTTPProxy "%" "%%"}}"
 DefaultEnvironment=HTTPS_PROXY="{{replace .Proxy.HTTPSProxy "%" "%%"}}"
 {{end -}}
 {{if .Proxy.NoProxy -}}
-DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}},{{.RendezvousIP}}"
-{{else -}}
-DefaultEnvironment=NO_PROXY="{{.RendezvousIP}}"
+DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
 {{end -}}
 {{end -}}

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -82,7 +82,6 @@ type agentTemplateData struct {
 	TokenExpiry               string
 	AuthType                  string
 	CaBundleMount             string
-	RendezvousIP              string
 }
 
 // Name returns the human-friendly name of the asset.
@@ -290,7 +289,6 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 		numMasters, numWorkers,
 		osImage,
 		infraEnv.Spec.Proxy,
-		a.RendezvousIP,
 	)
 
 	err = bootstrap.AddStorageFiles(&config, "/", "agent/files", agentTemplateData)
@@ -410,7 +408,7 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseIm
 	haveMirrorConfig bool,
 	numMasters, numWorkers int,
 	osImage *models.OsImage,
-	proxy *v1beta1.Proxy, rendezvousIP string) *agentTemplateData {
+	proxy *v1beta1.Proxy) *agentTemplateData {
 	return &agentTemplateData{
 		ServiceProtocol:           "http",
 		PullSecret:                pullSecret,
@@ -431,7 +429,6 @@ func getTemplateData(name, pullSecret, releaseImageList, releaseImage, releaseIm
 		Token:                     token,
 		TokenExpiry:               tokenExpiry,
 		CaBundleMount:             caBundleMount,
-		RendezvousIP:              rendezvousIP,
 	}
 }
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -94,8 +94,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 
 	publicKey := "-----BEGIN EC PUBLIC KEY-----\nMHcCAQEEIOSCfDNmx0qe6dncV4tg==\n-----END EC PUBLIC KEY-----\n"
 	token := "someToken"
-	rendezvousIP := "192.168.111.80"
-	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy, rendezvousIP)
+	templateData := getTemplateData(clusterName, pullSecret, releaseImageList, releaseImage, releaseImageMirror, publicContainerRegistries, "minimal-iso", infraEnvID, publicKey, gencrypto.AuthType, token, "", "", haveMirrorConfig, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, osImage, proxy)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -112,7 +111,6 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, publicKey, templateData.PublicKeyPEM)
 	assert.Equal(t, gencrypto.AuthType, templateData.AuthType)
 	assert.Equal(t, token, templateData.Token)
-	assert.Equal(t, rendezvousIP, templateData.RendezvousIP)
 
 }
 

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -236,7 +236,7 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 				rendezvousIP = agentConfig.Config.RendezvousIP
 			}
 
-			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy, rendezvousIP))
+			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy, &installConfig.Config.Networking.MachineNetwork, rendezvousIP))
 		}
 
 		if installConfig.Config.Platform.BareMetal != nil {

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -131,6 +131,7 @@ func (*AgentClusterInstall) Dependencies() []asset.Asset {
 		&workflow.AgentWorkflow{},
 		&agent.OptionalInstallConfig{},
 		&agentconfig.AgentHosts{},
+		&agentconfig.AgentConfig{},
 	}
 }
 
@@ -141,7 +142,8 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 	agentWorkflow := &workflow.AgentWorkflow{}
 	installConfig := &agent.OptionalInstallConfig{}
 	agentHosts := &agentconfig.AgentHosts{}
-	dependencies.Get(agentWorkflow, agentHosts, installConfig)
+	agentConfig := &agentconfig.AgentConfig{}
+	dependencies.Get(agentWorkflow, agentHosts, installConfig, agentConfig)
 
 	// This manifest is not required for AddNodes workflow
 	if agentWorkflow.Workflow == workflow.AgentWorkflowTypeAddNodes {
@@ -229,7 +231,12 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 		}
 
 		if installConfig.Config.Proxy != nil {
-			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy))
+			rendezvousIP := ""
+			if agentConfig.Config != nil {
+				rendezvousIP = agentConfig.Config.RendezvousIP
+			}
+
+			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy, rendezvousIP))
 		}
 
 		if installConfig.Config.Platform.BareMetal != nil {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -40,10 +40,10 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	})
 
 	installConfigWithProxy := getValidOptionalInstallConfig()
-	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy))
+	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, ""))
 
 	goodProxyACI := getGoodACI()
-	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy))
+	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"))
 
 	goodACIDualStackVIPs := getGoodACIDualStack()
 	goodACIDualStackVIPs.Spec.APIVIPs = []string{"192.168.122.10", "2001:db8:1111:2222:ffff:ffff:ffff:cafe"}
@@ -150,6 +150,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				&agent.OptionalInstallConfig{},
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedError: "missing configuration or manifest file",
 		},
@@ -159,6 +160,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfig(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACI,
 		},
@@ -168,6 +170,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithoutNetworkType,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACI,
 		},
@@ -177,6 +180,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithFIPS,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodFIPSACI,
 		},
@@ -186,6 +190,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithProxy,
 				&agentconfig.AgentHosts{},
+				getValidAgentConfig(),
 			},
 			expectedConfig: goodProxyACI,
 		},
@@ -195,6 +200,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigDualStack(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: getGoodACIDualStack(),
 		},
@@ -204,6 +210,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigDualStackDualVIPs(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACIDualStackVIPs,
 		},
@@ -213,6 +220,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithCapabilities,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodCapabilitiesACI,
 		},
@@ -222,6 +230,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithNetworkOverride,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodNetworkOverrideACI,
 		},
@@ -231,6 +240,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithCPUPartitioning,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodCPUPartitioningACI,
 		},
@@ -240,6 +250,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWExternalPlatform,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodExternalPlatformACI,
 		},
@@ -249,6 +260,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWExternalOCIPlatform,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodExternalOCIPlatformACI,
 		},
@@ -258,6 +270,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigWithProvisioning(),
 				getAgentHostsWithBMCConfig(),
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodBaremetalPlatformBMCACI,
 		},

--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/types"
@@ -19,11 +21,20 @@ func getPullSecretName(clusterName string) string {
 	return clusterName + "-pull-secret"
 }
 
-func getProxy(proxy *types.Proxy) *aiv1beta1.Proxy {
+func getProxy(proxy *types.Proxy, rendezvousIP string) *aiv1beta1.Proxy {
+	// if proxy set add the rendezvousIP to noproxy
+	noProxy := proxy.NoProxy
+	if (proxy.HTTPProxy != "" || proxy.HTTPSProxy != "") && rendezvousIP != "" {
+		if noProxy == "" {
+			noProxy = rendezvousIP
+		} else {
+			noProxy = fmt.Sprintf("%s,%s", noProxy, rendezvousIP)
+		}
+	}
 	return &aiv1beta1.Proxy{
 		HTTPProxy:  proxy.HTTPProxy,
 		HTTPSProxy: proxy.HTTPSProxy,
-		NoProxy:    proxy.NoProxy,
+		NoProxy:    noProxy,
 	}
 }
 

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -65,7 +65,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		if installConfig.Config != nil {
-			err := i.generateManifest(installConfig.ClusterName(), installConfig.ClusterNamespace(), installConfig.Config.SSHKey, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy, string(installConfig.Config.ControlPlane.Architecture), rendezvousIP)
+			err := i.generateManifest(installConfig.ClusterName(), installConfig.ClusterNamespace(), installConfig.Config.SSHKey, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy, string(installConfig.Config.ControlPlane.Architecture), &installConfig.Config.Networking.MachineNetwork, rendezvousIP)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 		}
 
 	case workflow.AgentWorkflowTypeAddNodes:
-		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.UserCaBundle, clusterInfo.Proxy, clusterInfo.Architecture, rendezvousIP)
+		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.UserCaBundle, clusterInfo.Proxy, clusterInfo.Architecture, nil, rendezvousIP)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 	return i.finish()
 }
 
-func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, additionalTrustBundle string, proxy *types.Proxy, architecture, rendezvousIP string) error {
+func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, additionalTrustBundle string, proxy *types.Proxy, architecture string, machineNetwork *[]types.MachineNetworkEntry, rendezvousIP string) error {
 	infraEnv := &aiv1beta1.InfraEnv{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "InfraEnv",
@@ -122,7 +122,7 @@ func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, addit
 		infraEnv.Spec.AdditionalTrustBundle = additionalTrustBundle
 	}
 	if proxy != nil {
-		infraEnv.Spec.Proxy = getProxy(proxy, rendezvousIP)
+		infraEnv.Spec.Proxy = getProxy(proxy, machineNetwork, rendezvousIP)
 	}
 
 	i.Config = infraEnv

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -91,7 +91,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 					Namespace: getProxyValidOptionalInstallConfig().ClusterNamespace(),
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
-					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy),
+					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"),
 					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig().ClusterName()),
@@ -124,7 +124,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 					Namespace: getProxyValidOptionalInstallConfig().ClusterNamespace(),
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
-					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy),
+					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"),
 					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig().ClusterName()),

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -243,6 +243,12 @@ func getValidAgentConfig() *agentconfig.AgentConfig {
 	}
 }
 
+func getValidAgentConfigProxy() *agentconfig.AgentConfig {
+	agentConfig := getValidAgentConfig()
+	agentConfig.Config.RendezvousIP = "10.10.11.1"
+	return agentConfig
+}
+
 func getValidAgentHostsConfig() *agentconfig.AgentHosts {
 	return &agentconfig.AgentHosts{
 		Hosts: []agenttypes.Host{


### PR DESCRIPTION
If proxy is defined in install-config, add the MachineNetwork that contains the RendezvousIP to the noproxy field in the generated manifests to ensure the Rendezvous host can be accessed.

This is an additional fix beyond https://github.com/openshift/installer/pull/9083 as it was found that when just setting the IP in 10-default-env.conf it did not get passed to the assisted-installer when it was started.