### PR TITLE
OCPBUGS-44523: Remove unused variable from ASH arm template 06_workers.json

### DIFF
--- a/upi/azurestack/06_workers.json
+++ b/upi/azurestack/06_workers.json
@@ -49,7 +49,6 @@
     "nodeSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('nodeSubnetName'))]",
     "infraLoadBalancerName" : "[parameters('baseName')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
-    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "imageName" : "[parameters('baseName')]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-cluster')]",
     "numberOfNodes" : "[parameters('numberOfNodes')]",


### PR DESCRIPTION
The content of arm template 06_workers.json in installer repo is shown in [official azure stack hub upi installation doc](https://docs.openshift.com/container-platform/4.17/installing/installing_azure/upi/installing-azure-user-infra.html#installation-creating-azure-worker_installing-azure-user-infra),  variables `identityName` is not being used, remove it to avoid confusion from user when creating UPI cluster on azure stack hub.