### PR TITLE
OSASINFRA-3730: Add support for storing OpenStack CA bundles

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -16,8 +16,8 @@ data:
 {{- else if .CloudCreds.IBMCloud}}
   ibmcloud_api_key: {{.CloudCreds.IBMCloud.Base64encodeAPIKey}}
 {{- else if .CloudCreds.OpenStack}}
-  clouds.yaml: {{.CloudCreds.OpenStack.Base64encodeCloudCreds}}
-  clouds.conf: {{.CloudCreds.OpenStack.Base64encodeCloudCredsINI}}
+  clouds.yaml: {{.CloudCreds.OpenStack.Base64encodeCloudsYAML}}
+  clouds.conf: {{.CloudCreds.OpenStack.Base64encodeCloudsConf}}
 {{- else if .CloudCreds.VSphere}}
 {{- range .CloudCreds.VSphere}}
   {{.VCenter}}.username: {{.Base64encodeUsername}}

--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -18,6 +18,9 @@ data:
 {{- else if .CloudCreds.OpenStack}}
   clouds.yaml: {{.CloudCreds.OpenStack.Base64encodeCloudsYAML}}
   clouds.conf: {{.CloudCreds.OpenStack.Base64encodeCloudsConf}}
+{{- if .CloudCreds.OpenStack.Base64encodeCACert}}
+  cacert: {{.CloudCreds.OpenStack.Base64encodeCACert}}
+{{- end}}
 {{- else if .CloudCreds.VSphere}}
 {{- range .CloudCreds.VSphere}}
   {{.VCenter}}.username: {{.Base64encodeUsername}}

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -189,11 +189,11 @@ func (o *Openshift) Generate(ctx context.Context, dependencies asset.Parents) er
 		}
 
 		credsEncoded := base64.StdEncoding.EncodeToString(marshalled)
-		credsINIEncoded := base64.StdEncoding.EncodeToString(cloudProviderConf)
+		cloudProviderConfEncoded := base64.StdEncoding.EncodeToString(cloudProviderConf)
 		cloudCreds = cloudCredsSecretData{
 			OpenStack: &OpenStackCredsSecretData{
-				Base64encodeCloudCreds:    credsEncoded,
-				Base64encodeCloudCredsINI: credsINIEncoded,
+				Base64encodeCloudsYAML: credsEncoded,
+				Base64encodeCloudsConf: cloudProviderConfEncoded,
 			},
 		}
 	case vspheretypes.Name:

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -158,8 +158,14 @@ func (o *Openshift) Generate(ctx context.Context, dependencies asset.Parents) er
 			return err
 		}
 
-		// We need to replace the local cacert path with one that is used in OpenShift
+		var caCert []byte
 		if cloud.CACertFile != "" {
+			var err error
+			caCert, err = os.ReadFile(cloud.CACertFile)
+			if err != nil {
+				return err
+			}
+			// We need to replace the local cacert path with one that is used in OpenShift
 			cloud.CACertFile = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
 		}
 
@@ -190,10 +196,12 @@ func (o *Openshift) Generate(ctx context.Context, dependencies asset.Parents) er
 
 		credsEncoded := base64.StdEncoding.EncodeToString(marshalled)
 		cloudProviderConfEncoded := base64.StdEncoding.EncodeToString(cloudProviderConf)
+		caCertEncoded := base64.StdEncoding.EncodeToString(caCert)
 		cloudCreds = cloudCredsSecretData{
 			OpenStack: &OpenStackCredsSecretData{
 				Base64encodeCloudsYAML: credsEncoded,
 				Base64encodeCloudsConf: cloudProviderConfEncoded,
+				Base64encodeCACert:     caCertEncoded,
 			},
 		}
 	case vspheretypes.Name:

--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -27,6 +27,7 @@ func (e Error) Unwrap() error { return e.err }
 
 // CloudProviderConfigSecret generates the cloud provider config for the OpenStack
 // platform, that will be stored in the system secret.
+// TODO: I think this is crud for the legacy cloud-provider and is no longer needed. Burn it with fire?
 func CloudProviderConfigSecret(cloud *clientconfig.Cloud) ([]byte, error) {
 	domainID := cloud.AuthInfo.DomainID
 	if domainID == "" {

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -34,8 +34,8 @@ type IBMCloudCredsSecretData struct {
 
 // OpenStackCredsSecretData holds encoded credentials and is used to generate cloud-creds secret
 type OpenStackCredsSecretData struct {
-	Base64encodeCloudCreds    string
-	Base64encodeCloudCredsINI string
+	Base64encodeCloudsYAML string
+	Base64encodeCloudsConf string
 }
 
 // VSphereCredsSecretData holds encoded credentials and is used to generated cloud-creds secret

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -36,6 +36,7 @@ type IBMCloudCredsSecretData struct {
 type OpenStackCredsSecretData struct {
 	Base64encodeCloudsYAML string
 	Base64encodeCloudsConf string
+	Base64encodeCACert     string
 }
 
 // VSphereCredsSecretData holds encoded credentials and is used to generated cloud-creds secret


### PR DESCRIPTION
If a CA bundle is required to talk to your OpenStack then obviously all services that talk to the cloud need to have both credentials and said bundle. Currently, these users can get their credentials via cloud credential operator, but they need to source their CA bundle from elsewhere (typically by extracting it from the cloud controller manager's configuration). This makes configuration of services more complicated than necessary.

Continue the resolution of the issue by storing the CA bundle, if any, in the root secret on OpenStack. When coupled with the changes introduced in openshift/cloud-credential-operator#780, this allows us to dole out the bundle to anyone who asks for it via a `CredentialsRequest`.

~While we're here, we also tweak the configuration for the cloud provider to (a) start generating the configuration file in the new format expected by `cluster-cloud-controller-manager-operator` and (b) stop generating an old secret that only the old, now-removed in-tree OpenStack cloud provider needed and used.~

**EDIT:** I have deferred the above changes to a different PR.