### PR TITLE
OCPBUGS-45429: Set the right resource group in bootstrap destroy

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -715,6 +715,9 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 	}
 
 	resourceGroupName := fmt.Sprintf("%s-rg", in.Metadata.InfraID)
+	if in.Metadata.Azure.ResourceGroupName != "" {
+		resourceGroupName = in.Metadata.Azure.ResourceGroupName
+	}
 	securityGroupName := fmt.Sprintf("%s-nsg", in.Metadata.InfraID)
 	sshRuleName := fmt.Sprintf("%s_ssh_in", in.Metadata.InfraID)
 


### PR DESCRIPTION
Setting the right resource group by checking if the user has provided an existing resource group for installation and have the bootstrap destroy use it to clean resources properly.