### PR TITLE
OCPBUGS-44925: aws: add ec2:AllocateAddress perm requirement.

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -303,6 +303,10 @@ var permissions = map[PermissionGroup][]string{
 		"kms:ListGrants",
 	},
 	PermissionPublicIpv4Pool: {
+		// Needed by CAPA to allocate an IP from the pool.
+		"ec2:AllocateAddress",
+		// Needed by CAPA to associate an IP with an instance.
+		"ec2:AssociateAddress",
 		// Needed to check the IP pools during install-config validation
 		"ec2:DescribePublicIpv4Pools",
 		// Needed by terraform because of bootstrap EIP created


### PR DESCRIPTION
It's needed by CAPA when Ipv4Pools are supplied.