### PR TITLE
[release-4.16] CORS-3753: Allow mocking of the Azure client everywhere

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -373,7 +373,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, w := range workers {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1beta1.AzureMachineProviderSpec) //nolint:errcheck // legacy, pre-linter
 		}
-		client := aztypes.NewClient(session)
+		client, err := installConfig.Azure.Client()
+		if err != nil {
+			return err
+		}
 		hyperVGeneration, err := client.GetHyperVGenerationVersion(context.TODO(), masterConfigs[0].VMSize, masterConfigs[0].Location, "")
 		if err != nil {
 			return err

--- a/pkg/asset/installconfig/azure/metadata.go
+++ b/pkg/asset/installconfig/azure/metadata.go
@@ -12,7 +12,7 @@ import (
 // from external APIs).
 type Metadata struct {
 	session *Session
-	client  *Client
+	client  API
 	dnsCfg  *DNSConfig
 
 	// CloudName indicates the Azure cloud environment (e.g. public, gov't).
@@ -70,7 +70,7 @@ func (m *Metadata) unlockedSession() (*Session, error) {
 }
 
 // Client holds an Azure Client that implements calls to the Azure API.
-func (m *Metadata) Client() (*Client, error) {
+func (m *Metadata) Client() (API, error) {
 	if m.client == nil {
 		ssn, err := m.Session()
 		if err != nil {
@@ -79,6 +79,12 @@ func (m *Metadata) Client() (*Client, error) {
 		m.client = NewClient(ssn)
 	}
 	return m.client, nil
+}
+
+// UseMockClient returns the provided client from Client() instead of creating
+// a new one.
+func (m *Metadata) UseMockClient(client API) {
+	m.client = client
 }
 
 // DNSConfig holds an Azure DNSConfig Client that implements calls to the Azure API.

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -224,11 +224,10 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 
-		session, err := installConfig.Azure.Session()
+		client, err := installConfig.Azure.Client()
 		if err != nil {
-			return fmt.Errorf("failed to fetch session: %w", err)
+			return err
 		}
-		client := icazure.NewClient(session)
 
 		if len(mpool.Zones) == 0 {
 			// if no azs are given we set to []string{""} for convenience over later operations.
@@ -276,6 +275,11 @@ func (c *ClusterAPI) Generate(dependencies asset.Parents) error {
 		useImageGallery := false
 		masterUserDataSecretName := "master-user-data"
 		resourceGroupName := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
+
+		session, err := installConfig.Azure.Session()
+		if err != nil {
+			return err
+		}
 
 		azureMachines, err := azure.GenerateMachines(installConfig.Config.Platform.Azure, &pool, masterUserDataSecretName, clusterID.InfraID, "master", capabilities, useImageGallery, installConfig.Config.Platform.Azure.UserTags, hyperVGen, subnet, resourceGroupName, session.Credentials.SubscriptionID)
 		if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
 	"github.com/openshift/installer/pkg/asset/machines/baremetal"
@@ -347,12 +346,11 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 
-		session, err := installConfig.Azure.Session()
+		client, err := installConfig.Azure.Client()
 		if err != nil {
-			return errors.Wrap(err, "failed to fetch session")
+			return err
 		}
 
-		client := icazure.NewClient(session)
 		if len(mpool.Zones) == 0 {
 			azs, err := client.GetAvailabilityZones(context.TODO(), ic.Platform.Azure.Region, mpool.InstanceType)
 			if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -31,7 +31,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
@@ -448,12 +447,11 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Azure)
 
-			session, err := installConfig.Azure.Session()
+			client, err := installConfig.Azure.Client()
 			if err != nil {
-				return errors.Wrap(err, "failed to fetch session")
+				return err
 			}
 
-			client := icazure.NewClient(session)
 			if len(mpool.Zones) == 0 {
 				azs, err := client.GetAvailabilityZones(context.TODO(), ic.Platform.Azure.Region, mpool.InstanceType)
 				if err != nil {


### PR DESCRIPTION
Currently the Azure client can only be mocked in unit tests of the `pkg/asset/installconfig/azure` package. Using the mockable interface consistently and adding a public interface to set it up will allow other packages to write unit tests for code involving the Azure client.

This is a backport from #9219