### PR TITLE
Power VS: Disallow clusterOSImage install-configuration parameter

### DIFF
--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -167,6 +167,8 @@ func (a *PlatformProvisionCheck) Generate(ctx context.Context, dependencies asse
 			return err
 		}
 
+		powervsconfig.ValidateClusterOSImageNotSet(client, ic.Config)
+
 		err = powervsconfig.ValidateTransitGateway(client, ic.Config)
 		if err != nil {
 			return err

--- a/pkg/asset/installconfig/powervs/validation.go
+++ b/pkg/asset/installconfig/powervs/validation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/installer/pkg/types"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
+	"github.com/sirupsen/logrus"
 )
 
 // Validate executes platform specific validation/
@@ -306,6 +307,13 @@ func ValidateServiceInstance(client API, ic *types.InstallConfig) error {
 	}
 
 	return nil
+}
+
+// ValidateClusterOSImageNotSet validates that the platform.powervs.clusterOSImage is not set.
+func ValidateClusterOSImageNotSet(client API, ic *types.InstallConfig) {
+	if ic.Platform.PowerVS.ClusterOSImage != "" {
+		logrus.Warnf("The value of platform.powervs.clusterOSImage will be ignored.")
+	}
 }
 
 // ValidateTransitGateway validates the optional transit gateway name in our install config.

--- a/pkg/asset/machines/powervs/machines.go
+++ b/pkg/asset/machines/powervs/machines.go
@@ -29,9 +29,6 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	// The other two, we should standardize a name including the cluster id.
 	image := fmt.Sprintf("rhcos-%s", clusterID)
 	var network string
-	if platform.ClusterOSImage != "" {
-		image = platform.ClusterOSImage
-	}
 
 	total := int64(1)
 	if pool.Replicas != nil {

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -178,11 +178,6 @@ func osImage(ctx context.Context, config *types.InstallConfig, nodeArch types.Ar
 		}
 		return "", fmt.Errorf("%s: No vmware build found", st.FormatPrefix(archName))
 	case powervs.Name:
-		// Check for image URL override
-		if config.Platform.PowerVS.ClusterOSImage != "" {
-			return config.Platform.PowerVS.ClusterOSImage, nil
-		}
-
 		if streamArch.Images.PowerVS != nil {
 			var (
 				vpcRegion string


### PR DESCRIPTION
platform.powervs.clusterOSImage was used to override the default RHCOS image being installed on cluster nodes. This parameter is no longer supported. This PR removes it.