### PR TITLE
OCPBUGS-50534: Fix panic when there are no available IPs

### DIFF
--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -267,7 +267,11 @@ func getNextAvailableIP(ctx context.Context, installConfig *installconfig.Instal
 	if err != nil {
 		return "", fmt.Errorf("failed to get azure ip availability: %w", err)
 	}
-	if *availableIP.Available {
+	if availableIP == nil {
+		return "", errors.New("failed to get available IP in given machine network: this error may be caused by lack of necessary permissions")
+	}
+	ipAvail := *availableIP
+	if ipAvail.Available != nil && *ipAvail.Available {
 		for _, cidrRange := range machineCidr {
 			_, ipnet, err := net.ParseCIDR(cidrRange.CIDR.String())
 			if err != nil {
@@ -278,10 +282,10 @@ func getNextAvailableIP(ctx context.Context, installConfig *installconfig.Instal
 			}
 		}
 	}
-	if *availableIP.AvailableIPAddresses == nil || len(*availableIP.AvailableIPAddresses) == 0 {
+	if ipAvail.AvailableIPAddresses == nil || len(*ipAvail.AvailableIPAddresses) == 0 {
 		return "", fmt.Errorf("failed to get an available IP in given virtual network for LB: %w", err)
 	}
-	for _, ip := range *availableIP.AvailableIPAddresses {
+	for _, ip := range *ipAvail.AvailableIPAddresses {
 		for _, cidrRange := range machineCidr {
 			_, ipnet, err := net.ParseCIDR(cidrRange.CIDR.String())
 			if err != nil {


### PR DESCRIPTION
Adding a fix to check if ips are available to prevent a panic.