### PR TITLE
CORS-3923, CORS-3927: Support confidential cluster installation on SEV-SNP and TDX nodes on GCP

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -489,12 +489,32 @@ spec:
                       confidentialCompute:
                         default: Disabled
                         description: |-
-                          ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                          If enabled OnHostMaintenance is required to be set to "Terminate".
-                          If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+                          confidentialCompute is an optional field defining whether the instance should have
+                          Confidential Computing enabled or not, and the Confidential Computing technology of choice.
+                              With Disabled, Confidential Computing is disabled.
+                              With Enabled, Confidential Computing is enabled with no preference on the
+                          Confidential Computing technology. The platform chooses a default i.e. AMD SEV,
+                          which is subject to change over time.
+                              With AMDEncryptedVirtualization, Confidential Computing is enabled with
+                          AMD Secure Encrypted Virtualization (AMD SEV).
+                              With AMDEncryptedVirtualizationNestedPaging, Confidential Computing is
+                          enabled with AMD Secure Encrypted Virtualization Secure Nested Paging
+                          (AMD SEV-SNP).
+                              With IntelTrustedDomainExtensions, Confidential Computing is enabled with
+                          Intel Trusted Domain Extensions (Intel TDX).
+                              If any value other than Disabled is set, a machine type and region that supports
+                          Confidential Computing must be specified. Machine series and regions supporting
+                          Confidential Computing technologies can be checked at
+                          https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+                              If any value other than Disabled is set, onHostMaintenance is required to be set
+                          to "Terminate".
                         enum:
+                        - ""
                         - Enabled
                         - Disabled
+                        - AMDEncryptedVirtualization
+                        - AMDEncryptedVirtualizationNestedPaging
+                        - IntelTrustedDomainExtensions
                         type: string
                       onHostMaintenance:
                         default: Migrate
@@ -1726,12 +1746,32 @@ spec:
                         confidentialCompute:
                           default: Disabled
                           description: |-
-                            ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                            If enabled OnHostMaintenance is required to be set to "Terminate".
-                            If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+                            confidentialCompute is an optional field defining whether the instance should have
+                            Confidential Computing enabled or not, and the Confidential Computing technology of choice.
+                                With Disabled, Confidential Computing is disabled.
+                                With Enabled, Confidential Computing is enabled with no preference on the
+                            Confidential Computing technology. The platform chooses a default i.e. AMD SEV,
+                            which is subject to change over time.
+                                With AMDEncryptedVirtualization, Confidential Computing is enabled with
+                            AMD Secure Encrypted Virtualization (AMD SEV).
+                                With AMDEncryptedVirtualizationNestedPaging, Confidential Computing is
+                            enabled with AMD Secure Encrypted Virtualization Secure Nested Paging
+                            (AMD SEV-SNP).
+                                With IntelTrustedDomainExtensions, Confidential Computing is enabled with
+                            Intel Trusted Domain Extensions (Intel TDX).
+                                If any value other than Disabled is set, a machine type and region that supports
+                            Confidential Computing must be specified. Machine series and regions supporting
+                            Confidential Computing technologies can be checked at
+                            https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+                                If any value other than Disabled is set, onHostMaintenance is required to be set
+                            to "Terminate".
                           enum:
+                          - ""
                           - Enabled
                           - Disabled
+                          - AMDEncryptedVirtualization
+                          - AMDEncryptedVirtualizationNestedPaging
+                          - IntelTrustedDomainExtensions
                           type: string
                         onHostMaintenance:
                           default: Migrate
@@ -2900,12 +2940,32 @@ spec:
                       confidentialCompute:
                         default: Disabled
                         description: |-
-                          ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                          If enabled OnHostMaintenance is required to be set to "Terminate".
-                          If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+                          confidentialCompute is an optional field defining whether the instance should have
+                          Confidential Computing enabled or not, and the Confidential Computing technology of choice.
+                              With Disabled, Confidential Computing is disabled.
+                              With Enabled, Confidential Computing is enabled with no preference on the
+                          Confidential Computing technology. The platform chooses a default i.e. AMD SEV,
+                          which is subject to change over time.
+                              With AMDEncryptedVirtualization, Confidential Computing is enabled with
+                          AMD Secure Encrypted Virtualization (AMD SEV).
+                              With AMDEncryptedVirtualizationNestedPaging, Confidential Computing is
+                          enabled with AMD Secure Encrypted Virtualization Secure Nested Paging
+                          (AMD SEV-SNP).
+                              With IntelTrustedDomainExtensions, Confidential Computing is enabled with
+                          Intel Trusted Domain Extensions (Intel TDX).
+                              If any value other than Disabled is set, a machine type and region that supports
+                          Confidential Computing must be specified. Machine series and regions supporting
+                          Confidential Computing technologies can be checked at
+                          https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+                              If any value other than Disabled is set, onHostMaintenance is required to be set
+                          to "Terminate".
                         enum:
+                        - ""
                         - Enabled
                         - Disabled
+                        - AMDEncryptedVirtualization
+                        - AMDEncryptedVirtualizationNestedPaging
+                        - IntelTrustedDomainExtensions
                         type: string
                       onHostMaintenance:
                         default: Migrate
@@ -4956,12 +5016,32 @@ spec:
                       confidentialCompute:
                         default: Disabled
                         description: |-
-                          ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                          If enabled OnHostMaintenance is required to be set to "Terminate".
-                          If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+                          confidentialCompute is an optional field defining whether the instance should have
+                          Confidential Computing enabled or not, and the Confidential Computing technology of choice.
+                              With Disabled, Confidential Computing is disabled.
+                              With Enabled, Confidential Computing is enabled with no preference on the
+                          Confidential Computing technology. The platform chooses a default i.e. AMD SEV,
+                          which is subject to change over time.
+                              With AMDEncryptedVirtualization, Confidential Computing is enabled with
+                          AMD Secure Encrypted Virtualization (AMD SEV).
+                              With AMDEncryptedVirtualizationNestedPaging, Confidential Computing is
+                          enabled with AMD Secure Encrypted Virtualization Secure Nested Paging
+                          (AMD SEV-SNP).
+                              With IntelTrustedDomainExtensions, Confidential Computing is enabled with
+                          Intel Trusted Domain Extensions (Intel TDX).
+                              If any value other than Disabled is set, a machine type and region that supports
+                          Confidential Computing must be specified. Machine series and regions supporting
+                          Confidential Computing technologies can be checked at
+                          https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+                              If any value other than Disabled is set, onHostMaintenance is required to be set
+                          to "Terminate".
                         enum:
+                        - ""
                         - Enabled
                         - Disabled
+                        - AMDEncryptedVirtualization
+                        - AMDEncryptedVirtualizationNestedPaging
+                        - IntelTrustedDomainExtensions
                         type: string
                       onHostMaintenance:
                         default: Migrate

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -9,6 +9,9 @@ type FeatureSwitch string
 // applicable when ConfidentialCompute is Enabled.
 type OnHostMaintenanceType string
 
+// ConfidentialComputePolicy indicates the setting for the ConfidentialCompute feature.
+type ConfidentialComputePolicy string
+
 const (
 	// PDSSD is the constant string representation for persistent disk ssd disk types.
 	PDSSD = "pd-ssd"
@@ -65,6 +68,15 @@ const (
 
 	// OnHostMaintenanceTerminate indicates that the OnHostMaintenance feature is set to Terminate.
 	OnHostMaintenanceTerminate OnHostMaintenanceType = "Terminate"
+
+	// ConfidentialComputePolicySEV indicates that the ConfidentialCompute feature is set to AMDEncryptedVirtualization.
+	ConfidentialComputePolicySEV ConfidentialComputePolicy = "AMDEncryptedVirtualization"
+
+	// ConfidentialComputePolicySEVSNP indicates that the ConfidentialCompute feature is set to AMDEncryptedVirtualizationNestedPaging.
+	ConfidentialComputePolicySEVSNP ConfidentialComputePolicy = "AMDEncryptedVirtualizationNestedPaging"
+
+	// ConfidentialComputePolicyTDX indicates that the ConfidentialCompute feature is set to IntelTrustedDomainExtensions.
+	ConfidentialComputePolicyTDX ConfidentialComputePolicy = "IntelTrustedDomainExtensions"
 )
 
 // MachinePool stores the configuration for a machine pool installed on GCP.
@@ -111,12 +123,28 @@ type MachinePool struct {
 	// +optional
 	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
 
-	// ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-	// If enabled OnHostMaintenance is required to be set to "Terminate".
-	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
+	// confidentialCompute is an optional field defining whether the instance should have
+	// Confidential Computing enabled or not, and the Confidential Computing technology of choice.
+	//     With Disabled, Confidential Computing is disabled.
+	//     With Enabled, Confidential Computing is enabled with no preference on the
+	// Confidential Computing technology. The platform chooses a default i.e. AMD SEV,
+	// which is subject to change over time.
+	//     With AMDEncryptedVirtualization, Confidential Computing is enabled with
+	// AMD Secure Encrypted Virtualization (AMD SEV).
+	//     With AMDEncryptedVirtualizationNestedPaging, Confidential Computing is
+	// enabled with AMD Secure Encrypted Virtualization Secure Nested Paging
+	// (AMD SEV-SNP).
+	//     With IntelTrustedDomainExtensions, Confidential Computing is enabled with
+	// Intel Trusted Domain Extensions (Intel TDX).
+	//     If any value other than Disabled is set, a machine type and region that supports
+	// Confidential Computing must be specified. Machine series and regions supporting
+	// Confidential Computing technologies can be checked at
+	// https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+	//     If any value other than Disabled is set, onHostMaintenance is required to be set
+	// to "Terminate".
 	// +kubebuilder:default="Disabled"
 	// +default="Disabled"
-	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +kubebuilder:validation:Enum="";Enabled;Disabled;AMDEncryptedVirtualization;AMDEncryptedVirtualizationNestedPaging;IntelTrustedDomainExtensions
 	// +optional
 	ConfidentialCompute string `json:"confidentialCompute,omitempty"`
 

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -79,6 +79,15 @@ const (
 	ConfidentialComputePolicyTDX ConfidentialComputePolicy = "IntelTrustedDomainExtensions"
 )
 
+var (
+	// ConfidentialComputePolicyToSupportedInstanceType is a map containing machine types and the list of confidential computing technologies each of them support.
+	ConfidentialComputePolicyToSupportedInstanceType = map[ConfidentialComputePolicy][]string{
+		ConfidentialComputePolicySEV:    {"c2d", "n2d", "c3d"},
+		ConfidentialComputePolicySEVSNP: {"n2d"},
+		ConfidentialComputePolicyTDX:    {"c3"},
+	}
+)
+
 // MachinePool stores the configuration for a machine pool installed on GCP.
 type MachinePool struct {
 	// Zones is list of availability zones that can be used.

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -33,8 +34,22 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), diskType, sets.List(gcp.ComputeSupportedDisks)))
 	}
 
-	if p.ConfidentialCompute != "" && p.ConfidentialCompute != string(gcp.DisabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("OnHostMaintenance"), p.OnHostMaintenance, fmt.Sprintf("OnHostMaintenace must be set to Terminate when ConfidentialCompute is %s", p.ConfidentialCompute)))
+	if p.ConfidentialCompute != "" && p.ConfidentialCompute != string(gcp.DisabledFeature) {
+		if p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("OnHostMaintenance"), p.OnHostMaintenance, fmt.Sprintf("OnHostMaintenace must be set to Terminate when ConfidentialCompute is %s", p.ConfidentialCompute)))
+		}
+
+		instanceType, _, _ := strings.Cut(p.InstanceType, "-")
+		confidentialCompute := gcp.ConfidentialComputePolicy(p.ConfidentialCompute)
+		if confidentialCompute == gcp.ConfidentialComputePolicy(gcp.EnabledFeature) {
+			confidentialCompute = gcp.ConfidentialComputePolicySEV
+		}
+		supportedMachineTypes, ok := gcp.ConfidentialComputePolicyToSupportedInstanceType[confidentialCompute]
+		if !ok {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("confidentialCompute"), p.ConfidentialCompute, fmt.Sprintf("Unknown confidential computing technology %s", p.ConfidentialCompute)))
+		} else if !slices.Contains(supportedMachineTypes, instanceType) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), p.InstanceType, fmt.Sprintf("Machine type do not support %s. Machine types supporting %s: %s", p.ConfidentialCompute, p.ConfidentialCompute, strings.Join(supportedMachineTypes, ", "))))
+		}
 	}
 
 	for i, tag := range p.Tags {

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -33,8 +33,8 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), diskType, sets.List(gcp.ComputeSupportedDisks)))
 	}
 
-	if p.ConfidentialCompute == string(gcp.EnabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("OnHostMaintenance"), p.OnHostMaintenance, "OnHostMaintenace must be set to Terminate when ConfidentialCompute is Enabled"))
+	if p.ConfidentialCompute != "" && p.ConfidentialCompute != string(gcp.DisabledFeature) && p.OnHostMaintenance != string(gcp.OnHostMaintenanceTerminate) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("OnHostMaintenance"), p.OnHostMaintenance, fmt.Sprintf("OnHostMaintenace must be set to Terminate when ConfidentialCompute is %s", p.ConfidentialCompute)))
 	}
 
 	for i, tag := range p.Tags {

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -100,6 +100,30 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is Enabled`,
 		},
+		{
+			name: "AMDEncryptedVirtualization confidential compute with incorrect on host maintenance",
+			pool: &gcp.MachinePool{
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEV),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceMigrate),
+			},
+			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is AMDEncryptedVirtualization`,
+		},
+		{
+			name: "AMDEncryptedVirtualizationNestedPaging confidential compute with incorrect on host maintenance",
+			pool: &gcp.MachinePool{
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEVSNP),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceMigrate),
+			},
+			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is AMDEncryptedVirtualizationNestedPaging`,
+		},
+		{
+			name: "IntelTrustedDomainExtensions confidential compute with incorrect on host maintenance",
+			pool: &gcp.MachinePool{
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicyTDX),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceMigrate),
+			},
+			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is IntelTrustedDomainExtensions`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -88,6 +88,7 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "enable confidential compute with correct on host maintenance",
 			pool: &gcp.MachinePool{
+				InstanceType:        "c2d-standard-4",
 				ConfidentialCompute: string(gcp.EnabledFeature),
 				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
 			},
@@ -123,6 +124,57 @@ func TestValidateMachinePool(t *testing.T) {
 				OnHostMaintenance:   string(gcp.OnHostMaintenanceMigrate),
 			},
 			expected: `test-path.OnHostMaintenance: Invalid value: "Migrate": OnHostMaintenace must be set to Terminate when ConfidentialCompute is IntelTrustedDomainExtensions`,
+		},
+		{
+			name: "AMDEncryptedVirtualization confidential compute with unsupported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "c3-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEV),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+			expected: `test-path.type: Invalid value: "c3-standard-4": Machine type do not support AMDEncryptedVirtualization. Machine types supporting AMDEncryptedVirtualization: c2d, n2d, c3d`,
+		},
+		{
+			name: "AMDEncryptedVirtualization confidential compute with supported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "c3d-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEV),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+		},
+		{
+			name: "AMDEncryptedVirtualizationNestedPaging confidential compute with unsupported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "c2d-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEVSNP),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+			expected: `test-path.type: Invalid value: "c2d-standard-4": Machine type do not support AMDEncryptedVirtualizationNestedPaging. Machine types supporting AMDEncryptedVirtualizationNestedPaging: n2d`,
+		},
+		{
+			name: "AMDEncryptedVirtualizationNestedPaging confidential compute with supported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "n2d-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicySEVSNP),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+		},
+		{
+			name: "IntelTrustedDomainExtensions confidential compute with unsupported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "n2d-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicyTDX),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
+			expected: `test-path.type: Invalid value: "n2d-standard-4": Machine type do not support IntelTrustedDomainExtensions. Machine types supporting IntelTrustedDomainExtensions: c3`,
+		},
+		{
+			name: "IntelTrustedDomainExtensions confidential compute with supported machine type",
+			pool: &gcp.MachinePool{
+				InstanceType:        "c3-standard-4",
+				ConfidentialCompute: string(gcp.ConfidentialComputePolicyTDX),
+				OnHostMaintenance:   string(gcp.OnHostMaintenanceTerminate),
+			},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This patch series aims to support installing a cluster on AMD SEV SNP or TDX confidential nodes on GCP.
Previously, only AMD SEV nodes were supported, which were configured through the `confidentialCompute: Enabled` configuration flag.
Now that GCP supports specifying the confidential instance type, we are letting users specify which node type (SEV/SEV-SNP/TDX) they would like to deploy the cluster on.
This can be done by using any of the new available values in `condidentialCompute` such as `AMDEncryptedVirtualization` (similar to `Enabled`), `AMDEncryptedVirtualizationNestedPaging` (AMD SEV-SNP) or `IntelTrustedDomainExtensions` (Intel TDX).

This series depend on the following patches:
- https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1410
- https://github.com/openshift/api/pull/2165
- https://github.com/openshift/machine-api-operator/pull/1326
- https://github.com/openshift/machine-api-provider-gcp/pull/110

Which have been merged now and and vendored in this patch.

A new cluster-api-provider-gcp release containing the changes I submitted isn't available yet. I created the `data/data/cluster-api/gcp-infrastructure-components.yaml` myself. I'm not sure if that's a valid approach, or if we should rather wait until a new version is out.