### PR TITLE
OCPBUGS-45218: aws: fix perm requirement for edge nodes

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -405,10 +405,9 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				instanceTypes := awsdefaults.InstanceTypes(installConfig.Config.Platform.AWS.Region, arch, configv1.HighlyAvailableTopologyMode)
 				switch pool.Name {
 				case types.MachinePoolEdgeRoleName:
-					ok := awsSetPreferredInstanceByEdgeZone(ctx, instanceTypes, installConfig.AWS, zones)
-					if !ok {
-						logrus.Warnf("failed to find preferred instance type for one or more zones in the %s pool, using default: %s", pool.Name, instanceTypes[0])
-						mpool.InstanceType = instanceTypes[0]
+					if !awsSetPreferredInstanceByEdgeZone(ctx, instanceTypes, installConfig.AWS, zones) {
+						// Using the default instance type from the non-edge pool often fails.
+						return fmt.Errorf("failed to find instance type for one or more zones in the %s pool. Please specify an instance type in the install-config.yaml", pool.Name)
 					}
 				default:
 					mpool.InstanceType, err = aws.PreferredInstanceType(ctx, installConfig.AWS, instanceTypes, mpool.Zones)


### PR DESCRIPTION
If an edge machine pool is specified without an instance type, the installer needs the `ec2:DescribeInstanceTypeOfferings` permission to derive the correct instance type available according to the local/wavelength zones being used.

Before this change, the permission was optional and its absence would result in the installer picking a hard-coded non-edge pool instance type which can cause unsupported configuration issues in mapi's output:
```
     providerStatus:
      conditions:
      - lastTransitionTime: "2024-11-28T15:32:09Z"
        message: 'error launching instance: The requested configuration is currently
          not supported. Please check the documentation for supported configurations.'
        reason: MachineCreationFailed
        status: "False"
        type: MachineCreation
```