### PR TITLE
CORS-3867 CORS-3868: deprecate platform.subnets and introduce platform.vpc.subnets field in install-config

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2790,6 +2790,8 @@ spec:
                       Subnets specifies existing subnets (by ID) where cluster
                       resources will be created.  Leave unset to have the installer
                       create subnets in a new VPC on your behalf.
+
+                      Deprecated: use platform.aws.vpc.subnets
                     items:
                       type: string
                     type: array
@@ -2809,6 +2811,67 @@ spec:
                       UserTags additional keys and values that the installer will add
                       as tags to all resources that it creates. Resources created by the
                       cluster itself may not include these tags.
+                    type: object
+                  vpc:
+                    description: VPC specifies the VPC configuration for the cluster.
+                    properties:
+                      subnets:
+                        description: |-
+                          Subnets defines the subnets in an existing VPC and can optionally specify their intended roles.
+                          If no roles are specified on any subnet, then the subnet roles are decided automatically.
+                          In this case, the VPC must not contain any subnets without the kubernetes.io/cluster/<cluster-id> tag.
+
+                          For manually specified subnet role selection, each subnet must have at least one assigned role,
+                          and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
+                          However, if the cluster scope is internal, then ControlPlaneExternalLB is not required.
+
+                          Subnets must contain unique IDs, and can include no more than 10 subnets with the IngressController role.
+
+                          Leave this field unset to have the installer create subnets in a new VPC on your behalf.
+                        items:
+                          description: Subnet specifies a subnet in an existing VPC
+                            and can optionally specify their intended roles.
+                          properties:
+                            id:
+                              description: |-
+                                ID specifies the subnet ID of an existing subnet.
+                                The subnet ID must start with "subnet-", consist only of alphanumeric characters,
+                                and must be exactly 24 characters long.
+                              maxLength: 24
+                              minLength: 24
+                              pattern: ^subnet-[0-9A-Za-z]+$
+                              type: string
+                            roles:
+                              description: |-
+                                Roles specifies the roles (aka functions) that the subnet will provide in the cluster.
+                                If no roles are specified on any subnet, then the subnet roles are decided automatically.
+                                Each role must be unique.
+                              items:
+                                description: SubnetRole specifies the role (aka function)
+                                  that the subnet will provide in the cluster.
+                                properties:
+                                  type:
+                                    description: |-
+                                      Type specifies the type of role (aka function) that the subnet will provide in the cluster.
+                                      Role types include ClusterNode, EdgeNode, Bootstrap, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
+                                    enum:
+                                    - ClusterNode
+                                    - EdgeNode
+                                    - Bootstrap
+                                    - IngressControllerLB
+                                    - ControlPlaneExternalLB
+                                    - ControlPlaneInternalLB
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              maxItems: 5
+                              type: array
+                          required:
+                          - id
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 required:
                 - region

--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -49,7 +49,7 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 }
 
 func tagSharedVPCResources(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
-	if len(installConfig.Config.Platform.AWS.Subnets) == 0 {
+	if len(installConfig.Config.Platform.AWS.DeprecatedSubnets) == 0 {
 		return nil
 	}
 

--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -49,7 +49,7 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 }
 
 func tagSharedVPCResources(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
-	if len(installConfig.Config.Platform.AWS.DeprecatedSubnets) == 0 {
+	if len(installConfig.Config.Platform.AWS.VPC.Subnets) == 0 {
 		return nil
 	}
 

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -221,7 +221,7 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 		var privateSubnets []string
 		var publicSubnets []string
 
-		if len(installConfig.Config.Platform.AWS.DeprecatedSubnets) > 0 {
+		if len(installConfig.Config.Platform.AWS.VPC.Subnets) > 0 {
 			subnets, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {
 				return err

--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -221,7 +221,7 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 		var privateSubnets []string
 		var publicSubnets []string
 
-		if len(installConfig.Config.Platform.AWS.Subnets) > 0 {
+		if len(installConfig.Config.Platform.AWS.DeprecatedSubnets) > 0 {
 			subnets, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {
 				return err

--- a/pkg/asset/installconfig/aws/metadata.go
+++ b/pkg/asset/installconfig/aws/metadata.go
@@ -26,14 +26,14 @@ type Metadata struct {
 	instanceTypes     map[string]InstanceType
 
 	Region   string                     `json:"region,omitempty"`
-	Subnets  []string                   `json:"subnets,omitempty"`
+	Subnets  []typesaws.Subnet          `json:"subnets,omitempty"`
 	Services []typesaws.ServiceEndpoint `json:"services,omitempty"`
 
 	mutex sync.Mutex
 }
 
 // NewMetadata initializes a new Metadata object.
-func NewMetadata(region string, subnets []string, services []typesaws.ServiceEndpoint) *Metadata {
+func NewMetadata(region string, subnets []typesaws.Subnet, services []typesaws.ServiceEndpoint) *Metadata {
 	return &Metadata{Region: region, Subnets: subnets, Services: services}
 }
 
@@ -211,7 +211,12 @@ func (m *Metadata) populateSubnets(ctx context.Context) error {
 		return err
 	}
 
-	sb, err := subnets(ctx, session, m.Region, m.Subnets)
+	subnetIDs := make([]string, len(m.Subnets))
+	for i, subnet := range m.Subnets {
+		subnetIDs[i] = string(subnet.ID)
+	}
+
+	sb, err := subnets(ctx, session, m.Region, subnetIDs)
 	m.vpc = sb.VPC
 	m.privateSubnets = sb.Private
 	m.publicSubnets = sb.Public

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -482,7 +482,7 @@ func ValidateCreds(ssn *session.Session, groups []PermissionGroup, region string
 // RequiredPermissionGroups returns a set of required permissions for a given cluster configuration.
 func RequiredPermissionGroups(ic *types.InstallConfig) []PermissionGroup {
 	permissionGroups := []PermissionGroup{PermissionCreateBase}
-	usingExistingVPC := len(ic.AWS.Subnets) != 0
+	usingExistingVPC := len(ic.AWS.DeprecatedSubnets) != 0
 	usingExistingPrivateZone := len(ic.AWS.HostedZone) != 0
 
 	if !usingExistingVPC {
@@ -724,7 +724,7 @@ func includesZones(installConfig *types.InstallConfig) bool {
 		mpool.Set(compute.Platform.AWS)
 	}
 
-	return len(mpool.Zones) > 0 || len(installConfig.AWS.Subnets) > 0
+	return len(mpool.Zones) > 0 || len(installConfig.AWS.DeprecatedSubnets) > 0
 }
 
 // includesAssumeRole checks if a custom IAM role is specified in the install-config.

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -482,7 +482,7 @@ func ValidateCreds(ssn *session.Session, groups []PermissionGroup, region string
 // RequiredPermissionGroups returns a set of required permissions for a given cluster configuration.
 func RequiredPermissionGroups(ic *types.InstallConfig) []PermissionGroup {
 	permissionGroups := []PermissionGroup{PermissionCreateBase}
-	usingExistingVPC := len(ic.AWS.DeprecatedSubnets) != 0
+	usingExistingVPC := len(ic.AWS.VPC.Subnets) != 0
 	usingExistingPrivateZone := len(ic.AWS.HostedZone) != 0
 
 	if !usingExistingVPC {
@@ -724,7 +724,7 @@ func includesZones(installConfig *types.InstallConfig) bool {
 		mpool.Set(compute.Platform.AWS)
 	}
 
-	return len(mpool.Zones) > 0 || len(installConfig.AWS.DeprecatedSubnets) > 0
+	return len(mpool.Zones) > 0 || len(installConfig.AWS.VPC.Subnets) > 0
 }
 
 // includesAssumeRole checks if a custom IAM role is specified in the install-config.

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -576,7 +576,7 @@ func TestVPCPermissions(t *testing.T) {
 		t.Run("create network permissions when VPC not specified", func(t *testing.T) {
 			t.Run("for standard regions", func(t *testing.T) {
 				ic := validInstallConfig()
-				ic.AWS.Subnets = nil
+				ic.AWS.DeprecatedSubnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
@@ -584,7 +584,7 @@ func TestVPCPermissions(t *testing.T) {
 			t.Run("for secret regions", func(t *testing.T) {
 				ic := validInstallConfig()
 				ic.AWS.Region = "us-iso-east-1"
-				ic.AWS.Subnets = nil
+				ic.AWS.DeprecatedSubnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
@@ -592,7 +592,7 @@ func TestVPCPermissions(t *testing.T) {
 		})
 		t.Run("delete network permissions when VPC not specified for standard region", func(t *testing.T) {
 			ic := validInstallConfig()
-			ic.AWS.Subnets = nil
+			ic.AWS.DeprecatedSubnets = nil
 			ic.AWS.HostedZone = ""
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.Contains(t, requiredPerms, PermissionDeleteNetworking)
@@ -625,7 +625,7 @@ func TestVPCPermissions(t *testing.T) {
 		t.Run("delete shared network permissions", func(t *testing.T) {
 			t.Run("when VPC not specified", func(t *testing.T) {
 				ic := validInstallConfig()
-				ic.AWS.Subnets = nil
+				ic.AWS.DeprecatedSubnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.NotContains(t, requiredPerms, PermissionDeleteSharedNetworking)
@@ -769,7 +769,7 @@ func TestIncludesZones(t *testing.T) {
 			ic := validInstallConfig()
 			ic.ControlPlane.Platform.AWS.Zones = []string{}
 			ic.Compute[0].Platform.AWS.Zones = []string{}
-			ic.AWS.Subnets = []string{}
+			ic.AWS.DeprecatedSubnets = []string{}
 			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
 				Zones: []string{"a", "b"},
 			}
@@ -779,14 +779,14 @@ func TestIncludesZones(t *testing.T) {
 		t.Run("zones specified in controlPlane", func(t *testing.T) {
 			ic := validInstallConfig()
 			ic.Compute[0].Platform.AWS.Zones = []string{}
-			ic.AWS.Subnets = []string{}
+			ic.AWS.DeprecatedSubnets = []string{}
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.NotContains(t, requiredPerms, PermissionDefaultZones)
 		})
 		t.Run("zones specified in compute", func(t *testing.T) {
 			ic := validInstallConfig()
 			ic.ControlPlane.Platform.AWS.Zones = []string{}
-			ic.AWS.Subnets = []string{}
+			ic.AWS.DeprecatedSubnets = []string{}
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.NotContains(t, requiredPerms, PermissionDefaultZones)
 		})
@@ -800,7 +800,7 @@ func TestIncludesZones(t *testing.T) {
 	})
 	t.Run("Should be false when neither zones nor subnets specified", func(t *testing.T) {
 		ic := validInstallConfig()
-		ic.AWS.Subnets = []string{}
+		ic.AWS.DeprecatedSubnets = []string{}
 		ic.ControlPlane.Platform.AWS.Zones = []string{}
 		ic.Compute[0].Platform.AWS.Zones = []string{}
 		requiredPerms := RequiredPermissionGroups(ic)

--- a/pkg/asset/installconfig/aws/permissions_test.go
+++ b/pkg/asset/installconfig/aws/permissions_test.go
@@ -576,7 +576,7 @@ func TestVPCPermissions(t *testing.T) {
 		t.Run("create network permissions when VPC not specified", func(t *testing.T) {
 			t.Run("for standard regions", func(t *testing.T) {
 				ic := validInstallConfig()
-				ic.AWS.DeprecatedSubnets = nil
+				ic.AWS.VPC.Subnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
@@ -584,7 +584,7 @@ func TestVPCPermissions(t *testing.T) {
 			t.Run("for secret regions", func(t *testing.T) {
 				ic := validInstallConfig()
 				ic.AWS.Region = "us-iso-east-1"
-				ic.AWS.DeprecatedSubnets = nil
+				ic.AWS.VPC.Subnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.Contains(t, requiredPerms, PermissionCreateNetworking)
@@ -592,7 +592,7 @@ func TestVPCPermissions(t *testing.T) {
 		})
 		t.Run("delete network permissions when VPC not specified for standard region", func(t *testing.T) {
 			ic := validInstallConfig()
-			ic.AWS.DeprecatedSubnets = nil
+			ic.AWS.VPC.Subnets = nil
 			ic.AWS.HostedZone = ""
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.Contains(t, requiredPerms, PermissionDeleteNetworking)
@@ -625,7 +625,7 @@ func TestVPCPermissions(t *testing.T) {
 		t.Run("delete shared network permissions", func(t *testing.T) {
 			t.Run("when VPC not specified", func(t *testing.T) {
 				ic := validInstallConfig()
-				ic.AWS.DeprecatedSubnets = nil
+				ic.AWS.VPC.Subnets = nil
 				ic.AWS.HostedZone = ""
 				requiredPerms := RequiredPermissionGroups(ic)
 				assert.NotContains(t, requiredPerms, PermissionDeleteSharedNetworking)
@@ -769,7 +769,7 @@ func TestIncludesZones(t *testing.T) {
 			ic := validInstallConfig()
 			ic.ControlPlane.Platform.AWS.Zones = []string{}
 			ic.Compute[0].Platform.AWS.Zones = []string{}
-			ic.AWS.DeprecatedSubnets = []string{}
+			ic.AWS.VPC.Subnets = []aws.Subnet{}
 			ic.AWS.DefaultMachinePlatform = &aws.MachinePool{
 				Zones: []string{"a", "b"},
 			}
@@ -779,14 +779,14 @@ func TestIncludesZones(t *testing.T) {
 		t.Run("zones specified in controlPlane", func(t *testing.T) {
 			ic := validInstallConfig()
 			ic.Compute[0].Platform.AWS.Zones = []string{}
-			ic.AWS.DeprecatedSubnets = []string{}
+			ic.AWS.VPC.Subnets = []aws.Subnet{}
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.NotContains(t, requiredPerms, PermissionDefaultZones)
 		})
 		t.Run("zones specified in compute", func(t *testing.T) {
 			ic := validInstallConfig()
 			ic.ControlPlane.Platform.AWS.Zones = []string{}
-			ic.AWS.DeprecatedSubnets = []string{}
+			ic.AWS.VPC.Subnets = []aws.Subnet{}
 			requiredPerms := RequiredPermissionGroups(ic)
 			assert.NotContains(t, requiredPerms, PermissionDefaultZones)
 		})
@@ -800,7 +800,7 @@ func TestIncludesZones(t *testing.T) {
 	})
 	t.Run("Should be false when neither zones nor subnets specified", func(t *testing.T) {
 		ic := validInstallConfig()
-		ic.AWS.DeprecatedSubnets = []string{}
+		ic.AWS.VPC.Subnets = []aws.Subnet{}
 		ic.ControlPlane.Platform.AWS.Zones = []string{}
 		ic.Compute[0].Platform.AWS.Zones = []string{}
 		requiredPerms := RequiredPermissionGroups(ic)

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -71,7 +71,7 @@ func Validate(ctx context.Context, meta *Metadata, config *types.InstallConfig) 
 	for idx, compute := range config.Compute {
 		fldPath := field.NewPath("compute").Index(idx)
 		if compute.Name == types.MachinePoolEdgeRoleName {
-			if len(config.Platform.AWS.DeprecatedSubnets) == 0 {
+			if len(config.Platform.AWS.VPC.Subnets) == 0 {
 				if compute.Platform.AWS == nil {
 					allErrs = append(allErrs, field.Required(fldPath.Child("platform", "aws"), "edge compute pools are only supported on the AWS platform"))
 				}
@@ -108,8 +108,8 @@ func validatePlatform(ctx context.Context, meta *Metadata, fldPath *field.Path, 
 		return allErrs
 	}
 
-	if len(platform.DeprecatedSubnets) > 0 {
-		allErrs = append(allErrs, validateSubnets(ctx, meta, fldPath.Child("subnets"), platform.DeprecatedSubnets, networking, publish)...)
+	if len(platform.VPC.Subnets) > 0 {
+		allErrs = append(allErrs, validateSubnets(ctx, meta, fldPath.Child("vpc").Child("subnets"), platform.VPC.Subnets, networking, publish)...)
 	} else if awstypes.IsPublicOnlySubnetsEnabled() {
 		allErrs = append(allErrs, field.Required(fldPath.Child("subnets"), "subnets must be specified for public-only subnets clusters"))
 	}
@@ -207,16 +207,16 @@ func validatePublicIpv4Pool(ctx context.Context, meta *Metadata, fldPath *field.
 	return nil
 }
 
-func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, subnets []string, networking *types.Networking, publish types.PublishingStrategy) field.ErrorList {
+func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, subnets []awstypes.Subnet, networking *types.Networking, publish types.PublishingStrategy) field.ErrorList {
 	allErrs := field.ErrorList{}
 	privateSubnets, err := meta.PrivateSubnets(ctx)
 	if err != nil {
 		return append(allErrs, field.Invalid(fldPath, subnets, err.Error()))
 	}
 	privateSubnetsIdx := map[string]int{}
-	for idx, id := range subnets {
-		if _, ok := privateSubnets[id]; ok {
-			privateSubnetsIdx[id] = idx
+	for idx, subnet := range subnets {
+		if _, ok := privateSubnets[string(subnet.ID)]; ok {
+			privateSubnetsIdx[string(subnet.ID)] = idx
 		}
 	}
 	if len(privateSubnets) == 0 {
@@ -231,9 +231,9 @@ func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, s
 		logrus.Warnf("Public subnets should not be provided when publish is set to %s", types.InternalPublishingStrategy)
 	}
 	publicSubnetsIdx := map[string]int{}
-	for idx, id := range subnets {
-		if _, ok := publicSubnets[id]; ok {
-			publicSubnetsIdx[id] = idx
+	for idx, subnet := range subnets {
+		if _, ok := publicSubnets[string(subnet.ID)]; ok {
+			publicSubnetsIdx[string(subnet.ID)] = idx
 		}
 	}
 	if len(publicSubnets) == 0 && awstypes.IsPublicOnlySubnetsEnabled() {
@@ -245,9 +245,9 @@ func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, s
 		return append(allErrs, field.Invalid(fldPath, subnets, err.Error()))
 	}
 	edgeSubnetsIdx := map[string]int{}
-	for idx, id := range subnets {
-		if _, ok := edgeSubnets[id]; ok {
-			edgeSubnetsIdx[id] = idx
+	for idx, subnet := range subnets {
+		if _, ok := edgeSubnets[string(subnet.ID)]; ok {
+			edgeSubnetsIdx[string(subnet.ID)] = idx
 		}
 	}
 
@@ -282,11 +282,11 @@ func validateMachinePool(ctx context.Context, meta *Metadata, fldPath *field.Pat
 	// - is valid when installing in existing VPC; or
 	// - is valid in new VPC when Local Zone name is defined
 	if poolName == types.MachinePoolEdgeRoleName {
-		if len(platform.DeprecatedSubnets) > 0 {
+		if len(platform.VPC.Subnets) > 0 {
 			edgeSubnets, err := meta.EdgeSubnets(ctx)
 			if err != nil {
 				errMsg := fmt.Sprintf("%s pool. %v", poolName, err.Error())
-				return append(allErrs, field.Invalid(field.NewPath("subnets"), platform.DeprecatedSubnets, errMsg))
+				return append(allErrs, field.Invalid(field.NewPath("platform", "aws", "vpc", "subnets"), platform.VPC.Subnets, errMsg))
 			}
 			if len(edgeSubnets) == 0 {
 				return append(allErrs, field.Required(fldPath, "the provided subnets must include valid subnets for the specified edge zones"))
@@ -310,7 +310,7 @@ func validateMachinePool(ctx context.Context, meta *Metadata, fldPath *field.Pat
 	if pool.Zones != nil && len(pool.Zones) > 0 {
 		availableZones := sets.New[string]()
 		diffErrMsgPrefix := "One or more zones are unavailable"
-		if len(platform.DeprecatedSubnets) > 0 {
+		if len(platform.VPC.Subnets) > 0 {
 			diffErrMsgPrefix = "No subnets provided for zones"
 			var subnets Subnets
 			if poolName == types.MachinePoolEdgeRoleName {

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -438,7 +438,7 @@ func TestValidate(t *testing.T) {
 		}(),
 		availZones:    validAvailZones(),
 		publicSubnets: validPublicSubnets(),
-		expectErr:     `^\[platform\.aws\.subnets: Invalid value: \[\]string{\"valid-public-subnet-a\", \"valid-public-subnet-b\", \"valid-public-subnet-c\"}: No private subnets found, controlPlane\.platform\.aws\.zones: Invalid value: \[\]string{\"a\", \"b\", \"c\"}: No subnets provided for zones \[a b c\], compute\[0\]\.platform\.aws\.zones: Invalid value: \[\]string{\"a\", \"b\", \"c\"}: No subnets provided for zones \[a b c\]\]$`,
+		expectErr:     `^\[platform\.aws\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"valid-public-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: No private subnets found, controlPlane\.platform\.aws\.zones: Invalid value: \[\]string\{\"a\", \"b\", \"c\"\}: No subnets provided for zones \[a b c\], compute\[0\]\.platform\.aws\.zones: Invalid value: \[\]string\{\"a\", \"b\", \"c\"\}: No subnets provided for zones \[a b c\]\]$`,
 	}, {
 		name: "invalid no public subnets",
 		installConfig: func() *types.InstallConfig {
@@ -452,7 +452,7 @@ func TestValidate(t *testing.T) {
 		}(),
 		availZones:     validAvailZones(),
 		privateSubnets: validPrivateSubnets(),
-		expectErr:      `^platform\.aws\.subnets: Invalid value: \[\]string{\"valid-private-subnet-a\", \"valid-private-subnet-b\", \"valid-private-subnet-c\"}: No public subnet provided for zones \[a b c\]$`,
+		expectErr:      `^platform\.aws\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"valid-private-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: No public subnet provided for zones \[a b c\]$`,
 	}, {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
@@ -473,7 +473,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		expectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks$`,
+		expectErr: `^platform\.aws\.vpc\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": subnet's CIDR range start 192\.168\.126\.0 is outside of the specified machine networks$`,
 	}, {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
@@ -501,7 +501,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		expectErr: `^\[platform\.aws\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks, platform\.aws\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": subnet's CIDR range start 192.168.127.0 is outside of the specified machine networks\]$`,
+		expectErr: `^\[platform\.aws\.vpc\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": subnet's CIDR range start 192\.168\.126\.0 is outside of the specified machine networks, platform\.aws\.vpc\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": subnet's CIDR range start 192\.168\.127\.0 is outside of the specified machine networks\]$`,
 	}, {
 		name: "invalid missing public subnet in a zone",
 		installConfig: func() *types.InstallConfig {
@@ -519,7 +519,7 @@ func TestValidate(t *testing.T) {
 			return s
 		}(),
 		publicSubnets: validPublicSubnets(),
-		expectErr:     `^platform\.aws\.subnets: Invalid value: \[\]string{\"valid-private-subnet-a\", \"valid-private-subnet-b\", \"valid-private-subnet-c\", \"valid-public-subnet-a\", \"valid-public-subnet-b\", \"valid-public-subnet-c\", \"no-matching-public-private-zone\"}: No public subnet provided for zones \[f\]$`,
+		expectErr:     `^platform\.aws\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"valid-private-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"no-matching-public-private-zone\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: No public subnet provided for zones \[f\]$`,
 	}, {
 		name: "invalid multiple private in same zone",
 		installConfig: func() *types.InstallConfig {
@@ -537,7 +537,7 @@ func TestValidate(t *testing.T) {
 			return s
 		}(),
 		publicSubnets: validPublicSubnets(),
-		expectErr:     `^platform\.aws\.subnets\[6\]: Invalid value: \"valid-private-zone-c-2\": private subnet valid-private-subnet-c is also in zone c$`,
+		expectErr:     `^platform\.aws\.vpc\.subnets\[6\]: Invalid value: \"valid-private-zone-c-2\": private subnet valid-private-subnet-c is also in zone c$`,
 	}, {
 		name: "invalid multiple public in same zone",
 		installConfig: func() *types.InstallConfig {
@@ -555,7 +555,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		expectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"valid-public-zone-c-2\": public subnet valid-public-subnet-c is also in zone c$`,
+		expectErr: `^platform\.aws\.vpc\.subnets\[6\]: Invalid value: \"valid-public-zone-c-2\": public subnet valid-public-subnet-c is also in zone c$`,
 	}, {
 		name: "invalid multiple public edge in same zone",
 		installConfig: func() *types.InstallConfig {
@@ -574,7 +574,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		expectErr: `^platform\.aws\.subnets\[9\]: Invalid value: \"valid-public-zone-edge-c-2\": edge subnet valid-public-subnet-edge-c is also in zone edge-c$`,
+		expectErr: `^platform\.aws\.vpc\.subnets\[9\]: Invalid value: \"valid-public-zone-edge-c-2\": edge subnet valid-public-subnet-edge-c is also in zone edge-c$`,
 	}, {
 		name:           "invalid edge pool missing valid subnets",
 		installConfig:  validInstallConfigEdgeSubnets(),
@@ -640,8 +640,8 @@ func TestValidate(t *testing.T) {
 			for subnet := range edgeSubnets {
 				c.Platform.AWS.VPC.Subnets = append(c.Platform.AWS.VPC.Subnets, aws.Subnet{ID: aws.AWSSubnetID(subnet)})
 			}
-			sort.Slice(c.Platform.AWS.Subnets, func(i, j int) bool {
-				subnets := c.Platform.AWS.Subnets
+			sort.Slice(c.Platform.AWS.VPC.Subnets, func(i, j int) bool {
+				subnets := c.Platform.AWS.VPC.Subnets
 				return subnets[i].ID < subnets[j].ID
 			})
 			return c
@@ -650,7 +650,7 @@ func TestValidate(t *testing.T) {
 		privateSubnets: Subnets{},
 		publicSubnets:  Subnets{},
 		edgeSubnets:    validEdgeSubnets(),
-		expectErr:      `^\[platform\.aws\.subnets: Invalid value: \[\]string{\"valid-public-subnet-edge-a\", \"valid-public-subnet-edge-b\", \"valid-public-subnet-edge-c\"}: No private subnets found, controlPlane\.platform\.aws\.zones: Invalid value: \[\]string{\"a\", \"b\", \"c\"}: No subnets provided for zones \[a b c\], compute\[0\]\.platform\.aws\.zones: Invalid value: \[\]string{\"a\", \"b\", \"c\"}: No subnets provided for zones \[a b c\]]$`,
+		expectErr:      `^\[platform\.aws\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"valid-public-subnet-edge-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-edge-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-edge-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: No private subnets found, controlPlane\.platform\.aws\.zones: Invalid value: \[\]string\{\"a\", \"b\", \"c\"\}: No subnets provided for zones \[a b c\], compute\[0\]\.platform\.aws\.zones: Invalid value: \[\]string\{\"a\", \"b\", \"c\"\}: No subnets provided for zones \[a b c\]\]$`,
 	}, {
 		name: "invalid no subnet for control plane zones",
 		installConfig: func() *types.InstallConfig {
@@ -888,7 +888,7 @@ func TestValidate(t *testing.T) {
 		privateSubnets: validPrivateSubnets(),
 		availZones:     validAvailZones(),
 		publicOnly:     "true",
-		expectErr:      `platform\.aws\.subnets: Required value: public subnets are required for a public-only subnets cluster`,
+		expectErr:      `^\[platform\.aws\.vpc\.subnets: Required value: public subnets are required for a public-only subnets cluster, platform\.aws\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"valid-private-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-private-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-a\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-b\", Roles:\[\]aws\.SubnetRole\(nil\)\}, aws\.Subnet\{ID:\"valid-public-subnet-c\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: No public subnet provided for zones \[a b c\]\]$`,
 	}, {
 		name:           "valid public-only subnets install config",
 		installConfig:  validInstallConfig(),

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -55,7 +55,7 @@ func validInstallConfig() *types.InstallConfig {
 		Platform: types.Platform{
 			AWS: &aws.Platform{
 				Region: "us-east-1",
-				Subnets: []string{
+				DeprecatedSubnets: []string{
 					"valid-private-subnet-a",
 					"valid-private-subnet-b",
 					"valid-private-subnet-c",
@@ -97,7 +97,7 @@ func validInstallConfigEdgeSubnets() *types.InstallConfig {
 	ic := validInstallConfig()
 	edgeSubnets := validEdgeSubnets()
 	for subnet := range edgeSubnets {
-		ic.Platform.AWS.Subnets = append(ic.Platform.AWS.Subnets, subnet)
+		ic.Platform.AWS.DeprecatedSubnets = append(ic.Platform.AWS.DeprecatedSubnets, subnet)
 	}
 	ic.Compute = append(ic.Compute, types.MachinePool{
 		Name: types.MachinePoolEdgeRoleName,
@@ -281,7 +281,7 @@ func TestValidate(t *testing.T) {
 		name: "valid no byo",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = nil
+			c.Platform.AWS.DeprecatedSubnets = nil
 			return c
 		}(),
 		availZones: validAvailZones(),
@@ -289,7 +289,7 @@ func TestValidate(t *testing.T) {
 		name: "valid no byo",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = []string{}
+			c.Platform.AWS.DeprecatedSubnets = []string{}
 			return c
 		}(),
 		availZones: validAvailZones(),
@@ -311,7 +311,7 @@ func TestValidate(t *testing.T) {
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
 			c.Publish = types.InternalPublishingStrategy
-			c.Platform.AWS.Subnets = []string{
+			c.Platform.AWS.DeprecatedSubnets = []string{
 				"valid-private-subnet-a",
 				"valid-private-subnet-b",
 				"valid-private-subnet-c",
@@ -427,7 +427,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid no private subnets",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = []string{
+			c.Platform.AWS.DeprecatedSubnets = []string{
 				"valid-public-subnet-a",
 				"valid-public-subnet-b",
 				"valid-public-subnet-c",
@@ -441,7 +441,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid no public subnets",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = []string{
+			c.Platform.AWS.DeprecatedSubnets = []string{
 				"valid-private-subnet-a",
 				"valid-private-subnet-b",
 				"valid-private-subnet-c",
@@ -455,7 +455,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "invalid-cidr-subnet")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "invalid-cidr-subnet")
 			return c
 		}(),
 		availZones: func() []string {
@@ -476,7 +476,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "invalid-private-cidr-subnet", "invalid-public-cidr-subnet")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "invalid-private-cidr-subnet", "invalid-public-cidr-subnet")
 			return c
 		}(),
 		availZones: func() []string {
@@ -504,7 +504,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid missing public subnet in a zone",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "no-matching-public-private-zone")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "no-matching-public-private-zone")
 			return c
 		}(),
 		availZones: validAvailZones(),
@@ -522,7 +522,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid multiple private in same zone",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "valid-private-zone-c-2")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "valid-private-zone-c-2")
 			return c
 		}(),
 		availZones: validAvailZones(),
@@ -540,7 +540,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid multiple public in same zone",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "valid-public-zone-c-2")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "valid-public-zone-c-2")
 			return c
 		}(),
 		availZones:     validAvailZones(),
@@ -558,7 +558,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid multiple public edge in same zone",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfigEdgeSubnets()
-			c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, "valid-public-zone-edge-c-2")
+			c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, "valid-public-zone-edge-c-2")
 			return c
 		}(),
 		availZones:     validAvailZonesWithEdge(),
@@ -585,7 +585,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid edge pool missing zones",
 		installConfig: func() *types.InstallConfig {
 			ic := validInstallConfig()
-			ic.Platform.AWS.Subnets = []string{}
+			ic.Platform.AWS.DeprecatedSubnets = []string{}
 			ic.ControlPlane = &types.MachinePool{}
 			edgePool := types.MachinePool{
 				Name: types.MachinePoolEdgeRoleName,
@@ -601,7 +601,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid edge pool empty zones",
 		installConfig: func() *types.InstallConfig {
 			ic := validInstallConfig()
-			ic.Platform.AWS.Subnets = []string{}
+			ic.Platform.AWS.DeprecatedSubnets = []string{}
 			ic.ControlPlane = &types.MachinePool{}
 			edgePool := types.MachinePool{
 				Name: types.MachinePoolEdgeRoleName,
@@ -619,7 +619,7 @@ func TestValidate(t *testing.T) {
 		name: "invalid edge pool missing platform definition",
 		installConfig: func() *types.InstallConfig {
 			ic := validInstallConfig()
-			ic.Platform.AWS.Subnets = []string{}
+			ic.Platform.AWS.DeprecatedSubnets = []string{}
 			ic.ControlPlane = &types.MachinePool{}
 			edgePool := types.MachinePool{
 				Name:     types.MachinePoolEdgeRoleName,
@@ -633,12 +633,12 @@ func TestValidate(t *testing.T) {
 		name: "invalid edge pool missing subnets on availability zones",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfigEdgeSubnets()
-			c.Platform.AWS.Subnets = []string{}
+			c.Platform.AWS.DeprecatedSubnets = []string{}
 			edgeSubnets := validEdgeSubnets()
 			for subnet := range edgeSubnets {
-				c.Platform.AWS.Subnets = append(c.Platform.AWS.Subnets, subnet)
+				c.Platform.AWS.DeprecatedSubnets = append(c.Platform.AWS.DeprecatedSubnets, subnet)
 			}
-			sort.Strings(c.Platform.AWS.Subnets)
+			sort.Strings(c.Platform.AWS.DeprecatedSubnets)
 			return c
 		}(),
 		availZones:     validAvailZonesOnlyEdge(),
@@ -850,7 +850,7 @@ func TestValidate(t *testing.T) {
 			c := validInstallConfig()
 			c.Publish = types.InternalPublishingStrategy
 			c.Platform.AWS.PublicIpv4Pool = "ipv4pool-ec2-123"
-			c.Platform.AWS.Subnets = []string{}
+			c.Platform.AWS.DeprecatedSubnets = []string{}
 			return c
 		}(),
 		availZones: validAvailZones(),
@@ -870,7 +870,7 @@ func TestValidate(t *testing.T) {
 		name: "no subnets specified for public-only subnets cluster",
 		installConfig: func() *types.InstallConfig {
 			c := validInstallConfig()
-			c.Platform.AWS.Subnets = []string{}
+			c.Platform.AWS.DeprecatedSubnets = []string{}
 			return c
 		}(),
 		privateSubnets: validPrivateSubnets(),
@@ -901,7 +901,7 @@ func TestValidate(t *testing.T) {
 				publicSubnets:     test.publicSubnets,
 				edgeSubnets:       test.edgeSubnets,
 				instanceTypes:     test.instanceTypes,
-				Subnets:           test.installConfig.Platform.AWS.Subnets,
+				Subnets:           test.installConfig.Platform.AWS.DeprecatedSubnets,
 			}
 			if test.proxy != "" {
 				os.Setenv("HTTP_PROXY", test.proxy)
@@ -1039,7 +1039,7 @@ func TestValidateForProvisioning(t *testing.T) {
 				instanceTypes:     validInstanceTypes(),
 				Region:            editedInstallConfig.AWS.Region,
 				vpc:               "valid-private-subnet-a",
-				Subnets:           editedInstallConfig.Platform.AWS.Subnets,
+				Subnets:           editedInstallConfig.Platform.AWS.DeprecatedSubnets,
 			}
 
 			err := ValidateForProvisioning(route53Client, editedInstallConfig, meta)

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -122,7 +122,7 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 func (a *InstallConfig) finishAWS() error {
 	// Set the Default Edge Compute pool when the subnets in AWS Local Zones are defined,
 	// when installing a cluster in existing VPC.
-	if len(a.Config.Platform.AWS.DeprecatedSubnets) > 0 {
+	if len(a.Config.Platform.AWS.VPC.Subnets) > 0 {
 		edgeSubnets, err := a.AWS.EdgeSubnets(context.TODO())
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to load edge subnets: %v", err))
@@ -140,7 +140,7 @@ func (a *InstallConfig) finishAWS() error {
 
 func (a *InstallConfig) finish(ctx context.Context, filename string) error {
 	if a.Config.AWS != nil {
-		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.DeprecatedSubnets, a.Config.AWS.ServiceEndpoints)
+		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.VPC.Subnets, a.Config.AWS.ServiceEndpoints)
 		if err := a.finishAWS(); err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -122,7 +122,7 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 func (a *InstallConfig) finishAWS() error {
 	// Set the Default Edge Compute pool when the subnets in AWS Local Zones are defined,
 	// when installing a cluster in existing VPC.
-	if len(a.Config.Platform.AWS.Subnets) > 0 {
+	if len(a.Config.Platform.AWS.DeprecatedSubnets) > 0 {
 		edgeSubnets, err := a.AWS.EdgeSubnets(context.TODO())
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to load edge subnets: %v", err))
@@ -140,7 +140,7 @@ func (a *InstallConfig) finishAWS() error {
 
 func (a *InstallConfig) finish(ctx context.Context, filename string) error {
 	if a.Config.AWS != nil {
-		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.Subnets, a.Config.AWS.ServiceEndpoints)
+		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.DeprecatedSubnets, a.Config.AWS.ServiceEndpoints)
 		if err := a.finishAWS(); err != nil {
 			return err
 		}

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -95,7 +95,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 	case awstypes.Name:
 		subnets := map[string]string{}
 		bootstrapSubnets := map[string]string{}
-		if len(ic.Platform.AWS.Subnets) > 0 {
+		if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
 			// fetch private subnets to master nodes.
 			subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -95,7 +95,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 	case awstypes.Name:
 		subnets := map[string]string{}
 		bootstrapSubnets := map[string]string{}
-		if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
+		if len(ic.Platform.AWS.VPC.Subnets) > 0 {
 			// fetch private subnets to master nodes.
 			subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -174,7 +174,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 	switch ic.Platform.Name() {
 	case awstypes.Name:
 		subnets := map[string]string{}
-		if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
+		if len(ic.Platform.AWS.VPC.Subnets) > 0 {
 			subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {
 				return err

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -174,7 +174,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 	switch ic.Platform.Name() {
 	case awstypes.Name:
 		subnets := map[string]string{}
-		if len(ic.Platform.AWS.Subnets) > 0 {
+		if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
 			subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
 			if err != nil {
 				return err

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -337,7 +337,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 		case awstypes.Name:
 			subnets := icaws.Subnets{}
 			zones := icaws.Zones{}
-			if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
+			if len(ic.Platform.AWS.VPC.Subnets) > 0 {
 				var subnetsMeta icaws.Subnets
 				switch pool.Name {
 				case types.MachinePoolEdgeRoleName:

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -337,7 +337,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 		case awstypes.Name:
 			subnets := icaws.Subnets{}
 			zones := icaws.Zones{}
-			if len(ic.Platform.AWS.Subnets) > 0 {
+			if len(ic.Platform.AWS.DeprecatedSubnets) > 0 {
 				var subnetsMeta icaws.Subnets
 				switch pool.Name {
 				case types.MachinePoolEdgeRoleName:

--- a/pkg/asset/manifests/aws/zones.go
+++ b/pkg/asset/manifests/aws/zones.go
@@ -138,7 +138,7 @@ func setSubnets(ctx context.Context, in *zonesInput) error {
 	}
 
 	// BYO VPC ("unmanaged") deployments
-	if len(in.InstallConfig.Config.AWS.Subnets) > 0 {
+	if len(in.InstallConfig.Config.AWS.DeprecatedSubnets) > 0 {
 		if err := in.GatherSubnetsFromMetadata(ctx); err != nil {
 			return fmt.Errorf("failed to get subnets from metadata: %w", err)
 		}

--- a/pkg/asset/manifests/aws/zones.go
+++ b/pkg/asset/manifests/aws/zones.go
@@ -138,7 +138,7 @@ func setSubnets(ctx context.Context, in *zonesInput) error {
 	}
 
 	// BYO VPC ("unmanaged") deployments
-	if len(in.InstallConfig.Config.AWS.DeprecatedSubnets) > 0 {
+	if len(in.InstallConfig.Config.AWS.VPC.Subnets) > 0 {
 		if err := in.GatherSubnetsFromMetadata(ctx); err != nil {
 			return fmt.Errorf("failed to get subnets from metadata: %w", err)
 		}

--- a/pkg/asset/quota/aws/aws.go
+++ b/pkg/asset/quota/aws/aws.go
@@ -76,7 +76,7 @@ func network(config *types.InstallConfig, machines []*machineapi.AWSMachineProvi
 			Region: config.Platform.AWS.Region,
 			Count:  2,
 		})
-		if len(config.Platform.AWS.DeprecatedSubnets) == 0 {
+		if len(config.Platform.AWS.VPC.Subnets) == 0 {
 			ret = append(ret, []quota.Constraint{{
 				Name:   "vpc/L-F678F1CE", // 1 vpc
 				Region: config.Platform.AWS.Region,

--- a/pkg/asset/quota/aws/aws.go
+++ b/pkg/asset/quota/aws/aws.go
@@ -76,7 +76,7 @@ func network(config *types.InstallConfig, machines []*machineapi.AWSMachineProvi
 			Region: config.Platform.AWS.Region,
 			Count:  2,
 		})
-		if len(config.Platform.AWS.Subnets) == 0 {
+		if len(config.Platform.AWS.DeprecatedSubnets) == 0 {
 			ret = append(ret, []quota.Constraint{{
 				Name:   "vpc/L-F678F1CE", // 1 vpc
 				Region: config.Platform.AWS.Region,

--- a/pkg/explain/fields_lookup_test.go
+++ b/pkg/explain/fields_lookup_test.go
@@ -41,7 +41,9 @@ perform the installation.`,
 		path: []string{"platform", "aws", "subnets"},
 		desc: `Subnets specifies existing subnets (by ID) where cluster
 resources will be created.  Leave unset to have the installer
-create subnets in a new VPC on your behalf.`,
+create subnets in a new VPC on your behalf.
+
+Deprecated: use platform.aws.vpc.subnets`,
 	}, {
 		path: []string{"platform", "aws", "userTags"},
 		desc: `UserTags additional keys and values that the installer will add

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -276,6 +276,8 @@ override existing defaults of AWS Services.
 resources will be created.  Leave unset to have the installer
 create subnets in a new VPC on your behalf.
 
+Deprecated: use platform.aws.vpc.subnets
+
     userProvisionedDNS <string>
       Default: "Disabled"
       Valid Values: "Enabled","Disabled"
@@ -459,7 +461,8 @@ RESOURCE: <[]string>
   Subnets specifies existing subnets (by ID) where cluster
 resources will be created.  Leave unset to have the installer
 create subnets in a new VPC on your behalf.
-		`,
+
+Deprecated: use platform.aws.vpc.subnets`,
 	}, {
 		path: []string{"platform", "aws", "userTags"},
 		desc: `

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -285,7 +285,10 @@ provisioned by the Installer.
     userTags <object>
       UserTags additional keys and values that the installer will add
 as tags to all resources that it creates. Resources created by the
-cluster itself may not include these tags.`,
+cluster itself may not include these tags.
+
+    vpc <object>
+      VPC specifies the VPC configuration for the cluster.`,
 	}, {
 		path: []string{"platform", "azure"},
 		desc: `FIELDS:

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -33,8 +33,10 @@ type Platform struct {
 	// resources will be created.  Leave unset to have the installer
 	// create subnets in a new VPC on your behalf.
 	//
+	// Deprecated: use platform.aws.vpc.subnets
+	//
 	// +optional
-	Subnets []string `json:"subnets,omitempty"`
+	DeprecatedSubnets []string `json:"subnets,omitempty"`
 
 	// VPC specifies the VPC configuration for the cluster.
 	//

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -36,6 +36,11 @@ type Platform struct {
 	// +optional
 	Subnets []string `json:"subnets,omitempty"`
 
+	// VPC specifies the VPC configuration for the cluster.
+	//
+	// +optional
+	VPC VPC `json:"vpc,omitempty"`
+
 	// HostedZone is the ID of an existing hosted zone into which to add DNS
 	// records for the cluster's internal API. An existing hosted zone can
 	// only be used when also using existing subnets. The hosted zone must be
@@ -143,6 +148,87 @@ type ServiceEndpoint struct {
 	// +kubebuilder:validation:Pattern=`^https://`
 	URL string `json:"url"`
 }
+
+// VPC configures the VPC for the cluster.
+type VPC struct {
+	// Subnets defines the subnets in an existing VPC and can optionally specify their intended roles.
+	// If no roles are specified on any subnet, then the subnet roles are decided automatically.
+	// In this case, the VPC must not contain any subnets without the kubernetes.io/cluster/<cluster-id> tag.
+	//
+	// For manually specified subnet role selection, each subnet must have at least one assigned role,
+	// and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
+	// However, if the cluster scope is internal, then ControlPlaneExternalLB is not required.
+	//
+	// Subnets must contain unique IDs, and can include no more than 10 subnets with the IngressController role.
+	//
+	// Leave this field unset to have the installer create subnets in a new VPC on your behalf.
+	//
+	// +listType=atomic
+	// +optional
+	Subnets []Subnet `json:"subnets,omitempty"`
+}
+
+// Subnet specifies a subnet in an existing VPC and can optionally specify their intended roles.
+type Subnet struct {
+	// ID specifies the subnet ID of an existing subnet.
+	// The subnet ID must start with "subnet-", consist only of alphanumeric characters,
+	// and must be exactly 24 characters long.
+	//
+	// +required
+	ID AWSSubnetID `json:"id"`
+
+	// Roles specifies the roles (aka functions) that the subnet will provide in the cluster.
+	// If no roles are specified on any subnet, then the subnet roles are decided automatically.
+	// Each role must be unique.
+	//
+	// +kubebuilder:validation:MaxItems=5
+	// +optional
+	Roles []SubnetRole `json:"roles,omitempty"`
+}
+
+// SubnetRole specifies the role (aka function) that the subnet will provide in the cluster.
+type SubnetRole struct {
+	// Type specifies the type of role (aka function) that the subnet will provide in the cluster.
+	// Role types include ClusterNode, EdgeNode, Bootstrap, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
+	//
+	// +required
+	Type SubnetRoleType `json:"type"`
+}
+
+// AWSSubnetID is a reference to an AWS subnet ID.
+// +kubebuilder:validation:MinLength=24
+// +kubebuilder:validation:MaxLength=24
+// +kubebuilder:validation:Pattern=`^subnet-[0-9A-Za-z]+$`
+type AWSSubnetID string // nolint:revive
+
+// SubnetRoleType defines the type of role (aka function) that the subnet will provide in the cluster.
+// +kubebuilder:validation:Enum:="ClusterNode";"EdgeNode";"Bootstrap";"IngressControllerLB";"ControlPlaneExternalLB";"ControlPlaneInternalLB"
+type SubnetRoleType string
+
+const (
+	// ClusterNodeSubnetRole specifies subnets that will be used as subnets for the
+	// control plane and compute nodes.
+	ClusterNodeSubnetRole SubnetRoleType = "ClusterNode"
+
+	// EdgeNodeSubnetRole specifies subnets that will be used as edge subnets residing
+	// in Local or Wavelength Zones for edge compute nodes.
+	EdgeNodeSubnetRole SubnetRoleType = "EdgeNode"
+
+	// BootstrapSubnetRole specifies subnets that will be used as subnets for the
+	// bootstrap node used to create the cluster.
+	BootstrapSubnetRole SubnetRoleType = "Bootstrap"
+
+	// IngressControllerLBSubnetRole specifies subnets used by the default IngressController.
+	IngressControllerLBSubnetRole SubnetRoleType = "IngressControllerLB"
+
+	// ControlPlaneExternalLBSubnetRole specifies subnets used by the external control plane
+	// load balancer that serves the Kubernetes API server.
+	ControlPlaneExternalLBSubnetRole SubnetRoleType = "ControlPlaneExternalLB"
+
+	// ControlPlaneInternalLBSubnetRole specifies subnets used by the internal control plane
+	// load balancer that serves the Kubernetes API server.
+	ControlPlaneInternalLBSubnetRole SubnetRoleType = "ControlPlaneInternalLB"
+)
 
 // IsSecretRegion returns true if the region is part of either the ISO or ISOB partitions.
 func IsSecretRegion(region string) bool {

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -60,7 +60,7 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 func validateSecurityGroups(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.DeprecatedSubnets) == 0 {
+	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.VPC.Subnets) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("platform.subnets"), "subnets must be provided when additional security groups are present"))
 	}
 

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -60,7 +60,7 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 func validateSecurityGroups(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.Subnets) == 0 {
+	if len(p.AdditionalSecurityGroupIDs) > 0 && len(platform.DeprecatedSubnets) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("platform.subnets"), "subnets must be provided when additional security groups are present"))
 	}
 

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -155,8 +155,13 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "valid security group config",
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "valid-subnet-1"},
+						{ID: "valid-subnet-2"},
+					},
+				},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: []string{
@@ -173,8 +178,13 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "invalid security group config exceeds maximum",
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "valid-subnet-1"},
+						{ID: "valid-subnet-2"},
+					},
+				},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: tooManySecurityGroups,
@@ -184,8 +194,13 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "valid maximum security group config",
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "valid-subnet-1"},
+						{ID: "valid-subnet-2"},
+					},
+				},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: tooManySecurityGroups[:maxUserSecurityGroupsCount],

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -155,8 +155,8 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "valid security group config",
 			platform: &aws.Platform{
-				Region:  "us-east-1",
-				Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: []string{
@@ -173,8 +173,8 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "invalid security group config exceeds maximum",
 			platform: &aws.Platform{
-				Region:  "us-east-1",
-				Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: tooManySecurityGroups,
@@ -184,8 +184,8 @@ func Test_ValdidateSecurityGroups(t *testing.T) {
 		{
 			name: "valid maximum security group config",
 			platform: &aws.Platform{
-				Region:  "us-east-1",
-				Subnets: []string{"valid-subnet-1", "valid-subnet-2"},
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"valid-subnet-1", "valid-subnet-2"},
 			},
 			pool: &aws.MachinePool{
 				AdditionalSecurityGroupIDs: tooManySecurityGroups[:maxUserSecurityGroupsCount],

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -35,7 +35,7 @@ func ValidatePlatform(p *aws.Platform, cm types.CredentialsMode, fldPath *field.
 	}
 
 	if p.HostedZone != "" {
-		if len(p.Subnets) == 0 {
+		if len(p.DeprecatedSubnets) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostedZone"), p.HostedZone, "may not use an existing hosted zone when not using existing subnets"))
 		}
 	}

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -35,7 +35,7 @@ func ValidatePlatform(p *aws.Platform, cm types.CredentialsMode, fldPath *field.
 	}
 
 	if p.HostedZone != "" {
-		if len(p.DeprecatedSubnets) == 0 {
+		if len(p.VPC.Subnets) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostedZone"), p.HostedZone, "may not use an existing hosted zone when not using existing subnets"))
 		}
 	}

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -36,9 +36,9 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "hosted zone with subnets",
 			platform: &aws.Platform{
-				Region:     "us-east-1",
-				Subnets:    []string{"test-subnet"},
-				HostedZone: "test-hosted-zone",
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"test-subnet"},
+				HostedZone:        "test-hosted-zone",
 			},
 		},
 		{
@@ -209,19 +209,19 @@ func TestValidatePlatform(t *testing.T) {
 			name:     "valid hosted zone & role should not throw an error",
 			credMode: types.PassthroughCredentialsMode,
 			platform: &aws.Platform{
-				Region:         "us-east-1",
-				Subnets:        []string{"test-subnet"},
-				HostedZone:     "test-hosted-zone",
-				HostedZoneRole: "test-hosted-zone-role",
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"test-subnet"},
+				HostedZone:        "test-hosted-zone",
+				HostedZoneRole:    "test-hosted-zone-role",
 			},
 		},
 		{
 			name: "hosted zone role without credential mode should error",
 			platform: &aws.Platform{
-				Region:         "us-east-1",
-				Subnets:        []string{"test-subnet"},
-				HostedZone:     "test-hosted-zone",
-				HostedZoneRole: "test-hosted-zone-role",
+				Region:            "us-east-1",
+				DeprecatedSubnets: []string{"test-subnet"},
+				HostedZone:        "test-hosted-zone",
+				HostedZoneRole:    "test-hosted-zone-role",
 			},
 			expected: `^test-path\.hostedZoneRole: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified$`,
 		},

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -36,9 +36,13 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "hosted zone with subnets",
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"test-subnet"},
-				HostedZone:        "test-hosted-zone",
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "test-subnet"},
+					},
+				},
+				HostedZone: "test-hosted-zone",
 			},
 		},
 		{
@@ -209,19 +213,27 @@ func TestValidatePlatform(t *testing.T) {
 			name:     "valid hosted zone & role should not throw an error",
 			credMode: types.PassthroughCredentialsMode,
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"test-subnet"},
-				HostedZone:        "test-hosted-zone",
-				HostedZoneRole:    "test-hosted-zone-role",
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "test-subnet"},
+					},
+				},
+				HostedZone:     "test-hosted-zone",
+				HostedZoneRole: "test-hosted-zone-role",
 			},
 		},
 		{
 			name: "hosted zone role without credential mode should error",
 			platform: &aws.Platform{
-				Region:            "us-east-1",
-				DeprecatedSubnets: []string{"test-subnet"},
-				HostedZone:        "test-hosted-zone",
-				HostedZoneRole:    "test-hosted-zone-role",
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "test-subnet"},
+					},
+				},
+				HostedZone:     "test-hosted-zone",
+				HostedZoneRole: "test-hosted-zone-role",
 			},
 			expected: `^test-path\.hostedZoneRole: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified$`,
 		},

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilsslice "k8s.io/utils/strings/slices"
 
@@ -298,5 +299,21 @@ func convertAWS(config *types.InstallConfig) error {
 			config.AWS.DefaultMachinePlatform.AMIID = ami
 		}
 	}
+
+	// Subnets field is deprecated in favor of VPC.Subnets.
+	fldPath := field.NewPath("platform", "aws")
+	if config.AWS.DeprecatedSubnets != nil && config.AWS.VPC.Subnets != nil { // nolint: staticcheck
+		return field.Forbidden(fldPath.Child("subnets"), fmt.Sprintf("cannot specify %s and %s together", fldPath.Child("subnets"), fldPath.Child("vpc", "subnets")))
+	} else if config.AWS.DeprecatedSubnets != nil { // nolint: staticcheck
+		var subnets []aws.Subnet
+		for _, subnetID := range config.AWS.DeprecatedSubnets { // nolint: staticcheck
+			subnets = append(subnets, aws.Subnet{
+				ID: aws.AWSSubnetID(subnetID),
+			})
+		}
+		config.AWS.VPC.Subnets = subnets
+		logrus.Warnf("%s is deprecated. Converted to %s", fldPath.Child("subnets"), fldPath.Child("vpc", "subnets"))
+	}
+
 	return nil
 }

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -752,7 +752,7 @@ func TestConvertInstallConfig(t *testing.T) {
 				Platform: types.Platform{
 					AWS: &aws.Platform{
 						DeprecatedSubnets: []string{"subnet-01234567890abcdef", "subnet-abcdef01234567890"},
-						VPC: aws.VPCSpec{
+						VPC: aws.VPC{
 							Subnets: []aws.Subnet{
 								{ID: "subnet-01234567890abcdef"},
 								{ID: "subnet-abcdef01234567890"},
@@ -771,7 +771,7 @@ func TestConvertInstallConfig(t *testing.T) {
 				Platform: types.Platform{
 					AWS: &aws.Platform{
 						DeprecatedSubnets: []string{"subnet-01234567890abcdef", "subnet-abcdef01234567890"},
-						VPC: aws.VPCSpec{
+						VPC: aws.VPC{
 							Subnets: []aws.Subnet{
 								{ID: "subnet-01234567890abcdef"},
 								{ID: "subnet-abcdef01234567890"},

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -733,6 +733,55 @@ func TestConvertInstallConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "aws deprecated subnets",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					AWS: &aws.Platform{
+						DeprecatedSubnets: []string{"subnet-01234567890abcdef", "subnet-abcdef01234567890"},
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					AWS: &aws.Platform{
+						DeprecatedSubnets: []string{"subnet-01234567890abcdef", "subnet-abcdef01234567890"},
+						VPC: aws.VPCSpec{
+							Subnets: []aws.Subnet{
+								{ID: "subnet-01234567890abcdef"},
+								{ID: "subnet-abcdef01234567890"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "aws deprecated subnets with vpc.subnets",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					AWS: &aws.Platform{
+						DeprecatedSubnets: []string{"subnet-01234567890abcdef", "subnet-abcdef01234567890"},
+						VPC: aws.VPCSpec{
+							Subnets: []aws.Subnet{
+								{ID: "subnet-01234567890abcdef"},
+								{ID: "subnet-abcdef01234567890"},
+							},
+						},
+					},
+				},
+			},
+			expectedError: `Forbidden: cannot specify platform\.aws.subnets and platform\.aws\.vpc.subnets together`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Following proposal for selecting LB subnets, the field platform.vpc.subnets will be introduced for more flexible configurations. This enhancement proposal is available reference [0].

There are some adjustments to the API markers and descriptions in comparison to the proposal.
- Organize field description for easier read.
- Correct kubebuilder:validation:MaxItems on array field

This field is dropped in place of the deprecated `platform.subnets` field.

Part of [CORS-3440](https://issues.redhat.com//browse/CORS-3440)

References:

[0] https://github.com/openshift/enhancements/blob/2890cccf20ebcb94fce901f7afb170ca680aa2d9/enhancements/installer/aws-lb-subnet-selection.md