### PR TITLE
OCPBUGS-50920: Rely on path declaration of base image

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -33,7 +33,6 @@ RUN dnf install -y nmstate openshift-clients && \
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
-ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
 ENTRYPOINT ["/bin/openshift-install"]

--- a/images/installer-altinfra/Dockerfile.ci
+++ b/images/installer-altinfra/Dockerfile.ci
@@ -31,7 +31,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
-ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
 # We're not really an operator, we're just getting some data into the release image.

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -28,7 +28,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manif
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
-ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
 # We're not really an operator, we're just getting some data into the release image.

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -112,6 +112,5 @@ RUN mkdir /output/.ssh && chown 1000:1000 "/output/.ssh/" && chmod -R g=u "/outp
 
 RUN chown 1000:1000 /output && chmod -R g=u "/output/.bluemix/"
 USER 1000:1000
-ENV PATH /bin
 ENV HOME /output
 WORKDIR /output

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -47,6 +47,5 @@ RUN ln -s /bin/yq-go /bin/yq && chmod +x /bin/yq
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
-ENV PATH /bin
 ENV HOME /output
 WORKDIR /output

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -62,7 +62,6 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
-ENV PATH /bin:/usr/local/bin
 ENV HOME /output
 ENV LC_ALL en_US.UTF-8
 WORKDIR /output


### PR DESCRIPTION
Starting with 4.19, the PATH environment variable is actively used in CI to manage idempotent repositories that work both in CI as locally. By overriding the PATH environment variable, machine-os-images gets unfortunate repositories as a result. I suspect this path override can just disappear.