### PR TITLE
OCPBUGS-45692: Modified ova template name to use failure domain name

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -403,9 +403,8 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		}
 
 		pool.Platform.VSphere = &mpool
-		templateName := clusterID.InfraID + "-rhcos"
 
-		c.FileList, err = vspherecapi.GenerateMachines(ctx, clusterID.InfraID, ic, &pool, templateName, "master", installConfig.VSphere)
+		c.FileList, err = vspherecapi.GenerateMachines(ctx, clusterID.InfraID, ic, &pool, "master", installConfig.VSphere)
 		if err != nil {
 			return fmt.Errorf("unable to generate CAPI machines for vSphere %w", err)
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -463,9 +463,8 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		}
 
 		pool.Platform.VSphere = &mpool
-		templateName := clusterID.InfraID + "-rhcos"
 
-		data, err := vsphere.Machines(clusterID.InfraID, ic, &pool, templateName, "master", masterUserDataSecretName)
+		data, err := vsphere.Machines(clusterID.InfraID, ic, &pool, "master", masterUserDataSecretName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}

--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -71,8 +71,8 @@ func getNetworkInventoryPath(vcenterContext vsphere.VCenterContext, networkName 
 }
 
 // GenerateMachines returns a list of capi machines.
-func GenerateMachines(ctx context.Context, clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage string, role string, metadata *vsphere.Metadata) ([]*asset.RuntimeFile, error) {
-	data, err := Machines(clusterID, config, pool, osImage, role, "")
+func GenerateMachines(ctx context.Context, clusterID string, config *types.InstallConfig, pool *types.MachinePool, role string, metadata *vsphere.Metadata) ([]*asset.RuntimeFile, error) {
+	data, err := Machines(clusterID, config, pool, role, "")
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve machines: %w", err)
 	}

--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -19,6 +19,7 @@ import (
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
+	"github.com/openshift/installer/pkg/utils"
 )
 
 // MachineData contains all result output from the Machines() function.
@@ -32,7 +33,7 @@ type MachineData struct {
 }
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) (*MachineData, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) (*MachineData, error) {
 	data := &MachineData{}
 	if configPlatform := config.Platform.Name(); configPlatform != vsphere.Name {
 		return data, fmt.Errorf("non vsphere configuration: %q", configPlatform)
@@ -107,7 +108,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 
 		osImageForZone := failureDomain.Topology.Template
 		if failureDomain.Topology.Template == "" {
-			osImageForZone = fmt.Sprintf("%s-%s-%s", osImage, failureDomain.Region, failureDomain.Zone)
+			osImageForZone = utils.GenerateVSphereTemplateName(clusterID, failureDomain.Name)
 		}
 
 		vcenter, err := getVCenterFromServerName(failureDomain.Server, platform)

--- a/pkg/asset/machines/vsphere/machines_test.go
+++ b/pkg/asset/machines/vsphere/machines_test.go
@@ -413,7 +413,7 @@ func TestConfigMasters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
-			data, err := Machines(clusterID, tc.installConfig, tc.machinePool, "", "", "")
+			data, err := Machines(clusterID, tc.installConfig, tc.machinePool, "", "")
 			assertOnUnexpectedErrorState(t, tc.expectedError, err)
 
 			if len(tc.workspaces) > 0 {
@@ -492,7 +492,7 @@ func TestHostsToMachines(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
-			data, err := Machines(clusterID, tc.installConfig, tc.machinePool, "", tc.role, "")
+			data, err := Machines(clusterID, tc.installConfig, tc.machinePool, tc.role, "")
 			assertOnUnexpectedErrorState(t, tc.expectedError, err)
 
 			// Check machine counts

--- a/pkg/asset/machines/vsphere/machinesets.go
+++ b/pkg/asset/machines/vsphere/machinesets.go
@@ -11,6 +11,7 @@ import (
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
+	"github.com/openshift/installer/pkg/utils"
 )
 
 func getMachineSetWithPlatform(
@@ -112,7 +113,7 @@ func getDefinedZonesFromTopology(p *vsphere.Platform) (map[string]vsphere.Failur
 }
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*machineapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]*machineapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != vsphere.Name {
 		return nil, fmt.Errorf("non vsphere configuration: %q", configPlatform)
 	}
@@ -162,7 +163,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 
 		osImageForZone := failureDomain.Topology.Template
 		if failureDomain.Topology.Template == "" {
-			osImageForZone = fmt.Sprintf("%s-%s-%s", osImage, failureDomain.Region, failureDomain.Zone)
+			osImageForZone = utils.GenerateVSphereTemplateName(clusterID, failureDomain.Name)
 		}
 		machineset, err := getMachineSetWithPlatform(
 			clusterID,

--- a/pkg/asset/machines/vsphere/machinesets_test.go
+++ b/pkg/asset/machines/vsphere/machinesets_test.go
@@ -97,7 +97,6 @@ var machineComputePoolUndefinedZones = types.MachinePool{
 
 func TestConfigMachinesets(t *testing.T) {
 	clusterID := "test"
-	osImage := "test-cluster-xyzxyz-rhcos"
 	installConfig, err := parseInstallConfig()
 
 	if err != nil {
@@ -241,7 +240,7 @@ func TestConfigMachinesets(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
-			machineSets, err := MachineSets(clusterID, tc.installConfig, tc.machinePool, osImage, "", "")
+			machineSets, err := MachineSets(clusterID, tc.installConfig, tc.machinePool, "", "")
 			assertOnUnexpectedErrorState(t, tc.expectedError, err)
 
 			if len(tc.workspaces) > 0 {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -583,9 +583,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 			mpool.Set(ic.Platform.VSphere.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.VSphere)
 			pool.Platform.VSphere = &mpool
-			templateName := clusterID.InfraID + "-rhcos"
 
-			sets, err := vsphere.MachineSets(clusterID.InfraID, ic, &pool, templateName, "worker", workerUserDataSecretName)
+			sets, err := vsphere.MachineSets(clusterID.InfraID, ic, &pool, "worker", workerUserDataSecretName)
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -596,9 +595,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 			// If static IPs are configured, we must generate worker machines and scale the machinesets to 0.
 			if ic.Platform.VSphere.Hosts != nil {
 				logrus.Debug("Generating worker machines with static IPs.")
-				templateName := clusterID.InfraID + "-rhcos"
 
-				data, err := vsphere.Machines(clusterID.InfraID, ic, &pool, templateName, "worker", workerUserDataSecretName)
+				data, err := vsphere.Machines(clusterID.InfraID, ic, &pool, "worker", workerUserDataSecretName)
 				if err != nil {
 					return errors.Wrap(err, "failed to create worker machine objects")
 				}

--- a/pkg/asset/manifests/vsphere/infrastructure.go
+++ b/pkg/asset/manifests/vsphere/infrastructure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
+	"github.com/openshift/installer/pkg/utils"
 )
 
 // GetInfraPlatformSpec constructs VSpherePlatformSpec for the infrastructure spec
@@ -30,7 +31,7 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig, clusterID string) *co
 		if topology.ComputeCluster != "" && topology.Networks[0] != "" {
 			template := topology.Template
 			if len(template) == 0 {
-				template = fmt.Sprintf("/%s/vm/%s-rhcos-%s-%s", topology.Datacenter, clusterID, failureDomain.Region, failureDomain.Zone)
+				template = fmt.Sprintf("/%s/vm/%s", topology.Datacenter, utils.GenerateVSphereTemplateName(clusterID, failureDomain.Name))
 			}
 
 			failureDomainSpec := configv1.VSpherePlatformFailureDomainSpec{

--- a/pkg/infrastructure/vsphere/clusterapi/import.go
+++ b/pkg/infrastructure/vsphere/clusterapi/import.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 
 	"github.com/openshift/installer/pkg/types/vsphere"
+	"github.com/openshift/installer/pkg/utils"
 )
 
 func debugCorruptOva(cachedImage string, err error) error {
@@ -58,8 +59,16 @@ func checkOvaSecureBoot(ovfEnvelope *ovf.Envelope) bool {
 }
 
 func importRhcosOva(ctx context.Context, session *session.Session, folder *object.Folder, cachedImage, clusterID, tagID, diskProvisioningType string, failureDomain vsphere.FailureDomain) error {
-	name := fmt.Sprintf("%s-rhcos-%s-%s", clusterID, failureDomain.Region, failureDomain.Zone)
+	// Name originally was cluster id + fd.region + fd.zone.  This could cause length of ova to be longer than max allowed.
+	// So for now, we are going to make cluster id  + fd.name
+	name := utils.GenerateVSphereTemplateName(clusterID, failureDomain.Name)
 	logrus.Infof("Importing OVA %v into failure domain %v.", name, failureDomain.Name)
+
+	// OVA name must not exceed 80 characters
+	if len(name) > 80 {
+		logrus.Warningf("Unable to generate ova template name due to exceeding 80 characters. Cluster=\"%v\" Failure Domain=\"%v\" results in \"%v\"", clusterID, failureDomain.Name, name)
+		return fmt.Errorf("ova name \"%v\" exceeed 80 characters (%d)", name, len(name))
+	}
 
 	archive := &importer.TapeArchive{Path: cachedImage}
 

--- a/pkg/utils/vmware.go
+++ b/pkg/utils/vmware.go
@@ -116,3 +116,8 @@ func ConstructKargsFromNetworkConfig(ipAddrs []string, nameservers []string, gat
 	logrus.Debugf("Generated karg: [%v].", outKargs)
 	return outKargs, nil
 }
+
+// GenerateVSphereTemplateName returns expected template name.
+func GenerateVSphereTemplateName(clusterID, fdName string) string {
+	return fmt.Sprintf("%s-rhcos-%s", clusterID, fdName)
+}


### PR DESCRIPTION
OCPBUGS-45692

### Changes
- Modified importRhcosOva() to check for max length
- Modified importRhcosOva() to use failure domain name as part of OVA filename instead of region and zone.