### PR TITLE
CORS-3825: pkg/infrastructure/azure: support nvme

### DIFF
--- a/pkg/infrastructure/azure/compute.go
+++ b/pkg/infrastructure/azure/compute.go
@@ -122,6 +122,13 @@ func CreateGalleryImage(ctx context.Context, in *CreateGalleryImageInput) (*Crea
 		}
 		features = append(features, to.Ptr(feature))
 	}
+	if in.HyperVGeneration == armcompute.HyperVGenerationV2 {
+		feature := armcompute.GalleryImageFeature{
+			Name:  to.Ptr("DiskControllerTypes"),
+			Value: to.Ptr("SCSI, NVMe"),
+		}
+		features = append(features, to.Ptr(feature))
+	}
 
 	galleryImagesClient := in.ComputeClientFactory.NewGalleryImagesClient()
 	galleryImagesPoller, err := galleryImagesClient.BeginCreateOrUpdate(


### PR DESCRIPTION
Updates the installer-generated image definition to indicate support for NVME (and SCSI) disk controllers. Without this feature on the image definition, certain VM families will fail to provision with a message such as:

> The VM size 'Standard_D8ds_v6' cannot boot with OS image or disk. Please check that disk controller types supported by the OS image or disk is one of the supported disk controller types for the VM size 'Standard_D8ds_v6'.

With the change in this commit, the VM will successfully provision.