### PR TITLE
OCPBUGS-45669: aws: fix Node Port Service rule removal

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -455,14 +455,6 @@ func removeNodeServiceAllRule(ctx context.Context, session *session.Session, sgI
 					{CidrIp: aws.String("0.0.0.0/0")},
 				},
 			},
-			{
-				IpProtocol: aws.String("tcp"),
-				FromPort:   aws.Int64(30000),
-				ToPort:     aws.Int64(32767),
-				Ipv6Ranges: []*ec2.Ipv6Range{
-					{CidrIpv6: aws.String("::/0")},
-				},
-			},
 		},
 	}
 	_, err := ec2.New(session).RevokeSecurityGroupIngressWithContext(ctx, input)


### PR DESCRIPTION
This is a fallout from https://github.com/openshift/installer/pull/9281

By including the Ipv6 params I've made it so AWS would only return a result if a rule satisfying both the Ipv4 and Ipv6 params was present, which is not the case currently.

Dropping the Ipv6 part as Ipv6 is not supported in 4.16.