### PR TITLE
[release-4.16] OCPBUGS-50547: aws/edge/byovpc: tag edge subnets with shared value

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -59,11 +59,19 @@ func tagSharedVPCResources(ctx context.Context, clusterID string, installConfig 
 		return err
 	}
 
-	ids := make([]*string, 0, len(privateSubnets)+len(publicSubnets))
+	edgeSubnets, err := installConfig.AWS.EdgeSubnets(ctx)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]*string, 0, len(privateSubnets)+len(publicSubnets)+len(edgeSubnets))
 	for id := range privateSubnets {
 		ids = append(ids, aws.String(id))
 	}
 	for id := range publicSubnets {
+		ids = append(ids, aws.String(id))
+	}
+	for id := range edgeSubnets {
 		ids = append(ids, aws.String(id))
 	}
 


### PR DESCRIPTION
Previously the subnets created by user (BYO VPC) on edge zones (Local or Wavelength zones) were not tagged with
kubernetes.io/cluster/<InfraID>:shared.

This change ensures installer is also setting the same cluster tag as regular zones.

This PR is a manual backport of https://github.com/openshift/installer/pull/9452, fixing a typo found on https://github.com/openshift/installer/pull/9480