### PR TITLE
no-jira: Relax serviceEndpoint URL validation for IBMCloud platform

### DIFF
--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -93,8 +93,8 @@ func validateServiceEndpoints(endpoints []configv1.IBMCloudServiceEndpoint, fldP
 // schemeRE is used to check whether a string starts with a scheme (URI format).
 var schemeRE = regexp.MustCompile("^([^:]+)://")
 
-// versionPath is the regexp for a trailing API version in URL path ('/v1', '/v22/', etc.)
-var versionPath = regexp.MustCompile(`(/v\d+[/]{0,1})$`)
+// versionPath is the regexp for a trailing API version in URL path ('/v1', '/v22/', /api/v1, etc.)
+var versionPath = regexp.MustCompile(`\/(api\/)?v\d+\/{0,1}`)
 
 // validateServiceURL checks that a string meets certain URI expectations.
 func validateServiceURL(uri string) error {

--- a/pkg/types/ibmcloud/validation/platform_test.go
+++ b/pkg/types/ibmcloud/validation/platform_test.go
@@ -217,6 +217,42 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			valid: true,
 		},
+		{
+			name: "valid url has api and version path, no trailing '/' for service endpoint",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.ServiceEndpoints = []configv1.IBMCloudServiceEndpoint{{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  "https://test-iam.random.local/api/v22",
+				}}
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name: "valid url has api and version path, with trailing '/' for service endpoint",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.ServiceEndpoints = []configv1.IBMCloudServiceEndpoint{{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  "https://test-iam.random.local/api/v2/",
+				}}
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name: "invalid url has api and version path, with invalid char service endpoint",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.ServiceEndpoints = []configv1.IBMCloudServiceEndpoint{{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  "https://test-iam.random.local/api/v2e",
+				}}
+				return p
+			}(),
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Relax endpoint regex validation to accept new endpoints from IBM services matching /api/v* or /v*