### PR TITLE
OCPBUGS-46375: Allow spaces in the aws tags [release-4.17]

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -14,7 +14,7 @@ import (
 )
 
 // tagRegex is used to check that the keys and values of a tag contain only valid characters.
-var tagRegex = regexp.MustCompile(`^[0-9A-Za-z_.:/=+-@]*$`)
+var tagRegex = regexp.MustCompile(`^[0-9A-Za-z_.:/=+-@\p{Z}]*$`)
 
 // kubernetesNamespaceRegex is used to check that a tag key is not in the kubernetes.io namespace.
 var kubernetesNamespaceRegex = regexp.MustCompile(`^([^/]*\.)?kubernetes.io/`)

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -161,6 +161,26 @@ func TestValidatePlatform(t *testing.T) {
 			expected: `^\Qtest-path.userTags[kubernetes.io/cluster/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags\E$`,
 		},
 		{
+			name: "invalid userTags, value with invalid characters",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"usage-user": "cloud-team-rebase-bot[bot]",
+				},
+			},
+			expected: `^\Qtest-path.userTags[usage-user]: Invalid value: "cloud-team-rebase-bot[bot]": value contains invalid characters`,
+		},
+		{
+			name: "valid userTags, value with spaces",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"test-key": "this test has spaces",
+				},
+				PropagateUserTag: true,
+			},
+		},
+		{
 			name: "valid userTags",
 			platform: &aws.Platform{
 				Region: "us-east-1",


### PR DESCRIPTION
Manual cherry-pick of #9197 

** White space should be allowed in aws tags.