### PR TITLE
CORS-3753: Allow mocking of the Azure client everywhere

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -371,7 +371,10 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 		for i, w := range workers {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
-		client := aztypes.NewClient(session)
+		client, err := installConfig.Azure.Client()
+		if err != nil {
+			return err
+		}
 		hyperVGeneration, err := client.GetHyperVGenerationVersion(ctx, masterConfigs[0].VMSize, masterConfigs[0].Location, "")
 		if err != nil {
 			return err

--- a/pkg/asset/installconfig/azure/metadata.go
+++ b/pkg/asset/installconfig/azure/metadata.go
@@ -12,7 +12,7 @@ import (
 // from external APIs).
 type Metadata struct {
 	session *Session
-	client  *Client
+	client  API
 	dnsCfg  *DNSConfig
 
 	// CloudName indicates the Azure cloud environment (e.g. public, gov't).
@@ -70,7 +70,7 @@ func (m *Metadata) unlockedSession() (*Session, error) {
 }
 
 // Client holds an Azure Client that implements calls to the Azure API.
-func (m *Metadata) Client() (*Client, error) {
+func (m *Metadata) Client() (API, error) {
 	if m.client == nil {
 		ssn, err := m.Session()
 		if err != nil {
@@ -79,6 +79,12 @@ func (m *Metadata) Client() (*Client, error) {
 		m.client = NewClient(ssn)
 	}
 	return m.client, nil
+}
+
+// UseMockClient returns the provided client from Client() instead of creating
+// a new one.
+func (m *Metadata) UseMockClient(client API) {
+	m.client = client
 }
 
 // DNSConfig holds an Azure DNSConfig Client that implements calls to the Azure API.

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -53,6 +53,21 @@ func (mr *MockAPIMockRecorder) AreMarketplaceImageTermsAccepted(ctx, publisher, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreMarketplaceImageTermsAccepted", reflect.TypeOf((*MockAPI)(nil).AreMarketplaceImageTermsAccepted), ctx, publisher, offer, sku)
 }
 
+// CheckIPAddressAvailability mocks base method.
+func (m *MockAPI) CheckIPAddressAvailability(ctx context.Context, resourceGroupName, virtualNetwork, ipAddr string) (*network.IPAddressAvailabilityResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckIPAddressAvailability", ctx, resourceGroupName, virtualNetwork, ipAddr)
+	ret0, _ := ret[0].(*network.IPAddressAvailabilityResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckIPAddressAvailability indicates an expected call of CheckIPAddressAvailability.
+func (mr *MockAPIMockRecorder) CheckIPAddressAvailability(ctx, resourceGroupName, virtualNetwork, ipAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckIPAddressAvailability", reflect.TypeOf((*MockAPI)(nil).CheckIPAddressAvailability), ctx, resourceGroupName, virtualNetwork, ipAddr)
+}
+
 // GetAvailabilityZones mocks base method.
 func (m *MockAPI) GetAvailabilityZones(ctx context.Context, region, instanceType string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -226,11 +226,10 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 
-		session, err := installConfig.Azure.Session()
+		client, err := installConfig.Azure.Client()
 		if err != nil {
-			return fmt.Errorf("failed to fetch session: %w", err)
+			return err
 		}
-		client := icazure.NewClient(session)
 
 		if len(mpool.Zones) == 0 {
 			azs, err := client.GetAvailabilityZones(ctx, ic.Platform.Azure.Region, mpool.InstanceType)
@@ -273,6 +272,11 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		subnet := ic.Azure.ControlPlaneSubnet
 
 		hyperVGen, err := icazure.GetHyperVGenerationVersion(capabilities, "")
+		if err != nil {
+			return err
+		}
+
+		session, err := installConfig.Azure.Session()
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
 	"github.com/openshift/installer/pkg/asset/machines/baremetal"
@@ -340,12 +339,11 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 
-		session, err := installConfig.Azure.Session()
+		client, err := installConfig.Azure.Client()
 		if err != nil {
-			return errors.Wrap(err, "failed to fetch session")
+			return err
 		}
 
-		client := icazure.NewClient(session)
 		if len(mpool.Zones) == 0 {
 			azs, err := client.GetAvailabilityZones(ctx, ic.Platform.Azure.Region, mpool.InstanceType)
 			if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -31,7 +31,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
@@ -453,12 +452,11 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 			mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Azure)
 
-			session, err := installConfig.Azure.Session()
+			client, err := installConfig.Azure.Client()
 			if err != nil {
-				return errors.Wrap(err, "failed to fetch session")
+				return err
 			}
 
-			client := icazure.NewClient(session)
 			if len(mpool.Zones) == 0 {
 				azs, err := client.GetAvailabilityZones(ctx, ic.Platform.Azure.Region, mpool.InstanceType)
 				if err != nil {

--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -262,12 +262,8 @@ func getNextAvailableIP(ctx context.Context, installConfig *installconfig.Instal
 	if err != nil {
 		return "", fmt.Errorf("failed to get azure client: %w", err)
 	}
-	vClient, err := client.GetVirtualNetworksClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get azure virtual network client: %w", err)
-	}
 
-	availableIP, err := vClient.CheckIPAddressAvailability(ctx, installConfig.Config.Azure.NetworkResourceGroupName, installConfig.Config.Azure.VirtualNetwork, lbip)
+	availableIP, err := client.CheckIPAddressAvailability(ctx, installConfig.Config.Azure.NetworkResourceGroupName, installConfig.Config.Azure.VirtualNetwork, lbip)
 	if err != nil {
 		return "", fmt.Errorf("failed to get azure ip availability: %w", err)
 	}


### PR DESCRIPTION
Currently the Azure client can only be mocked in unit tests of the `pkg/asset/installconfig/azure` package. Using the mockable interface consistently and adding a public interface to set it up will allow other packages to write unit tests for code involving the Azure client.