### PR TITLE
OCPBUGS-49737: Custom-DNS: Update master and worker user data secrets

### DIFF
--- a/pkg/asset/machines/arbiter.go
+++ b/pkg/asset/machines/arbiter.go
@@ -166,7 +166,7 @@ func (m *Arbiter) Generate(ctx context.Context, dependencies asset.Parents) erro
 		m.NetworkConfigSecretFiles = append(m.NetworkConfigSecretFiles, networkSecrets...)
 	}
 
-	data, err := userDataSecret(arbiterUserDataSecretName, mign.File.Data)
+	data, err := UserDataSecret(arbiterUserDataSecretName, mign.File.Data)
 	if err != nil {
 		return fmt.Errorf("failed to create user-data secret for arbiter machines: %w", err)
 	}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -512,7 +512,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		return fmt.Errorf("invalid Platform")
 	}
 
-	data, err := userDataSecret(masterUserDataSecretName, mign.File.Data)
+	data, err := UserDataSecret(masterUserDataSecretName, mign.File.Data)
 	if err != nil {
 		return errors.Wrap(err, "failed to create user-data secret for master machines")
 	}

--- a/pkg/asset/machines/userdata.go
+++ b/pkg/asset/machines/userdata.go
@@ -19,7 +19,9 @@ data:
   userData: {{.content}}
 `))
 
-func userDataSecret(name string, content []byte) ([]byte, error) {
+// UserDataSecret generates the user data secret that contains the
+// master or worker pointer ignition.
+func UserDataSecret(name string, content []byte) ([]byte, error) {
 	encodedData := map[string]string{
 		"name":    name,
 		"content": base64.StdEncoding.EncodeToString(content),

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -703,7 +703,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 		}
 	}
 
-	data, err := userDataSecret(workerUserDataSecretName, wign.File.Data)
+	data, err := UserDataSecret(workerUserDataSecretName, wign.File.Data)
 	if err != nil {
 		return errors.Wrap(err, "failed to create user-data secret for worker machines")
 	}


### PR DESCRIPTION
When the master and worker pointer ignitions are updated, also update the user data secret for each of these roles with their respective pointer ignition contents.
Update Bootstrap ignition with updated user data secret files for master and worker.