### PR TITLE
CORS-2508: aws: remove unused autoscaling:DescribeAutoScalingGroups perm

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -205,7 +205,6 @@ var permissions = map[PermissionGroup][]string{
 	},
 	// Permissions required for deleting base cluster resources
 	PermissionDeleteBase: {
-		"autoscaling:DescribeAutoScalingGroups",
 		"ec2:DeleteNetworkInterface",
 		"ec2:DeletePlacementGroup",
 		"ec2:DeleteTags",


### PR DESCRIPTION
With the analysis from https://issues.redhat.com/browse/SPLAT-1844, the permission is required by the installer but never used.