### PR TITLE
OCPBUGS-50657: PowerVS: destroy dhcp hack

### DIFF
--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -243,7 +243,6 @@ func (o *ClusterUninstaller) destroyCluster() error {
 	}, {
 		{name: "DHCPs", execute: o.destroyDHCPNetworks},
 	}, {
-		{name: "Power Subnets", execute: o.destroyPowerSubnets},
 		{name: "Images", execute: o.destroyImages},
 		{name: "VPCs", execute: o.destroyVPCs},
 	}, {
@@ -255,6 +254,8 @@ func (o *ClusterUninstaller) destroyCluster() error {
 	}, {
 		{name: "DNS Records", execute: o.destroyDNSRecords},
 		{name: "DNS Resource Records", execute: o.destroyResourceRecords},
+	}, {
+		{name: "Power Subnets", execute: o.destroyPowerSubnets},
 	}, {
 		{name: "Service Instances", execute: o.destroyServiceInstances},
 	}}


### PR DESCRIPTION
We are changing the destroy cluster slightly when deleting DHCP networks to also wait for the subnet to no longer exist.