### PR TITLE
OCPBUGS-45289: capi/aws: use LB name when finding Hosted Zone ID

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -174,7 +174,7 @@ func (*Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput) 
 		}
 
 		pubLB := awsCluster.Status.Network.SecondaryAPIServerELB
-		aliasZoneID, err := getHostedZoneIDForNLB(ctx, awsSession, awsCluster.Spec.Region, pubLB.DNSName)
+		aliasZoneID, err := getHostedZoneIDForNLB(ctx, awsSession, awsCluster.Spec.Region, pubLB.Name)
 		if err != nil {
 			return fmt.Errorf("failed to find HostedZone ID for NLB: %w", err)
 		}


### PR DESCRIPTION
We should use the LB name, not its DNS name, when listing load balancers with the AWS SDK otherwise the following error will happen:
```
failed to fetch Cluster: failed to generate asset \"Cluster\": failed to create cluster: failed provisioning resources after infrastructure ready: failed to find HostedZone ID for NLB: failed to list load balancers: ValidationError: The load balancer name 'yunjiang-ap55-sk6jl-ext-a6aae262b13b0580.elb.ap-southeast-5.amazonaws.com' cannot be longer than '32' characters\n\tstatus code: 400, request id: f8adce67-d844-4088-9289-4950ce4d0c83
```