### PR TITLE
OTA-1310: data/manifests/bootkube/cvo-overrides: Default to eus-4.12

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.12
+  channel: eus-4.12
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
So we can stop adding 4.12.z releases to `stable-4.12`, while it's in the EUS phase.  We'd ordinarily do that when the 4.y entered the EUS phase, which for [4.12 was on 2024-07-17][1].  But for 4.12 there was some agreement with Service Delivery to delay until whenever this commit merges :).  See openshift/cincinnati-graph-data#1173,  openshift/cincinnati-graph-data#1712, and #5765 for 4.6 precedent.  4.8 and 4.10 never had an EUS-only phase, so that's why 4.12 is the next 4.y taking a run at this.  The goal is to help folks who don't meet the EUS qualifications stay on releases that they have support for.

[1]: https://access.redhat.com/support/policy/updates/openshift#dates
[2]: https://github.com/openshift/cincinnati-graph-data/pull/1173
[3]: https://github.com/openshift/cincinnati-graph-data/pull/1712
[4]: https://github.com/openshift/installer/pull/5765