### PR TITLE
OCPBUGS-44193: move GCP zone filtering client-side

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -119,7 +119,7 @@ func (c *Client) GetMachineTypeWithZones(ctx context.Context, project, region, m
 		return nil, nil, err
 	}
 
-	pz, err := GetZones(ctx, svc, project, fmt.Sprintf("region eq .*%s", region))
+	pz, err := GetZones(ctx, svc, project, region)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -379,34 +379,33 @@ func (c *Client) GetRegions(ctx context.Context, project string) ([]string, erro
 	return computeRegions, nil
 }
 
-// GetZones uses the GCP Compute Service API to get a list of zones from a project.
-func GetZones(ctx context.Context, svc *compute.Service, project, filter string) ([]*compute.Zone, error) {
+// GetZones uses the GCP Compute Service API to get a list of zones with UP status in a region from a project.
+func GetZones(ctx context.Context, svc *compute.Service, project, region string) ([]*compute.Zone, error) {
 	req := svc.Zones.List(project)
-	if filter != "" {
-		req = req.Filter(filter)
-	}
-
 	zones := []*compute.Zone{}
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	if err := req.Pages(ctx, func(page *compute.ZoneList) error {
-		zones = append(zones, page.Items...)
+		for _, zone := range page.Items {
+			if strings.HasSuffix(zone.Region, region) && strings.EqualFold(zone.Status, "UP") {
+				zones = append(zones, zone)
+			}
+		}
 		return nil
 	}); err != nil {
 		return nil, errors.Wrapf(err, "failed to get zones from project %s", project)
 	}
-
 	return zones, nil
 }
 
 // GetZones uses the GCP Compute Service API to get a list of zones from a project.
-func (c *Client) GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error) {
+func (c *Client) GetZones(ctx context.Context, project, region string) ([]*compute.Zone, error) {
 	svc, err := c.getComputeService(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return GetZones(ctx, svc, project, filter)
+	return GetZones(ctx, svc, project, region)
 }
 
 func (c *Client) getCloudResourceService(ctx context.Context) (*cloudresourcemanager.Service, error) {

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -590,7 +590,7 @@ func ValidateCredentialMode(client API, ic *types.InstallConfig) field.ErrorList
 func validateZones(client API, ic *types.InstallConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	zones, err := client.GetZones(context.TODO(), ic.GCP.ProjectID, fmt.Sprintf("region eq .*%s", ic.GCP.Region))
+	zones, err := client.GetZones(context.TODO(), ic.GCP.ProjectID, ic.GCP.Region)
 	if err != nil {
 		return append(allErrs, field.InternalError(nil, err))
 	} else if len(zones) == 0 {

--- a/pkg/asset/machines/gcp/zones.go
+++ b/pkg/asset/machines/gcp/zones.go
@@ -29,10 +29,7 @@ func AvailabilityZones(project, region string) ([]string, error) {
 		return nil, errors.Wrap(err, "failed to create compute service")
 	}
 
-	regionURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s",
-		project, region)
-	filter := fmt.Sprintf("(region eq %s) (status eq UP)", regionURL)
-	zones, err := gcpconfig.GetZones(ctx, svc, project, filter)
+	zones, err := gcpconfig.GetZones(ctx, svc, project, region)
 	if err != nil {
 		return nil, errors.New("no zone was found")
 	}
@@ -64,7 +61,7 @@ func ZonesForInstanceType(project, region, instanceType string) ([]string, error
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	pZones, err := gcpconfig.GetZones(ctx, svc, project, fmt.Sprintf("(region eq .*%s) (status eq UP)", region))
+	pZones, err := gcpconfig.GetZones(ctx, svc, project, region)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zones for project: %w", err)
 	}


### PR DESCRIPTION
This commit removes GCP server-side filtering when listing zones. GCP imposes a "filtered list cost overhead quota" which limits the amount of server-side filtering we can utilize. More information can be found here:

https://cloud.google.com/compute/api-quota

We have seen CI jobs failing due to:

> level=fatal msg=failed to fetch Cluster API Machine Manifests: failed to generate asset "Cluster API Machine Manifests": failed to fetch availability zones: failed to get zones for project: failed to get zones from project XXXXXXXXXXXXXXXXXXXXXXXX: googleapi: Error 403: Quota exceeded for quota metric 'Filtered list cost overhead' and limit 'Filtered list cost overhead per minute' of service 'compute.googleapis.com' for consumer 'project_number:711936183532'.


GCP recommends utilizing client-side filters to resolve this: https://cloud.google.com/compute/docs/api/best-practices#client-side-filter