### PR TITLE
OCPBUGS-47504: Power VS: Private DNS service endpoint URL must end with /v1

### DIFF
--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -505,7 +505,7 @@ func leftInContext(ctx context.Context) time.Duration {
 // SetDefaultPrivateServiceEndpoints sets service endpoint overrides as needed for Disconnected install.
 func (m *Metadata) SetDefaultPrivateServiceEndpoints(ctx context.Context, overrides []configv1.PowerVSServiceEndpoint, cosRegion string, vpcRegion string) []configv1.PowerVSServiceEndpoint {
 	overrides = addOverride(overrides, string(configv1.IBMCloudServiceCOS), fmt.Sprintf("https://s3.direct.%s.cloud-object-storage.appdomain.cloud", cosRegion))
-	overrides = addOverride(overrides, string(configv1.IBMCloudServiceDNSServices), "https://api.private.dns-svcs.cloud.ibm.com")
+	overrides = addOverride(overrides, string(configv1.IBMCloudServiceDNSServices), "https://api.private.dns-svcs.cloud.ibm.com/v1")
 	overrides = addOverride(overrides, string(configv1.IBMCloudServiceIAM), "https://private.iam.cloud.ibm.com")
 	overrides = addOverride(overrides, "Power", fmt.Sprintf("https://private.%s.power-iaas.cloud.ibm.com", vpcRegion)) // FIXME confiv1.IBMCloudServicePower?
 	overrides = addOverride(overrides, string(configv1.IBMCloudServiceResourceController), "https://private.resource-controller.cloud.ibm.com")


### PR DESCRIPTION
What we set as `DNSServices` URL (for PowerVS) in the installer gets used in `ingress-operator` as base URL that must include `/v1` at the end. See;
- https://github.com/openshift/cluster-ingress-operator/blob/dbdff16b1173dd3992e5be42203e8afbae1cb06f/pkg/dns/ibm/private/dnssvcs_provider.go#L53
- https://github.com/IBM/networking-go-sdk/blob/074bbdabd90ee37195d8fb620cbd823cdbb2751a/dnssvcsv1/dns_svcs_v1.go#L47

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>