### PR TITLE
OCPBUGS-49594: aws/byo-ip added required permission ec2:ReleaseAddress

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -324,6 +324,8 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DescribePublicIpv4Pools",
 		// Needed by terraform because of bootstrap EIP created
 		"ec2:DisassociateAddress",
+		// Needed by openshift-install destroy cluster flow.
+		"ec2:ReleaseAddress",
 	},
 	PermissionDeleteIgnitionObjects: {
 		// Needed by terraform during the bootstrap destroy stage.


### PR DESCRIPTION
Previously clusters created with minimum permissions in existing VPC (unmanaged VPC or BYO VPC) and BYO Public IPv4 Pool address (BYO IP) on AWS failed to de-provision cluster without permissions to release EIP address (ec2:ReleaseAddress).

This change ensures ec2:ReleaseAddress permission is exported to the install-generated IAM policy when deploying a cluster on AWS with BYO VPC and BYO Public IPv4 Pool.

Blocks https://github.com/openshift/installer/pull/9413