### PR TITLE
OCPBUGS-46656: validate configured networks to not overlap with OVNKubernetes default subnets

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -399,17 +399,18 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 
 func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if n.NetworkType == "" {
+
+	if len(n.NetworkType) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkType"), "network provider type required"))
 	}
 
 	// NOTE(dulek): We're hardcoding "Kuryr" here as the plan is to remove it from the API very soon. We can remove
 	//              this check once some more general validation of the supported NetworkTypes is in place.
-	if n.NetworkType == "Kuryr" {
+	if strings.EqualFold(n.NetworkType, "Kuryr") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType Kuryr is not supported on OpenShift later than 4.14"))
 	}
 
-	if n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
+	if strings.EqualFold(n.NetworkType, string(operv1.NetworkTypeOpenShiftSDN)) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType OpenShiftSDN is not supported, please use OVNKubernetes"))
 	}
 
@@ -614,12 +615,13 @@ func validateNetworkingClusterNetworkMTU(c *types.InstallConfig, fldPath *field.
 
 	return allErrs
 }
-func validateOVNKubernetesConfig(n *types.Networking, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
 
+func validateOVNKubernetesConfig(n *types.Networking, fldPath *field.Path) field.ErrorList {
 	if n.OVNKubernetesConfig == nil {
 		return nil
 	}
+
+	allErrs := field.ErrorList{}
 
 	if !strings.EqualFold(n.NetworkType, string(operv1.NetworkTypeOVNKubernetes)) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "ovnKubernetesConfig may only be specified with the OVNKubernetes networkType"))

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -111,9 +111,8 @@ func ValidateInstallConfig(c *types.InstallConfig, usingAgentMethod bool) field.
 		}
 	}
 	if c.Networking != nil {
-		allErrs = append(allErrs, validateNetworking(c.Networking, c.IsSingleNodeOpenShift(), field.NewPath("networking"))...)
+		allErrs = append(allErrs, validateNetworking(c.Networking, field.NewPath("networking"))...)
 		allErrs = append(allErrs, validateNetworkingIPVersion(c.Networking, &c.Platform)...)
-		allErrs = append(allErrs, validateNetworkingForPlatform(c.Networking, &c.Platform, field.NewPath("networking"))...)
 		allErrs = append(allErrs, validateNetworkingClusterNetworkMTU(c, field.NewPath("networking", "clusterNetworkMTU"))...)
 		allErrs = append(allErrs, validateVIPsForPlatform(c.Networking, &c.Platform, field.NewPath("platform"))...)
 		allErrs = append(allErrs, validateOVNKubernetesConfig(c.Networking, field.NewPath("networking"))...)
@@ -398,7 +397,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 	return allErrs
 }
 
-func validateNetworking(n *types.Networking, singleNodeOpenShift bool, fldPath *field.Path) field.ErrorList {
+func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if n.NetworkType == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkType"), "network provider type required"))
@@ -414,69 +413,71 @@ func validateNetworking(n *types.Networking, singleNodeOpenShift bool, fldPath *
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType OpenShiftSDN is not supported, please use OVNKubernetes"))
 	}
 
-	if len(n.MachineNetwork) > 0 {
-		for i, network := range n.MachineNetwork {
-			if err := validate.SubnetCIDR(&network.CIDR.IPNet); err != nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("machineNetwork").Index(i), network.CIDR.String(), err.Error()))
-			}
-			for j, subNetwork := range n.MachineNetwork[0:i] {
-				if validate.DoCIDRsOverlap(&network.CIDR.IPNet, &subNetwork.CIDR.IPNet) {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("machineNetwork").Index(i), network.CIDR.String(), fmt.Sprintf("machine network must not overlap with machine network %d", j)))
-				}
-			}
-		}
-	} else {
+	if len(n.MachineNetwork) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineNetwork"), "at least one machine network is required"))
 	}
-
-	for i, sn := range n.ServiceNetwork {
-		if err := validate.ServiceSubnetCIDR(&sn.IPNet); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceNetwork").Index(i), sn.String(), err.Error()))
-		}
-		for _, network := range n.MachineNetwork {
-			if validate.DoCIDRsOverlap(&sn.IPNet, &network.CIDR.IPNet) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceNetwork").Index(i), sn.String(), "service network must not overlap with any of the machine networks"))
-			}
-		}
-		for j, snn := range n.ServiceNetwork[0:i] {
-			if validate.DoCIDRsOverlap(&sn.IPNet, &snn.IPNet) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceNetwork").Index(i), sn.String(), fmt.Sprintf("service network must not overlap with service network %d", j)))
-			}
-		}
+	for i, mn := range n.MachineNetwork {
+		allErrs = append(allErrs, validateMachineNetwork(n, &mn, i, fldPath.Child("machineNetwork").Index(i))...)
 	}
+
 	if len(n.ServiceNetwork) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("serviceNetwork"), "a service network is required"))
 	}
-
-	for i, cn := range n.ClusterNetwork {
-		allErrs = append(allErrs, validateClusterNetwork(n, &cn, i, fldPath.Child("clusterNetwork").Index(i))...)
+	for i, sn := range n.ServiceNetwork {
+		allErrs = append(allErrs, validateServiceNetwork(n, &sn, i, fldPath.Child("serviceNetwork").Index(i))...)
 	}
+
 	if len(n.ClusterNetwork) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterNetwork"), "cluster network required"))
+	}
+	for i, cn := range n.ClusterNetwork {
+		allErrs = append(allErrs, validateClusterNetwork(n, &cn, i, fldPath.Child("clusterNetwork").Index(i))...)
 	}
 
 	return allErrs
 }
 
-func validateNetworkingForPlatform(n *types.Networking, platform *types.Platform, fldPath *field.Path) field.ErrorList {
+func validateMachineNetwork(n *types.Networking, mn *types.MachineNetworkEntry, idx int, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	switch {
-	default:
-		warningMsgFmt := "%s: %s overlaps with default Docker Bridge subnet"
-		for idx, mn := range n.MachineNetwork {
-			if validate.DoCIDRsOverlap(&mn.CIDR.IPNet, validate.DockerBridgeSubnet) {
-				logrus.Warnf(warningMsgFmt, fldPath.Child("machineNetwork").Index(idx), mn.CIDR.String())
-			}
+
+	if err := validate.SubnetCIDR(&mn.CIDR.IPNet); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, mn.CIDR.String(), err.Error()))
+		return allErrs // CIDR value is invalid, so no further validation.
+	}
+
+	if validate.DoCIDRsOverlap(&mn.CIDR.IPNet, validate.DockerBridgeSubnet) {
+		logrus.Warnf("%s: %s overlaps with default Docker Bridge subnet", fldPath, mn.CIDR.String())
+	}
+
+	for i, subNetwork := range n.MachineNetwork[0:idx] {
+		if validate.DoCIDRsOverlap(&mn.CIDR.IPNet, &subNetwork.CIDR.IPNet) {
+			allErrs = append(allErrs, field.Invalid(fldPath, mn.CIDR.String(), fmt.Sprintf("machine network must not overlap with machine network %d", i)))
 		}
-		for idx, sn := range n.ServiceNetwork {
-			if validate.DoCIDRsOverlap(&sn.IPNet, validate.DockerBridgeSubnet) {
-				logrus.Warnf(warningMsgFmt, fldPath.Child("serviceNetwork").Index(idx), sn.String())
-			}
+	}
+
+	return allErrs
+}
+
+func validateServiceNetwork(n *types.Networking, sn *ipnet.IPNet, idx int, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if err := validate.ServiceSubnetCIDR(&sn.IPNet); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, sn.String(), err.Error()))
+		return allErrs // CIDR value is invalid, so no further validation.
+	}
+
+	if validate.DoCIDRsOverlap(&sn.IPNet, validate.DockerBridgeSubnet) {
+		logrus.Warnf("%s: %s overlaps with default Docker Bridge subnet", fldPath, sn.String())
+	}
+
+	for _, mn := range n.MachineNetwork {
+		if validate.DoCIDRsOverlap(&sn.IPNet, &mn.CIDR.IPNet) {
+			allErrs = append(allErrs, field.Invalid(fldPath, sn.String(), "service network must not overlap with any of the machine networks"))
 		}
-		for idx, cn := range n.ClusterNetwork {
-			if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, validate.DockerBridgeSubnet) {
-				logrus.Warnf(warningMsgFmt, fldPath.Child("clusterNetwork").Index(idx), cn.CIDR.String())
-			}
+	}
+	for i, snn := range n.ServiceNetwork[0:idx] {
+		if validate.DoCIDRsOverlap(&sn.IPNet, &snn.IPNet) {
+			allErrs = append(allErrs, field.Invalid(fldPath, sn.String(), fmt.Sprintf("service network must not overlap with service network %d", i)))
 		}
 	}
 	return allErrs
@@ -484,9 +485,16 @@ func validateNetworkingForPlatform(n *types.Networking, platform *types.Platform
 
 func validateClusterNetwork(n *types.Networking, cn *types.ClusterNetworkEntry, idx int, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
 	if err := validate.SubnetCIDR(&cn.CIDR.IPNet); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("cidr"), cn.CIDR.IPNet.String(), err.Error()))
+		return allErrs // CIDR value is invalid, so no further validation.
 	}
+
+	if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, validate.DockerBridgeSubnet) {
+		logrus.Warnf("%s: %s overlaps with default Docker Bridge subnet", fldPath.Index(idx), cn.CIDR.String())
+	}
+
 	for _, network := range n.MachineNetwork {
 		if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, &network.CIDR.IPNet) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("cidr"), cn.CIDR.String(), "cluster network must not overlap with any of the machine networks"))

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -464,17 +464,17 @@ func validateNetworkingForPlatform(n *types.Networking, platform *types.Platform
 	default:
 		warningMsgFmt := "%s: %s overlaps with default Docker Bridge subnet"
 		for idx, mn := range n.MachineNetwork {
-			if validate.DoCIDRsOverlap(&mn.CIDR.IPNet, validate.DockerBridgeCIDR) {
+			if validate.DoCIDRsOverlap(&mn.CIDR.IPNet, validate.DockerBridgeSubnet) {
 				logrus.Warnf(warningMsgFmt, fldPath.Child("machineNetwork").Index(idx), mn.CIDR.String())
 			}
 		}
 		for idx, sn := range n.ServiceNetwork {
-			if validate.DoCIDRsOverlap(&sn.IPNet, validate.DockerBridgeCIDR) {
+			if validate.DoCIDRsOverlap(&sn.IPNet, validate.DockerBridgeSubnet) {
 				logrus.Warnf(warningMsgFmt, fldPath.Child("serviceNetwork").Index(idx), sn.String())
 			}
 		}
 		for idx, cn := range n.ClusterNetwork {
-			if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, validate.DockerBridgeCIDR) {
+			if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, validate.DockerBridgeSubnet) {
 				logrus.Warnf(warningMsgFmt, fldPath.Child("clusterNetwork").Index(idx), cn.CIDR.String())
 			}
 		}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -340,13 +340,31 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking: Required value: networking is required$`,
 		},
 		{
-			name: "invalid network type",
+			name: "invalid empty network type",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.NetworkType = ""
 				return c
 			}(),
 			expectedError: `^networking.networkType: Required value: network provider type required$`,
+		},
+		{
+			name: "invalid Kuryr network type",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.NetworkType = "Kuryr"
+				return c
+			}(),
+			expectedError: `^networking\.networkType: Invalid value: "Kuryr": networkType Kuryr is not supported on OpenShift later than 4\.14$`,
+		},
+		{
+			name: "invalid OpenShiftSDN network type",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.NetworkType = "OpenShiftSDN"
+				return c
+			}(),
+			expectedError: `^networking\.networkType: Invalid value: "OpenShiftSDN": networkType OpenShiftSDN is not supported, please use OVNKubernetes$`,
 		},
 		{
 			name: "missing service network",
@@ -367,27 +385,13 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.serviceNetwork\[0\]: Invalid value: "13\.0\.128\.0/16": invalid network address. got 13\.0\.128\.0/16, expecting 13\.0\.0\.0/16$`,
 		},
 		{
-			name: "overlapping service network and machine cidr",
+			name: "overlapping service network and machine network",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.ServiceNetwork[0] = *ipnet.MustParseCIDR("10.0.2.0/24")
 				return c
 			}(),
 			expectedError: `^networking\.serviceNetwork\[0\]: Invalid value: "10\.0\.2\.0/24": service network must not overlap with any of the machine networks$`,
-		},
-		{
-			name: "overlapping machine network and machine network",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Networking.MachineNetwork = []types.MachineNetworkEntry{
-					{CIDR: *ipnet.MustParseCIDR("13.0.0.0/16")},
-					{CIDR: *ipnet.MustParseCIDR("13.0.2.0/24")},
-				}
-
-				return c
-			}(),
-			// also triggers the only-one-machine-network validation
-			expectedError: `^networking\.machineNetwork\[1\]: Invalid value: "13\.0\.2\.0/24": machine network must not overlap with machine network 0$`,
 		},
 		{
 			name: "overlapping service network and service network",
@@ -404,7 +408,49 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^\[networking\.serviceNetwork\[1\]: Invalid value: "13\.0\.2\.0/24": service network must not overlap with service network 0, networking\.serviceNetwork: Invalid value: "13\.0\.0\.0/16, 13\.0\.2\.0/24": only one service network can be specified]$`,
 		},
 		{
-			name: "overlapping service network and IPv4 InternalJoinSubnet",
+			name: "overlapping service network and default OVNKubernetes join networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ServiceNetwork = []ipnet.IPNet{
+					*ipnet.MustParseCIDR("100.64.2.0/24"),
+					*ipnet.MustParseCIDR("fd98::/112"),
+				}
+				return c
+			}(),
+			expectedError: `^\[networking\.serviceNetwork\[0\]: Invalid value: "100\.64\.2\.0/24": must not overlap with OVNKubernetes default internal subnet 100\.64\.0\.0/16, networking\.serviceNetwork\[1\]: Invalid value: "fd98::/112": must not overlap with OVNKubernetes default internal subnet fd98::/64\]$`,
+		},
+		{
+			name: "overlapping service network and default OVNKubernetes switch networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ServiceNetwork = []ipnet.IPNet{
+					*ipnet.MustParseCIDR("100.88.2.0/24"),
+					*ipnet.MustParseCIDR("fd97::/112"),
+				}
+				return c
+			}(),
+			expectedError: `^\[networking\.serviceNetwork\[0\]: Invalid value: "100\.88\.2\.0/24": must not overlap with OVNKubernetes default transit subnet 100\.88\.0\.0/16, networking\.serviceNetwork\[1\]: Invalid value: "fd97::/112": must not overlap with OVNKubernetes default transit subnet fd97::/64\]$`,
+		},
+		{
+			name: "overlapping service network and default OVNKubernetes masquerade networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ServiceNetwork = []ipnet.IPNet{
+					*ipnet.MustParseCIDR("169.254.2.0/24"),
+					*ipnet.MustParseCIDR("fd69::/112"),
+				}
+				return c
+			}(),
+			expectedError: `^\[networking\.serviceNetwork\[0\]: Invalid value: "169\.254\.2\.0/24": must not overlap with OVNKubernetes default masquerade subnet 169\.254\.0\.0/17, networking\.serviceNetwork\[1\]: Invalid value: "fd69::/112": must not overlap with OVNKubernetes default masquerade subnet fd69::/112\]$`,
+		},
+		{
+			name: "overlapping service network and user-provided IPv4 InternalJoinSubnet",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.ServiceNetwork[0] = *ipnet.MustParseCIDR("13.0.2.0/24")
@@ -414,7 +460,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.ovnKubernetesConfig.ipv4.internalJoinSubnet: Invalid value: "13\.0\.0\.0/16": must not overlap with serviceNetwork 13\.0\.2\.0/24$`,
 		},
 		{
-			name: "overlapping machine network and IPv4 InternalJoinSubnet",
+			name: "overlapping machine network and user-provided IPv4 InternalJoinSubnet",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.OVNKubernetesConfig = &types.OVNKubernetesConfig{IPv4: &types.IPv4OVNKubernetesConfig{InternalJoinSubnet: ipnet.MustParseCIDR("10.0.2.0/24")}}
@@ -423,7 +469,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.ovnKubernetesConfig.ipv4.internalJoinSubnet: Invalid value: "10\.0\.2\.0/24": must not overlap with machineNetwork 10\.0\.0\.0/16$`,
 		},
 		{
-			name: "overlapping cluster network and IPv4 InternalJoinSubnet",
+			name: "overlapping cluster network and user-provided IPv4 InternalJoinSubnet",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.OVNKubernetesConfig = &types.OVNKubernetesConfig{IPv4: &types.IPv4OVNKubernetesConfig{InternalJoinSubnet: ipnet.MustParseCIDR("192.168.0.0/16")}}
@@ -432,7 +478,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.ovnKubernetesConfig\.ipv4\.internalJoinSubnet: Invalid value: "192\.168\.0\.0/16": must not overlap with clusterNetwork 192\.168\.1\.0/24$`,
 		},
 		{
-			name: "HTTPProxy overlapping with IPv4 Internal Join Subnet",
+			name: "HTTPProxy overlapping with user-provided IPv4 Internal Join Subnet",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Proxy.HTTPProxy = "http://100.64.1.2:3030"
@@ -443,7 +489,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^proxy.httpProxy: Invalid value: "http://100.64.1.2:3030": proxy value is part of the ovn-kubernetes IPv4 InternalJoinSubnet$`,
 		},
 		{
-			name: "invalid IPv4 InternalJoinSubnet",
+			name: "invalid user-provided IPv4 InternalJoinSubnet",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.OVNKubernetesConfig = &types.OVNKubernetesConfig{IPv4: &types.IPv4OVNKubernetesConfig{InternalJoinSubnet: ipnet.MustParseCIDR("192.168.2.0/16")}}
@@ -452,7 +498,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.ovnKubernetesConfig\.ipv4\.internalJoinSubnet: Invalid value: "192\.168\.2\.0/16": invalid network address. got 192\.168\.2\.0/16, expecting 192\.168\.0\.0/16$`,
 		},
 		{
-			name: "IPv4 InternalJoinSubnet too smal",
+			name: "user-provided IPv4 InternalJoinSubnet too small",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.OVNKubernetesConfig = &types.OVNKubernetesConfig{IPv4: &types.IPv4OVNKubernetesConfig{InternalJoinSubnet: ipnet.MustParseCIDR("100.64.0.0/24")}}
@@ -485,6 +531,38 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.machineNetwork\[0\]: Invalid value: "11\.0\.128\.0/16": invalid network address. got 11\.0\.128\.0/16, expecting 11\.0\.0\.0/16$`,
 		},
 		{
+			name: "overlapping machine network and machine network",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("13.0.0.0/16")},
+					{CIDR: *ipnet.MustParseCIDR("13.0.2.0/24")},
+				}
+
+				return c
+			}(),
+			// also triggers the only-one-machine-network validation
+			expectedError: `^networking\.machineNetwork\[1\]: Invalid value: "13\.0\.2\.0/24": machine network must not overlap with machine network 0$`,
+		},
+		{
+			name: "overlapping machine network and default OVNKubernetes networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("100.64.2.0/24")},
+					{CIDR: *ipnet.MustParseCIDR("100.88.2.0/24")},
+					{CIDR: *ipnet.MustParseCIDR("169.254.2.0/24")},
+					{CIDR: *ipnet.MustParseCIDR("fd98::/48")},
+					{CIDR: *ipnet.MustParseCIDR("fd97::/48")},
+					{CIDR: *ipnet.MustParseCIDR("fd69::/48")},
+				}
+				return c
+			}(),
+			expectedError: `\[networking\.machineNetwork\[0\]: Invalid value: "100\.64\.2\.0/24": must not overlap with OVNKubernetes default internal subnet 100\.64\.0\.0/16, networking\.machineNetwork\[1\]: Invalid value: "100\.88\.2\.0/24": must not overlap with OVNKubernetes default transit subnet 100\.88\.0\.0/16, networking\.machineNetwork\[2\]: Invalid value: "169\.254\.2\.0/24": must not overlap with OVNKubernetes default masquerade subnet 169\.254\.0\.0/17, networking\.machineNetwork\[3\]: Invalid value: "fd98::/48": must not overlap with OVNKubernetes default internal subnet fd98::/64, networking\.machineNetwork\[4\]: Invalid value: "fd97::/48": must not overlap with OVNKubernetes default transit subnet fd97::/64, networking\.machineNetwork\[5\]: Invalid value: "fd69::/48": must not overlap with OVNKubernetes default masquerade subnet fd69::/112\]`,
+		},
+		{
 			name: "invalid cluster network",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -494,7 +572,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.clusterNetwork\[0]\.cidr: Invalid value: "12\.0\.128\.0/16": invalid network address. got 12\.0\.128\.0/16, expecting 12\.0\.0\.0/16$`,
 		},
 		{
-			name: "overlapping cluster network and machine cidr",
+			name: "overlapping cluster network and machine network",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.Networking.ClusterNetwork[0].CIDR = *ipnet.MustParseCIDR("10.0.3.0/24")
@@ -522,6 +600,24 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^networking\.clusterNetwork\[1]\.cidr: Invalid value: "12\.0\.3\.0/24": cluster network must not overlap with cluster network 0$`,
+		},
+		{
+			name: "overlapping cluster network and default OVNKubernetes networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ClusterNetwork = []types.ClusterNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("100.64.2.0/24"), HostPrefix: 28},
+					{CIDR: *ipnet.MustParseCIDR("100.88.2.0/24"), HostPrefix: 28},
+					{CIDR: *ipnet.MustParseCIDR("169.254.2.0/24"), HostPrefix: 28},
+					{CIDR: *ipnet.MustParseCIDR("fd98::/48"), HostPrefix: 64},
+					{CIDR: *ipnet.MustParseCIDR("fd97::/48"), HostPrefix: 64},
+					{CIDR: *ipnet.MustParseCIDR("fd69::/48"), HostPrefix: 64},
+				}
+				return c
+			}(),
+			expectedError: `^\[networking\.clusterNetwork\[0\]\.cidr: Invalid value: "100\.64\.2\.0/24": must not overlap with OVNKubernetes default internal subnet 100\.64\.0\.0/16, networking\.clusterNetwork\[1\]\.cidr: Invalid value: "100\.88\.2\.0/24": must not overlap with OVNKubernetes default transit subnet 100\.88\.0\.0/16, networking\.clusterNetwork\[2\]\.cidr: Invalid value: "169\.254\.2\.0/24": must not overlap with OVNKubernetes default masquerade subnet 169\.254\.0\.0/17, networking\.clusterNetwork\[3\]\.cidr: Invalid value: "fd98::/48": must not overlap with OVNKubernetes default internal subnet fd98::/64, networking\.clusterNetwork\[4\]\.cidr: Invalid value: "fd97::/48": must not overlap with OVNKubernetes default transit subnet fd97::/64, networking\.clusterNetwork\[5\]\.cidr: Invalid value: "fd69::/48": must not overlap with OVNKubernetes default masquerade subnet fd69::/112\]$`,
 		},
 		{
 			name: "cluster network host prefix too large",
@@ -567,19 +663,18 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "multiple cluster network host prefix different",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				// Use dual-stack config to ensure the validation only applies to IPv4 CIDRs
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
 				c.Networking.ClusterNetwork = append(c.Networking.ClusterNetwork,
 					types.ClusterNetworkEntry{
 						CIDR:       *ipnet.MustParseCIDR("192.168.2.0/24"),
 						HostPrefix: 30,
 					},
-					types.ClusterNetworkEntry{
-						CIDR:       *ipnet.MustParseCIDR("ffd2::/48"),
-						HostPrefix: 64,
-					},
 				)
 				return c
 			}(),
-			expectedError: `^networking\.clusterNetwork\[1]\.hostPrefix: Invalid value: 30: cluster network host subnetwork prefix must be the same value for IPv4 networks$`,
+			expectedError: `^networking\.clusterNetwork\[2]\.hostPrefix: Invalid value: 30: cluster network host subnetwork prefix must be the same value for IPv4 networks$`,
 		},
 		{
 			name: "networking clusterNetworkMTU - valid high limit ovn",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -19,11 +19,33 @@ import (
 )
 
 var (
-	// DockerBridgeCIDR is the network range that is used by default network for docker.
-	DockerBridgeCIDR = func() *net.IPNet {
-		_, cidr, _ := net.ParseCIDR("172.17.0.0/16")
-		return cidr
-	}()
+	// DockerBridgeSubnet is the default v4 subnet for Docker.
+	DockerBridgeSubnet = cidrToIPNet("172.17.0.0/16")
+
+	// OVNIPv4JoinSubnet is the default v4 subnet for join switches.
+	OVNIPv4JoinSubnet = cidrToIPNet("100.64.0.0/16")
+
+	// OVNIPv4TransitSubnet is the default v4 subnet for transit switches.
+	OVNIPv4TransitSubnet = cidrToIPNet("100.88.0.0/16")
+
+	// OVNIPv4MasqueradeSubnet is the default v4 masquerade subnet.
+	// In OCP <= 4.17, the default is 169.254.169.0/29.
+	OVNIPv4MasqueradeSubnet = cidrToIPNet("169.254.0.0/17")
+
+	// OVNIPv6JoinSubnet is the default v6 subnet for join switches.
+	OVNIPv6JoinSubnet = cidrToIPNet("fd98::/64")
+
+	// OVNIPv6TransitSubnet is the default v6 subnet for transit switches.
+	OVNIPv6TransitSubnet = cidrToIPNet("fd97::/64")
+
+	// OVNIPv6MasqueradeSubnet is the default v6 masquerade subnet.
+	// In OCP <= 4.17, the default is fd69::/125.
+	OVNIPv6MasqueradeSubnet = cidrToIPNet("fd69::/112")
+
+	cidrToIPNet = func(cidr string) *net.IPNet {
+		_, subnet, _ := net.ParseCIDR(cidr) //nolint:errcheck
+		return subnet
+	}
 )
 
 // CABundle checks if the given string contains valid certificate(s) and returns an error if not.

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -183,12 +183,8 @@ func SubnetCIDR(cidr *net.IPNet) error {
 
 // ServiceSubnetCIDR checks if the given IP net is a valid CIDR for the Kubernetes service network
 func ServiceSubnetCIDR(cidr *net.IPNet) error {
-	if cidr.IP.IsUnspecified() {
-		return errors.New("address must be specified")
-	}
-	nip := cidr.IP.Mask(cidr.Mask)
-	if nip.String() != cidr.IP.String() {
-		return fmt.Errorf("invalid network address. got %s, expecting %s", cidr.String(), (&net.IPNet{IP: nip, Mask: cidr.Mask}).String())
+	if err := SubnetCIDR(cidr); err != nil {
+		return err
 	}
 	maskLen, addrLen := cidr.Mask.Size()
 	if addrLen == 32 && maskLen < 12 {


### PR DESCRIPTION
## Description

Machine, Service and Cluster networks must not overlap with any of the default OVNKubernetes subnets (i.e. join, transit and masquerade). If any type of subnets are defined by users in the install-config, validate networks against those values instead.

**Notes:**
- I included some code refactoring to make the changes cleaner. Some of them are not directly related to the bug, but nice to clean up along the way. Please let me know if you need me exclude them.
- I think we might also need to validate [proxy IP](https://github.com/openshift/installer/blob/2640fe0888e4ca993819feaf9037055abb8c3a18/pkg/types/validation/installconfig.go#L1221). I will follow up with another PR for that if it is confirmed that its neeed.