### PR TITLE
NO-ISSUE: Fix owning component name in machine config templates

### DIFF
--- a/data/data/manifests/bootkube/machine-config-server-ca-configmap.yaml.template
+++ b/data/data/manifests/bootkube/machine-config-server-ca-configmap.yaml.template
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-machine-config-operator
   annotations:
     openshift.io/description: CA bundle that stores all valid CAs for the MachineConfigServer TLS certificate
-    openshift.io/owning-component: machine-config-operator
+    openshift.io/owning-component: Machine Config Operator
   labels:
     auth.openshift.io/managed-certificate-type: ca-bundle
 data:

--- a/data/data/manifests/bootkube/machine-config-server-ca-secret.yaml.template
+++ b/data/data/manifests/bootkube/machine-config-server-ca-secret.yaml.template
@@ -4,7 +4,7 @@ metadata:
   name: machine-config-server-ca
   namespace: openshift-machine-config-operator
   annotations:
-    openshift.io/owning-component: machine-config-operator
+    openshift.io/owning-component: Machine Config Operator
     openshift.io/description: CA used to sign the MachineConfigServer TLS certificate
     auth.openshift.io/certificate-issuer: {{.RootCAIssuerName}}
     auth.openshift.io/certificate-not-after: {{.RootCANotAfter}}

--- a/data/data/manifests/bootkube/machine-config-server-tls-secret.yaml.template
+++ b/data/data/manifests/bootkube/machine-config-server-tls-secret.yaml.template
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-machine-config-operator
   annotations:
     openshift.io/description: Secret containing the MachineConfigServer TLS certificate and key
-    openshift.io/owning-component: machine-config-operator
+    openshift.io/owning-component: Machine Config Operator
     auth.openshift.io/certificate-hostnames: {{.McsHostName}}
     auth.openshift.io/certificate-issuer: {{.RootCAIssuerName}}
     auth.openshift.io/certificate-not-after: {{.McsTLSCertNotAfter}}


### PR DESCRIPTION
Minor follow-up to https://github.com/openshift/installer/pull/9309. The string used for owning component name wasn't accurate and is fixed now. 