### PR TITLE
MGMT-19545: add optional release registry field to the IBI installation config

### DIFF
--- a/pkg/asset/imagebased/image/ignition.go
+++ b/pkg/asset/imagebased/image/ignition.go
@@ -47,6 +47,7 @@ type ibiConfigurationFile struct {
 	ExtraPartitionNumber uint     `json:"extraPartitionNumber,omitempty"`
 	ExtraPartitionStart  string   `json:"extraPartitionStart,omitempty"`
 	InstallationDisk     string   `json:"installationDisk"`
+	ReleaseRegistry      string   `json:"releaseRegistry,omitempty"`
 	SeedImage            string   `json:"seedImage"`
 	SeedVersion          string   `json:"seedVersion"`
 	Shutdown             bool     `json:"shutdown,omitempty"`
@@ -96,6 +97,7 @@ func (i *Ignition) Generate(_ context.Context, dependencies asset.Parents) error
 		ExtraPartitionNumber: ibiConfig.ExtraPartitionNumber,
 		ExtraPartitionStart:  ibiConfig.ExtraPartitionStart,
 		InstallationDisk:     ibiConfig.InstallationDisk,
+		ReleaseRegistry:      ibiConfig.ReleaseRegistry,
 		SeedVersion:          ibiConfig.SeedVersion,
 		SeedImage:            ibiConfig.SeedImage,
 		Shutdown:             ibiConfig.Shutdown,

--- a/pkg/asset/imagebased/image/ignition_test.go
+++ b/pkg/asset/imagebased/image/ignition_test.go
@@ -117,7 +117,7 @@ podman rm lca-cli
 /usr/local/bin/lca-cli ibi -f "${ibi_config}"
 `,
 
-				"/var/tmp/ibi-configuration.json": "{\"extraPartitionLabel\":\"var-lib-containers\",\"extraPartitionNumber\":5,\"extraPartitionStart\":\"-40G\",\"installationDisk\":\"/dev/vda\",\"seedImage\":\"quay.io/openshift-kni/seed-image:4.16.0\",\"seedVersion\":\"4.16.0\"}\n",
+				"/var/tmp/ibi-configuration.json": "{\"extraPartitionLabel\":\"var-lib-containers\",\"extraPartitionNumber\":5,\"extraPartitionStart\":\"-40G\",\"installationDisk\":\"/dev/vda\",\"releaseRegistry\":\"mirror.quay.io\",\"seedImage\":\"quay.io/openshift-kni/seed-image:4.16.0\",\"seedVersion\":\"4.16.0\"}\n",
 
 				"/etc/containers/registries.conf": "credential-helpers = []\nshort-name-mode = \"\"\nunqualified-search-registries = []\n\n[[registry]]\n  location = \"quay.io\"\n  mirror-by-digest-only = true\n  prefix = \"\"\n\n  [[registry.mirror]]\n    location = \"mirror-quay.io\"\n",
 

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -55,6 +55,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 seedImage: quay.io/openshift-kni/seed-image:4.16.0
 seedVersion: 4.16.0
 installationDisk: /dev/vda
+releaseRegistry: mirror.quay.io
 networkConfig:
   interfaces:
     - name: eth0
@@ -395,6 +396,7 @@ func ibiConfig() *ImageBasedInstallationConfigBuilder {
 			ExtraPartitionStart:  "-40G",
 			ExtraPartitionLabel:  defaultExtraPartitionLabel,
 			ExtraPartitionNumber: 5,
+			ReleaseRegistry:      "mirror.quay.io",
 			Shutdown:             false,
 			SSHKey:               "",
 			PullSecret:           "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}",

--- a/pkg/types/imagebased/imagebased_config_types.go
+++ b/pkg/types/imagebased/imagebased_config_types.go
@@ -30,7 +30,8 @@ type Config struct {
 	// +optional
 	NetworkConfig *aiv1beta1.NetConfig `json:"networkConfig,omitempty"`
 
-	// ReleaseRegistry is the container registry used to host the release image of the seed cluster.
+	// ReleaseRegistry is the container registry that hosts the OpenShift
+	// release-image content of the cluster during the deployment step.
 	// +optional
 	ReleaseRegistry string `json:"releaseRegistry,omitempty"`
 
@@ -107,6 +108,12 @@ type InstallationConfig struct {
 
 	// PullSecret is the secret to use when pulling images.
 	PullSecret string `json:"pullSecret"`
+
+	// ReleaseRegistry is the container image registry that hosts the OpenShift
+	// release-image content and is used when precaching the cluster's container
+	// images during the preparation/installation step only.
+	// +optional
+	ReleaseRegistry string `json:"releaseRegistry,omitempty"`
 
 	// SeedImage is the seed image to use for the installation. This image will be
 	// used to prepare the installation disk.


### PR DESCRIPTION
This change adds the optional `ReleaseRegistry` field in the IBI installation config. This field is used as a replacement for the seed release registry in the seed cluster's image pull-specs, when the seed container image is generated in a disconnected SNO (i.e. with mirror registries configured).

It is related to: https://github.com/openshift-kni/lifecycle-agent/pull/727.