### PR TITLE
OCPBUGS-47477: aws: skip dead zones on us-east-1 when discovering AZs

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	typesaws "github.com/openshift/installer/pkg/types/aws"
+	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
 )
 
 // Zones stores the map of Zone attributes indexed by Zone Name.
@@ -95,7 +96,7 @@ func availabilityZones(ctx context.Context, session *session.Session, region str
 	if len(zones) == 0 {
 		return nil, fmt.Errorf("no zones with type availability-zone in %s", region)
 	}
-	return zones, nil
+	return awsdefaults.SupportedZones(zones), nil
 }
 
 // edgeZones retrieves a list of zones type 'local-zone' and 'wavelength-zone' in the region.

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -3,6 +3,8 @@ package defaults
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -24,6 +26,10 @@ var (
 			// "us-east-1":      {"m6g.xlarge", "m6gd.xlarge"},
 		},
 	}
+	// Skip undesired zones in the discovery.
+	// - us-east-1e is a well-known limited zone, with limited offering of
+	// 	 instance types supported by installer.
+	skippedZones = []string{"us-east-1e"}
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -71,4 +77,9 @@ func InstanceTypes(region string, arch types.Architecture, topology configv1.Top
 			"r5.2xlarge",
 		}
 	}
+}
+
+// SupportedZones returns the list of supported zones.
+func SupportedZones(zones []string) []string {
+	return sets.List(sets.New(zones...).Difference(sets.New(skippedZones...)))
 }


### PR DESCRIPTION
This PR introduce zone skip when installer discover the zones from metadata/AWS API.

The `us-east-1e` is a dead zone in US Virginia, create network resources on that zone is useless as it does not offers supported instance types. That zone was causing the `WARNING`/failure when installing a cluster without setting the zone in IC:

```
WARNING failed to find default instance type for worker pool: no instance type found for the zone constraint 
WARNING failed to find default instance type: no instance type found for the zone constraint 
```
