### PR TITLE
ARO-12457: Include bootstrap docker config file in go module

### DIFF
--- a/data/data/tools.go
+++ b/data/data/tools.go
@@ -8,5 +8,5 @@ import "embed"
 // this package and no other codebases should either, as we intend to remove it
 // once ARO has moved off the wrapper.
 
-//go:embed bootstrap/* manifests/* coreos/*
+//go:embed all:bootstrap manifests/* coreos/*
 var _ embed.FS


### PR DESCRIPTION
The /root/.docker/config.json.template file was not included because there was an invisible directory in the path. Without this file there will be no pull secret in the bootstrap node.