### PR TITLE
OCPBUGS-48228: Envtest: Configure IPv6 service network for API Service

### DIFF
--- a/pkg/clusterapi/localcontrolplane.go
+++ b/pkg/clusterapi/localcontrolplane.go
@@ -58,6 +58,7 @@ type localControlPlane struct {
 	KubeconfigPath string
 	EtcdLog        *os.File
 	APIServerLog   *os.File
+	APIServerArgs  map[string]string
 }
 
 // Run launches the local control plane.
@@ -98,12 +99,16 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 				Out:     c.EtcdLog,
 				Err:     c.EtcdLog,
 			},
-			APIServer: &envtest.APIServer{
-				Out: c.APIServerLog,
-				Err: c.APIServerLog,
-			},
 		},
 	}
+	apiServer := &envtest.APIServer{
+		Out: c.APIServerLog,
+		Err: c.APIServerLog,
+	}
+	for key, value := range c.APIServerArgs {
+		apiServer.Configure().Set(key, value)
+	}
+	c.Env.ControlPlane.APIServer = apiServer
 	c.Cfg, err = c.Env.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
When the host that runs the OpenShift install is configured with IPv6 only, the kube-apiserver created with envtest would fail as the service-cluster-ip-range would be configured with a default IPv4 CIDR and the public address family, which is the host address, would be configured with an IPv6. This commit fixes the issue by setting a default IPv6 CIDR to service-cluster-ip-range, in case the host has no IPv4 available.