### PR TITLE
OCPBUGS-45491: Align vSphere UPI haproxy config with IPI

### DIFF
--- a/upi/vsphere/lb/haproxy.erb.tmpl
+++ b/upi/vsphere/lb/haproxy.erb.tmpl
@@ -1,10 +1,10 @@
 defaults
-  maxconn 20000
+  maxconn 40000
   mode    tcp
   log     /var/run/haproxy/haproxy-log.sock local0
   option  dontlognull
   retries 3
-  timeout http-request 10s
+  timeout http-request 30s
   timeout queue        1m
   timeout connect      10s
   timeout client       86400s
@@ -28,11 +28,12 @@ frontend router-https
     default_backend router-https
 
 backend api-server
+    timeout check 10s
     option  httpchk GET /readyz HTTP/1.0
     option  log-health-checks
     balance roundrobin
 <% foreach ($addr in $api) { -%>
-    server <%= $addr %> <%= $addr %>:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
+    server <%= $addr %> <%= $addr %>:6443 weight 1 verify none check check-ssl inter 5s fall 3 rise 1
 <% } -%>
 
 backend machine-config-server

--- a/upi/vsphere/lb/haproxy.tmpl
+++ b/upi/vsphere/lb/haproxy.tmpl
@@ -1,10 +1,10 @@
 defaults
-  maxconn 20000
+  maxconn 40000
   mode    tcp
   log     /var/run/haproxy/haproxy-log.sock local0
   option  dontlognull
   retries 3
-  timeout http-request 10s
+  timeout http-request 30s
   timeout queue        1m
   timeout connect      10s
   timeout client       86400s
@@ -28,11 +28,12 @@ frontend router-https
     default_backend router-https
 
 backend api-server
+    timeout check 10s
     option  httpchk GET /readyz HTTP/1.0
     option  log-health-checks
     balance roundrobin
     %{ for addr in api ~}
-    server ${addr} ${addr}:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
+    server ${addr} ${addr}:6443 weight 1 verify none check check-ssl inter 5s fall 3 rise 1
     %{ endfor ~}
 
 backend machine-config-server


### PR DESCRIPTION
We are experiencing the following test failure:

API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients

Updating haproxy configuration to match IPI in the hopes of resolving the issue