### PR TITLE
OCPBUGS-51084: PowerVS: Specify chrony config for Disconnected deploy

### DIFF
--- a/pkg/asset/machines/machineconfig/chrony.go
+++ b/pkg/asset/machines/machineconfig/chrony.go
@@ -1,0 +1,59 @@
+package machineconfig
+
+import (
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/installer/pkg/asset/ignition"
+)
+
+// ForCustomNTP lays down chrony.conf with given NTP server.
+func ForCustomNTP(role string, server string) (*mcfgv1.MachineConfig, error) {
+	chronyConf, err := createChronyConf(server)
+	if err != nil {
+		return nil, err
+	}
+
+	ignConfig := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+		Storage: igntypes.Storage{
+			Files: []igntypes.File{},
+		},
+	}
+	ignConfig.Storage.Files = append(ignConfig.Storage.Files, ignition.FileFromString("/etc/chrony.conf", "root", 0644, chronyConf))
+
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-chrony", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: rawExt,
+		},
+	}, nil
+}
+
+func createChronyConf(server string) (string, error) {
+	unit := `server %s iburst
+driftfile /var/lib/chrony/drift
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony`
+	return fmt.Sprintf(unit, server), nil
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -58,6 +58,7 @@ import (
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
+	powervsdefaults "github.com/openshift/installer/pkg/types/powervs/defaults"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 	ibmcloudapi "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis"
 	ibmcloudprovider "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1"
@@ -558,6 +559,15 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 				return errors.Wrap(err, "failed to create ignition for Power SMT for master machines")
 			}
 			machineConfigs = append(machineConfigs, ignPowerSMT)
+		}
+
+		if installConfig.Config.Publish == types.InternalPublishingStrategy &&
+			(len(installConfig.Config.ImageDigestSources) > 0 || len(installConfig.Config.DeprecatedImageContentSources) > 0) {
+			ignChrony, err := machineconfig.ForCustomNTP("master", powervsdefaults.DefaultNTPServer)
+			if err != nil {
+				return errors.Wrap(err, "failed to create ignition for custom NTP for master machines")
+			}
+			machineConfigs = append(machineConfigs, ignChrony)
 		}
 	}
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -59,6 +59,7 @@ import (
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
+	powervsdefaults "github.com/openshift/installer/pkg/types/powervs/defaults"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 	ibmcloudapi "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis"
 	ibmcloudprovider "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1"
@@ -318,6 +319,15 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 					return errors.Wrap(err, "failed to create ignition for Power SMT for worker machines")
 				}
 				machineConfigs = append(machineConfigs, ignPowerSMT)
+			}
+
+			if installConfig.Config.Publish == types.InternalPublishingStrategy &&
+				(len(installConfig.Config.ImageDigestSources) > 0 || len(installConfig.Config.DeprecatedImageContentSources) > 0) {
+				ignChrony, err := machineconfig.ForCustomNTP("worker", powervsdefaults.DefaultNTPServer)
+				if err != nil {
+					return errors.Wrap(err, "failed to create ignition for custom NTP for worker machines")
+				}
+				machineConfigs = append(machineConfigs, ignChrony)
 			}
 		}
 		// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.

--- a/pkg/types/powervs/defaults/platform.go
+++ b/pkg/types/powervs/defaults/platform.go
@@ -9,6 +9,11 @@ import (
 	"github.com/openshift/installer/pkg/types/powervs"
 )
 
+const (
+	// DefaultNTPServer is the FQDN of IBM Cloud NTP server.
+	DefaultNTPServer = "time.adn.networklayer.com"
+)
+
 var (
 	// DefaultMachineCIDR is the PowerVS default IP address space from
 	// which to assign machine IPs.


### PR DESCRIPTION
In Disconnected scenario, the VMs won't have free access to the standard NTP server/pool. Therefore, they need a custom NTP server that PowerVS specifically permits access to via special routing for disconnected VMs/workspace. This PR introduces an ability to lay down `/etc/chrony.conf` with the provided NTP server name, which has been verified working as intended on PowerVS.