### PR TITLE
OCPBUGS-46051: IBMCloud: Fix CAPI AZ handling

### DIFF
--- a/pkg/asset/manifests/ibmcloud/cluster.go
+++ b/pkg/asset/manifests/ibmcloud/cluster.go
@@ -69,9 +69,11 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	// If no Control Plane subnets were provided in InstallConfig, we build a default set to cover all provided zones, or zones in the region.
 	if len(controlPlaneSubnets) == 0 {
 		var zones []string
-		// Use provided Control Plane zones, or default to all zones in the Region.
-		if len(installConfig.Config.ControlPlane.Platform.IBMCloud.Zones) != 0 {
-			zones = installConfig.Config.ControlPlane.Platform.IBMCloud.Zones
+		// Use provided Control Plane zones, DefaultMachinePlatform zones, or default to all zones in the Region.
+		if ibmcloudCPPlatform := installConfig.Config.ControlPlane.Platform.IBMCloud; ibmcloudCPPlatform != nil && ibmcloudCPPlatform.Zones != nil && len(ibmcloudCPPlatform.Zones) != 0 { //nolint: gocritic //checking multiple fields are set and populated
+			zones = ibmcloudCPPlatform.Zones
+		} else if platform.DefaultMachinePlatform != nil && platform.DefaultMachinePlatform.Zones != nil && len(platform.DefaultMachinePlatform.Zones) != 0 {
+			zones = platform.DefaultMachinePlatform.Zones
 		} else {
 			var err error
 			zones, err = client.GetVPCZonesForRegion(context.TODO(), platform.Region)
@@ -111,10 +113,12 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	// If no Compute subnets were provided in InstallConfig, we build a default set to cover all specified zones, or zones in the region.
 	if len(computeSubnets) == 0 {
 		var zones []string
-		// Use provided Compute zones, or default to all zones in the Region.
+		// Use provided Compute zones, DefaultMachinePlatform zones, or default to all zones in the Region.
 		// NOTE(cjschaef): We only process the first Compute definition, which may result in complications if additional Compute definitions request different Zones.
-		if len(installConfig.Config.Compute[0].Platform.IBMCloud.Zones) != 0 {
-			zones = installConfig.Config.Compute[0].Platform.IBMCloud.Zones
+		if ibmcloudComputePlatform := installConfig.Config.Compute[0].Platform.IBMCloud; ibmcloudComputePlatform != nil && ibmcloudComputePlatform.Zones != nil && len(ibmcloudComputePlatform.Zones) != 0 { //nolint: gocritic //checking multiple fields are set and populated
+			zones = ibmcloudComputePlatform.Zones
+		} else if platform.DefaultMachinePlatform != nil && platform.DefaultMachinePlatform.Zones != nil && len(platform.DefaultMachinePlatform.Zones) != 0 {
+			zones = platform.DefaultMachinePlatform.Zones
 		} else {
 			var err error
 			zones, err = client.GetVPCZonesForRegion(context.TODO(), platform.Region)


### PR DESCRIPTION
Use AZ's provided for controlPlane or compute nodes, if provided in those blocks. Also, check defaultMachinePlatform for zones before defaulting to all AZ's in IBM Cloud Region.

Related: https://issues.redhat.com/browse/OCPBUGS-46051