### PR TITLE
OCPBUGS-48645:  azure: use separate /var to avoid growfs timeouts

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
+	aztypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
@@ -223,7 +224,8 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 		}},
 	)
 
-	if platform == nutanixtypes.Name {
+	switch platform {
+	case nutanixtypes.Name:
 		// Inserts the file "/etc/hostname" with the bootstrap machine name to the bootstrap ignition data
 		hostname := fmt.Sprintf("%s-bootstrap", clusterID.InfraID)
 		hostnameFile := igntypes.File{
@@ -239,6 +241,9 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 			},
 		}
 		a.Config.Storage.Files = append(a.Config.Storage.Files, hostnameFile)
+	case aztypes.Name:
+		// See https://issues.redhat.com/browse/OCPBUGS-43625
+		ignition.AppendVarPartition(a.Config)
 	}
 
 	return nil

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -7,11 +7,13 @@ import (
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
+	"github.com/openshift/installer/pkg/types/azure"
 )
 
 const (
@@ -41,6 +43,12 @@ func (a *Master) Generate(_ context.Context, dependencies asset.Parents) error {
 	dependencies.Get(installConfig, rootCA)
 
 	a.Config = pointerIgnitionConfig(installConfig.Config, rootCA.Cert(), "master")
+
+	if installConfig.Config.Platform.Name() == azure.Name {
+		logrus.Debugf("Adding /var partition to skip CoreOS growfs step")
+		// See https://issues.redhat.com/browse/OCPBUGS-43625
+		ignition.AppendVarPartition(a.Config)
+	}
 
 	data, err := ignition.Marshal(a.Config)
 	if err != nil {


### PR DESCRIPTION
Manual cherry-pick of #9378
Using the workaround of a separate /var partition until the issue is fixed in RHCOS.

/jira cherry-pick OCPBUGS-48576