### PR TITLE
OCPBUGS-47489: pkg/gcp/destroy: add waits to prevent leaks during heavy load

### DIFF
--- a/pkg/destroy/gcp/address.go
+++ b/pkg/destroy/gcp/address.go
@@ -90,18 +90,8 @@ func (o *ClusterUninstaller) deleteAddress(ctx context.Context, item cloudResour
 		return fmt.Errorf("invalid address type %q", item.typeName)
 	}
 
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete address %s: %w", item.name, err)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete address %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted address %s", item.name)
+	if err = o.handleOperation(op, err, item, "address"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/address.go
+++ b/pkg/destroy/gcp/address.go
@@ -84,16 +84,15 @@ func (o *ClusterUninstaller) deleteAddress(ctx context.Context, item cloudResour
 	switch item.typeName {
 	case globalAddressResource:
 		op, err = o.computeSvc.GlobalAddresses.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = global
 	case regionalAddressResource:
 		op, err = o.computeSvc.Addresses.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = regional
 	default:
 		return fmt.Errorf("invalid address type %q", item.typeName)
 	}
 
-	if err = o.handleOperation(op, err, item, "address"); err != nil {
-		return err
-	}
-	return nil
+	return o.handleOperation(ctx, op, err, item, "address")
 }
 
 // destroyAddresses removes all address resources that have a name prefixed

--- a/pkg/destroy/gcp/backendservice.go
+++ b/pkg/destroy/gcp/backendservice.go
@@ -79,16 +79,15 @@ func (o *ClusterUninstaller) deleteBackendService(ctx context.Context, item clou
 	switch item.typeName {
 	case globalBackendServiceResource:
 		op, err = o.computeSvc.BackendServices.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = global
 	case regionBackendServiceResource:
 		op, err = o.computeSvc.RegionBackendServices.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = regional
 	default:
 		return fmt.Errorf("invalid backend service type %q", item.typeName)
 	}
 
-	if err = o.handleOperation(op, err, item, "backend service"); err != nil {
-		return err
-	}
-	return nil
+	return o.handleOperation(ctx, op, err, item, "backend service")
 }
 
 // destroyBackendServices removes all backend services resources that have a name prefixed

--- a/pkg/destroy/gcp/backendservice.go
+++ b/pkg/destroy/gcp/backendservice.go
@@ -85,18 +85,8 @@ func (o *ClusterUninstaller) deleteBackendService(ctx context.Context, item clou
 		return fmt.Errorf("invalid backend service type %q", item.typeName)
 	}
 
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete backend service %s: %w", item.name, err)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete backend service %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted backend service %s", item.name)
+	if err = o.handleOperation(op, err, item, "backend service"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/cloudresource.go
+++ b/pkg/destroy/gcp/cloudresource.go
@@ -12,9 +12,21 @@ type cloudResource struct {
 	url      string
 	zone     string
 	quota    []gcp.QuotaUsage
+	scope    resourceScope
 }
 
 type cloudResources map[string]cloudResource
+
+// resourceScope captures whether a resource is global or regional.
+// Currently this is only used for resources handled by the compute service
+// in order to perform wait operations to ensure they are successfully deleted.
+type resourceScope string
+
+const (
+	global   resourceScope = "global"
+	regional resourceScope = "regional"
+	zonal    resourceScope = "zonal"
+)
 
 func (r cloudResources) insert(resources ...cloudResource) cloudResources {
 	for _, resource := range resources {

--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -124,10 +124,8 @@ func (o *ClusterUninstaller) deleteDisk(ctx context.Context, item cloudResource)
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Disks.Delete(o.ProjectID, item.zone, item.name).RequestId(o.requestID(item.typeName, item.zone, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "disk"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = zonal
+	return o.handleOperation(ctx, op, err, item, "disk")
 }
 
 // destroyDisks removes all disk resources that have a name prefixed

--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -124,18 +124,8 @@ func (o *ClusterUninstaller) deleteDisk(ctx context.Context, item cloudResource)
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Disks.Delete(o.ProjectID, item.zone, item.name).RequestId(o.requestID(item.typeName, item.zone, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.zone, item.name)
-		return errors.Wrapf(err, "failed to delete disk %s in zone %s", item.name, item.zone)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.zone, item.name)
-		return errors.Errorf("failed to delete disk %s in zone %s with error: %s", item.name, item.zone, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted disk %s", item.name)
+	if err = o.handleOperation(op, err, item, "disk"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -89,18 +89,8 @@ func (o *ClusterUninstaller) deleteFirewall(ctx context.Context, item cloudResou
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Firewalls.Delete(item.project, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete firewall %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete firewall %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted firewall rule %s", item.name)
+	if err = o.handleOperation(op, err, item, "firewall"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -89,10 +89,8 @@ func (o *ClusterUninstaller) deleteFirewall(ctx context.Context, item cloudResou
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Firewalls.Delete(item.project, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "firewall"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "firewall")
 }
 
 // destroyFirewalls removes all firewall resources that have a name prefixed

--- a/pkg/destroy/gcp/forwardingrule.go
+++ b/pkg/destroy/gcp/forwardingrule.go
@@ -86,16 +86,15 @@ func (o *ClusterUninstaller) deleteForwardingRule(ctx context.Context, item clou
 	switch item.typeName {
 	case globalForwardingRuleResource:
 		op, err = o.computeSvc.GlobalForwardingRules.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = global
 	case regionForwardingRuleResource:
 		op, err = o.computeSvc.ForwardingRules.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = regional
 	default:
 		return fmt.Errorf("invalid forwarding rule type %q", item.typeName)
 	}
 
-	if err = o.handleOperation(op, err, item, "forwarding rule"); err != nil {
-		return err
-	}
-	return nil
+	return o.handleOperation(ctx, op, err, item, "forwarding rule")
 }
 
 // destroyForwardingRules removes all forwarding rules with a name prefixed

--- a/pkg/destroy/gcp/forwardingrule.go
+++ b/pkg/destroy/gcp/forwardingrule.go
@@ -92,18 +92,8 @@ func (o *ClusterUninstaller) deleteForwardingRule(ctx context.Context, item clou
 		return fmt.Errorf("invalid forwarding rule type %q", item.typeName)
 	}
 
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete forwarding rule %s: %w", item.name, err)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete forwarding rule %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted forwarding rule %s", item.name)
+	if err = o.handleOperation(op, err, item, "forwarding rule"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -40,6 +40,9 @@ const (
 	capgProviderOwnedLabelFmt = "capg-cluster-%s"
 
 	ownedLabelValue = "owned"
+
+	// DONE represents the done status for a compute service operation.
+	DONE = "DONE"
 )
 
 // ClusterUninstaller holds the various options for the cluster we want to delete
@@ -408,7 +411,6 @@ func operationErrorMessage(op *compute.Operation) string {
 }
 
 func (o *ClusterUninstaller) handleOperation(ctx context.Context, op *compute.Operation, err error, item cloudResource, resourceType string) error {
-
 	identifier := []string{item.typeName, item.name}
 	if item.zone != "" {
 		identifier = []string{item.typeName, item.zone, item.name}
@@ -422,11 +424,11 @@ func (o *ClusterUninstaller) handleOperation(ctx context.Context, op *compute.Op
 	// wait for operation to complete before checking any further
 	op, err = o.waitFor(ctx, op, item)
 
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
+	if op != nil && op.Status == DONE && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID(identifier...)
 		return fmt.Errorf("failed to delete %s %s with error: %s", resourceType, item.name, operationErrorMessage(op))
 	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
+	if (err != nil && isNoOp(err)) || (op != nil && op.Status == DONE) {
 		o.resetRequestID(identifier...)
 		o.deletePendingItems(item.typeName, []cloudResource{item})
 		o.Logger.Infof("Deleted %s %s", resourceType, item.name)

--- a/pkg/destroy/gcp/healthcheck.go
+++ b/pkg/destroy/gcp/healthcheck.go
@@ -78,16 +78,15 @@ func (o *ClusterUninstaller) deleteHealthCheck(ctx context.Context, item cloudRe
 	switch item.typeName {
 	case globalHealthCheckResource:
 		op, err = o.computeSvc.HealthChecks.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = global
 	case regionHealthCheckResource:
 		op, err = o.computeSvc.RegionHealthChecks.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+		item.scope = regional
 	default:
 		return fmt.Errorf("invalid health check type %q", item.typeName)
 	}
 
-	if err = o.handleOperation(op, err, item, "health check"); err != nil {
-		return err
-	}
-	return nil
+	return o.handleOperation(ctx, op, err, item, "health check")
 }
 
 // destroyHealthChecks removes all health check resources that have a name prefixed

--- a/pkg/destroy/gcp/healthcheck.go
+++ b/pkg/destroy/gcp/healthcheck.go
@@ -84,18 +84,8 @@ func (o *ClusterUninstaller) deleteHealthCheck(ctx context.Context, item cloudRe
 		return fmt.Errorf("invalid health check type %q", item.typeName)
 	}
 
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete health check %s: %w", item.name, err)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return fmt.Errorf("failed to delete health check %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted health check %s", item.name)
+	if err = o.handleOperation(op, err, item, "health check"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/httphealthcheck.go
+++ b/pkg/destroy/gcp/httphealthcheck.go
@@ -60,10 +60,8 @@ func (o *ClusterUninstaller) deleteHTTPHealthCheck(ctx context.Context, item clo
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.HttpHealthChecks.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "HTTP health check"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "HTTP health check")
 }
 
 // destroyHTTPHealthChecks removes all HTTP health check resources that have a name prefixed

--- a/pkg/destroy/gcp/image.go
+++ b/pkg/destroy/gcp/image.go
@@ -59,10 +59,8 @@ func (o *ClusterUninstaller) deleteImage(ctx context.Context, item cloudResource
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Images.Delete(o.ProjectID, item.name).Context(ctx).RequestId(o.requestID(item.typeName, item.name)).Do()
-	if err = o.handleOperation(op, err, item, "image"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "image")
 }
 
 // destroyImages removes all image resources with a name prefixed

--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -143,11 +143,11 @@ func (o *ClusterUninstaller) stopInstance(ctx context.Context, item cloudResourc
 		o.resetRequestID(stopInstanceResourceName, item.zone, item.name)
 		return errors.Wrapf(err, "failed to stop instance %s in zone %s", item.name, item.zone)
 	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
+	if op != nil && op.Status == DONE && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID(stopInstanceResourceName, item.zone, item.name)
 		return errors.Errorf("failed to stop instance %s in zone %s with error: %s", item.name, item.zone, operationErrorMessage(op))
 	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
+	if (err != nil && isNoOp(err)) || (op != nil && op.Status == DONE) {
 		o.resetRequestID(stopInstanceResourceName, item.name)
 		o.deletePendingItems(stopInstanceResourceName, []cloudResource{item})
 		o.Logger.Infof("Stopped instance %s", item.name)

--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -106,10 +106,8 @@ func (o *ClusterUninstaller) deleteInstance(ctx context.Context, item cloudResou
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Instances.Delete(o.ProjectID, item.zone, item.name).RequestId(o.requestID(item.typeName, item.zone, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "instance"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = zonal
+	return o.handleOperation(ctx, op, err, item, "instance")
 }
 
 // destroyInstances searches for instances across all zones that have a name that starts with

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -68,10 +68,8 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ctx context.Context, item cloud
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.InstanceGroups.Delete(o.ProjectID, item.zone, item.name).RequestId(o.requestID(item.typeName, item.zone, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "instance group"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = zonal
+	return o.handleOperation(ctx, op, err, item, "instance group")
 }
 
 // destroyInstanceGroups searches for instance groups that have a name prefixed

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -68,18 +68,8 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ctx context.Context, item cloud
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.InstanceGroups.Delete(o.ProjectID, item.zone, item.name).RequestId(o.requestID(item.typeName, item.zone, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.zone, item.name)
-		return errors.Wrapf(err, "failed to delete instance group %s in zone %s", item.name, item.zone)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(instanceGroupResourceName, item.zone, item.name)
-		return errors.Errorf("failed to delete instance group %s in zone %s with error: %s", item.name, item.zone, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted instance group %s", item.name)
+	if err = o.handleOperation(op, err, item, "instance group"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -53,10 +53,8 @@ func (o *ClusterUninstaller) deleteNetwork(ctx context.Context, item cloudResour
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Networks.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "network"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "network")
 }
 
 // destroyNetworks removes all vpc network resources prefixed

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -53,18 +53,8 @@ func (o *ClusterUninstaller) deleteNetwork(ctx context.Context, item cloudResour
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Networks.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete network %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete network %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted network %s", item.name)
+	if err = o.handleOperation(op, err, item, "network"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/route.go
+++ b/pkg/destroy/gcp/route.go
@@ -71,10 +71,8 @@ func (o *ClusterUninstaller) deleteRoute(ctx context.Context, item cloudResource
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Routes.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "route"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "route")
 }
 
 // destroyRutes removes all route resources that have a name prefixed

--- a/pkg/destroy/gcp/route.go
+++ b/pkg/destroy/gcp/route.go
@@ -71,18 +71,8 @@ func (o *ClusterUninstaller) deleteRoute(ctx context.Context, item cloudResource
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Routes.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete route %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete route %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted route %s", item.name)
+	if err = o.handleOperation(op, err, item, "route"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -59,18 +59,8 @@ func (o *ClusterUninstaller) deleteRouter(ctx context.Context, item cloudResourc
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Routers.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete router %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete router %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted router %s", item.name)
+	if err = o.handleOperation(op, err, item, "router"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -59,10 +59,8 @@ func (o *ClusterUninstaller) deleteRouter(ctx context.Context, item cloudResourc
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Routers.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "router"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "router")
 }
 
 // destroyRouters removes all router resources that have a name prefixed

--- a/pkg/destroy/gcp/subnetwork.go
+++ b/pkg/destroy/gcp/subnetwork.go
@@ -68,10 +68,8 @@ func (o *ClusterUninstaller) deleteSubnetwork(ctx context.Context, item cloudRes
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Subnetworks.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "subnetwork"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = regional
+	return o.handleOperation(ctx, op, err, item, "subnetwork")
 }
 
 // destroySubNetworks removes all subnetwork resources that have a name prefixed

--- a/pkg/destroy/gcp/subnetwork.go
+++ b/pkg/destroy/gcp/subnetwork.go
@@ -68,18 +68,8 @@ func (o *ClusterUninstaller) deleteSubnetwork(ctx context.Context, item cloudRes
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.Subnetworks.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete subnetwork %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete subnetwork %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted subnetwork %s", item.name)
+	if err = o.handleOperation(op, err, item, "subnetwork"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/targetTCPProxies.go
+++ b/pkg/destroy/gcp/targetTCPProxies.go
@@ -61,10 +61,8 @@ func (o *ClusterUninstaller) deleteTargetTCPProxy(ctx context.Context, item clou
 	defer cancel()
 
 	op, err := o.computeSvc.TargetTcpProxies.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "target tcp proxy"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = global
+	return o.handleOperation(ctx, op, err, item, "target tcp proxy")
 }
 
 // destroyTargetTCPProxies removes all target tcp proxy resources that have a name prefixed

--- a/pkg/destroy/gcp/targetpool.go
+++ b/pkg/destroy/gcp/targetpool.go
@@ -64,18 +64,8 @@ func (o *ClusterUninstaller) deleteTargetPool(ctx context.Context, item cloudRes
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.TargetPools.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Wrapf(err, "failed to delete target pool %s", item.name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID(item.typeName, item.name)
-		return errors.Errorf("failed to delete target pool %s with error: %s", item.name, operationErrorMessage(op))
-	}
-	if (err != nil && isNoOp(err)) || (op != nil && op.Status == "DONE") {
-		o.resetRequestID(item.typeName, item.name)
-		o.deletePendingItems(item.typeName, []cloudResource{item})
-		o.Logger.Infof("Deleted target pool %s", item.name)
+	if err = o.handleOperation(op, err, item, "target pool"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/targetpool.go
+++ b/pkg/destroy/gcp/targetpool.go
@@ -64,10 +64,8 @@ func (o *ClusterUninstaller) deleteTargetPool(ctx context.Context, item cloudRes
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	op, err := o.computeSvc.TargetPools.Delete(o.ProjectID, o.Region, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
-	if err = o.handleOperation(op, err, item, "target pool"); err != nil {
-		return err
-	}
-	return nil
+	item.scope = regional
+	return o.handleOperation(ctx, op, err, item, "target pool")
 }
 
 // destroyTargetPools removes target pools resources that have a name prefixed


### PR DESCRIPTION
We're slowly leaking backend services. This PR adds waits to make sure the operation is done before proceeding.  This refactors the destroy code to add a central operation handling function to facilitate this change.