### PR TITLE
OCPBUGS-44560: Add note about additional networks using IPv6

### DIFF
--- a/docs/user/openstack/deploy_dual_stack_cluster.md
+++ b/docs/user/openstack/deploy_dual_stack_cluster.md
@@ -33,6 +33,8 @@ Given the above example uses a provider network, this network can be added to th
 $ openstack router set --external-gateway dualstack <router-id>
 ```
 
+**Note**: Any additional IPv6 Subnet that is used in the OpenShift cluster, should be added to a neutron router to provide router advertisements.
+
 ## Creating Dual-Stack API and Ingress VIPs Ports for the cluster
 
 You must create the API and Ingress VIPs Ports with the following commands:

--- a/docs/user/openstack/deploy_single_stack_ipv6_cluster.md
+++ b/docs/user/openstack/deploy_single_stack_ipv6_cluster.md
@@ -36,6 +36,8 @@ Given the above example uses a provider network, this network can be added to th
 $ openstack router set --external-gateway v6-network <router-id>
 ```
 
+**Note**: Any additional IPv6 Subnet that is used in the OpenShift cluster, should be added to a neutron router to provide router advertisements.
+
 ## Creating IPv6 API and Ingress VIPs Ports for the cluster
 
 You must create the API and Ingress VIPs Ports with the following commands:


### PR DESCRIPTION
When using a network as an additional network in the OCP cluster that has an IPv6 Subnet, that subnet must be included in the router to provide router advertisements, otherwise the interface wouldn't get an address configured. This happens because the network manager is configured with method=auto.