### PR TITLE
AGENT-1052: Remove Validation for "At Least One Interface Must Be Defined for Each Node"

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/ha_hosts_no_interfaces_no_macAddress.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/ha_hosts_no_interfaces_no_macAddress.txt
@@ -1,0 +1,58 @@
+# Verify a default configuration for the SNO topology
+
+exec openshift-install agent create image --dir $WORK
+
+stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+!isoIgnitionContains agent.x86_64.iso /etc/assisted/hostconfig/changehostname1/mac_addresses
+isoIgnitionContains agent.x86_64.iso /etc/assisted/hostconfig/changehostname1/role
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 3
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20
+hosts:
+- hostname: changehostname1
+  role: master
+  rootDeviceHints:
+    deviceName: /dev/sda
+- hostname: changehostname2
+  role: master
+  rootDeviceHints:
+    deviceName: /dev/sda
+- hostname: changehostname3
+  role: master
+  rootDeviceHints:
+    deviceName: /dev/sda

--- a/pkg/asset/agent/agentconfig/agenthosts.go
+++ b/pkg/asset/agent/agentconfig/agenthosts.go
@@ -144,10 +144,6 @@ func (a *AgentHosts) validateHostInterfaces(hostPath *field.Path, host agent.Hos
 	var allErrs field.ErrorList
 
 	interfacePath := hostPath.Child("Interfaces")
-	if len(host.Interfaces) == 0 {
-		allErrs = append(allErrs, field.Required(interfacePath, "at least one interface must be defined for each node"))
-	}
-
 	for j := range host.Interfaces {
 		mac := host.Interfaces[j].MacAddress
 		macAddressPath := interfacePath.Index(j).Child("macAddress")

--- a/pkg/asset/agent/agentconfig/agenthosts_test.go
+++ b/pkg/asset/agent/agentconfig/agenthosts_test.go
@@ -178,6 +178,19 @@ func TestAgentHosts_Generate(t *testing.T) {
 				agentHost().name("test-2").role("worker").interfaces(iface("enp3s1", "28:d2:44:d2:b2:1b")).networkConfig(agentNetworkConfigTwo)),
 		},
 		{
+			name: "multi-host-no-interfaces-from-agent-config",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&joiner.AddNodesConfig{},
+				getInstallConfigSingleHost(),
+				getAgentConfigMissingInterfaces(),
+			},
+			expectedConfig: agentHosts().hosts(
+				agentHost().name("control-0.example.org").role("master"),
+				agentHost().name("control-1.example.org").role("master"),
+				agentHost().name("control-2.example.org").role("master")),
+		},
+		{
 			name: "multi-host-from-install-config",
 			dependencies: []asset.Asset{
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
@@ -307,17 +320,6 @@ func TestAgentHosts_Generate(t *testing.T) {
 				getNoHostsAgentConfig(),
 			},
 			expectedError:  "invalid Hosts configuration: Hosts[0].Host: Forbidden: Host test has role 'worker' and has the rendezvousIP assigned to it. The rendezvousIP must be assigned to a control plane host.",
-			expectedConfig: nil,
-		},
-		{
-			name: "host-missing-interface-error",
-			dependencies: []asset.Asset{
-				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
-				&joiner.AddNodesConfig{},
-				getInstallConfigSingleHost(),
-				getAgentConfigMissingInterfaces(),
-			},
-			expectedError:  "invalid Hosts configuration: [Hosts[0].Interfaces: Required value: at least one interface must be defined for each node, Hosts[1].Interfaces: Required value: at least one interface must be defined for each node, Hosts[2].Interfaces: Required value: at least one interface must be defined for each node]",
 			expectedConfig: nil,
 		},
 		{


### PR DESCRIPTION
Remove the validation so that agent-config.yaml can be valid even if no interfaces/mac-addresses are defined when defining host information.