### PR TITLE
MGMT-19292: align image based extraPartitionlabel with var-lib-containers partition label

### DIFF
--- a/pkg/asset/imagebased/image/ignition_test.go
+++ b/pkg/asset/imagebased/image/ignition_test.go
@@ -117,7 +117,7 @@ podman rm lca-cli
 /usr/local/bin/lca-cli ibi -f "${ibi_config}"
 `,
 
-				"/var/tmp/ibi-configuration.json": "{\"extraPartitionLabel\":\"varlibcontainers\",\"extraPartitionNumber\":5,\"extraPartitionStart\":\"-40G\",\"installationDisk\":\"/dev/vda\",\"seedImage\":\"quay.io/openshift-kni/seed-image:4.16.0\",\"seedVersion\":\"4.16.0\"}\n",
+				"/var/tmp/ibi-configuration.json": "{\"extraPartitionLabel\":\"var-lib-containers\",\"extraPartitionNumber\":5,\"extraPartitionStart\":\"-40G\",\"installationDisk\":\"/dev/vda\",\"seedImage\":\"quay.io/openshift-kni/seed-image:4.16.0\",\"seedVersion\":\"4.16.0\"}\n",
 
 				"/etc/containers/registries.conf": "credential-helpers = []\nshort-name-mode = \"\"\nunqualified-search-registries = []\n\n[[registry]]\n  location = \"quay.io\"\n  mirror-by-digest-only = true\n  prefix = \"\"\n\n  [[registry.mirror]]\n    location = \"mirror-quay.io\"\n",
 

--- a/pkg/asset/imagebased/image/imagebased_config.go
+++ b/pkg/asset/imagebased/image/imagebased_config.go
@@ -30,7 +30,7 @@ const (
 var (
 	configFilename              = "image-based-installation-config.yaml"
 	allowedFlags                = []string{"--append-karg", "--delete-karg", "--save-partlabel", "--save-partindex"}
-	defaultExtraPartitionLabel  = "varlibcontainers"
+	defaultExtraPartitionLabel  = "var-lib-containers"
 	defaultExtraPartitionStart  = "-40G"
 	defaultExtraPartitionNumber = uint(5)
 )

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -393,7 +393,7 @@ func ibiConfig() *ImageBasedInstallationConfigBuilder {
 			SeedVersion:          "4.16.0",
 			InstallationDisk:     "/dev/vda",
 			ExtraPartitionStart:  "-40G",
-			ExtraPartitionLabel:  "varlibcontainers",
+			ExtraPartitionLabel:  defaultExtraPartitionLabel,
 			ExtraPartitionNumber: 5,
 			Shutdown:             false,
 			SSHKey:               "",

--- a/pkg/types/imagebased/imagebased_config_types.go
+++ b/pkg/types/imagebased/imagebased_config_types.go
@@ -62,7 +62,7 @@ type InstallationConfig struct {
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
 	// ExtraPartitionLabel label of extra partition used for /var/lib/containers.
-	// Default is varlibcontainers
+	// Default is var-lib-containers
 	// +optional
 	ExtraPartitionLabel string `json:"extraPartitionLabel,omitempty"`
 


### PR DESCRIPTION
[MGMT-19292](https://issues.redhat.com//browse/MGMT-19292): align image based extraPartitionlabel with var-lib-containers partition label