### PR TITLE
OCPBUGS-49737: Custom-DNS: GCP, AWS: Update worker pointer Ignition

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -73,6 +73,7 @@ func (c *Cluster) Dependencies() []asset.Asset {
 		&kubeconfig.AdminClient{},
 		&bootstrap.Bootstrap{},
 		&machine.Master{},
+		&machine.Worker{},
 		&machines.Worker{},
 		&machines.ClusterAPI{},
 		new(rhcos.Image),

--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -91,14 +91,15 @@ func (*Provider) PreProvision(ctx context.Context, in clusterapi.PreProvisionInp
 // infrastructure CR. The infrastructure CR is updated and added to the ignition files. CAPA creates a
 // bucket for ignition, and this ignition data will be placed in the bucket.
 func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]*corev1.Secret, error) {
-	editedBootstrapIgn, editedMasterIgn, err := editIgnition(ctx, in)
+	ignOutput, err := editIgnition(ctx, in)
 	if err != nil {
-		return nil, fmt.Errorf("failed to edit bootstrap ignition: %w", err)
+		return nil, fmt.Errorf("failed to edit bootstrap master or worker ignition: %w", err)
 	}
 
 	ignSecrets := []*corev1.Secret{
-		clusterapi.IgnitionSecret(editedBootstrapIgn, in.InfraID, "bootstrap"),
-		clusterapi.IgnitionSecret(editedMasterIgn, in.InfraID, "master"),
+		clusterapi.IgnitionSecret(ignOutput.UpdatedBootstrapIgn, in.InfraID, "bootstrap"),
+		clusterapi.IgnitionSecret(ignOutput.UpdatedMasterIgn, in.InfraID, "master"),
+		clusterapi.IgnitionSecret(ignOutput.UpdatedWorkerIgn, in.InfraID, "worker"),
 	}
 	return ignSecrets, nil
 }

--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -82,6 +82,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	rhcosImage := new(rhcos.Image)
 	bootstrapIgnAsset := &bootstrap.Bootstrap{}
 	masterIgnAsset := &machine.Master{}
+	workerIgnAsset := &machine.Worker{}
 	tfvarsAsset := &tfvars.TerraformVariables{}
 	rootCA := &tls.RootCA{}
 	parents.Get(
@@ -94,6 +95,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		rhcosImage,
 		bootstrapIgnAsset,
 		masterIgnAsset,
+		workerIgnAsset,
 		capiMachinesAsset,
 		tfvarsAsset,
 		rootCA,
@@ -279,6 +281,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	if err != nil {
 		return fileList, fmt.Errorf("unable to inject installation info: %w", err)
 	}
+	workerIgnData := workerIgnAsset.Files()[0].Data
 	ignitionSecrets := []*corev1.Secret{}
 
 	// The cloud-platform may need to override the default
@@ -288,6 +291,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 			Client:           cl,
 			BootstrapIgnData: bootstrapIgnData,
 			MasterIgnData:    masterIgnData,
+			WorkerIgnData:    workerIgnData,
 			InfraID:          clusterID.InfraID,
 			InstallConfig:    installConfig,
 			TFVarsAsset:      tfvarsAsset,

--- a/pkg/infrastructure/clusterapi/types.go
+++ b/pkg/infrastructure/clusterapi/types.go
@@ -65,10 +65,18 @@ type IgnitionInput struct {
 	Client           client.Client
 	BootstrapIgnData []byte
 	MasterIgnData    []byte
+	WorkerIgnData    []byte
 	InfraID          string
 	InstallConfig    *installconfig.InstallConfig
 	TFVarsAsset      *tfvars.TerraformVariables
 	RootCA           *tls.RootCA
+}
+
+// IgnitionOutput collects updated Ignition Data for Bootstrap, Master and Worker nodes.
+type IgnitionOutput struct {
+	UpdatedBootstrapIgn []byte
+	UpdatedMasterIgn    []byte
+	UpdatedWorkerIgn    []byte
 }
 
 // InfraReadyProvider defines the InfraReady hook, which is

--- a/pkg/infrastructure/gcp/clusterapi/ignition.go
+++ b/pkg/infrastructure/gcp/clusterapi/ignition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	capg "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,9 +19,12 @@ import (
 // editIgnition attempts to edit the contents of the bootstrap ignition when the user has selected
 // a custom DNS configuration. Find the public and private load balancer addresses and fill in the
 // infrastructure file within the ignition struct.
-func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, []byte, error) {
+func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) (*clusterapi.IgnitionOutput, error) {
 	if in.InstallConfig.Config.GCP.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
-		return in.BootstrapIgnData, in.MasterIgnData, nil
+		return &clusterapi.IgnitionOutput{
+			UpdatedBootstrapIgn: in.BootstrapIgnData,
+			UpdatedMasterIgn:    in.MasterIgnData,
+			UpdatedWorkerIgn:    in.WorkerIgnData}, nil
 	}
 
 	gcpCluster := &capg.GCPCluster{}
@@ -29,12 +33,12 @@ func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, []b
 		Namespace: capiutils.Namespace,
 	}
 	if err := in.Client.Get(ctx, key, gcpCluster); err != nil {
-		return nil, nil, fmt.Errorf("failed to get GCP cluster: %w", err)
+		return nil, fmt.Errorf("failed to get GCP cluster: %w", err)
 	}
 
 	svc, err := NewComputeService()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	project := in.InstallConfig.Config.GCP.ProjectID
@@ -48,7 +52,7 @@ func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, []b
 		addressCut := apiIPAddress[strings.LastIndex(apiIPAddress, "/")+1:]
 		computeAddressObj, err := svc.GlobalAddresses.Get(project, addressCut).Context(ctx).Do()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get global compute address: %w", err)
+			return nil, fmt.Errorf("failed to get global compute address: %w", err)
 		}
 
 		computeAddress = computeAddressObj.Address
@@ -58,8 +62,8 @@ func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) ([]byte, []b
 	addressIntCut := apiIntIPAddress[strings.LastIndex(apiIntIPAddress, "/")+1:]
 	computeIntAddress, err := svc.Addresses.Get(project, in.InstallConfig.Config.GCP.Region, addressIntCut).Context(ctx).Do()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get compute address: %w", err)
+		return nil, fmt.Errorf("failed to get compute address: %w", err)
 	}
-
+	logrus.Debugf("GCP: Editing Ignition files to start in-cluster DNS when UserProvisionedDNS is enabled")
 	return clusterapi.EditIgnition(in, gcp.Name, []string{computeAddress}, []string{computeIntAddress.Address})
 }


### PR DESCRIPTION
Update the worker pointer ignition with the api-int LB IP in place of the api-int URL when userProvisionedDNS is enabled.