### PR TITLE
OCPBUGS-45999: Always set cross_tenant_replication_enabled parameter to false

### DIFF
--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -66,14 +66,15 @@ data "azurerm_user_assigned_identity" "keyvault_identity" {
 }
 
 resource "azurerm_storage_account" "cluster" {
-  name                            = "cluster${var.random_storage_account_suffix}"
-  resource_group_name             = data.azurerm_resource_group.main.name
-  location                        = var.azure_region
-  account_tier                    = var.azure_keyvault_name != "" ? "Premium" : "Standard"
-  account_replication_type        = "LRS"
-  min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
-  allow_nested_items_to_be_public = var.azure_keyvault_name != "" ? true : false
-  tags                            = var.azure_extra_tags
+  name                             = "cluster${var.random_storage_account_suffix}"
+  resource_group_name              = data.azurerm_resource_group.main.name
+  location                         = var.azure_region
+  account_tier                     = var.azure_keyvault_name != "" ? "Premium" : "Standard"
+  account_replication_type         = "LRS"
+  min_tls_version                  = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
+  allow_nested_items_to_be_public  = var.azure_keyvault_name != "" ? true : false
+  tags                             = var.azure_extra_tags
+  cross_tenant_replication_enabled = false
 
   dynamic "customer_managed_key" {
     for_each = var.azure_keyvault_name != "" ? [1] : []


### PR DESCRIPTION
** The new versions default to false for cross_tenant_replication_enabled. This change is required for security purposes. ** This security voilation blocks using and scaling Clusters in Public cloud environments for the Banking and Financial industry which need to comply to BAFIN and PCI-DSS regulations.