### PR TITLE
Increase Nutanix image creation timeout to 20 minutes

### DIFF
--- a/pkg/types/nutanix/helpers.go
+++ b/pkg/types/nutanix/helpers.go
@@ -27,7 +27,7 @@ const (
 	metadataFilePath = "openstack/latest/meta_data.json"
 	userDataFilePath = "openstack/latest/user_data"
 	sleepTime        = 10 * time.Second
-	timeout          = 5 * time.Minute
+	timeout          = 20 * time.Minute
 
 	// Category Key format: "kubernetes-io-cluster-<cluster-id>".
 	categoryKeyPrefix = "kubernetes-io-cluster-"


### PR DESCRIPTION
The image creation timeout in pkg/nutanix/helpers.go has been updated from 5 minutes to 20 minutes. This change addresses an issue where the installer would fail if the image creation process exceeded the previous 5-minute limit. The increased timeout ensures that the installer can accommodate longer image creation durations, improving its reliability in environments with slower operations.