### PR TITLE
[release-4.14] OCPBUGS-6271: Adding VIPs Validation for agent based vsphere installation

### DIFF
--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -95,6 +95,10 @@ apiVersion: v1
 metadata:
   name: test-cluster
 baseDomain: test-domain
+networking:
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
 platform:
   vsphere:
     apiVips:
@@ -102,7 +106,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
+			expectedError: "invalid install-config configuration: [platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.ingressVIPs: Required value: must specify at least one VIP for the Ingress]",
 		},
 		{
 			name: "no compute.replicas set for SNO",

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -111,7 +111,7 @@ func ValidateInstallConfig(c *types.InstallConfig, usingAgentMethod bool) field.
 		allErrs = append(allErrs, validateNetworking(c.Networking, c.IsSingleNodeOpenShift(), field.NewPath("networking"))...)
 		allErrs = append(allErrs, validateNetworkingIPVersion(c.Networking, &c.Platform)...)
 		allErrs = append(allErrs, validateNetworkingForPlatform(c.Networking, &c.Platform, field.NewPath("networking"))...)
-		allErrs = append(allErrs, validateVIPsForPlatform(c.Networking, &c.Platform, field.NewPath("platform"))...)
+		allErrs = append(allErrs, validateVIPsForPlatform(c.Networking, &c.Platform, usingAgentMethod, field.NewPath("platform"))...)
 	} else {
 		allErrs = append(allErrs, field.Required(field.NewPath("networking"), "networking is required"))
 	}
@@ -511,7 +511,7 @@ type vipFields struct {
 
 // validateVIPsForPlatform validates the VIPs (for API and Ingress) for the
 // given platform
-func validateVIPsForPlatform(network *types.Networking, platform *types.Platform, fldPath *field.Path) field.ErrorList {
+func validateVIPsForPlatform(network *types.Networking, platform *types.Platform, usingAgentMethod bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	virtualIPs := vips{}
@@ -553,7 +553,11 @@ func validateVIPsForPlatform(network *types.Networking, platform *types.Platform
 			Ingress: platform.VSphere.IngressVIPs,
 		}
 
-		allErrs = append(allErrs, validateAPIAndIngressVIPs(virtualIPs, newVIPsFields, false, false, network, fldPath.Child(vsphere.Name))...)
+		if usingAgentMethod {
+			allErrs = append(allErrs, validateAPIAndIngressVIPs(virtualIPs, newVIPsFields, true, true, network, fldPath.Child(vsphere.Name))...)
+		} else {
+			allErrs = append(allErrs, validateAPIAndIngressVIPs(virtualIPs, newVIPsFields, false, false, network, fldPath.Child(vsphere.Name))...)
+		}
 	case platform.Ovirt != nil:
 		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.Ovirt.APIVIPs, fldPath.Child(ovirt.Name, newVIPsFields.APIVIPs))...)
 		allErrs = append(allErrs, ensureIPv4IsFirstInDualStackSlice(&platform.Ovirt.IngressVIPs, fldPath.Child(ovirt.Name, newVIPsFields.IngressVIPs))...)


### PR DESCRIPTION
**SUMMARY**
Include the VIP validation, which is required for agent-based VSphere installation

**TESTING**

**Test Case1**: Generate agent installer iso file with out providing the APIVIPs and INGRESSVIPs in install-config.yaml for vsphere
Result: ISO didnt generate instead it said
```
ERROR failed to write asset (Agent Installer ISO) to disk: cannot generate ISO image due to configuration errors 
FATAL failed to fetch Agent Installer ISO: failed to load asset "Install Config": invalid install-config configuration: [platform.vsphere.apiVIPs: Required value: must specify at least one VIP for the API, platform.vsphere.ingressVIPs: Required value: must specify at least one VIP for the Ingress] 
```
**Test Case2**: Generate agent installer iso file with APIVIPs and INGRESSVIPs in install-config.yaml for vsphere
Result: SUCCESS




