### PR TITLE
OCPBUGS-44611: [release-4.17] capi/aws: set Node Port Service CIDR override

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -150,6 +150,7 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 						CidrBlocks:  sshRuleCidr,
 					},
 				},
+				NodePortIngressRuleCidrBlocks: []string{capiutils.CIDRFromInstallConfig(ic).String()},
 			},
 			S3Bucket: &capa.S3Bucket{
 				Name:                    GetIgnitionBucketName(clusterID.InfraID),


### PR DESCRIPTION
If we don't, CAPA will use "0.0.0.0/0", which is too permissive. Let's use the cluster's CIDR block instead.

Manual cherry-pick of https://github.com/openshift/installer/pull/9127