### PR TITLE
OCPBUGS-45175: Ironic external url port should change based on protocol

### DIFF
--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -95,7 +95,11 @@ func externalURLs(apiVIPs []string, protocol string) (externalURLv4 string, exte
 	if len(apiVIPs) > 1 {
 		// IPv6 BMCs may not be able to reach IPv4 servers, use the right callback URL for them.
 		// Warning: when backporting to 4.12 or earlier, change the port to 80!
-		externalURL := fmt.Sprintf("%s://%s/", protocol, net.JoinHostPort(apiVIPs[1], "6180"))
+		port := "6180"
+		if protocol == "https" {
+			port = "6183"
+		}
+		externalURL := fmt.Sprintf("%s://%s/", protocol, net.JoinHostPort(apiVIPs[1], port))
 		if utilsnet.IsIPv6String(apiVIPs[1]) {
 			externalURLv6 = externalURL
 		}

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -59,6 +59,7 @@ func TestTemplatingManagedIPv6(t *testing.T) {
 		ProvisioningDHCPRange:   "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff",
 		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",
 		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
+		APIVIPs:                 []string{"53.78.144.26", "d601:602e:6397:a048:f516:dc63:1e83:fcaa"},
 	}
 	openshiftDependency := []asset.Asset{
 		&manifests.Openshift{},
@@ -74,6 +75,7 @@ func TestTemplatingManagedIPv6(t *testing.T) {
 	assert.Equal(t, result.ProvisioningIP, "fd2e:6f44:5dd8:b856::2")
 	assert.Equal(t, result.IronicUsername, "bootstrap-ironic-user")
 	assert.Equal(t, result.IronicPassword, "passw0rd")
+	assert.Equal(t, result.ExternalURLv6, "https://[d601:602e:6397:a048:f516:dc63:1e83:fcaa]:6183/")
 }
 
 func TestTemplatingUnmanagedIPv6(t *testing.T) {
@@ -97,4 +99,5 @@ func TestTemplatingUnmanagedIPv6(t *testing.T) {
 	assert.Equal(t, result.ProvisioningDHCPAllowList, "")
 	assert.Equal(t, result.IronicUsername, "bootstrap-ironic-user")
 	assert.Equal(t, result.IronicPassword, "passw0rd")
+	assert.Equal(t, result.ExternalURLv6, "")
 }


### PR DESCRIPTION
Default port for ironic is 6180 but it's not configured for TLS
The secure port for ironic TLS connection is 6183
Change the port value based on the protocol used