### PR TITLE
OCPBUGS-45317: node-joiner PXE artifacts should be prefixed "node"

### DIFF
--- a/cmd/node-joiner/testdata/add-nodes-pxe.txt
+++ b/cmd/node-joiner/testdata/add-nodes-pxe.txt
@@ -3,14 +3,14 @@
 
 exec node-joiner add-nodes --pxe --kubeconfig=$WORK/kubeconfig --log-level=debug --dir=$WORK
 
-exists $WORK/boot-artifacts/agent.x86_64-initrd.img
-exists $WORK/boot-artifacts/agent.x86_64-rootfs.img
-exists $WORK/boot-artifacts/agent.x86_64-vmlinuz
-exists $WORK/boot-artifacts/agent.x86_64.ipxe
+exists $WORK/boot-artifacts/node.x86_64-initrd.img
+exists $WORK/boot-artifacts/node.x86_64-rootfs.img
+exists $WORK/boot-artifacts/node.x86_64-vmlinuz
+exists $WORK/boot-artifacts/node.x86_64.ipxe
 
-grep 'initrd --name initrd http://user-specified-pxe-infra.com/agent.x86_64-initrd.img' $WORK/boot-artifacts/agent.x86_64.ipxe
-grep 'kernel http://user-specified-pxe-infra.com/agent.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/agent.x86_64-rootfs.img  fips=1' $WORK/boot-artifacts/agent.x86_64.ipxe
-! grep 'coreos.liveiso=' $WORK/boot-artifacts/agent.x86_64.ipxe
+grep 'initrd --name initrd http://user-specified-pxe-infra.com/node.x86_64-initrd.img' $WORK/boot-artifacts/node.x86_64.ipxe
+grep 'kernel http://user-specified-pxe-infra.com/node.x86_64-vmlinuz initrd=initrd coreos.live.rootfs_url=http://user-specified-pxe-infra.com/node.x86_64-rootfs.img  fips=1' $WORK/boot-artifacts/node.x86_64.ipxe
+! grep 'coreos.liveiso=' $WORK/boot-artifacts/node.x86_64.ipxe
 
 -- nodes-config.yaml --
 bootArtifactsBaseURL: http://user-specified-pxe-infra.com

--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -26,6 +26,10 @@ const (
 	// bootArtifactsPath is the path where boot files are created.
 	// e.g. initrd, kernel and rootfs.
 	bootArtifactsPath = "boot-artifacts"
+	// agentFilePrefix is the prefix used for day 1 images.
+	agentFilePrefix = "agent"
+	// nodeFilePrefix is the prefix used for day 2 images.
+	nodeFilePrefix = "node"
 )
 
 // AgentArtifacts is an asset that generates all the artifacts that could be used
@@ -241,8 +245,8 @@ func createDir(bootArtifactsFullPath string) error {
 	return nil
 }
 
-func extractRootFS(bootArtifactsFullPath, agentISOPath, arch string) error {
-	agentRootfsimgFile := filepath.Join(bootArtifactsFullPath, fmt.Sprintf("agent.%s-rootfs.img", arch))
+func extractRootFS(bootArtifactsFullPath, agentISOPath, filePrefix, arch string) error {
+	agentRootfsimgFile := filepath.Join(bootArtifactsFullPath, fmt.Sprintf("%s.%s-rootfs.img", filePrefix, arch))
 	rootfsReader, err := os.Open(filepath.Join(agentISOPath, "images", "pxeboot", "rootfs.img"))
 	if err != nil {
 		return err

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -242,7 +242,7 @@ func (a *AgentImage) PersistToFile(directory string) error {
 			if err != nil {
 				return err
 			}
-			err = extractRootFS(bootArtifactsFullPath, a.tmpPath, a.cpuArch)
+			err = extractRootFS(bootArtifactsFullPath, a.tmpPath, agentFilePrefix, a.cpuArch)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
instead of "agent".

The "agent" prefix is used for the day 1 agent ISO.

The "node" prefix is used for day-2 artifacts, both ISO and PXE.