### PR TITLE
OCPBUGS-48089: validate hostPrefix to be the same when multiple  clusternetwork CIDRs are present

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2378,6 +2378,8 @@ spec:
                         HostPrefix is the prefix size to allocate to each node from the CIDR.
                         For example, 24 would allocate 2^8=256 adresses to each node. If this
                         field is not used by the plugin, it can be left unset.
+                        When multiple CIDRs of the same family (i.e. IPv4/IPv6) are present,
+                        their HostPrefix value must be the same.
                       format: int32
                       type: integer
                     hostSubnetLength:
@@ -2413,6 +2415,8 @@ spec:
                         HostPrefix is the prefix size to allocate to each node from the CIDR.
                         For example, 24 would allocate 2^8=256 adresses to each node. If this
                         field is not used by the plugin, it can be left unset.
+                        When multiple CIDRs of the same family (i.e. IPv4/IPv6) are present,
+                        their HostPrefix value must be the same.
                       format: int32
                       type: integer
                     hostSubnetLength:

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -45,7 +45,7 @@ feature set.
         The default is 10.128.0.0/14 with a host prefix of /23.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
         * `hostPrefix` (required integer): The prefix size to allocate to each node from the CIDR.
-        For example, 24 would allocate 2^8=256 addresses to each node. If this field is not used by the plugin, it can be left unset.
+        For example, 24 would allocate 2^8=256 addresses to each node. If this field is not used by the plugin, it can be left unset. When multiple CIDRs of the same family (i.e. IPv4/IPv6) are present, their `hostPrefix` value must be the same.
     * `machineNetwork` (optional array of objects): The IP address pools for machines.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
             The default is 10.0.0.0/16 for all platforms other than libvirt.

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -441,6 +441,8 @@ type ClusterNetworkEntry struct {
 	// HostPrefix is the prefix size to allocate to each node from the CIDR.
 	// For example, 24 would allocate 2^8=256 adresses to each node. If this
 	// field is not used by the plugin, it can be left unset.
+	// When multiple CIDRs of the same family (i.e. IPv4/IPv6) are present,
+	// their HostPrefix value must be the same.
 	// +optional
 	HostPrefix int32 `json:"hostPrefix,omitempty"`
 


### PR DESCRIPTION
## Description

When multiple clusternetwork CIDRs are present, hostPrefix fields must be specified with the same value. If not, it can impact traffic between pods in different subnets.

The patch applies validation for IPv4 CIDR. For IPv6, the only option for hostPrefix is 64, thus naturally satisfying the requirement.

Other related changes:
- Only validate for negative host prefix when the prefix is actually used. 
- Added a test case for negative host prefix.

## References

- https://issues.redhat.com/browse/OCPBUGS-46514 (debug steps and explanation for root cause)
- https://access.redhat.com/solutions/7100460 (temporary solution for existing cluster)