### PR TITLE
OCPBUGS-50961: Power VS: Log accurate error when deploying Internal with no vpcName

### DIFF
--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -257,6 +258,14 @@ func (m *Metadata) IsVPCPermittedNetwork(ctx context.Context, vpcName string, ba
 	}
 
 	return false, nil
+}
+
+// EnsureVPCNameIsSpecifiedForInternal checks if platform.powervs.vpcName is specified when the publishing strategy is Internal.
+func (m *Metadata) EnsureVPCNameIsSpecifiedForInternal(vpcName string) error {
+	if strings.Compare(vpcName, "") == 0 {
+		return fmt.Errorf("a pre-existing VPC is required when deploying with an Internal publishing strategy")
+	}
+	return nil
 }
 
 // EnsureVPCIsPermittedNetwork checks if a VPC is permitted to the DNS zone and adds it if it is not.

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -172,7 +172,12 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 
 	// Use a custom resolver if using an Internal publishing strategy
 	if installConfig.Config.Publish == types.InternalPublishingStrategy {
-		dnsServerIP, err := installConfig.PowerVS.GetDNSServerIP(context.TODO(), installConfig.Config.PowerVS.VPCName)
+		var dnsServerIP string
+		err := installConfig.PowerVS.EnsureVPCNameIsSpecifiedForInternal(installConfig.Config.PowerVS.VPCName)
+		if err != nil {
+			return nil, err
+		}
+		dnsServerIP, err = installConfig.PowerVS.GetDNSServerIP(context.TODO(), installConfig.Config.PowerVS.VPCName)
 		if err != nil {
 			return nil, fmt.Errorf("unable to find a DNS server for specified VPC: %s %w", installConfig.Config.PowerVS.VPCName, err)
 		}


### PR DESCRIPTION
When deploying a cluster with an internal publishing strategy with no `vpcName` key in the install-configuration, manifest files cannot be generated, and the following error is shown: `failed to find VPC`. Given that no `vpcName` key was specified in the first place, this error is inaccurate. Correct the error message to reflect the actual requirement in this case, which is to specify a `vpcName: name` key-value pair.