### PR TITLE
OCPBUGS-50919: Fixes panic during GCP tags fetch due to unstable network

### DIFF
--- a/pkg/asset/installconfig/gcp/usertags.go
+++ b/pkg/asset/installconfig/gcp/usertags.go
@@ -151,7 +151,7 @@ func (t *TagManager) validateAndPersistUserTags(ctx context.Context, project str
 				nonexistentTags = append(nonexistentTags, name)
 				continue
 			}
-			return fmt.Errorf("failed to fetch user-defined tag %s(%d): %w", name, gErr.HTTPCode(), err)
+			return fmt.Errorf("failed to fetch user-defined tag %s: %w", name, err)
 		}
 		processedTags.addTag(tagValue.Parent, tagValue.Name)
 	}

--- a/pkg/asset/installconfig/gcp/usertags_test.go
+++ b/pkg/asset/installconfig/gcp/usertags_test.go
@@ -203,7 +203,7 @@ func TestGetUserTags(t *testing.T) {
 			name:          "failed to fetch tag",
 			userTags:      testTags[40:],
 			processedTags: nil,
-			expectedError: `failed to fetch user-defined tag openshift/key52/value52(500): googleapi: Error 500: Internal error while fetching 'openshift/key52/value52'`,
+			expectedError: `failed to fetch user-defined tag openshift/key52/value52: googleapi: Error 500: Internal error while fetching 'openshift/key52/value52'`,
 		},
 	}
 


### PR DESCRIPTION
PR fixes the panic observed when fetching the GCP tags during `create` stage of installation. The issue was happening because of referencing the empty google API error, which could be because of the unstable network and since the call was not reaching the server.

/cc @jianli-wei @barbacbd 