### PR TITLE
OSASINFRA-3238: Improve API and Ingress VIPs validation

### DIFF
--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -686,7 +686,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [platform.vsphere.apiVIPs: Invalid value: "192.168.122.10": VIP for the API must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6, platform.vsphere.ingressVIPs: Invalid value: "192.168.122.11": VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6]`,
+			expectedError: `invalid install-config configuration: [platform.vsphere.apiVIPs: Invalid value: "192.168.122.10": clusterNetwork primary IP Family and primary IP family for the API VIP should match, platform.vsphere.apiVIPs: Invalid value: "192.168.122.10": machineNetwork primary IP Family and primary IP family for the API VIP should match, platform.vsphere.apiVIPs: Invalid value: "192.168.122.10": serviceNetwork primary IP Family and primary IP family for the API VIP should match, platform.vsphere.ingressVIPs: Invalid value: "192.168.122.11": clusterNetwork primary IP Family and primary IP family for the Ingress VIP should match, platform.vsphere.ingressVIPs: Invalid value: "192.168.122.11": machineNetwork primary IP Family and primary IP family for the Ingress VIP should match, platform.vsphere.ingressVIPs: Invalid value: "192.168.122.11": serviceNetwork primary IP Family and primary IP family for the Ingress VIP should match]`,
 		},
 		{
 			name: "ingressVIP missing and vcenter vSphere credentials are present",

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -977,19 +977,27 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 			allErrs = append(allErrs, field.Required(fldPath.Child(fieldNames.IngressVIPs), "must specify VIP for ingress, when VIP for API is set"))
 		}
 
-		if len(vips.API) == 1 {
-			hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
+		hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
 
-			apiVIPIPFamily := corev1.IPv4Protocol
-			if utilsnet.IsIPv6String(vips.API[0]) {
-				apiVIPIPFamily = corev1.IPv6Protocol
-			}
+		apiVIPIPFamily := corev1.IPv4Protocol
+		if utilsnet.IsIPv6String(vips.API[0]) {
+			apiVIPIPFamily = corev1.IPv6Protocol
+		}
 
-			if hasIPv4 && hasIPv6 && apiVIPIPFamily != presence["machineNetwork"].Primary {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API[0], "VIP for the API must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
+		if hasIPv4 && hasIPv6 {
+			for _, k := range sortedPresenceKeys(presence) {
+				v := presence[k]
+				if v.Primary != apiVIPIPFamily {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API[0], fmt.Sprintf("%s primary IP Family and primary IP family for the API VIP should match", k)))
+				}
 			}
-		} else if len(vips.API) == 2 {
-			if isDualStack, _ := utilsnet.IsDualStackIPStrings(vips.API); !isDualStack {
+		}
+
+		if len(vips.API) == 2 {
+			if isDualStack, err := utilsnet.IsDualStackIPStrings(vips.API); !isDualStack {
+				if err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath, vips, err.Error()))
+				}
 				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.APIVIPs), vips.API, "If two API VIPs are given, one must be an IPv4 address, the other an IPv6"))
 			}
 		}
@@ -1020,19 +1028,27 @@ func validateAPIAndIngressVIPs(vips vips, fieldNames vipFields, vipIsRequired, r
 			allErrs = append(allErrs, field.Required(fldPath.Child(fieldNames.APIVIPs), "must specify VIP for API, when VIP for ingress is set"))
 		}
 
-		if len(vips.Ingress) == 1 {
-			hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
+		hasIPv4, hasIPv6, presence, _ := inferIPVersionFromInstallConfig(n)
 
-			ingressVIPIPFamily := corev1.IPv4Protocol
-			if utilsnet.IsIPv6String(vips.Ingress[0]) {
-				ingressVIPIPFamily = corev1.IPv6Protocol
-			}
+		ingressVIPIPFamily := corev1.IPv4Protocol
+		if utilsnet.IsIPv6String(vips.Ingress[0]) {
+			ingressVIPIPFamily = corev1.IPv6Protocol
+		}
 
-			if hasIPv4 && hasIPv6 && ingressVIPIPFamily != presence["machineNetwork"].Primary {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress[0], "VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
+		if hasIPv4 && hasIPv6 {
+			for _, k := range sortedPresenceKeys(presence) {
+				v := presence[k]
+				if v.Primary != ingressVIPIPFamily {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress[0], fmt.Sprintf("%s primary IP Family and primary IP family for the Ingress VIP should match", k)))
+				}
 			}
-		} else if len(vips.Ingress) == 2 {
-			if isDualStack, _ := utilsnet.IsDualStackIPStrings(vips.Ingress); !isDualStack {
+		}
+
+		if len(vips.Ingress) == 2 {
+			if isDualStack, err := utilsnet.IsDualStackIPStrings(vips.Ingress); !isDualStack {
+				if err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath, vips, err.Error()))
+				}
 				allErrs = append(allErrs, field.Invalid(fldPath.Child(fieldNames.IngressVIPs), vips.Ingress, "If two Ingress VIPs are given, one must be an IPv4 address, the other an IPv6"))
 			}
 		}
@@ -1609,4 +1625,14 @@ func validateFencingForPlatform(config *types.InstallConfig, fldPath *field.Path
 		errs = append(errs, field.Forbidden(fldPath, fmt.Sprintf("fencing is only supported on baremetal, external or none platforms, instead %s platform was found", config.Platform.Name())))
 	}
 	return errs
+}
+
+// sortedPresenceKeys returns map keys in sorted order for consistent error messages.
+func sortedPresenceKeys(presence ipAddressTypeByField) []string {
+	keys := make([]string, 0, len(presence))
+	for k := range presence {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }


### PR DESCRIPTION
• This commit enhances VIPs validation to ensure the primary IP family of the VIPs matches the primary IP family of all the network fields. 
• Code repurposed from prior closed PR (#7504)