### PR TITLE
OCPBUGS-44171: Validate aws userTags when supplied

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -74,17 +74,8 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 		allErrs = append(allErrs, field.TooMany(fldPath, len(tags), userTagLimit))
 	}
 	for key, value := range tags {
-		if strings.EqualFold(key, "Name") {
-			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Name key is not allowed for user defined tags"))
-		}
-		if propagatingTags {
-			if err := validateTag(key, value); err != nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Key(key), value, err.Error()))
-			}
-		} else {
-			if strings.HasPrefix(key, "kubernetes.io/cluster/") {
-				allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags"))
-			}
+		if err := validateTag(key, value); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), value, err.Error()))
 		}
 	}
 	return allErrs
@@ -99,6 +90,9 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 //   - The key is not in the kubernetes.io namespace.
 //   - The key is not in the openshift.io namespace.
 func validateTag(key, value string) error {
+	if strings.EqualFold(key, "Name") {
+		return fmt.Errorf("\"Name\" key is not allowed for user defined tags")
+	}
 	if !tagRegex.MatchString(key) {
 		return fmt.Errorf("key contains invalid characters")
 	}

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -148,7 +148,7 @@ func TestValidatePlatform(t *testing.T) {
 					"Name": "test-cluster",
 				},
 			},
-			expected: `^\Qtest-path.userTags[Name]: Invalid value: "test-cluster": Name key is not allowed for user defined tags\E$`,
+			expected: `^\Qtest-path.userTags[Name]: Invalid value: "test-cluster": "Name" key is not allowed for user defined tags\E$`,
 		},
 		{
 			name: "invalid userTags, key with kubernetes.io/cluster/",
@@ -159,6 +159,16 @@ func TestValidatePlatform(t *testing.T) {
 				},
 			},
 			expected: `^\Qtest-path.userTags[kubernetes.io/cluster/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags\E$`,
+		},
+		{
+			name: "invalid userTags, value with invalid characters",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"usage-user": "cloud-team-rebase-bot[bot]",
+				},
+			},
+			expected: `^\Qtest-path.userTags[usage-user]: Invalid value: "cloud-team-rebase-bot[bot]": value contains invalid characters`,
 		},
 		{
 			name: "valid userTags",


### PR DESCRIPTION
** AWS User tags support white space as valid characters. 
** User tags should be validated every time that they are supplied not only when propagateTags is True.