### PR TITLE
OCPBUGS-44167: Ensure rendezvousIP is checked against host IP

### DIFF
--- a/pkg/asset/agent/agentconfig/agenthosts.go
+++ b/pkg/asset/agent/agentconfig/agenthosts.go
@@ -201,8 +201,17 @@ func (a *AgentHosts) validateRendezvousIPNotWorker(rendezvousIP string, hosts []
 
 	if rendezvousIP != "" {
 		for i, host := range hosts {
+			if host.Role != workerRole {
+				continue
+			}
 			hostPath := field.NewPath("Hosts").Index(i)
-			if strings.Contains(string(host.NetworkConfig.Raw), rendezvousIP) && host.Role == workerRole {
+			hostIPs, err := agentAsset.GetAllHostIPs(host.NetworkConfig)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(hostPath, host.NetworkConfig, err.Error()))
+				continue
+			}
+			_, found := hostIPs[rendezvousIP]
+			if found {
 				errMsg := "Host " + host.Hostname + " has role 'worker' and has the rendezvousIP assigned to it. The rendezvousIP must be assigned to a control plane host."
 				allErrs = append(allErrs, field.Forbidden(hostPath.Child("Host"), errMsg))
 			}

--- a/pkg/asset/agent/agentconfig/agenthosts_test.go
+++ b/pkg/asset/agent/agentconfig/agenthosts_test.go
@@ -71,6 +71,36 @@ const (
   state: up
   type: ethernet
 `
+	agentNetworkConfigEmbeddedRendezvousIPOne = `interfaces:
+- ipv4:
+    address:
+    - ip: 192.168.111.1
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  mac-address: 28:d2:44:d2:b2:1b
+  name: eth0
+  state: up
+  type: ethernet
+`
+	agentNetworkConfigEmbeddedRendezvousIPTwo = `interfaces:
+- ipv4:
+    address:
+    - ip: 192.168.111.2
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  mac-address: 28:d2:44:d2:b2:1b
+  name: eth0
+  state: up
+  type: ethernet
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.111.126
+    next-hop-interface: eth0
+    table-id: 254
+`
 )
 
 func TestAgentHosts_Generate(t *testing.T) {
@@ -290,6 +320,18 @@ func TestAgentHosts_Generate(t *testing.T) {
 			expectedError:  "invalid Hosts configuration: [Hosts[0].Interfaces: Required value: at least one interface must be defined for each node, Hosts[1].Interfaces: Required value: at least one interface must be defined for each node, Hosts[2].Interfaces: Required value: at least one interface must be defined for each node]",
 			expectedConfig: nil,
 		},
+		{
+			name: "rendezvousip-in-worker-config",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.AddNodesConfig{},
+				getNoHostsInstallConfig(),
+				getAgentConfigMultiHostEmbeddedRendezvousIP(),
+			},
+			expectedConfig: agentHosts().hosts(
+				agentHost().name("test").role("master").interfaces(iface("enp3s1", "28:d2:44:d2:b2:1a")).deviceHint().networkConfig(agentNetworkConfigEmbeddedRendezvousIPOne),
+				agentHost().name("test-2").role("worker").interfaces(iface("enp3s1", "28:d2:44:d2:b2:1b")).networkConfig(agentNetworkConfigEmbeddedRendezvousIPTwo)),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -414,6 +456,14 @@ func getAgentConfigMultiHost() *AgentConfig {
 		},
 	}
 	a.Config.Hosts = append(a.Config.Hosts, host)
+	return a
+}
+
+func getAgentConfigMultiHostEmbeddedRendezvousIP() *AgentConfig {
+	a := getAgentConfigMultiHost()
+	a.Config.RendezvousIP = "192.168.111.1"
+	a.Config.Hosts[0].NetworkConfig.Raw = []byte(agentNetworkConfigEmbeddedRendezvousIPOne)
+	a.Config.Hosts[1].NetworkConfig.Raw = []byte(agentNetworkConfigEmbeddedRendezvousIPTwo)
 	return a
 }
 

--- a/pkg/asset/agent/common.go
+++ b/pkg/asset/agent/common.go
@@ -1,16 +1,35 @@
 package agent
 
 import (
+	"fmt"
+
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/external"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
+
+type nmStateConfig struct {
+	Interfaces []struct {
+		IPV4 struct {
+			Address []struct {
+				IP string `yaml:"ip,omitempty"`
+			} `yaml:"address,omitempty"`
+		} `yaml:"ipv4,omitempty"`
+		IPV6 struct {
+			Address []struct {
+				IP string `yaml:"ip,omitempty"`
+			} `yaml:"address,omitempty"`
+		} `yaml:"ipv6,omitempty"`
+	} `yaml:"interfaces,omitempty"`
+}
 
 const (
 	// ExternalPlatformNameOci is the name of the external platform for OCP.
@@ -98,4 +117,53 @@ func GetUserManagedNetworkingByPlatformType(platformType hiveext.PlatformType) *
 	default:
 		return swag.Bool(false)
 	}
+}
+
+// GetFirstIP returns the firt IP found in the nmstate configuration for this host.
+func GetFirstIP(nmstateRaw []byte) (string, error) {
+	var nmStateConfig nmStateConfig
+	err := yaml.Unmarshal(nmstateRaw, &nmStateConfig)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling NMStateConfig: %w", err)
+	}
+
+	for _, intf := range nmStateConfig.Interfaces {
+		for _, addr4 := range intf.IPV4.Address {
+			if addr4.IP != "" {
+				return addr4.IP, nil
+			}
+		}
+		for _, addr6 := range intf.IPV6.Address {
+			if addr6.IP != "" {
+				return addr6.IP, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// GetAllHostIPs returns a map of host IPs from the nmstate configuration for this host.
+func GetAllHostIPs(config aiv1beta1.NetConfig) (map[string]struct{}, error) {
+	var nmStateConfig nmStateConfig
+	hostIPs := make(map[string]struct{})
+
+	err := yaml.Unmarshal(config.Raw, &nmStateConfig)
+	if err != nil {
+		return hostIPs, fmt.Errorf("error unmarshalling NMStateConfig: %w", err)
+	}
+
+	for _, intf := range nmStateConfig.Interfaces {
+		for _, addr4 := range intf.IPV4.Address {
+			if addr4.IP != "" {
+				hostIPs[addr4.IP] = struct{}{}
+			}
+		}
+		for _, addr6 := range intf.IPV6.Address {
+			if addr6.IP != "" {
+				hostIPs[addr6.IP] = struct{}{}
+			}
+		}
+	}
+	return hostIPs, nil
 }


### PR DESCRIPTION
The rendezvousIP is currently checked against any substring in the nmstate configuration which can result in validation failure if the next-hop-address matches the rendezvousIP. Ensure that the check is against the host IP.