### PR TITLE
OCPBUGS-46470: Power VS: ResourceManager also to override for Internal deploy

### DIFF
--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -504,12 +504,13 @@ func leftInContext(ctx context.Context) time.Duration {
 
 // SetDefaultPrivateServiceEndpoints sets service endpoint overrides as needed for Disconnected install.
 func (m *Metadata) SetDefaultPrivateServiceEndpoints(ctx context.Context, overrides []configv1.PowerVSServiceEndpoint, cosRegion string, vpcRegion string) []configv1.PowerVSServiceEndpoint {
-	overrides = addOverride(overrides, "COS", fmt.Sprintf("https://s3.direct.%s.cloud-object-storage.appdomain.cloud", cosRegion))
-	overrides = addOverride(overrides, "DNSServices", "https://api.private.dns-svcs.cloud.ibm.com")
-	overrides = addOverride(overrides, "IAM", "https://private.iam.cloud.ibm.com")
-	overrides = addOverride(overrides, "Power", fmt.Sprintf("https://private.%s.power-iaas.cloud.ibm.com", vpcRegion))
-	overrides = addOverride(overrides, "ResourceController", "https://private.resource-controller.cloud.ibm.com")
-	overrides = addOverride(overrides, "VPC", fmt.Sprintf("https://%s.private.iaas.cloud.ibm.com", vpcRegion))
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceCOS), fmt.Sprintf("https://s3.direct.%s.cloud-object-storage.appdomain.cloud", cosRegion))
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceDNSServices), "https://api.private.dns-svcs.cloud.ibm.com")
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceIAM), "https://private.iam.cloud.ibm.com")
+	overrides = addOverride(overrides, "Power", fmt.Sprintf("https://private.%s.power-iaas.cloud.ibm.com", vpcRegion)) // FIXME confiv1.IBMCloudServicePower?
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceResourceController), "https://private.resource-controller.cloud.ibm.com")
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceResourceManager), "https://private.resource-controller.cloud.ibm.com")
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceVPC), fmt.Sprintf("https://%s.private.iaas.cloud.ibm.com", vpcRegion))
 	return overrides
 }
 

--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -434,7 +434,7 @@ func (c *BxClient) MapServiceEndpointsForCAPI(cfg *powervs.Metadata) []string {
 		"COS":                "cos",
 		"Power":              "powervs",
 		"ResourceController": "", // FIXME CAPI recognizes "rc," but crashes if passed in...
-		"ResourceManager":    "rm",
+		"ResourceManager":    "", // FIXME? masters unable to get their ignition if "rm" override is present...
 		"VPC":                "vpc",
 	}
 	overrides := make([]string, 0, len(cfg.ServiceEndpoints))

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -330,7 +330,7 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 			ResourceGroup:    installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
 			CISInstanceCRN:   cisInstanceCRN,
 			DNSInstanceCRN:   dnsInstanceCRN,
-			ServiceEndpoints: installConfig.Config.Platform.PowerVS.ServiceEndpoints,
+			ServiceEndpoints: config.Spec.PlatformSpec.PowerVS.ServiceEndpoints,
 		}
 	case nutanix.Name:
 		config.Spec.PlatformSpec.Type = configv1.NutanixPlatformType

--- a/pkg/asset/manifests/powervs/cloudproviderconfig.go
+++ b/pkg/asset/manifests/powervs/cloudproviderconfig.go
@@ -43,6 +43,7 @@ type provider struct {
 	IamEndpointOverride      string `gcfg:"iamEndpointOverride"`
 	PowerVSEndpointOverride  string `gcfg:"powerVSEndpointOverride"`
 	RcEndpointOverride       string `gcfg:"rcEndpointOverride"`
+	RmEndpointOverride       string `gcfg:"rmEndpointOverride"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the IBM Power VS platform.
@@ -51,12 +52,15 @@ func CloudProviderConfig(infraID string, accountID string, vpcName string, regio
 	rcEndpointOverride := ""
 	powerVSEndpointOverride := ""
 	vpcEndpointOverride := ""
+	rmEndpointOverride := ""
 	for _, endpoint := range endpointOverrides {
 		switch endpoint.Name {
 		case string(configv1.IBMCloudServiceIAM):
 			iamEndpointOverride = endpoint.URL
 		case string(configv1.IBMCloudServiceResourceController):
 			rcEndpointOverride = endpoint.URL
+		case string(configv1.IBMCloudServiceResourceManager):
+			rmEndpointOverride = endpoint.URL
 		case "Power": // FIXME configv1.IBMCloudServicePower?
 			powerVSEndpointOverride = endpoint.URL
 		case string(configv1.IBMCloudServiceVPC):
@@ -90,6 +94,7 @@ func CloudProviderConfig(infraID string, accountID string, vpcName string, regio
 			IamEndpointOverride:      iamEndpointOverride,
 			PowerVSEndpointOverride:  powerVSEndpointOverride,
 			RcEndpointOverride:       rcEndpointOverride,
+			RmEndpointOverride:       rmEndpointOverride,
 		},
 	}
 	buf := &bytes.Buffer{}
@@ -122,4 +127,5 @@ g2EndpointOverride = {{.Provider.G2EndpointOverride}}
 iamEndpointOverride = {{.Provider.IamEndpointOverride}}
 powerVSEndpointOverride = {{.Provider.PowerVSEndpointOverride}}
 rcEndpointOverride = {{.Provider.RcEndpointOverride}}
+rmEndpointOverride = {{.Provider.RmEndpointOverride}}
 `


### PR DESCRIPTION
Further debugging revealed `ResourceManager` endpoint must also be overridden for Disconnected deploy on PowerVS with CAPI. Like #9143, this PR starts setting/passing `ResourceManager` override to CCM. 

One thing that's perhaps noteworthy is that we are adding logic of those endpoint overrides to be in `platformStatus` as well (as in `platformSpec`) in `pkg/asset/manifests/infrastructure.go`, which should be the way, rather than `machine-controller` container in `machine-api-controllers` pod trying to update `platformStatus` which RBAC blocks.