### PR TITLE
OCPBUGS-44938: Handle multiple mirror entries for source

### DIFF
--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -716,7 +716,7 @@ func TestIgnition_getMirrorFromRelease(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "some.registry.org/release",
-						Mirror:   "some.mirror.org",
+						Mirrors:  []string{"some.mirror.org"},
 					},
 				},
 			},
@@ -733,7 +733,7 @@ func TestIgnition_getMirrorFromRelease(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "registry.ci.openshift.org/ocp/release",
-						Mirror:   "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+						Mirrors:  []string{"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"},
 					},
 				},
 			},
@@ -750,15 +750,38 @@ func TestIgnition_getMirrorFromRelease(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
-						Mirror:   "localhost:5000/openshift4/openshift/release",
+						Mirrors:  []string{"localhost:5000/openshift4/openshift/release"},
 					},
 					{
 						Location: "quay.io/openshift-release-dev/ocp-release",
-						Mirror:   "localhost:5000/openshift-release-dev/ocp-release",
+						Mirrors:  []string{"localhost:5000/openshift-release-dev/ocp-release"},
 					},
 				},
 			},
 			expectedMirror: "localhost:5000/openshift-release-dev/ocp-release@sha256:300bce8246cf880e792e106607925de0a404484637627edf5f517375517d54a4",
+		},
+		{
+			name:    "mirror-match-multiple-mirrors",
+			release: "registry.ci.openshift.org/ocp/release:4.18.0-0.nightly-foo",
+			registriesConf: mirror.RegistriesConf{
+				File: &asset.File{
+					Filename: "registries.conf",
+					Data:     []byte(""),
+				},
+				MirrorConfig: []mirror.RegistriesConfig{
+					{
+						Location: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						Mirrors: []string{"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
+							"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"},
+					},
+					{
+						Location: "registry.ci.openshift.org/ocp/release",
+						Mirrors: []string{"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
+							"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"},
+					},
+				},
+			},
+			expectedMirror: "virthost.ostest.test.metalkube.org:5000/localimages/ocp-release:4.18.0-0.nightly-foo",
 		},
 	}
 	for _, tc := range cases {
@@ -793,7 +816,7 @@ func TestIgnition_getPublicContainerRegistries(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "some.registry.org/release",
-						Mirror:   "some.mirror.org",
+						Mirrors:  []string{"some.mirror.org"},
 					},
 				},
 			},
@@ -809,11 +832,11 @@ func TestIgnition_getPublicContainerRegistries(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
-						Mirror:   "localhost:5000/openshift4/openshift/release",
+						Mirrors:  []string{"localhost:5000/openshift4/openshift/release"},
 					},
 					{
 						Location: "registry.ci.openshift.org/ocp/release",
-						Mirror:   "localhost:5000/openshift-release-dev/ocp-release",
+						Mirrors:  []string{"localhost:5000/openshift-release-dev/ocp-release"},
 					},
 				},
 			},
@@ -829,11 +852,11 @@ func TestIgnition_getPublicContainerRegistries(t *testing.T) {
 				MirrorConfig: []mirror.RegistriesConfig{
 					{
 						Location: "registry.ci.openshift.org/ocp-v4.0-art-dev",
-						Mirror:   "localhost:5000/openshift4/openshift/release",
+						Mirrors:  []string{"localhost:5000/openshift4/openshift/release"},
 					},
 					{
 						Location: "registry.ci.openshift.org/ocp/release",
-						Mirror:   "localhost:5000/openshift-release-dev/ocp-release",
+						Mirrors:  []string{"localhost:5000/openshift-release-dev/ocp-release"},
 					},
 				},
 			},

--- a/pkg/asset/agent/image/oc_test.go
+++ b/pkg/asset/agent/image/oc_test.go
@@ -21,11 +21,11 @@ func TestGetIcspContents(t *testing.T) {
 			mirrorConfig: []mirror.RegistriesConfig{
 				{
 					Location: "registry.ci.openshift.org/ocp/release",
-					Mirror:   "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+					Mirrors:  []string{"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"},
 				},
 				{
 					Location: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
-					Mirror:   "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+					Mirrors:  []string{"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"},
 				},
 			},
 			expectedConfig: "apiVersion: operator.openshift.io/v1alpha1\nkind: ImageContentSourcePolicy\nmetadata:\n  creationTimestamp: null\n  name: image-policy\nspec:\n  repositoryDigestMirrors:\n  - mirrors:\n    - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image\n    source: registry.ci.openshift.org/ocp/release\n  - mirrors:\n    - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image\n    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev\n",

--- a/pkg/asset/agent/image/releaseextract.go
+++ b/pkg/asset/agent/image/releaseextract.go
@@ -401,7 +401,7 @@ func getIcspContents(mirrorConfig []mirror.RegistriesConfig) ([]byte, error) {
 
 	icsp.Spec.RepositoryDigestMirrors = make([]operatorv1alpha1.RepositoryDigestMirrors, len(mirrorConfig))
 	for i, mirrorRegistries := range mirrorConfig {
-		icsp.Spec.RepositoryDigestMirrors[i] = operatorv1alpha1.RepositoryDigestMirrors{Source: mirrorRegistries.Location, Mirrors: []string{mirrorRegistries.Mirror}}
+		icsp.Spec.RepositoryDigestMirrors[i] = operatorv1alpha1.RepositoryDigestMirrors{Source: mirrorRegistries.Location, Mirrors: mirrorRegistries.Mirrors}
 	}
 
 	// Convert to json first so json tags are handled

--- a/pkg/asset/agent/image/unconfigured_ignition_test.go
+++ b/pkg/asset/agent/image/unconfigured_ignition_test.go
@@ -48,7 +48,7 @@ func TestUnconfiguredIgnition_Generate(t *testing.T) {
 					MirrorConfig: []mirror.RegistriesConfig{
 						{
 							Location: "some.registry.org/release",
-							Mirror:   "some.mirror.org",
+							Mirrors:  []string{"some.mirror.org"},
 						},
 					},
 				},

--- a/pkg/asset/agent/mirror/registriesconf_test.go
+++ b/pkg/asset/agent/mirror/registriesconf_test.go
@@ -202,6 +202,68 @@ unqualified-search-registries = []
 `,
 		},
 		{
+			name: "image-digest-sources-multiple-mirrors",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.ClusterInfo{},
+				&agent.OptionalInstallConfig{
+					Supplied: true,
+					AssetBase: installconfig.AssetBase{
+						Config: &types.InstallConfig{
+							ObjectMeta: v1.ObjectMeta{
+								Namespace: "cluster-0",
+							},
+							ImageDigestSources: []types.ImageDigestSource{
+								{
+									Source: "registry.ci.openshift.org/ocp/release",
+									Mirrors: []string{
+										"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+										"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
+									},
+								},
+								{
+									Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+									Mirrors: []string{
+										"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+										"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
+									},
+								},
+							},
+						},
+					},
+				},
+				&releaseimage.Image{
+					PullSpec: "registry.ci.openshift.org/ocp/release:4.11.0-0.ci-2022-05-16-202609",
+				},
+			},
+			expectedConfig: `credential-helpers = []
+short-name-mode = ""
+unqualified-search-registries = []
+
+[[registry]]
+  location = "registry.ci.openshift.org/ocp/release"
+  mirror-by-digest-only = true
+  prefix = ""
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/ocp-release"
+
+[[registry]]
+  location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+  mirror-by-digest-only = true
+  prefix = ""
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/ocp-release"
+`,
+		},
+		{
 			name: "add-nodes command - missing-config",
 			dependencies: []asset.Asset{
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeAddNodes},
@@ -222,12 +284,14 @@ unqualified-search-registries = []
 							Source: "registry.ci.openshift.org/ocp/release",
 							Mirrors: []string{
 								"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+								"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
 							},
 						},
 						{
 							Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
 							Mirrors: []string{
 								"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+								"virthost.ostest.test.metalkube.org:5000/localimages/ocp-release",
 							},
 						},
 					},
@@ -247,6 +311,9 @@ unqualified-search-registries = []
   [[registry.mirror]]
     location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
 
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/ocp-release"
+
 [[registry]]
   location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
   mirror-by-digest-only = true
@@ -254,6 +321,9 @@ unqualified-search-registries = []
 
   [[registry.mirror]]
     location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/ocp-release"
 `,
 		},
 	}


### PR DESCRIPTION
If a mirror source contains multiple mirror entries, the tmp icsp file created for the agent-based installer 'oc' commands would only contain the first entry. This could cause a failure of the 'oc' command in a disconnected environment with multiple entries. Fix to handle multiple mirrors properly.