### PR TITLE
OCPBUGS-48719: Add new tested azure arm instance type to doc

### DIFF
--- a/docs/user/azure/tested_instance_types_aarch64.md
+++ b/docs/user/azure/tested_instance_types_aarch64.md
@@ -5,3 +5,9 @@
 * `standardDPLSv5Family`
 * `standardEPSv5Family`
 * `standardEPDSv5Family`
+* `StandardDpdsv6Family`
+* `StandardDpldsv6Famil`
+* `StandardDplsv6Family`
+* `StandardDpsv6Family`
+* `StandardEpdsv6Family`
+* `StandardEpsv6Family`


### PR DESCRIPTION
Following arm instance type families are detected during 4.18 full function test, and verified by QE, append them into azure arm doc.

* StandardDpdsv6Family
* StandardDpldsv6Family
* StandardDplsv6Family
* StandardDpsv6Family
* StandardEpdsv6Family
* StandardEpsv6Family