### PR TITLE
OCPBUGS-50004: Add cluster:master_nodes metric retrieval in docs

### DIFF
--- a/docs/user/openstack/observability.md
+++ b/docs/user/openstack/observability.md
@@ -303,8 +303,8 @@ once every 30 seconds.
 
 [ocp-federation-docs]: https://docs.openshift.com/container-platform/4.17/observability/monitoring/accessing-third-party-monitoring-apis.html#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-monitoring-apis-by-using-the-cli
 
-In this example, we will only request two metrics: `kube_node_info` and
-`kube_persistentvolume_info` (see the `params.match[]` query below).
+In this example, we will only request three metrics: `kube_node_info`, `kube_persistentvolume_info`
+and `cluster:master_nodes` (see the `params.match[]` query below).
 
 While connected to the RHOSO cluster, apply this manifest:
 
@@ -319,7 +319,7 @@ metadata:
 spec:
   params:
     'match[]':
-    - '{__name__=~"kube_node_info|kube_persistentvolume_info"}'
+    - '{__name__=~"kube_node_info|kube_persistentvolume_info|cluster:master_nodes"}'
   metricsPath: '/federate'
   authorization:
     type: Bearer


### PR DESCRIPTION
The `cluster:master_nodes` metric needs to be added to the scrapeconfig match query so it can be scraped from the shift-on-stack cluster.
It's required for running the correlated query defined at [1].

[1] https://github.com/openshift/installer/blob/main/docs/user/openstack/observability.md#example