### PR TITLE
ARO-12457: data/data: include bootkube files in go module

### DIFF
--- a/data/data/tools.go
+++ b/data/data/tools.go
@@ -8,5 +8,5 @@ import "embed"
 // this package and no other codebases should either, as we intend to remove it
 // once ARO has moved off the wrapper.
 
-//go:embed bootstrap/* manifests/*
+//go:embed bootstrap/* manifests/* coreos/*
 var _ embed.FS

--- a/data/data/tools.go
+++ b/data/data/tools.go
@@ -1,0 +1,12 @@
+package data
+
+import "embed"
+
+// This file and the package it creates are intended to distribute the static
+// assets of this data directory in the go module, specifically for consumption
+// by the ARO wrapper on a temporary basis. The installer itself does not import
+// this package and no other codebases should either, as we intend to remove it
+// once ARO has moved off the wrapper.
+
+//go:embed bootstrap/* manifests/*
+var _ embed.FS


### PR DESCRIPTION
The ARO wrapper needs to vendor the static assets from the data/data directory in order to generate manifest and ignition assets. This PR Adds a data/data package and uses a side effect of `//go:embed` to include specific data directories in our go module.

The aro-wrapper can vendor these assets simply by doing something like:

```go
package main

import (
	_ "github.com/openshift/installer/data/data"
)

func main() {
}
```
In my testing that resulted in the top-level files from /data/data and the embedded directories being included in the vendor directory:

```shell
ls vendor/github.com/openshift/installer/data/data/
bootstrap  config.tf  install.openshift.io_installconfigs.yaml  manifests  terraform.rc  tools.go
```

This is intended to be temporary. The installer does not use this package. Once ARO has moved off the wrapper (to use the openshift-install binary directly) this file and package can be removed.