### PR TITLE
OCPBUGS-45995: Always set AllowCrossTenantReplication parameter to false

### DIFF
--- a/pkg/infrastructure/azure/storage.go
+++ b/pkg/infrastructure/azure/storage.go
@@ -97,12 +97,13 @@ func CreateStorageAccount(ctx context.Context, in *CreateStorageAccountInput) (*
 		Location: to.Ptr(in.Region),
 		SKU:      &sku,
 		Properties: &armstorage.AccountPropertiesCreateParameters{
-			AllowBlobPublicAccess: to.Ptr(false),
-			AllowSharedKeyAccess:  to.Ptr(allowSharedKeyAccess),
-			IsLocalUserEnabled:    to.Ptr(true),
-			LargeFileSharesState:  to.Ptr(armstorage.LargeFileSharesStateEnabled),
-			PublicNetworkAccess:   to.Ptr(armstorage.PublicNetworkAccessEnabled),
-			MinimumTLSVersion:     &minimumTLSVersion,
+			AllowBlobPublicAccess:       to.Ptr(false),
+			AllowSharedKeyAccess:        to.Ptr(allowSharedKeyAccess),
+			IsLocalUserEnabled:          to.Ptr(true),
+			LargeFileSharesState:        to.Ptr(armstorage.LargeFileSharesStateEnabled),
+			PublicNetworkAccess:         to.Ptr(armstorage.PublicNetworkAccessEnabled),
+			MinimumTLSVersion:           &minimumTLSVersion,
+			AllowCrossTenantReplication: to.Ptr(false), // must remain false to comply with BAFIN and PCI-DSS regulations
 		},
 		Tags: in.Tags,
 	}


### PR DESCRIPTION
** force set AllowCrossTenantReplication to false during azure service account creation. 
** This security voilation blocks using and scaling Clusters in Public cloud environments for the Banking and Financial industry which need to comply to BAFIN and PCI-DSS regulations.