### PR TITLE
OCPBUGS-45984: IBMCloud Fix VPC-COS IAM Auth

### DIFF
--- a/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
@@ -171,7 +171,7 @@ func (p Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionIn
 
 	// Create IAM authorization for VPC to COS access for Custom Image Creation
 	logrus.Debugf("creating iam authorization for vpc to cos access")
-	err = client.CreateIAMAuthorizationPolicy(ctx, "is", "image", "cloud-object-storage", *cosInstance.ID, []string{"crn:v1:bluemix:public:iam::::serviceRole:Reader"})
+	err = client.CreateIAMAuthorizationPolicy(ctx, "is", "image", "cloud-object-storage", *cosInstance.GUID, []string{"crn:v1:bluemix:public:iam::::serviceRole:Reader"})
 	if err != nil {
 		return fmt.Errorf("failed creating vpc-cos IAM authorization policy: %w", err)
 	}


### PR DESCRIPTION
Fix the IAM Authorization between IBM Cloud VPC and IBM Cloud COS, to allow for VPC Custom Image creation as part of CAPI Infrastructure support.

Related: https://issues.redhat.com/browse/OCPBUGS-45984