### PR TITLE
OCPBUGS-50574: Check for vmgroup when create capv machine fd name

### DIFF
--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -150,10 +150,14 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			},
 		}
 
-		if failureDomainName, ok := data.MachineFailureDomain[machine.Name]; ok {
-			vsphereMachine.Spec.FailureDomain = &failureDomainName
-		} else {
-			return nil, fmt.Errorf("unable to find failure domain for machine %s", machine.Name)
+		// only set failureDomainName if VMGroup is defined as vm-host group
+		// is the only scenario we create vspherefailuredomainspec and vspheredeploymentzone
+		if providerSpec.Workspace.VMGroup != "" {
+			if failureDomainName, ok := data.MachineFailureDomain[machine.Name]; ok {
+				vsphereMachine.Spec.FailureDomain = &failureDomainName
+			} else {
+				return nil, fmt.Errorf("unable to find failure domain for machine %s", machine.Name)
+			}
 		}
 
 		// If we have additional disks to add to VM, lets iterate through them and add to CAPV machine


### PR DESCRIPTION
This commit adds an additional check for
the providerSpec workspace vmgroup if its not empty. If it is non-empty then add the failure domain name to the VSphereMachineSpec otherwise do not define and leave empty.


This solves two problems:
- Excessive alerting from capv that the failure domain doesn't exist
- capv unable to delete bootstrap node
