### PR TITLE
[release-4.15] OCPBUGS-45207: add chrony.conf file when additional NTP sources are configured

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/assets/with_additional_ntp_sources.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/with_additional_ntp_sources.txt
@@ -1,0 +1,80 @@
+# Verify that the most relevant assets are properly generated in the ISO
+
+exec openshift-install agent create image --dir $WORK
+
+exists $WORK/agent.x86_64.iso
+
+isocmp agent.x86_64.iso /etc/chrony.conf expected/chrony.conf
+isocmp agent.x86_64.iso /etc/assisted/manifests/infraenv.yaml expected/infraenv.yaml
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 1
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+additionalNTPSources:
+- 0.clock.ntp.org
+- 1.clock.ntp.org
+
+-- expected/chrony.conf --
+server 0.clock.ntp.org iburst
+server 1.clock.ntp.org iburst
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony
+-- expected/infraenv.yaml --
+metadata:
+  creationTimestamp: null
+  name: ostest
+  namespace: cluster0
+spec:
+  additionalNTPSources:
+  - 0.clock.ntp.org
+  - 1.clock.ntp.org
+  clusterRef:
+    name: ostest
+    namespace: cluster0
+  cpuArchitecture: x86_64
+  ipxeScriptType: ""
+  nmStateConfigLabelSelector:
+    matchLabels:
+      infraenvs.agent-install.openshift.io: ostest
+  pullSecretRef:
+    name: ostest-pull-secret
+  sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+status:
+  agentLabelSelector: {}
+  bootArtifacts:
+    initrd: ""
+    ipxeScript: ""
+    kernel: ""
+    rootfs: ""
+  debugInfo:
+    eventsURL: ""


### PR DESCRIPTION
This is a manual cherry-pick of #9247 

(It required a small manual fix in the integration test)