### PR TITLE
OCPBUGS-48570:[Nutanix] Installation failed with timeout when uploading images to PC

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4239,6 +4239,11 @@ spec:
                       PreloadedOSImageName uses the named preloaded RHCOS image from PC/PE,
                       instead of create and upload a new image for each cluster.
                     type: string
+                  prismAPICallTimeout:
+                    description: |-
+                      PrismAPICallTimeout sets the timeout (in minutes) for the prism-api calls.
+                      If not configured, the default value of 10 minutes will be used as the prism-api call timeout.
+                    type: integer
                   prismCentral:
                     description: |-
                       PrismCentral is the endpoint (address and port) and credentials to

--- a/pkg/infrastructure/nutanix/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/nutanix/clusterapi/clusterapi.go
@@ -37,6 +37,10 @@ func (p Provider) PreProvision(ctx context.Context, in infracapi.PreProvisionInp
 	// load the rhcos image to prism_central.
 
 	ic := in.InstallConfig.Config
+
+	// Set the prismAPICallTimeoutDuration
+	nutanixtypes.SetPrismAPICallTimeoutDuration(ic.Platform.Nutanix)
+
 	nutanixCl, err := nutanixtypes.CreateNutanixClientFromPlatform(ic.Platform.Nutanix)
 	if err != nil {
 		return fmt.Errorf("failed to create nutanix client: %w", err)
@@ -130,6 +134,10 @@ func (p Provider) PreProvision(ctx context.Context, in infracapi.PreProvisionInp
 // Load the ignition iso image to prism_central.
 func (p Provider) Ignition(ctx context.Context, in infracapi.IgnitionInput) ([]*corev1.Secret, error) {
 	ic := in.InstallConfig.Config
+
+	// Set the prismAPICallTimeoutDuration
+	nutanixtypes.SetPrismAPICallTimeoutDuration(ic.Platform.Nutanix)
+
 	nutanixCl, err := nutanixtypes.CreateNutanixClientFromPlatform(ic.Platform.Nutanix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nutanix client: %w", err)

--- a/pkg/types/nutanix/defaults/platform.go
+++ b/pkg/types/nutanix/defaults/platform.go
@@ -5,4 +5,9 @@ import (
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
-func SetPlatformDefaults(p *nutanix.Platform) {}
+func SetPlatformDefaults(p *nutanix.Platform) {
+	if p.PrismAPICallTimeout == nil {
+		timeout := nutanix.DefaultPrismAPICallTimeout
+		p.PrismAPICallTimeout = &timeout
+	}
+}

--- a/pkg/types/nutanix/defaults/platform_test.go
+++ b/pkg/types/nutanix/defaults/platform_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/openshift/installer/pkg/types/nutanix"
 )
 
-const testClusterName = "test-cluster"
-
 func defaultPlatform() *nutanix.Platform {
-	return &nutanix.Platform{}
+	timeout := nutanix.DefaultPrismAPICallTimeout
+	return &nutanix.Platform{PrismAPICallTimeout: &timeout}
 }
 
 func TestSetPlatformDefaults(t *testing.T) {

--- a/pkg/types/nutanix/platform.go
+++ b/pkg/types/nutanix/platform.go
@@ -84,6 +84,11 @@ type Platform struct {
 	// FailureDomains configures failure domains for the Nutanix platform.
 	// +optional
 	FailureDomains []FailureDomain `json:"failureDomains,omitempty"`
+
+	// PrismAPICallTimeout sets the timeout (in minutes) for the prism-api calls.
+	// If not configured, the default value of 10 minutes will be used as the prism-api call timeout.
+	// +optional
+	PrismAPICallTimeout *int `json:"prismAPICallTimeout,omitempty"`
 }
 
 // PrismCentral holds the endpoint and credentials data used to connect to the Prism Central

--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -79,6 +79,13 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 		}
 	}
 
+	// validate prismAPICallTimeout if configured
+	if p.PrismAPICallTimeout != nil {
+		if *p.PrismAPICallTimeout <= 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("prismAPICallTimeout"), *p.PrismAPICallTimeout, "must be a positive integer value"))
+		}
+	}
+
 	// validate failureDomains if configured
 	if len(p.FailureDomains) > 0 {
 		pattern := "[a-z0-9]([-a-z0-9]*[a-z0-9])?"

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -188,6 +188,16 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			expectedError: `^test-path\.prismCentral\.endpoint\.address: Invalid value: "https://test-pc": must be the domain name or IP address of the Prism Central$`,
 		},
+		{
+			name: "prismAPICallTimeout must be a positive integer",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				timeout := -1
+				p.PrismAPICallTimeout = &timeout
+				return p
+			}(),
+			expectedError: `^test-path\.prismAPICallTimeout: Invalid value: -1: must be a positive integer value$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
OCPBUGS-48570
[Nutanix] Installation failed with timeout when uploading images to PC

Fix this customer hit issue by making the prism-api call timeout value a configurable parameter in the install-config.yaml as platform.nutanix.prismAPICallTimeout (with the default value of 5 minutes).