### PR TITLE
OCPBUGS-44068: PowerVS: Fix MissingSecurityGroupRules

### DIFF
--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -207,11 +207,7 @@ func createLoadBalancerDNSRecords(ctx context.Context, in clusterapi.InfraReadyI
 
 func findMissingSecurityGroupRules(ctx context.Context, in clusterapi.InfraReadyInput, vpcID string) (sets.Set[int64], error) {
 	foundPorts := sets.Set[int64]{}
-	wantedPorts := sets.New[int64](22, 10258, 22623)
-
-	if in.InstallConfig.Config.Publish == types.InternalPublishingStrategy {
-		wantedPorts = wantedPorts.Insert(6443, 443, 5000)
-	}
+	wantedPorts := sets.New[int64](22, 443, 5000, 6443, 10258, 22623)
 
 	existingRules, err := in.InstallConfig.PowerVS.ListSecurityGroupRules(ctx, vpcID)
 	if err != nil {


### PR DESCRIPTION
When the user provides an existing VPC, the IBM CAPI will not add ports 443, 5000, and 6443 to the VPC's security group. It is safe to always check for these ports since we only add them if they are missing.