### PR TITLE
CORS-3474: IBMCloud: Add CAPI Ignition for bootstrap node.

### DIFF
--- a/pkg/asset/ignition/bootstrap/ibmcloud/storage.go
+++ b/pkg/asset/ignition/bootstrap/ibmcloud/storage.go
@@ -1,0 +1,43 @@
+package ibmcloud
+
+import (
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/installer/pkg/asset/ignition"
+)
+
+// GenerateIgnitionShimWithCredentials creates an Ignition Config shim, directing additional configuration request to the provided URL, typically a COS object. A provided IAM access token is embedded within the Ignition Config as an HTTP header.
+func GenerateIgnitionShimWithCredentials(url string, iamToken string) ([]byte, error) {
+	config := &igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+			Config: igntypes.IgnitionConfig{
+				Replace: igntypes.Resource{
+					Source: ptr.To(url),
+					// NOTE(cjschaef): Replace authorization with Service ID credentials.
+					HTTPHeaders: igntypes.HTTPHeaders{
+						{
+							Name:  "Authorization",
+							Value: ptr.To(fmt.Sprintf("Bearer %s", iamToken)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ignition.Marshal(config)
+}
+
+// GetIgnitionBucketName returns the name for the COS Bucket designed to hold temporary bootstrap Ignition data.
+func GetIgnitionBucketName(infraID string) string {
+	return fmt.Sprintf("%s-bootstrap-ignition", infraID)
+}
+
+// GetIgnitionFileName returns the name of the file in COS which holds the bootstrap Ignition config.
+func GetIgnitionFileName() string {
+	return "bootstrap.ign"
+}

--- a/pkg/asset/installconfig/ibmcloud/client.go
+++ b/pkg/asset/installconfig/ibmcloud/client.go
@@ -120,6 +120,14 @@ const (
 	keyProtectDefaultURLTemplate = "https://%s.kms.cloud.ibm.com"
 )
 
+// COSResourceNotFoundError represents an error for a COS resource that is not found.
+type COSResourceNotFoundError struct{}
+
+// Error returns the error message for the COSResourceNotFoundError error type.
+func (e *COSResourceNotFoundError) Error() string {
+	return "COS Resource Not Found"
+}
+
 // VPCResourceNotFoundError represents an error for a VPC resoruce that is not found.
 type VPCResourceNotFoundError struct{}
 
@@ -513,7 +521,7 @@ func (c *Client) GetCOSInstanceByName(ctx context.Context, cosName string) (*res
 		}
 	}
 
-	return nil, fmt.Errorf("failed to find cos instance %s", cosName)
+	return nil, &COSResourceNotFoundError{}
 }
 
 // GetDNSInstance gets a specific DNS Services instance by its CRN.


### PR DESCRIPTION
IBM Cloud VPC has a limit for userdata allowed for VPC Instances. Bootstrap Ignition data must be uploaded to a COS Bucket and retrieved via Ignition configuration instead.

Related: https://issues.redhat.com/browse/CORS-3474