### PR TITLE
WIP: refactor gcp destroy

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -111,7 +111,7 @@ func (o *ClusterUninstaller) discoverCloudControllerLoadBalancerResources(ctx co
 	o.insertPendingItems("forwardingrule", found)
 
 	// Discover associated target tcp proxies: loadBalancerName
-	found, err = o.listTargetTCPProxiesWithFilter(ctx, globalTargetTCPProxyResource, "items(name),nextPageToken", loadBalancerNameFilter)
+	found, err = o.listTargetTCPProxiesWithFilter(ctx, "items(name),nextPageToken", loadBalancerNameFilter)
 	if err != nil {
 		return err
 	}

--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -127,19 +127,5 @@ func (o *ClusterUninstaller) deleteDisk(ctx context.Context, item cloudResource)
 // destroyDisks removes all disk resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyDisks(ctx context.Context) error {
-	found, err := o.listDisks(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("disk", found)
-	for _, item := range items {
-		err := o.deleteDisk(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("disk"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "disk", o.listDisks, o.deleteDisk)
 }

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -105,19 +105,5 @@ func (o *ClusterUninstaller) deleteFirewall(ctx context.Context, item cloudResou
 // destroyFirewalls removes all firewall resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyFirewalls(ctx context.Context) error {
-	found, err := o.listFirewalls(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("firewall", found)
-	for _, item := range items {
-		err := o.deleteFirewall(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("firewall"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "firewall", o.listFirewalls, o.deleteFirewall)
 }

--- a/pkg/destroy/gcp/httphealthcheck.go
+++ b/pkg/destroy/gcp/httphealthcheck.go
@@ -77,19 +77,5 @@ func (o *ClusterUninstaller) deleteHTTPHealthCheck(ctx context.Context, item clo
 // destroyHTTPHealthChecks removes all HTTP health check resources that have a name prefixed
 // with the cluster's infra ID
 func (o *ClusterUninstaller) destroyHTTPHealthChecks(ctx context.Context) error {
-	found, err := o.listHTTPHealthChecks(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("httphealthcheck", found)
-	for _, item := range items {
-		err := o.deleteHTTPHealthCheck(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("httphealthcheck"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "httphealthcheck", o.listHTTPHealthChecks, o.deleteHTTPHealthCheck)
 }

--- a/pkg/destroy/gcp/image.go
+++ b/pkg/destroy/gcp/image.go
@@ -77,19 +77,5 @@ func (o *ClusterUninstaller) deleteImage(ctx context.Context, item cloudResource
 // destroyImages removes all image resources with a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyImages(ctx context.Context) error {
-	found, err := o.listImages(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("image", found)
-	for _, item := range items {
-		err := o.deleteImage(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("image"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "image", o.listImages, o.deleteImage)
 }

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -86,19 +86,5 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ctx context.Context, item cloud
 // destroyInstanceGroups searches for instance groups that have a name prefixed
 // with the cluster's infra ID, and then deletes each instance found.
 func (o *ClusterUninstaller) destroyInstanceGroups(ctx context.Context) error {
-	found, err := o.listInstanceGroups(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("instancegroup", found)
-	for _, item := range items {
-		err := o.deleteInstanceGroup(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("instancegroup"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "instancegroup", o.listInstanceGroups, o.deleteInstanceGroup)
 }

--- a/pkg/destroy/gcp/route.go
+++ b/pkg/destroy/gcp/route.go
@@ -86,19 +86,5 @@ func (o *ClusterUninstaller) deleteRoute(ctx context.Context, item cloudResource
 // destroyRutes removes all route resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyRoutes(ctx context.Context) error {
-	found, err := o.listRoutes(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("route", found)
-	for _, item := range items {
-		err := o.deleteRoute(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("route"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "route", o.listRoutes, o.deleteRoute)
 }

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -77,19 +77,5 @@ func (o *ClusterUninstaller) deleteRouter(ctx context.Context, item cloudResourc
 // destroyRouters removes all router resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyRouters(ctx context.Context) error {
-	found, err := o.listRouters(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("router", found)
-	for _, item := range items {
-		err := o.deleteRouter(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("router"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "router", o.listRouters, o.deleteRouter)
 }

--- a/pkg/destroy/gcp/subnetwork.go
+++ b/pkg/destroy/gcp/subnetwork.go
@@ -86,19 +86,5 @@ func (o *ClusterUninstaller) deleteSubnetwork(ctx context.Context, item cloudRes
 // destroySubNetworks removes all subnetwork resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroySubnetworks(ctx context.Context) error {
-	found, err := o.listSubnetworks(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("subnetwork", found)
-	for _, item := range items {
-		err := o.deleteSubnetwork(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("subnetwork"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "subnetwork", o.listSubnetworks, o.deleteSubnetwork)
 }

--- a/pkg/destroy/gcp/targetpool.go
+++ b/pkg/destroy/gcp/targetpool.go
@@ -77,19 +77,5 @@ func (o *ClusterUninstaller) deleteTargetPool(ctx context.Context, item cloudRes
 // destroyTargetPools removes target pools resources that have a name prefixed
 // with the cluster's infra ID.
 func (o *ClusterUninstaller) destroyTargetPools(ctx context.Context) error {
-	found, err := o.listTargetPools(ctx)
-	if err != nil {
-		return err
-	}
-	items := o.insertPendingItems("targetpool", found)
-	for _, item := range items {
-		err := o.deleteTargetPool(ctx, item)
-		if err != nil {
-			o.errorTracker.suppressWarning(item.key, err, o.Logger)
-		}
-	}
-	if items = o.getPendingItems("targetpool"); len(items) > 0 {
-		return errors.Errorf("%d items pending", len(items))
-	}
-	return nil
+	return o.standardDestroy(ctx, "targetpool", o.listTargetPools, o.deleteTargetPool)
 }


### PR DESCRIPTION
An initial commit for larger refactoring GCP
destroy code, this encapsulates the boiler
plate destroy flow for many resources into
a reusable function.

This commit just contains the resources which
use the exact same flow. Several more resources
have very slight variations, either because
they have been updated over time or they
have been considered a special snowflake. These
should be easily adapted in a subsequent commit
but this commit keeps things simple for the
resources that require only minimal changes.

Encapsulating the boiler plate logic not only
makes the code easier to read, but makes the
code more maintainble by imposing structure:
it reduces the surface area for where
resource-specific changes can be introduced.