### PR TITLE
OCPBUGS-49319: IBMCloud: Drop CAPI metrics-bind-addr

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -243,7 +243,6 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 		ibmcloudFlags := []string{
 			"--provider-id-fmt=v2",
 			"-v=2",
-			"--metrics-bind-addr=0",
 			"--health-addr={{suggestHealthHostPort}}",
 			"--leader-elect=false",
 			"--webhook-port={{.WebhookPort}}",


### PR DESCRIPTION
Drop the metrics-bind-addr flag for the IBM Cloud CAPI deployment, as it does not appear to be supported in newer cluster-api releases.

Related: https://issues.redhat.com/browse/OCPBUGS-49319