### PR TITLE
Restrict kernel args `ip=dhcp,dhcp6` to the primary interface

### DIFF
--- a/pkg/asset/machines/machineconfig/ipv6.go
+++ b/pkg/asset/machines/machineconfig/ipv6.go
@@ -36,7 +36,7 @@ func ForDualStackAddresses(role string) (*mcfgv1.MachineConfig, error) {
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Config:          rawExt,
-			KernelArguments: []string{"ip=dhcp,dhcp6"},
+			KernelArguments: []string{"ip=enp3s0:dhcp,dhcp6"},
 		},
 	}, nil
 }

--- a/scripts/openstack/manifest-tests/dual-stack/test_machine-config.py
+++ b/scripts/openstack/manifest-tests/dual-stack/test_machine-config.py
@@ -24,7 +24,7 @@ class GenerateMachineConfig(unittest.TestCase):
         """Assert there are machine configs configuring the kernel args for masters and workers"""
         for machine_config in self.machine_configs:
             kernel_args = machine_config["spec"]["kernelArguments"]
-            self.assertIn("ip=dhcp,dhcp6", kernel_args)
+            self.assertIn("ip=enp3s0:dhcp,dhcp6", kernel_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When defining the kernel args with `ip=dhcp,dhcp6` without specifing the interface, the network manager connection profiles generated would contain the setting: `multi-connect=3`, which means the connection could be configured on various interfaces simultaneously, resulting in different connections having the same UUID. This commit fixes the issue by specifying the interface where that configuration should be enforced.