### PR TITLE
OCPBUGS-45685: Power VS: Create region-zone-sysType hierarchy

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -921,7 +921,7 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 
 		cpStanza := installConfig.Config.ControlPlane
 		if cpStanza == nil || cpStanza.Platform.PowerVS == nil || cpStanza.Platform.PowerVS.SysType == "" {
-			sysTypes, err := powervs.AvailableSysTypes(installConfig.Config.PowerVS.Region)
+			sysTypes, err := powervs.AvailableSysTypes(installConfig.Config.PowerVS.Region, installConfig.Config.PowerVS.Zone)
 			if err != nil {
 				return err
 			}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -157,7 +157,7 @@ func (a *PlatformProvisionCheck) Generate(ctx context.Context, dependencies asse
 			return err
 		}
 
-		err = powervsconfig.ValidateSystemTypeForRegion(client, ic.Config)
+		err = powervsconfig.ValidateSystemTypeForZone(client, ic.Config)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/powervs/regions.go
+++ b/pkg/asset/installconfig/powervs/regions.go
@@ -30,7 +30,11 @@ func IsKnownRegion(region string) bool {
 }
 
 func knownZones(region string) []string {
-	return powervs.Regions[region].Zones
+	zones := make([]string, 0, len(powervs.Regions[region].Zones))
+	for z := range powervs.Regions[region].Zones {
+		zones = append(zones, z)
+	}
+	return zones
 }
 
 // IsKnownZone return true is a specified zone is Known to the installer.

--- a/pkg/asset/installconfig/powervs/validation.go
+++ b/pkg/asset/installconfig/powervs/validation.go
@@ -255,14 +255,14 @@ func ValidateResourceGroup(client API, ic *types.InstallConfig) error {
 	return nil
 }
 
-// ValidateSystemTypeForRegion checks if the specified sysType is available in the target region.
-func ValidateSystemTypeForRegion(client API, ic *types.InstallConfig) error {
+// ValidateSystemTypeForZone checks if the specified sysType is available in the target zone.
+func ValidateSystemTypeForZone(client API, ic *types.InstallConfig) error {
 	if ic.ControlPlane == nil || ic.ControlPlane.Platform.PowerVS == nil || ic.ControlPlane.Platform.PowerVS.SysType == "" {
 		return nil
 	}
-	availableOnes, err := powervstypes.AvailableSysTypes(ic.PowerVS.Region)
+	availableOnes, err := powervstypes.AvailableSysTypes(ic.PowerVS.Region, ic.PowerVS.Zone)
 	if err != nil {
-		return fmt.Errorf("failed to obtain available SysTypes for: %s", ic.PowerVS.Region)
+		return fmt.Errorf("failed to obtain available SysTypes for: %s", ic.PowerVS.Zone)
 	}
 	requested := ic.ControlPlane.Platform.PowerVS.SysType
 	found := false
@@ -275,7 +275,7 @@ func ValidateSystemTypeForRegion(client API, ic *types.InstallConfig) error {
 	if found {
 		return nil
 	}
-	return fmt.Errorf("%s is not available in: %s", requested, ic.PowerVS.Region)
+	return fmt.Errorf("%s is not available in: %s", requested, ic.PowerVS.Zone)
 }
 
 // ValidateServiceInstance validates the optional service instance GUID in our install config.

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -41,7 +41,7 @@ var (
 		validPrivateSubnetUSSouth2ID,
 	}
 	validUserID = "valid-user@example.com"
-	validZone   = "dal10"
+	validZone   = "dal12"
 
 	existingDNSRecordsResponse = []powervs.DNSRecordResponse{
 		{
@@ -132,7 +132,7 @@ var (
 	}
 	defaultSysType           = "s922"
 	newSysType               = "s1022"
-	invalidRegion            = "foo"
+	invalidZone              = "dal11"
 	validServiceInstanceGUID = ""
 )
 
@@ -561,22 +561,22 @@ func TestValidatePERAvailability(t *testing.T) {
 	}
 }
 
-func TestValidateSystemTypeForRegion(t *testing.T) {
+func TestValidateSystemTypeForZone(t *testing.T) {
 	cases := []struct {
 		name     string
 		edits    editFunctions
 		errorMsg string
 	}{
 		{
-			name: "Unknown Region specified",
+			name: "Unknown Zone specified",
 			edits: editFunctions{
 				func(ic *types.InstallConfig) {
-					ic.Platform.PowerVS.Region = invalidRegion
+					ic.Platform.PowerVS.Zone = invalidZone
 					ic.ControlPlane.Platform.PowerVS = validMachinePool()
 					ic.ControlPlane.Platform.PowerVS.SysType = defaultSysType
 				},
 			},
-			errorMsg: fmt.Sprintf("failed to obtain available SysTypes for: %s", invalidRegion),
+			errorMsg: fmt.Sprintf("failed to obtain available SysTypes for: %s", invalidZone),
 		},
 		{
 			name: "No Platform block",
@@ -597,21 +597,23 @@ func TestValidateSystemTypeForRegion(t *testing.T) {
 			errorMsg: "",
 		},
 		{
-			name: "Unavailable SysType specified for Dallas Region",
+			name: "Unavailable SysType specified for dal12 zone",
 			edits: editFunctions{
 				func(ic *types.InstallConfig) {
 					ic.Platform.PowerVS.Region = validRegion
+					ic.Platform.PowerVS.Zone = validZone
 					ic.ControlPlane.Platform.PowerVS = validMachinePool()
 					ic.ControlPlane.Platform.PowerVS.SysType = newSysType
 				},
 			},
-			errorMsg: fmt.Sprintf("%s is not available in: %s", newSysType, validRegion),
+			errorMsg: fmt.Sprintf("%s is not available in: %s", newSysType, validZone),
 		},
 		{
-			name: "Good Region/SysType combo specified",
+			name: "Good Zone/SysType combo specified",
 			edits: editFunctions{
 				func(ic *types.InstallConfig) {
 					ic.Platform.PowerVS.Region = validRegion
+					ic.Platform.PowerVS.Zone = validZone
 					ic.ControlPlane.Platform.PowerVS = validMachinePool()
 					ic.ControlPlane.Platform.PowerVS.SysType = defaultSysType
 				},
@@ -634,7 +636,7 @@ func TestValidateSystemTypeForRegion(t *testing.T) {
 				edit(editedInstallConfig)
 			}
 
-			aggregatedErrors := powervs.ValidateSystemTypeForRegion(powervsClient, editedInstallConfig)
+			aggregatedErrors := powervs.ValidateSystemTypeForZone(powervsClient, editedInstallConfig)
 			if tc.errorMsg != "" {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -187,11 +187,11 @@ func defaultPowerVSMachinePoolPlatform(ic *types.InstallConfig) powervstypes.Mac
 		SysType:    "s922",
 	}
 
-	sysTypes, err = powervstypes.AvailableSysTypes(ic.PowerVS.Region)
+	sysTypes, err = powervstypes.AvailableSysTypes(ic.PowerVS.Region, ic.PowerVS.Zone)
 	if err == nil {
 		defaultMp.SysType = sysTypes[0]
 	} else {
-		logrus.Warnf("For given region %v, AvailableSysTypes returns %v", ic.PowerVS.Region, err)
+		logrus.Warnf("For given zone %v, AvailableSysTypes returns %v", ic.PowerVS.Zone, err)
 	}
 
 	return defaultMp

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -15,9 +15,13 @@ type Region struct {
 	Description string
 	VPCRegion   string
 	COSRegion   string
-	Zones       []string
-	SysTypes    []string
+	Zones       map[string]Zone
 	VPCZones    []string
+}
+
+// Zone holds the sysTypes for a zone in a IBM Power VS region.
+type Zone struct {
+	SysTypes []string
 }
 
 // Regions holds the regions for IBM Power VS, and descriptions used during the survey.
@@ -26,89 +30,140 @@ var Regions = map[string]Region{
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
-		Zones:       []string{"dal10", "dal12"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"us-south-1", "us-south-2", "us-south-3"},
+		Zones: map[string]Zone{
+			"dal10": {
+				SysTypes: []string{"s922", "s1022", "e980", "e1080"},
+			},
+			"dal12": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"eu-de": {
 		Description: "Frankfurt, Germany",
 		VPCRegion:   "eu-de",
 		COSRegion:   "eu-de",
-		Zones:       []string{"eu-de-1", "eu-de-2"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"eu-de-2", "eu-de-3"},
+		Zones: map[string]Zone{
+			"eu-de-1": {
+				SysTypes: []string{"s922", "s1022", "e980"},
+			},
+			"eu-de-2": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"eu-de-1", "eu-de-2", "eu-de-3"},
 	},
 	"lon": {
 		Description: "London, UK",
 		VPCRegion:   "eu-gb",
 		COSRegion:   "eu-gb",
-		Zones:       []string{"lon06"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
+		Zones: map[string]Zone{
+			"lon06": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
 	},
 	"mad": {
 		Description: "Madrid, Spain",
 		VPCRegion:   "eu-es",
 		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
-		Zones:       []string{"mad02", "mad04"},
-		SysTypes:    []string{"e980", "s1022"},
-		VPCZones:    []string{"eu-es-1", "eu-es-2"},
+		Zones: map[string]Zone{
+			"mad02": {
+				SysTypes: []string{"s922", "s1022", "e980"},
+			},
+			"mad04": {
+				SysTypes: []string{"s1022", "e980", "e1080"},
+			},
+		},
+		VPCZones: []string{"eu-es-1", "eu-es-2"},
 	},
 	"osa": {
 		Description: "Osaka, Japan",
 		VPCRegion:   "jp-osa",
 		COSRegion:   "jp-osa",
-		Zones:       []string{"osa21"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"jp-osa-1", "jp-osa-2", "jp-osa-3"},
+		Zones: map[string]Zone{
+			"osa21": {
+				SysTypes: []string{"s922", "s1022", "e980"},
+			},
+		},
+		VPCZones: []string{"jp-osa-1", "jp-osa-2", "jp-osa-3"},
 	},
 	"sao": {
 		Description: "São Paulo, Brazil",
 		VPCRegion:   "br-sao",
 		COSRegion:   "br-sao",
-		Zones:       []string{"sao01", "sao04"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"br-sao-1", "br-sao-2", "br-sao-3"},
+		Zones: map[string]Zone{
+			"sao01": {
+				SysTypes: []string{"s922", "e980"},
+			},
+			"sao04": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"br-sao-1", "br-sao-2", "br-sao-3"},
 	},
 	"syd": {
 		Description: "Sydney, Australia",
 		VPCRegion:   "au-syd",
 		COSRegion:   "au-syd",
-		Zones:       []string{"syd04", "syd05"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"au-syd-1", "au-syd-2", "au-syd-3"},
+		Zones: map[string]Zone{
+			"syd04": {
+				SysTypes: []string{"s922", "e980"},
+			},
+			"syd05": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"au-syd-1", "au-syd-2", "au-syd-3"},
 	},
 	"tor": {
-		Description: "Toronto, Cananda",
+		Description: "Toronto, Canada",
 		VPCRegion:   "ca-tor",
 		COSRegion:   "ca-tor",
-		Zones:       []string{"tor01"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"ca-tor-1", "ca-tor-2", "ca-tor-3"},
+		Zones: map[string]Zone{
+			"tor01": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"ca-tor-1", "ca-tor-2", "ca-tor-3"},
 	},
 	"us-east": {
 		Description: "Washington DC, USA",
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
-		Zones:       []string{"us-east"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
+		Zones: map[string]Zone{
+			"us-east": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
 	},
 	"us-south": {
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
-		Zones:       []string{"us-south"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"us-south-1", "us-south-2", "us-south-3"},
+		Zones: map[string]Zone{
+			"us-south": {
+				SysTypes: []string{"s922", "e980"},
+			},
+		},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"wdc": {
 		Description: "Washington DC, USA",
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
-		Zones:       []string{"wdc06", "wdc07"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
+		Zones: map[string]Zone{
+			"wdc06": {
+				SysTypes: []string{"s922", "e980"},
+			},
+			"wdc07": {
+				SysTypes: []string{"s922", "s1022", "e980", "e1080"},
+			},
+		},
+		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
 	},
 }
 
@@ -148,7 +203,7 @@ func ValidateVPCRegion(region string) bool {
 func ValidateZone(zone string) bool {
 	for r := range Regions {
 		for z := range Regions[r].Zones {
-			if zone == Regions[r].Zones[z] {
+			if zone == z {
 				return true
 			}
 		}
@@ -161,7 +216,7 @@ func ZoneNames() []string {
 	zones := []string{}
 	for r := range Regions {
 		for z := range Regions[r].Zones {
-			zones = append(zones, Regions[r].Zones[z])
+			zones = append(zones, z)
 		}
 	}
 	return zones
@@ -171,7 +226,7 @@ func ZoneNames() []string {
 func RegionFromZone(zone string) string {
 	for r := range Regions {
 		for z := range Regions[r].Zones {
-			if zone == Regions[r].Zones[z] {
+			if zone == z {
 				return r
 			}
 		}
@@ -180,19 +235,26 @@ func RegionFromZone(zone string) string {
 }
 
 // AvailableSysTypes returns the default system type for the zone.
-func AvailableSysTypes(region string) ([]string, error) {
+func AvailableSysTypes(region string, zone string) ([]string, error) {
 	knownRegion, ok := Regions[region]
 	if !ok {
 		return nil, fmt.Errorf("unknown region name provided")
 	}
-	return knownRegion.SysTypes, nil
+	var knownZone Zone
+	knownZone, ok = knownRegion.Zones[zone]
+	if !ok {
+		return nil, fmt.Errorf("unknown zone name provided")
+	}
+	return knownZone.SysTypes, nil
 }
 
 // AllKnownSysTypes returns aggregated known system types from all regions.
 func AllKnownSysTypes() sets.Set[string] {
 	sysTypes := sets.New[string]()
-	for _, region := range Regions {
-		sysTypes.Insert(region.SysTypes...)
+	for region := range Regions {
+		for _, zones := range Regions[region].Zones {
+			sysTypes.Insert(zones.SysTypes...)
+		}
 	}
 	return sysTypes
 }


### PR DESCRIPTION
Currently, every region is assigned a set of system types. However, system types can be different for different zones within a region. Hence, move sysTypes as children of zones rather than siblings of zones.