### PR TITLE
CORS-3835: Add gcp endpoints to the installer config

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3582,6 +3582,33 @@ spec:
                     description: Region specifies the GCP region where the cluster
                       will be created.
                     type: string
+                  serviceEndpoints:
+                    description: |-
+                      ServiceEndpoints list contains custom endpoints which will override default
+                      service endpoint of GCP Services.
+                      There must be only one ServiceEndpoint for a service.
+                    items:
+                      description: |-
+                        ServiceEndpoint stores the configuration for services to
+                        override existing defaults of GCP Services.
+                      properties:
+                        name:
+                          description: |-
+                            Name is the name of the GCP service.
+                            This must be provided and cannot be empty.
+                          type: string
+                        url:
+                          description: |-
+                            URL is fully qualified URI with scheme https, that overrides the default generated
+                            endpoint for a client.
+                            This must be provided and cannot be empty.
+                          pattern: ^https://
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
                   userLabels:
                     description: |-
                       userLabels has additional keys and values that the installer will add as

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -6,6 +6,23 @@ import (
 	"github.com/openshift/installer/pkg/types/dns"
 )
 
+const (
+	// CloudResourceManagerServiceName is the name and internal key for the cloud resource manager API endpoint.
+	CloudResourceManagerServiceName = "cloudresourcemanager"
+	// ComputeServiceName is the name and internal key for the compute API endpoint.
+	ComputeServiceName = "compute"
+	// DNSServiceName is the name and internal key for the DNS API endpoint.
+	DNSServiceName = "dns"
+	// FileServiceName is the name and internal key for the file API endpoint.
+	FileServiceName = "file"
+	// IAMServiceName is the name and internal key for the IAM API endpoint.
+	IAMServiceName = "iam"
+	// ServiceUsageServiceName is the name and internal key for the service usage API endpoint.
+	ServiceUsageServiceName = "serviceusage"
+	// StorageServiceName is the name and internal key for the storage API endpoint.
+	StorageServiceName = "storage"
+)
+
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -58,6 +58,27 @@ type Platform struct {
 	// +default="Disabled"
 	// +kubebuilder:validation:Enum="Enabled";"Disabled"
 	UserProvisionedDNS dns.UserProvisionedDNS `json:"userProvisionedDNS,omitempty"`
+
+	// ServiceEndpoints list contains custom endpoints which will override default
+	// service endpoint of GCP Services.
+	// There must be only one ServiceEndpoint for a service.
+	// +optional
+	ServiceEndpoints []ServiceEndpoint `json:"serviceEndpoints,omitempty"`
+}
+
+// ServiceEndpoint stores the configuration for services to
+// override existing defaults of GCP Services.
+type ServiceEndpoint struct {
+	// Name is the name of the GCP service.
+	// This must be provided and cannot be empty.
+	Name string `json:"name"`
+
+	// URL is fully qualified URI with scheme https, that overrides the default generated
+	// endpoint for a client.
+	// This must be provided and cannot be empty.
+	//
+	// +kubebuilder:validation:Pattern=`^https://`
+	URL string `json:"url"`
 }
 
 // UserLabel is a label to apply to GCP resources created for the cluster.

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -153,6 +153,114 @@ func TestValidatePlatform(t *testing.T) {
 			credentialsMode: types.MintCredentialsMode,
 			valid:           false,
 		},
+		{
+			name: "invalid gcp endpoint blank name",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "",
+						URL:  "https://my-custom-endpoint.example.com/copmute/v1/",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid gcp endpoint invalid name",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "badname",
+						URL:  "https://my-custom-endpoint.example.com/copmute/v1/",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid gcp endpoint duplicate name",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "https://my-custom-endpoint.example.com/compute/v1/",
+					},
+					{
+						Name: "compute",
+						URL:  "https://my-custom-endpoint.example.com/compute/v2/",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid gcp endpoint url blank",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid scheme gcp endpoint url",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "http://my-custom-endpoint.example.com/compute/v1/",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "valid gcp endpoint",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "https://my-custom-endpoint.example.com/compute/v1/",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid gcp endpoint relative path",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "/compute/v1/",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "valid gcp endpoint url no scheme",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				ServiceEndpoints: []gcp.ServiceEndpoint{
+					{
+						Name: "compute",
+						URL:  "my-custom-endpoint.example.com/compute/v1/",
+					},
+				},
+			},
+			valid: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
** Added the endpoints including the name and url to the install config.
** Added Specific endpoint names that able to be used/customized.
** Added validation for the GCP Service Endpoints.