### PR TITLE
OCPBUGS-45807: aws: fix sts:AssumeRole perm requirement

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -68,6 +68,9 @@ const (
 	// PermissionDefaultZones is a permission set required when zones are not set in the install-config.
 	PermissionDefaultZones PermissionGroup = "permission-default-zones"
 
+	// PermissionAssumeRole is a permission set required when an IAM role to be assumed is set in the install-config.
+	PermissionAssumeRole PermissionGroup = "permission-assume-role"
+
 	// PermissionMintCreds is a permission set required when minting credentials.
 	PermissionMintCreds PermissionGroup = "permission-mint-creds"
 
@@ -329,6 +332,10 @@ var permissions = map[PermissionGroup][]string{
 		// Needed to filter zones by instance type
 		"ec2:DescribeInstanceTypeOfferings",
 	},
+	PermissionAssumeRole: {
+		// Needed so the installer can use the provided custom IAM role
+		"sts:AssumeRole",
+	},
 	// From: https://github.com/openshift/cloud-credential-operator/blob/master/pkg/aws/utils.go
 	// TODO: export these in CCO so we don't have to duplicate them here.
 	PermissionMintCreds: {
@@ -516,6 +523,10 @@ func RequiredPermissionGroups(ic *types.InstallConfig) []PermissionGroup {
 		permissionGroups = append(permissionGroups, PermissionDefaultZones)
 	}
 
+	if includesAssumeRole(ic) {
+		permissionGroups = append(permissionGroups, PermissionAssumeRole)
+	}
+
 	return permissionGroups
 }
 
@@ -686,4 +697,9 @@ func includesZones(installConfig *types.InstallConfig) bool {
 	}
 
 	return len(mpool.Zones) > 0 || len(installConfig.AWS.Subnets) > 0
+}
+
+// includesAssumeRole checks if a custom IAM role is specified in the install-config.
+func includesAssumeRole(installConfig *types.InstallConfig) bool {
+	return len(installConfig.AWS.HostedZoneRole) > 0
 }

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -807,3 +807,17 @@ func TestIncludesZones(t *testing.T) {
 		assert.Contains(t, requiredPerms, PermissionDefaultZones)
 	})
 }
+
+func TestIncludesAssumeRole(t *testing.T) {
+	t.Run("Should be true when IAM role specified", func(t *testing.T) {
+		ic := validInstallConfig()
+		ic.AWS.HostedZoneRole = "custom-role"
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.Contains(t, requiredPerms, PermissionAssumeRole)
+	})
+	t.Run("Should be false when IAM role not specified", func(t *testing.T) {
+		ic := validInstallConfig()
+		requiredPerms := RequiredPermissionGroups(ic)
+		assert.NotContains(t, requiredPerms, PermissionAssumeRole)
+	})
+}


### PR DESCRIPTION
If a custom IAM role is specified, the installer needs the `sts:AssumeRole` to be able to use that role.

This fixes the following error:
```
level=fatal msg=failed to fetch Cluster Infrastructure Variables: failed to fetch dependency of "Cluster Infrastructure Variables": failed to generate asset "Platform Provisioning Check": aws.hostedZone: Invalid value: "Z01991651G3UXC4ZFDNDU": unable to retrieve hosted zone: could not get hosted zone: Z01991651G3UXC4ZFDNDU: AccessDenied: User: arn:aws:iam::<redacted>:user/ci-op-1c2w7jv2-ef4fe-minimal-perm-installer is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::<redacted>:role/ci-op-1c2w7jv2-ef4fe-shared-role
level=fatal msg=	status code: 403, request id: ab7160fa-ade9-4afe-aacd-782495dc9978
Installer exit with code 1
```