### PR TITLE
NO-ISSUE: Add mresvanis to imagebased approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -171,3 +171,4 @@ aliases:
     - patrickdillon
     - tsorya
     - zaneb
+    - mresvanis


### PR DESCRIPTION
This change adds `mresvanis` to the `imagebased` installer approvers.