### PR TITLE
WIP OCPBUGS-44193: Limit the number of times filters are used in GCP destroy

### DIFF
--- a/pkg/destroy/gcp/bucketobject.go
+++ b/pkg/destroy/gcp/bucketobject.go
@@ -8,12 +8,6 @@ import (
 )
 
 func (o *ClusterUninstaller) listBucketObjects(ctx context.Context, bucket cloudResource) ([]cloudResource, error) {
-	resources := o.getPendingItems(bucketObjectResourceName)
-	if len(resources) > 0 || o.destroyedResources.Has(bucketObjectResourceName) {
-		o.Logger.Debugf("found cloud resources for %s, skipping the api call with a filter", bucketObjectResourceName)
-		return resources, nil
-	}
-
 	o.Logger.Debugf("Listing objects for storage bucket %s", bucket.name)
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
@@ -33,6 +27,7 @@ func (o *ClusterUninstaller) listBucketObjects(ctx context.Context, bucket cloud
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch objects for bucket %s", bucket.name)
 	}
+	o.filteredResources.Insert(bucketObjectResourceName)
 	return result, nil
 }
 

--- a/pkg/destroy/gcp/forwardingrule.go
+++ b/pkg/destroy/gcp/forwardingrule.go
@@ -11,95 +11,83 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
-func (o *ClusterUninstaller) listForwardingRules(ctx context.Context, scope resourceScope) ([]cloudResource, error) {
-	return o.listForwardingRulesWithFilter(ctx, "items(name,region,loadBalancingScheme),nextPageToken", o.clusterIDFilter(), nil, scope)
-}
+const (
+	globalForwardingRuleResourceName = "forwardingrule"
+	regionForwardingRuleResourceName = "regionforwardingrule"
+)
 
-func createForwardingRuleResources(filterFunc func(*compute.ForwardingRule) bool, list *compute.ForwardingRuleList) []cloudResource {
-	result := []cloudResource{}
-
-	for _, item := range list.Items {
-		if filterFunc == nil || filterFunc(item) {
-			logrus.Debugf("Found forwarding rule: %s", item.Name)
-			var quota []gcp.QuotaUsage
-			if item.LoadBalancingScheme == "EXTERNAL" {
-				quota = []gcp.QuotaUsage{{
-					Metric: &gcp.Metric{
-						Service: gcp.ServiceComputeEngineAPI,
-						Limit:   "external_network_lb_forwarding_rules",
-						Dimensions: map[string]string{
-							"region": getNameFromURL("regions", item.Region),
-						},
-					},
-					Amount: 1,
-				}}
-			}
-			result = append(result, cloudResource{
-				key:      item.Name,
-				name:     item.Name,
-				typeName: "forwardingrule",
-				quota:    quota,
-			})
-		}
+func (o *ClusterUninstaller) listForwardingRules(ctx context.Context, typeName string) ([]cloudResource, error) {
+	resources, err := o.listForwardingRulesWithFilter(ctx, typeName, "items(name,region,loadBalancingScheme),nextPageToken", o.clusterIDFilter())
+	if err == nil {
+		o.filteredResources.Insert(typeName)
 	}
-
-	return result
+	return resources, err
 }
 
 // listForwardingRulesWithFilter lists forwarding rules in the project that satisfy the filter criteria.
 // The fields parameter specifies which fields should be returned in the result, the filter string contains
 // a filter string passed to the API to filter results. The filterFunc is a client-side filtering function
 // that determines whether a particular result should be returned or not.
-func (o *ClusterUninstaller) listForwardingRulesWithFilter(ctx context.Context, fields string, filter string, filterFunc func(*compute.ForwardingRule) bool, scope resourceScope) ([]cloudResource, error) {
-	o.Logger.Debugf("Listing %s forwarding rules", scope)
+func (o *ClusterUninstaller) listForwardingRulesWithFilter(ctx context.Context, typeName, fields, filter string) ([]cloudResource, error) {
+	o.Logger.Debugf("Listing forwarding rules")
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	result := []cloudResource{}
-
-	if scope == gcpGlobalResource {
-		req := o.computeSvc.GlobalForwardingRules.List(o.ProjectID).Fields(googleapi.Field(fields))
-		if len(filter) > 0 {
-			req = req.Filter(filter)
-		}
-		err := req.Pages(ctx, func(list *compute.ForwardingRuleList) error {
-			result = append(result, createForwardingRuleResources(filterFunc, list)...)
-			return nil
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to list global forwarding rules: %w", err)
-		}
-
-		return result, nil
+	var err error
+	var list *compute.ForwardingRuleList
+	switch typeName {
+	case globalForwardingRuleResourceName:
+		list, err = o.computeSvc.GlobalForwardingRules.List(o.ProjectID).Filter(filter).Fields(googleapi.Field(fields)).Context(ctx).Do()
+	case regionForwardingRuleResourceName:
+		list, err = o.computeSvc.ForwardingRules.List(o.ProjectID, o.Region).Filter(filter).Fields(googleapi.Field(fields)).Context(ctx).Do()
+	default:
+		return nil, fmt.Errorf("invalid forwarding rule type %q", typeName)
 	}
-
-	// Regional forwarding rules
-	req := o.computeSvc.ForwardingRules.List(o.ProjectID, o.Region).Fields(googleapi.Field(fields))
-	if len(filter) > 0 {
-		req = req.Filter(filter)
-	}
-	err := req.Pages(ctx, func(list *compute.ForwardingRuleList) error {
-		result = append(result, createForwardingRuleResources(filterFunc, list)...)
-		return nil
-	})
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to list regional forwarding rules: %w", err)
+		return nil, fmt.Errorf("failed to list forwarding rules: %w", err)
+	}
+
+	result := []cloudResource{}
+	for _, item := range list.Items {
+		logrus.Debugf("Found forwarding rule: %s", item.Name)
+		var quota []gcp.QuotaUsage
+		if item.LoadBalancingScheme == "EXTERNAL" {
+			quota = []gcp.QuotaUsage{{
+				Metric: &gcp.Metric{
+					Service: gcp.ServiceComputeEngineAPI,
+					Limit:   "external_network_lb_forwarding_rules",
+					Dimensions: map[string]string{
+						"region": getNameFromURL("regions", item.Region),
+					},
+				},
+				Amount: 1,
+			}}
+		}
+		result = append(result, cloudResource{
+			key:      item.Name,
+			name:     item.Name,
+			typeName: typeName,
+			quota:    quota,
+		})
 	}
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteForwardingRule(ctx context.Context, item cloudResource, scope resourceScope) error {
-	o.Logger.Debugf("Deleting %s forwarding rule %s", scope, item.name)
+func (o *ClusterUninstaller) deleteForwardingRule(ctx context.Context, item cloudResource) error {
+	o.Logger.Debugf("Deleting forwarding rule %s", item.name)
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	var op *compute.Operation
 	var err error
-	if scope == gcpGlobalResource {
+	var op *compute.Operation
+	switch item.typeName {
+	case globalForwardingRuleResourceName:
 		op, err = o.computeSvc.GlobalForwardingRules.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	} else {
+	case regionForwardingRuleResourceName:
 		op, err = o.computeSvc.ForwardingRules.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+	default:
+		return fmt.Errorf("invalid forwarding rule type %q", item.typeName)
 	}
 
 	if err != nil && !isNoOp(err) {
@@ -121,25 +109,46 @@ func (o *ClusterUninstaller) deleteForwardingRule(ctx context.Context, item clou
 // destroyForwardingRules removes all forwarding rules with a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyForwardingRules(ctx context.Context) error {
-	for _, scope := range []resourceScope{gcpRegionalResource, gcpGlobalResource} {
-		found, err := o.listForwardingRules(ctx, scope)
+	items := []cloudResource{}
+
+	if cachedResources, ok := o.findCachedResources(globalForwardingRuleResourceName); !ok {
+		found, err := o.listForwardingRules(ctx, globalForwardingRuleResourceName)
 		if err != nil {
-			return fmt.Errorf("failed to list forwarding rules: %w", err)
+			return err
 		}
-		items := o.insertPendingItems("forwardingrule", found)
-		for _, item := range items {
-			if err := o.deleteForwardingRule(ctx, item, scope); err != nil {
-				o.Logger.Errorf("error deleting forwarding rule %s: %w", item.name, err)
-				o.errorTracker.suppressWarning(item.key, err, o.Logger)
-			}
+		items = o.insertPendingItems(globalForwardingRuleResourceName, found)
+	} else {
+		items = append(items, cachedResources...)
+	}
+
+	if cachedResources, ok := o.findCachedResources(regionForwardingRuleResourceName); !ok {
+		found, err := o.listForwardingRules(ctx, regionForwardingRuleResourceName)
+		if err != nil {
+			return err
 		}
-		if items = o.getPendingItems("forwardingrule"); len(items) > 0 {
-			for _, item := range items {
-				if err := o.deleteForwardingRule(ctx, item, scope); err != nil {
-					return fmt.Errorf("error deleting pending forwarding rule %s: %w", item.name, err)
-				}
-			}
+		items = append(items, o.insertPendingItems(regionForwardingRuleResourceName, found)...)
+	} else {
+		items = append(items, cachedResources...)
+	}
+
+	for _, item := range items {
+		err := o.deleteForwardingRule(ctx, item)
+		if err != nil {
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
+
+	if items = o.getPendingItems(globalForwardingRuleResourceName); len(items) > 0 {
+		return fmt.Errorf("%d global forwarding rules pending", len(items))
+	}
+	o.Logger.Debugf("Adding Destroyed Resource %s", globalForwardingRuleResourceName)
+	o.destroyedResources.Insert(globalForwardingRuleResourceName)
+
+	if items = o.getPendingItems(regionForwardingRuleResourceName); len(items) > 0 {
+		return fmt.Errorf("%d regional forwarding rules pending", len(items))
+	}
+	o.Logger.Debugf("Adding Destroyed Resource %s", regionForwardingRuleResourceName)
+	o.destroyedResources.Insert(regionForwardingRuleResourceName)
+
 	return nil
 }

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/storage/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
@@ -78,6 +79,8 @@ type ClusterUninstaller struct {
 	errorTracker
 	requestIDTracker
 	pendingItemTracker
+
+	destroyedResources sets.Set[string]
 }
 
 // New returns a GCP destroyer from ClusterMetadata.
@@ -153,6 +156,8 @@ func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create filestore service: %w", err)
 	}
+
+	o.destroyedResources = sets.Set[string]{}
 
 	err = wait.PollImmediateInfinite(
 		time.Second*10,

--- a/pkg/destroy/gcp/targetTCPProxies.go
+++ b/pkg/destroy/gcp/targetTCPProxies.go
@@ -14,6 +14,11 @@ const (
 )
 
 func (o *ClusterUninstaller) listTargetTCPProxies(ctx context.Context, typeName string) ([]cloudResource, error) {
+	resources := o.getPendingItems(typeName)
+	if len(resources) > 0 || o.destroyedResources.Has(typeName) {
+		o.Logger.Debugf("found cloud resources for %s, skipping the api call with a filter", typeName)
+		return resources, nil
+	}
 	return o.listTargetTCPProxiesWithFilter(ctx, typeName, "items(name),nextPageToken", o.clusterIDFilter())
 }
 
@@ -89,6 +94,8 @@ func (o *ClusterUninstaller) destroyTargetTCPProxies(ctx context.Context) error 
 	if items = o.getPendingItems(globalTargetTCPProxyResource); len(items) > 0 {
 		return fmt.Errorf("%d global target tcp proxy pending", len(items))
 	}
+	o.Logger.Warnf("Adding Destroyed Resource %s", globalTargetTCPProxyResource)
+	o.destroyedResources.Insert(globalTargetTCPProxyResource)
 
 	return nil
 }


### PR DESCRIPTION
** The GCP destroy code is making requests with filters far too often. This is causing larger projects to reach quota limits.
** Using a cache system to skip filtered queries when we already gathered resources.