### PR TITLE
OCPBUGS-48827: aws/edge/byovpc: subnets tag kube cluster tag to shared

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -63,11 +63,19 @@ func tagSharedVPCResources(ctx context.Context, clusterID string, installConfig 
 		return err
 	}
 
-	ids := make([]*string, 0, len(privateSubnets)+len(publicSubnets))
-	for id := range privateSubnets {
+	edgeSubnets, err := installConfig.AWS.EdgeSubnets(ctx)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]*string, 0, len(privateSubnets)+len(publicSubnets)+len(edgeSubnets))
+	for id := range publicSubnets {
 		ids = append(ids, aws.String(id))
 	}
 	for id := range publicSubnets {
+		ids = append(ids, aws.String(id))
+	}
+	for id := range edgeSubnets {
 		ids = append(ids, aws.String(id))
 	}
 


### PR DESCRIPTION
Previously the subnets created by user (BYO VPC) on edge zones (Local or
Wavelength zones) were not tagged with
kubernetes.io/cluster/<InfraID>:shared.

This change ensures installer is also setting the same cluster tag as
regular zones.