### PR TITLE
AGENT-1022: add node-joiner --config-iso flag

### DIFF
--- a/cmd/node-joiner/main.go
+++ b/cmd/node-joiner/main.go
@@ -32,10 +32,15 @@ func nodeJoiner() error {
 			if err != nil {
 				return err
 			}
-			return nodejoiner.NewAddNodesCommand(dir, kubeConfig, &generatePXE)
+			generateConfigISO, err := cmd.Flags().GetBool("config-iso")
+			if err != nil {
+				return err
+			}
+			return nodejoiner.NewAddNodesCommand(dir, kubeConfig, generatePXE, generateConfigISO)
 		},
 	}
 	nodesAddCmd.Flags().BoolP("pxe", "p", false, "Instead of an ISO, generates PXE artifacts that can be used to boot the configured nodes to let them join an existing cluster")
+	nodesAddCmd.Flags().BoolP("config-iso", "", false, "Generates the config ISO instead of the standard ISO")
 
 	nodesMonitorCmd := &cobra.Command{
 		Use:   "monitor-add-nodes <ip-addresses>",

--- a/pkg/asset/agent/joiner/addnodesconfig.go
+++ b/pkg/asset/agent/joiner/addnodesconfig.go
@@ -44,8 +44,7 @@ type Config struct {
 
 // Params is used to store the command line parameters.
 type Params struct {
-	Kubeconfig  string `json:"kubeconfig,omitempty"`
-	GeneratePXE bool   `json:"generatePXE,omitempty"`
+	Kubeconfig string `json:"kubeconfig,omitempty"`
 }
 
 // Save stores the current parameters on disk.

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -9,7 +9,7 @@ import (
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
-	err := saveParams(directory, kubeconfigPath, nil)
+	err := saveParams(directory, kubeconfigPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch introduces a new node-joiner flag to explicitly generate the config ISO, instead of the regular one. 
It will also fix the `oc adm node-image create` command, since right now the config ISO is generated even when not really requested by the user.