### PR TITLE
MULTIARCH-5161: Power VS: Create VPEs as needed for Disconnected install

### DIFF
--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -97,7 +98,10 @@ func (m *Metadata) Generate(_ context.Context, parents asset.Parents) (err error
 	case vspheretypes.Name:
 		metadata.ClusterPlatformMetadata.VSphere = vsphere.Metadata(installConfig.Config)
 	case powervstypes.Name:
-		metadata.ClusterPlatformMetadata.PowerVS = powervs.Metadata(installConfig.Config, installConfig.PowerVS)
+		metadata.ClusterPlatformMetadata.PowerVS, err = powervs.Metadata(installConfig.Config, installConfig.PowerVS)
+		if err != nil {
+			return fmt.Errorf("failed to initialize PowerVS: %w", err)
+		}
 	case externaltypes.Name, nonetypes.Name:
 	case nutanixtypes.Name:
 		metadata.ClusterPlatformMetadata.Nutanix = nutanix.Metadata(installConfig.Config)

--- a/pkg/asset/cluster/powervs/powervs.go
+++ b/pkg/asset/cluster/powervs/powervs.go
@@ -10,9 +10,23 @@ import (
 )
 
 // Metadata converts an install configuration to PowerVS metadata.
-func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) *powervs.Metadata {
+func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) (*powervs.Metadata, error) {
 	cisCRN, _ := meta.CISInstanceCRN(context.TODO())
 	dnsCRN, _ := meta.DNSInstanceCRN(context.TODO())
+
+	overrides := config.Platform.PowerVS.ServiceEndpoints
+	if config.Publish == types.InternalPublishingStrategy &&
+		(len(config.ImageDigestSources) > 0 || len(config.DeprecatedImageContentSources) > 0) {
+		cosRegion, err := powervs.COSRegionForPowerVSRegion(config.PowerVS.Region)
+		if err != nil {
+			return nil, err
+		}
+		vpcRegion, err := powervs.VPCRegionForPowerVSRegion(config.PowerVS.Region)
+		if err != nil {
+			return nil, err
+		}
+		overrides = meta.SetDefaultPrivateServiceEndpoints(context.TODO(), overrides, cosRegion, vpcRegion)
+	}
 
 	return &powervs.Metadata{
 		BaseDomain:           config.BaseDomain,
@@ -23,7 +37,7 @@ func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) *powervs.Me
 		VPCRegion:            config.Platform.PowerVS.VPCRegion,
 		Zone:                 config.Platform.PowerVS.Zone,
 		ServiceInstanceGUID:  config.Platform.PowerVS.ServiceInstanceGUID,
-		ServiceEndpoints:     config.Platform.PowerVS.ServiceEndpoints,
+		ServiceEndpoints:     overrides,
 		TransitGatewayName:   config.Platform.PowerVS.TGName,
-	}
+	}, nil
 }

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -85,6 +85,9 @@ type API interface {
 
 	// Load Balancer
 	AddIPToLoadBalancerPool(ctx context.Context, lbID string, poolName string, port int64, ip string) error
+
+	// Virtual Private Endpoint Gateway
+	CreateVirtualPrivateEndpointGateway(ctx context.Context, name string, vpcID string, subnetID string, rgID string, targetCRN string) (*vpcv1.EndpointGateway, error)
 }
 
 // Client makes calls to the PowerVS API.
@@ -1458,4 +1461,74 @@ func (c *Client) AddIPToLoadBalancerPool(ctx context.Context, lbID string, poolN
 
 			return true, nil
 		})
+}
+
+// CreateVirtualPrivateEndpointGateway creates a VPE gateway with given target resource type and CRN.
+func (c *Client) CreateVirtualPrivateEndpointGateway(ctx context.Context, name string, vpcID string, subnetID string, rgID string, targetCRN string) (*vpcv1.EndpointGateway, error) {
+	var (
+		resp   *core.DetailedResponse
+		err    error
+		ok     bool
+		egs    *vpcv1.EndpointGatewayCollection
+		egRef  *vpcv1.EndpointGatewayTarget
+		idIntf *vpcv1.VPCIdentityByID
+		target *vpcv1.EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderCloudServicePrototype
+		rgIntf *vpcv1.ResourceGroupIdentityByID
+		ipIntf *vpcv1.EndpointGatewayReservedIPReservedIPIdentityByID
+	)
+
+	listOpts := c.vpcAPI.NewListEndpointGatewaysOptions()
+	listOpts.SetVPCID(vpcID)
+	egs, _, err = c.vpcAPI.ListEndpointGateways(listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, eg := range egs.EndpointGateways {
+		egRef, ok = eg.Target.(*vpcv1.EndpointGatewayTarget)
+		if !ok {
+			return nil, fmt.Errorf("invalid target inside returned EndpointGateway: %v", eg.Target)
+		}
+		if *egRef.CRN == targetCRN {
+			return &eg, nil
+		}
+	}
+
+	target, err = c.vpcAPI.NewEndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderCloudServicePrototype(targetCRN, vpcv1.EndpointGatewayTargetPrototypeResourceTypeProviderCloudServiceConst)
+	if err != nil {
+		return nil, err
+	}
+	idIntf, err = c.vpcAPI.NewVPCIdentityByID(vpcID)
+	if err != nil {
+		return nil, err
+	}
+	createOpts := c.vpcAPI.NewCreateEndpointGatewayOptions(target, idIntf)
+	createOpts.SetName(name)
+	createOpts.SetAllowDnsResolutionBinding(true)
+	rgIntf, err = c.vpcAPI.NewResourceGroupIdentityByID(rgID)
+	if err != nil {
+		return nil, err
+	}
+	createOpts.SetResourceGroup(rgIntf)
+	ipName := fmt.Sprintf("%s-ip", name)
+	createIPOpts := c.vpcAPI.NewCreateSubnetReservedIPOptions(subnetID)
+	createIPOpts.SetName(ipName)
+	createIPOpts.SetSubnetID(subnetID)
+	reservedIP, _, err := c.vpcAPI.CreateSubnetReservedIPWithContext(ctx, createIPOpts)
+	if err != nil {
+		return nil, err
+	}
+	ipIntf, err = c.vpcAPI.NewEndpointGatewayReservedIPReservedIPIdentityByID(*reservedIP.ID)
+	if err != nil {
+		return nil, err
+	}
+	ips := []vpcv1.EndpointGatewayReservedIPIntf{ipIntf}
+	createOpts.SetIps(ips)
+
+	eg, resp, err := c.vpcAPI.CreateEndpointGatewayWithContext(ctx, createOpts)
+	if err != nil {
+		logrus.Debugf("CreateEndpointGatewayWithContext returned %v", resp)
+		return nil, err
+	}
+	return eg, nil
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -125,6 +125,21 @@ func (mr *MockAPIMockRecorder) CreateSSHKey(ctx, serviceInstance, zone, sshKeyNa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSSHKey", reflect.TypeOf((*MockAPI)(nil).CreateSSHKey), ctx, serviceInstance, zone, sshKeyName, sshKey)
 }
 
+// CreateVirtualPrivateEndpointGateway mocks base method.
+func (m *MockAPI) CreateVirtualPrivateEndpointGateway(ctx context.Context, name, vpcID, subnetID, rgID, targetCRN string) (*vpcv1.EndpointGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVirtualPrivateEndpointGateway", ctx, name, vpcID, subnetID, rgID, targetCRN)
+	ret0, _ := ret[0].(*vpcv1.EndpointGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVirtualPrivateEndpointGateway indicates an expected call of CreateVirtualPrivateEndpointGateway.
+func (mr *MockAPIMockRecorder) CreateVirtualPrivateEndpointGateway(ctx, name, vpcID, subnetID, rgID, targetCRN interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualPrivateEndpointGateway", reflect.TypeOf((*MockAPI)(nil).CreateVirtualPrivateEndpointGateway), ctx, name, vpcID, subnetID, rgID, targetCRN)
+}
+
 // EnableDNSCustomResolver mocks base method.
 func (m *MockAPI) EnableDNSCustomResolver(ctx context.Context, dnsID, resolverID string) (*dnssvcsv1.CustomResolver, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -300,6 +300,11 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 			serviceGUID = installConfig.Config.PowerVS.ServiceInstanceGUID
 		}
 
+		cosRegion, err := powervstypes.COSRegionForPowerVSRegion(installConfig.Config.PowerVS.Region)
+		if err != nil {
+			return err
+		}
+
 		powervsConfig, err := powervsmanifests.CloudProviderConfig(
 			clusterID.InfraID,
 			accountID,
@@ -311,7 +316,7 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 			serviceName,
 			installConfig.Config.PowerVS.Region,
 			installConfig.Config.PowerVS.Zone,
-			installConfig.Config.PowerVS.ServiceEndpoints,
+			installConfig.PowerVS.SetDefaultPrivateServiceEndpoints(ctx, installConfig.Config.PowerVS.ServiceEndpoints, cosRegion, vpcRegion),
 		)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -311,6 +311,19 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 				URL:  service.URL,
 			})
 		}
+		if installConfig.Config.Publish == types.InternalPublishingStrategy &&
+			(len(installConfig.Config.ImageDigestSources) > 0 || len(installConfig.Config.DeprecatedImageContentSources) > 0) {
+			piRegion := installConfig.Config.PowerVS.Region
+			vpcRegion, err := powervs.VPCRegionForPowerVSRegion(piRegion)
+			if err != nil {
+				return fmt.Errorf("failed to determine VPC region: %w", err)
+			}
+			cosRegion, err := powervs.COSRegionForPowerVSRegion(piRegion)
+			if err != nil {
+				return fmt.Errorf("failed to determine COS region: %w", err)
+			}
+			config.Spec.PlatformSpec.PowerVS.ServiceEndpoints = installConfig.PowerVS.SetDefaultPrivateServiceEndpoints(ctx, config.Spec.PlatformSpec.PowerVS.ServiceEndpoints, cosRegion, vpcRegion)
+		}
 		config.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{
 			Region:           installConfig.Config.Platform.PowerVS.Region,
 			Zone:             installConfig.Config.Platform.PowerVS.Zone,

--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -344,8 +344,8 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 				"LOGLEVEL":           "2",
 			},
 		)
-		if cfg := metadata.PowerVS; cfg != nil && len(cfg.ServiceEndpoints) > 0 {
-			overrides := bxClient.FilterServiceEndpoints(cfg)
+		if cfg := metadata.PowerVS; cfg != nil {
+			overrides := bxClient.MapServiceEndpointsForCAPI(cfg)
 			if len(overrides) > 0 {
 				controller.Args = append(controller.Args, fmt.Sprintf("--service-endpoint=%s:%s", cfg.Region, strings.Join(overrides, ",")))
 			}


### PR DESCRIPTION
For Disconnected install on PowerVS, Virtual Private Endpoint Gateways (VPEs) must be created in the VPC that would be part of the infrastructure to allow traffic to the following private IBM Cloud endpoints;
- IAM
- COS (in the region)
- DNS services

Proposed code would first check if the necessary VPEs are already in place, comparing the target's CRN, and create one only when missing. 
Destroy logic for the below resources need to be developed (later);
- Reserved IPs (on the subnet)
- VPEs (in the VPC)