### PR TITLE
OCPBUGS-44924: aws: add missing ec2:GetConsoleOutput perm requirement 

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -116,6 +116,7 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DescribeVpcClassicLinkDnsSupport",
 		"ec2:DescribeVpcEndpoints",
 		"ec2:DescribeVpcs",
+		"ec2:GetConsoleOutput", // for gathering VM console logs in case of failure.
 		"ec2:GetEbsDefaultKmsKeyId",
 		"ec2:ModifyInstanceAttribute",
 		"ec2:ModifyNetworkInterfaceAttribute",


### PR DESCRIPTION
The permission is needed when bootstrapping fails and the installer tries to gather the VM console logs.