### PR TITLE
no-jira: gather: allow unconditional gather in CI

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -198,6 +198,20 @@ func clusterCreatePostRun(ctx context.Context) (int, error) {
 	}
 	timer.StopTimer("Bootstrap Complete")
 
+	// In CI, we want to collect an installer log bundle so we can examine bootstrap logs that aren't
+	// collectable anywhere else.
+	if gatherBootstrap, ok := os.LookupEnv("OPENSHIFT_INSTALL_GATHER_BOOTSTRAP"); ok && gatherBootstrap != "" {
+		timer.StartTimer("Bootstrap Gather")
+		logrus.Infof("OPENSHIFT_INSTALL_GATHER_BOOTSTRAP is set, will attempt to gather a log bundle")
+		bundlePath, gatherErr := runGatherBootstrapCmd(ctx, command.RootOpts.Dir)
+		if gatherErr != nil {
+			logrus.Warningf("Attempted to gather debug logs, and it failed: ", gatherErr)
+		} else {
+			logrus.Infof("Bootstrap gather logs captured here %q", bundlePath)
+		}
+		timer.StopTimer("Bootstrap Gather")
+	}
+
 	//
 	// Wait for the bootstrap to be destroyed.
 	//

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -205,7 +205,7 @@ func clusterCreatePostRun(ctx context.Context) (int, error) {
 		logrus.Infof("OPENSHIFT_INSTALL_GATHER_BOOTSTRAP is set, will attempt to gather a log bundle")
 		bundlePath, gatherErr := runGatherBootstrapCmd(ctx, command.RootOpts.Dir)
 		if gatherErr != nil {
-			logrus.Warningf("Attempted to gather debug logs, and it failed: ", gatherErr)
+			logrus.Warningf("Attempted to gather debug logs, and it failed: %q ", gatherErr)
 		} else {
 			logrus.Infof("Bootstrap gather logs captured here %q", bundlePath)
 		}


### PR DESCRIPTION
In CI, we want to collect an installer log bundle so we can examine bootstrap logs that aren't retrievable from anywhere else. This is especially important for problems that might happen during early install.

Release PR: https://github.com/openshift/release/pull/60534