### PR TITLE
OCPBUGS-45162: Delete tagged disks

### DIFF
--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -51,12 +51,11 @@ func (o *ClusterUninstaller) storageLabelOrClusterIDFilter() string {
 }
 
 func (o *ClusterUninstaller) listDisks(ctx context.Context) ([]cloudResource, error) {
-	return o.listDisksWithFilter(ctx, "items/*/disks(name,zone,type,sizeGb),nextPageToken", func(item *compute.Disk) bool {
+	return o.listDisksWithFilter(ctx, "items/*/disks(name,zone,type,sizeGb,labels),nextPageToken", func(item *compute.Disk) bool {
 		if o.isClusterResource(item.Name) || strings.HasPrefix(item.Name, o.formatClusterIDForStorage()) {
 			return true
 		}
 
-		// TODO: do labels get formatted as labels.%s, or is this only for filters
 		for key, value := range item.Labels {
 			if key == fmt.Sprintf(gcpconsts.ClusterIDLabelFmt, o.ClusterID) && value == ownedLabelValue {
 				return true


### PR DESCRIPTION
** When querying for disk information, the labels need to be grabbed from the api. The installer was searching for the label information, but the information was blank when returned by the API so it would never find the correct label (to be used during cluster resource deletion).