### PR TITLE
OCPBUGS-42670: Allow AdditionalTrustBundlePolicy to be set

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -357,12 +357,6 @@ func (a *OptionalInstallConfig) validateBMCConfig(installConfig *types.InstallCo
 }
 
 func warnUnusedConfig(installConfig *types.InstallConfig) {
-	// "Proxyonly" is the default set from generic install config code
-	if installConfig.AdditionalTrustBundlePolicy != "Proxyonly" {
-		fieldPath := field.NewPath("AdditionalTrustBundlePolicy")
-		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.AdditionalTrustBundlePolicy))
-	}
-
 	for i, compute := range installConfig.Compute {
 		if compute.Hyperthreading != "Enabled" {
 			fieldPath := field.NewPath(fmt.Sprintf("Compute[%d]", i), "Hyperthreading")

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -114,6 +114,8 @@ type agentClusterInstallInstallConfigOverrides struct {
 	Networking *types.Networking `json:"networking,omitempty"`
 	// Allow override of CPUPartitioning
 	CPUPartitioning types.CPUPartitioningMode `json:"cpuPartitioningMode,omitempty"`
+	// Allow override of AdditionalTrustBundlePolicy
+	AdditionalTrustBundlePolicy types.PolicyType `json:"additionalTrustBundlePolicy,omitempty"`
 }
 
 var _ asset.WritableAsset = (*AgentClusterInstall)(nil)
@@ -327,6 +329,11 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 		if installConfig.Config.CPUPartitioning != "" {
 			icOverridden = true
 			icOverrides.CPUPartitioning = installConfig.Config.CPUPartitioning
+		}
+
+		if installConfig.Config.AdditionalTrustBundlePolicy != "" && installConfig.Config.AdditionalTrustBundlePolicy != types.PolicyProxyOnly {
+			icOverridden = true
+			icOverrides.AdditionalTrustBundlePolicy = installConfig.Config.AdditionalTrustBundlePolicy
 		}
 
 		if icOverridden {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -129,6 +129,14 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 		installConfigOverrides: `{"platform":{"baremetal":{"hosts":[{"name":"control-0.example.org","bmc":{"username":"bmc-user","password":"password","address":"172.22.0.10","disableCertificateVerification":true},"role":"master","bootMACAddress":"98:af:65:a5:8d:01","hardwareProfile":""},{"name":"control-1.example.org","bmc":{"username":"user2","password":"foo","address":"172.22.0.11","disableCertificateVerification":false},"role":"master","bootMACAddress":"98:af:65:a5:8d:02","hardwareProfile":""},{"name":"control-2.example.org","bmc":{"username":"admin","password":"bar","address":"172.22.0.12","disableCertificateVerification":true},"role":"master","bootMACAddress":"98:af:65:a5:8d:03","hardwareProfile":""}],"clusterProvisioningIP":"172.22.0.3","provisioningNetwork":"Managed","provisioningNetworkInterface":"eth0","provisioningNetworkCIDR":"172.22.0.0/24","provisioningDHCPRange":"172.22.0.10,172.22.0.254"}}}`,
 	})
 
+	installConfigWithTrustBundlePolicy := getValidOptionalInstallConfig()
+	installConfigWithTrustBundlePolicy.Config.AdditionalTrustBundlePolicy = types.PolicyAlways
+
+	goodTrustBundlePolicyACI := getGoodACI()
+	goodTrustBundlePolicyACI.SetAnnotations(map[string]string{
+		installConfigOverrides: `{"additionalTrustBundlePolicy":"Always"}`,
+	})
+
 	cases := []struct {
 		name           string
 		dependencies   []asset.Asset
@@ -251,6 +259,15 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				getAgentHostsWithBMCConfig(),
 			},
 			expectedConfig: goodBaremetalPlatformBMCACI,
+		},
+		{
+			name: "valid configuration with AdditionalTrustBundlePolicy",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				installConfigWithTrustBundlePolicy,
+				&agentconfig.AgentHosts{},
+			},
+			expectedConfig: goodTrustBundlePolicyACI,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
For the agent-based installer, allow the setting of AdditionalTrustBundlePolicy via the install-config overrides.