### PR TITLE
OCPBUGS-46596: aws/permissions - defaults ec2:DescribeInstanceTypeOfferings

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -105,6 +105,7 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DescribeInstanceAttribute",
 		"ec2:DescribeInstanceCreditSpecifications",
 		"ec2:DescribeInstances",
+		"ec2:DescribeInstanceTypeOfferings", // Needed to filter zones by instance type
 		"ec2:DescribeInternetGateways",
 		"ec2:DescribeKeyPairs",
 		"ec2:DescribeNatGateways",
@@ -333,8 +334,6 @@ var permissions = map[PermissionGroup][]string{
 	PermissionDefaultZones: {
 		// Needed to list the zones available in the region
 		"ec2:DescribeAvailabilityZones",
-		// Needed to filter zones by instance type
-		"ec2:DescribeInstanceTypeOfferings",
 	},
 	PermissionAssumeRole: {
 		// Needed so the installer can use the provided custom IAM role


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-46596

Added AWS permission ec2:DescribeInstanceTypeOfferings to the default list to create cluster / PermissionCreateBase group.
