### PR TITLE
OCPBUGS-47724: AWS: Copy static MCO resources needed for custom-dns

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -454,6 +454,7 @@ then
 	copy_static_resources_for vsphere
 	copy_static_resources_for nutanix
 	copy_static_resources_for gcp
+	copy_static_resources_for aws
 
 	cp mco-bootstrap/manifests/* manifests/
 


### PR DESCRIPTION
Copy AWS static resources for the bootstrap instance of MCO.