### PR TITLE
OCPBUGS-50899: PowerVS: COS eu-es hack

### DIFF
--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -212,6 +212,11 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		File:   asset.File{Filename: "02_powervs-cluster.yaml"},
 	})
 
+	if vpcRegion != cosRegion {
+		logrus.Debugf("GenerateClusterAssets: vpcRegion(%s) is different than cosRegion(%s), cosRegion. Overriding bucket name", vpcRegion, cosRegion)
+		bucket = fmt.Sprintf("rhcos-powervs-images-%s", cosRegion)
+	}
+
 	powerVSImage = &capibm.IBMPowerVSImage{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: capibm.GroupVersion.String(),


### PR DESCRIPTION
If the COS location to use is different than the VPC region, then we need to rename the bucket name to correctly download the image.