### PR TITLE
AGENT-967: Improve monitoring output for multi-node

### DIFF
--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -37,7 +37,7 @@ func nodeJoiner() error {
 	}
 
 	nodesMonitorCmd := &cobra.Command{
-		Use:   "monitor-add-nodes",
+		Use:   "monitor-add-nodes <ip-addresses>",
 		Short: "Monitors the configured nodes while they are joining an existing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir, err := cmd.Flags().GetString("dir")

--- a/pkg/agent/logging.go
+++ b/pkg/agent/logging.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Constants representing logging levels.
+const (
+	Debug   = "Debug"
+	Info    = "Info"
+	Warning = "Warning"
+	Trace   = "Trace"
+	Error   = "Error"
+)
+
+const (
+	logInterval = 5
+)
+
+type logEntry struct {
+	level   string
+	message string
+}
+
+// Uses logger if ch is nil.
+func log(level, message string, logger *logrus.Logger, ch chan logEntry) {
+	if ch != nil {
+		ch <- logEntry{level: level, message: message}
+	} else {
+		switch level {
+		case Debug:
+			logger.Debug(message)
+		case Info:
+			logger.Info(message)
+		case Warning:
+			logger.Warn(message)
+		case Trace:
+			logger.Trace(message)
+		}
+	}
+}
+
+func printChannelLogs(ip string, ch chan logEntry) {
+	for len(ch) > 0 {
+		entry := <-ch
+		message := fmt.Sprintf("Node %s: %s", ip, entry.message)
+		switch entry.level {
+		case Debug:
+			logrus.Debug(message)
+		case Info:
+			logrus.Info(message)
+		case Warning:
+			logrus.Warn(message)
+		default:
+			logrus.Info(message)
+		}
+	}
+}
+
+func printLogs(wg *sync.WaitGroup, ipChanMap map[string]chan logEntry) {
+	defer wg.Done()
+	for {
+		if len(ipChanMap) == 0 {
+			// no IPs to monitor or all channels are closed, exit loop
+			break
+		}
+		for ip, ch := range ipChanMap {
+			if len(ch) == 0 {
+				// check if channel is closed
+				_, ok := <-ch
+				if !ok {
+					// channel is closed, remove IP from map to stop checking for logs
+					delete(ipChanMap, ip)
+				}
+			}
+			printChannelLogs(ip, ch)
+		}
+		time.Sleep(logInterval * time.Second)
+	}
+}

--- a/pkg/agent/monitoraddnodes_test.go
+++ b/pkg/agent/monitoraddnodes_test.go
@@ -48,7 +48,7 @@ func TestDecodedFirstCSRSubjectContainsHostname(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			containsHostname := containsHostname(decodedFirstCSRSubject([]byte(tt.request)), tt.hostnames)
+			containsHostname := containsHostname(decodedFirstCSRSubject([]byte(tt.request), nil), tt.hostnames)
 			assert.Equal(t, tt.expectedResult, containsHostname)
 		})
 	}
@@ -154,7 +154,7 @@ func TestFilterCSRsMatchingHostnames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filteredCSRs := filterCSRsMatchingHostname(tt.signerName, tt.csrs, tt.hostnames)
+			filteredCSRs := filterCSRsMatchingHostname(tt.signerName, tt.csrs, tt.hostnames, nil)
 			assert.Equal(t, tt.expectedResult, filteredCSRs)
 		})
 	}

--- a/pkg/agent/validations.go
+++ b/pkg/agent/validations.go
@@ -34,23 +34,20 @@ type validationResultHistory struct {
 	previousMessage string
 }
 
-func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger, logPrefix string) error {
+func checkValidations(cluster *models.Cluster, validationResults *validationResults, log *logrus.Logger, ch chan logEntry) error {
 	clusterLogPrefix := "Cluster validation: "
-	updatedClusterValidationHistory, err := updateValidationResultHistory(clusterLogPrefix, cluster.ValidationsInfo, validationResults.ClusterValidationHistory, log)
+	updatedClusterValidationHistory, err := updateValidationResultHistory(clusterLogPrefix, cluster.ValidationsInfo, validationResults.ClusterValidationHistory, log, ch)
 	if err != nil {
 		return err
 	}
 	validationResults.ClusterValidationHistory = updatedClusterValidationHistory
 
 	for _, h := range cluster.Hosts {
-		hostLogPrefix := logPrefix
-		if hostLogPrefix == "" {
-			hostLogPrefix = "Host " + h.RequestedHostname + " validation: "
-		}
+		hostLogPrefix := "Host " + h.RequestedHostname + " validation: "
 		if _, ok := validationResults.HostValidationHistory[h.RequestedHostname]; !ok {
 			validationResults.HostValidationHistory[h.RequestedHostname] = make(map[string]*validationResultHistory)
 		}
-		updatedHostValidationHistory, err := updateValidationResultHistory(hostLogPrefix, h.ValidationsInfo, validationResults.HostValidationHistory[h.RequestedHostname], log)
+		updatedHostValidationHistory, err := updateValidationResultHistory(hostLogPrefix, h.ValidationsInfo, validationResults.HostValidationHistory[h.RequestedHostname], log, ch)
 		if err != nil {
 			return err
 		}
@@ -59,8 +56,7 @@ func checkValidations(cluster *models.Cluster, validationResults *validationResu
 	return nil
 }
 
-func updateValidationResultHistory(logPrefix string, validationsInfoString string, validationHistory map[string]*validationResultHistory, log *logrus.Logger) (map[string]*validationResultHistory, error) {
-
+func updateValidationResultHistory(logPrefix string, validationsInfoString string, validationHistory map[string]*validationResultHistory, log *logrus.Logger, ch chan logEntry) (map[string]*validationResultHistory, error) {
 	if validationsInfoString == "" {
 		return validationHistory, nil
 	}
@@ -85,23 +81,23 @@ func updateValidationResultHistory(logPrefix string, validationsInfoString strin
 			case validationFailure, validationError:
 				validationHistory[r.ID].numFailures++
 			}
-			logValidationHistory(logPrefix, validationHistory[r.ID], log)
+			logValidationHistory(logPrefix, validationHistory[r.ID], log, ch)
 		}
 	}
 	return validationHistory, nil
 }
 
-func logValidationHistory(logPrefix string, history *validationResultHistory, log *logrus.Logger) {
+func logValidationHistory(logPrefix string, history *validationResultHistory, logger *logrus.Logger, ch chan logEntry) {
 	// First time we print something
 	if !history.seen {
 		history.seen = true
 		switch history.currentStatus {
 		case validationSuccess:
-			log.Debug(logPrefix + history.currentMessage)
+			log(Debug, logPrefix+history.currentMessage, logger, ch)
 		case validationFailure, validationError:
-			log.Warning(logPrefix + history.currentMessage)
+			log(Warning, logPrefix+history.currentMessage, logger, ch)
 		default:
-			log.Trace(logPrefix + history.currentMessage)
+			log(Trace, logPrefix+history.currentMessage, logger, ch)
 		}
 		return
 	}
@@ -110,12 +106,12 @@ func logValidationHistory(logPrefix string, history *validationResultHistory, lo
 		switch history.currentStatus {
 		case validationSuccess:
 			if history.previousStatus == validationError || history.previousStatus == validationFailure {
-				log.Info(logPrefix + history.currentMessage)
+				log(Info, logPrefix+history.currentMessage, logger, ch)
 			}
 		case validationFailure, validationError:
-			log.Warning(logPrefix + history.currentMessage)
+			log(Warning, logPrefix+history.currentMessage, logger, ch)
 		default:
-			log.Trace(logPrefix + history.currentMessage)
+			log(Trace, logPrefix+history.currentMessage, logger, ch)
 		}
 	}
 }

--- a/pkg/agent/validations_test.go
+++ b/pkg/agent/validations_test.go
@@ -179,8 +179,9 @@ func TestUpdateValidationHistory(t *testing.T) {
 				Hooks:     make(logrus.LevelHooks),
 				Level:     logrus.DebugLevel,
 			}
-			actualResult, _ := updateValidationResultHistory(testLogPrefix, tt.validationsInfo, tt.inputHistory, logger)
+			actualResult, err := updateValidationResultHistory(testLogPrefix, tt.validationsInfo, tt.inputHistory, logger, nil)
 			assert.Equal(t, tt.expectedResult, actualResult)
+			assert.Nil(t, err)
 		})
 	}
 }
@@ -299,7 +300,7 @@ func TestLogValidationHistory(t *testing.T) {
 			}
 			var hook = test.NewLocal(logger)
 
-			logValidationHistory(testLogPrefix, tt.inputHistory, logger)
+			logValidationHistory(testLogPrefix, tt.inputHistory, logger, nil)
 			actualResult := hook.LastEntry()
 
 			if actualResult == nil {


### PR DESCRIPTION
Monitoring output are now batched and displayed every 5 seconds for each node. This makes the logs easier to read because the logs for each node are more likely to be grouped together.