### PR TITLE
OCPBUGS-50649: vsphere - check if host is powered down or on standby before uploading template

### DIFF
--- a/pkg/infrastructure/vsphere/clusterapi/import.go
+++ b/pkg/infrastructure/vsphere/clusterapi/import.go
@@ -226,10 +226,10 @@ func findAvailableHostSystems(ctx context.Context, clusterHostSystems []*object.
 		// if distributed port group the cast will fail
 		networkFound := isNetworkAvailable(networkObjectRef, hostSystemManagedObject.Network)
 		datastoreFound := isDatastoreAvailable(datastore, hostSystemManagedObject.Datastore)
-		isUsable := hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStatePoweredOff && hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStateStandBy
+		hasUsablePowerState := hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStatePoweredOff && hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStateStandBy && !hostSystemManagedObject.Runtime.InMaintenanceMode
 
 		// if the network or datastore is not found or the ESXi host is in maintenance mode, powered off or in StandBy (DPM) continue the loop
-		if !networkFound || !datastoreFound || hostSystemManagedObject.Runtime.InMaintenanceMode || !isUsable {
+		if !networkFound || !datastoreFound || !hasUsablePowerState {
 			continue
 		}
 

--- a/pkg/infrastructure/vsphere/clusterapi/import.go
+++ b/pkg/infrastructure/vsphere/clusterapi/import.go
@@ -146,7 +146,6 @@ func importRhcosOva(ctx context.Context, session *session.Session, folder *objec
 		resourcePool.Reference(),
 		datastore.Reference(),
 		cisp)
-
 	if err != nil {
 		return fmt.Errorf("failed to create import spec: %w", err)
 	}
@@ -160,7 +159,6 @@ func importRhcosOva(ctx context.Context, session *session.Session, folder *objec
 	}
 
 	lease, err := resourcePool.ImportVApp(ctx, spec.ImportSpec, folder, hostSystem)
-
 	if err != nil {
 		return fmt.Errorf("failed to import vapp: %w", err)
 	}
@@ -228,9 +226,10 @@ func findAvailableHostSystems(ctx context.Context, clusterHostSystems []*object.
 		// if distributed port group the cast will fail
 		networkFound := isNetworkAvailable(networkObjectRef, hostSystemManagedObject.Network)
 		datastoreFound := isDatastoreAvailable(datastore, hostSystemManagedObject.Datastore)
+		isUsable := hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStatePoweredOff && hostSystemManagedObject.Runtime.PowerState != types.HostSystemPowerStateStandBy
 
-		// if the network or datastore is not found or the ESXi host is in maintenance mode continue the loop
-		if !networkFound || !datastoreFound || hostSystemManagedObject.Runtime.InMaintenanceMode {
+		// if the network or datastore is not found or the ESXi host is in maintenance mode, powered off or in StandBy (DPM) continue the loop
+		if !networkFound || !datastoreFound || hostSystemManagedObject.Runtime.InMaintenanceMode || !isUsable {
 			continue
 		}
 


### PR DESCRIPTION
We have intermittent issues with IPI Installations because it seems that the Installer does not check if a Host is in an unsuitable state (in this case Powered Off or StandBy, caused by VMware DPM).

This PR fixes that problem by checking for both states and including them in the decision.

When using the unpatched installer the following happens:
```
[snip]
level=info msg=Creating infrastructure resources...
level=debug msg=Obtaining RHCOS image file from '[https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202410211619-0/x86_64/rhcos-416.94.202410211619-0-vmware.x86_64.ova?sha256=6e4af5d1f51156e496d712ab1d386a96311cdd15392c63721e2dd4485bc07c29'](https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202410211619-0/x86_64/rhcos-416.94.202410211619-0-vmware.x86_64.ova?sha256=6e4af5d1f51156e496d712ab1d386a96311cdd15392c63721e2dd4485bc07c29%27)
level=debug msg=image download content length: 1305047040
level=debug msg=Unpacking file into "/root/.cache/openshift-installer/image_cache/rhcos-416.94.202410211619-0-vmware.x86_64.ova"...
level=debug msg=no known archive format detected for image, assuming no decompression necessary
level=debug msg=writing the RHCOS image was 1305047040 bytes
level=debug msg=Checksum validation is complete...
level=info msg=Importing OVA dev-cluster-5qj4d-rhcos-region_1-zone_1 into failure domain failure_domain_1.
level=debug msg=using ESXi d000-esx003.dev.io to import the OVA image  
level=error msg=failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed during pre-provisioning: unable to initialize folders and templates: failed to import ova: failed to lease wait: The operation is not allowed in the current connection state of the host.
End Of Pipeline
```

This then continues to happen, no matter how often you retry.

With the patched installer it looks like this: 

```
[snip]
level=info msg=Creating infrastructure resources...
level=debug msg=Obtaining RHCOS image file from '[https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202410211619-0/x86_64/rhcos-416.94.202410211619-0-vmware.x86_64.ova?sha256=6e4af5d1f51156e496d712ab1d386a96311cdd15392c63721e2dd4485bc07c29'](https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202410211619-0/x86_64/rhcos-416.94.202410211619-0-vmware.x86_64.ova?sha256=6e4af5d1f51156e496d712ab1d386a96311cdd15392c63721e2dd4485bc07c29%27)
level=debug msg=image download content length: 1305047040
level=debug msg=Unpacking file into "/root/.cache/openshift-installer/image_cache/rhcos-416.94.202410211619-0-vmware.x86_64.ova"...
level=debug msg=no known archive format detected for image, assuming no decompression necessary
level=debug msg=writing the RHCOS image was 1305047040 bytes
level=debug msg=Checksum validation is complete...
level=info msg=Importing OVA dev-cluster-mdjds-rhcos-region_1-zone_1 into failure domain failure_domain_1.
level=debug msg=using ESXi d000-esx001.dev.io to import the OVA image
level=debug msg=Creating cluster_install/cluster-api directory
level=debug msg=Extracting cluster_install/cluster-api/cluster-api file
level=debug msg=Creating cluster_install/cluster-api directory
level=debug msg=Extracting cluster_install/cluster-api/etcd file
level=debug msg=Extracting cluster_install/cluster-api/kube-apiserver file
level=warning msg=Received interrupt signal
level=info msg=Started local control plane with envtest
level=info msg=Stored kubeconfig for envtest in: /builds/cluster-installer/cluster_install/.clusterapi_output/envtest.kubeconfig
level=info msg=Running process: Cluster API with args [-v=2 --diagnostics-address=0 --health-addr=127.0.0.1:40129 --webhook-port=45765 --webhook-cert-dir=/tmp/envtest-serving-certs-3653338967 --kubeconfig= /builds/cluster-installer/cluster_install/.clusterapi_output/envtest.kubeconfig.clusterapi_output/envtest.kubeconfig]
level=debug msg=I0212 14:29:42.197455     110 cluster_cache_tracker.go:165] "Couldn't find controller pod metadata, the ClusterCacheTracker will always access clusters using the regular apiserver endpoint" component="remote/clustercachetracker"
level=debug msg=I0212 14:29:42.198227     110 webhook.go:158] "Registering a mutating webhook" logger="controller-runtime.builder" GVK="cluster.x-k8s.io/v1beta1, Kind=ClusterClass" path="/mutate-cluster-x-k8s-io-v1beta1-clusterclass"
level=debug msg=I0212 14:29:42.198335     110 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/mutate-cluster-x-k8s-io-v1beta1-clusterclass"
level=debug msg=I0212 14:29:42.198440     110 webhook.go:189] "Registering a validating webhook" logger="controller-runtime.builder" GVK="cluster.x-k8s.io/v1beta1, Kind=ClusterClass" path="/validate-cluster-x-k8s-io-v1beta1-clusterclass"
[snip]
```