### PR TITLE
CORS-3869: static validation for new vpc.subnets field

### DIFF
--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -216,9 +216,9 @@ const (
 	// in Local or Wavelength Zones for edge compute nodes.
 	EdgeNodeSubnetRole SubnetRoleType = "EdgeNode"
 
-	// BootstrapSubnetRole specifies subnets that will be used as subnets for the
+	// BootstrapNodeSubnetRole specifies subnets that will be used as subnets for the
 	// bootstrap node used to create the cluster.
-	BootstrapSubnetRole SubnetRoleType = "Bootstrap"
+	BootstrapNodeSubnetRole SubnetRoleType = "BootstrapNode"
 
 	// IngressControllerLBSubnetRole specifies subnets used by the default IngressController.
 	IngressControllerLBSubnetRole SubnetRoleType = "IngressControllerLB"

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -27,7 +28,7 @@ var openshiftNamespaceRegex = regexp.MustCompile(`^([^/]*\.)?openshift.io/`)
 const userTagLimit = 25
 
 // ValidatePlatform checks that the specified platform is valid.
-func ValidatePlatform(p *aws.Platform, cm types.CredentialsMode, fldPath *field.Path) field.ErrorList {
+func ValidatePlatform(p *aws.Platform, publish types.PublishingStrategy, cm types.CredentialsMode, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if p.Region == "" {
@@ -51,6 +52,7 @@ func ValidatePlatform(p *aws.Platform, cm types.CredentialsMode, fldPath *field.
 		}
 	}
 
+	allErrs = append(allErrs, validateSubnets(p.VPC.Subnets, publish, fldPath.Child("vpc", "subnets"))...)
 	allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
 	allErrs = append(allErrs, validateUserTags(p.UserTags, p.PropagateUserTag, fldPath.Child("userTags"))...)
 
@@ -162,4 +164,124 @@ func validateServiceURL(uri string) error {
 	}
 
 	return nil
+}
+
+func validateSubnets(subnets []aws.Subnet, publish types.PublishingStrategy, fldPath *field.Path) field.ErrorList {
+	if len(subnets) == 0 {
+		return nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	// Either all subnets must be assigned roles (manual role selection)
+	// or none of the subnets should have roles assigned (automatic role selection).
+	for _, subnet := range subnets {
+		if (len(subnet.Roles) > 0) != (len(subnets[0].Roles) > 0) {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "either all subnets must be assigned roles or none of the subnets should have roles assigned"))
+			break
+		}
+	}
+
+	supportedRoles := sets.New(
+		aws.ClusterNodeSubnetRole,
+		aws.EdgeNodeSubnetRole,
+		aws.BootstrapNodeSubnetRole,
+		aws.IngressControllerLBSubnetRole,
+		aws.ControlPlaneExternalLBSubnetRole,
+		aws.ControlPlaneInternalLBSubnetRole,
+	)
+	// A mapping of a role to its assigned subnets.
+	subnetsForRole := make(map[aws.SubnetRoleType][]aws.Subnet)
+	// An indicator whether none of the subnets are assigned roles.
+	autoRoleSelection := true
+	// A tracker to check duplicate subnet IDs.
+	subnetTracker := make(map[string]int)
+
+	for snIdx, subnet := range subnets {
+		subnetFldPath := fldPath.Index(snIdx)
+
+		// Subnet ID must be unique.
+		if _, ok := subnetTracker[string(subnet.ID)]; ok {
+			allErrs = append(allErrs, field.Duplicate(subnetFldPath.Child("id"), subnet.ID))
+		} else {
+			subnetTracker[string(subnet.ID)] = snIdx
+		}
+
+		// A set of role types assigned to a subnet
+		// for quick search later.
+		subnetRoleTypes := sets.New[aws.SubnetRoleType]()
+		// A tracker to check duplicate subnet roles.
+		roleTracker := make(map[string]int)
+
+		for rIdx, role := range subnet.Roles {
+			if !supportedRoles.Has(role.Type) {
+				allErrs = append(allErrs, field.NotSupported(subnetFldPath.Child("roles").Index(rIdx).Child("type"), role.Type, sets.List(supportedRoles)))
+				continue // Role type is unsupported. No further validation.
+			}
+
+			// Subnet roles must not contain duplicates.
+			if _, ok := roleTracker[string(role.Type)]; ok {
+				allErrs = append(allErrs, field.Duplicate(subnetFldPath.Child("roles").Index(rIdx).Child("type"), role.Type))
+			} else {
+				roleTracker[string(role.Type)] = rIdx
+			}
+
+			subnetRoleTypes.Insert(role.Type)
+		}
+
+		// Role ControlPlaneExternalLB and ControlPlaneInternalLB must not be both specified.
+		// on the same subnet.
+		if subnetRoleTypes.HasAll(aws.ControlPlaneExternalLBSubnetRole, aws.ControlPlaneInternalLBSubnetRole) {
+			allErrs = append(allErrs, field.Forbidden(subnetFldPath.Child("roles"), "must not have both ControlPlaneExternalLB and ControlPlaneInternalLB role"))
+		}
+
+		// EdgeNode cannot be combined with any other roles.
+		if subnetRoleTypes.Has(aws.EdgeNodeSubnetRole) && subnetRoleTypes.Len() > 1 {
+			allErrs = append(allErrs, field.Forbidden(subnetFldPath.Child("roles"), "must not combine EdgeNode role with any other roles"))
+		}
+
+		autoRoleSelection = autoRoleSelection && len(subnetRoleTypes) == 0
+		for rType := range subnetRoleTypes {
+			subnetsForRole[rType] = append(subnetsForRole[rType], subnet)
+		}
+	}
+
+	if !autoRoleSelection {
+		// The IngressController's API only allows 10 subnets.
+		if len(subnetsForRole[aws.IngressControllerLBSubnetRole]) > 10 {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "must not include more than 10 subnets with the IngressControllerLB role"))
+		}
+
+		// If the cluster is private, ControlPlaneExternalLB role is not allowed
+		// as only an internal control plane load balancer will be created.
+		if publish == types.InternalPublishingStrategy && len(subnetsForRole[aws.ControlPlaneExternalLBSubnetRole]) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "must not include subnets with the ControlPlaneExternalLBSubnetRole role in a private cluster"))
+		}
+
+		// ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB
+		// must be assigned to at least 1 subnet.
+		missingRoles := sets.New[aws.SubnetRoleType]()
+		for rType := range supportedRoles {
+			switch rType {
+			// EdgeNode role is optional.
+			case aws.EdgeNodeSubnetRole:
+			// If the cluster is internal, ControlPlaneExternalLB role is not required.
+			case aws.ControlPlaneExternalLBSubnetRole:
+				if publish == types.InternalPublishingStrategy {
+					continue
+				}
+				fallthrough
+			default:
+				if len(subnetsForRole[rType]) == 0 {
+					missingRoles.Insert(rType)
+				}
+			}
+		}
+
+		if missingRoles.Len() > 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath, subnets, fmt.Sprintf("roles %v must be assigned to at least 1 subnet", sets.List(missingRoles))))
+		}
+	}
+
+	return allErrs
 }

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -19,6 +19,7 @@ func TestValidatePlatform(t *testing.T) {
 		platform *aws.Platform
 		expected string
 		credMode types.CredentialsMode
+		publish  types.PublishingStrategy
 	}{
 		{
 			name: "minimal",
@@ -39,7 +40,7 @@ func TestValidatePlatform(t *testing.T) {
 				Region: "us-east-1",
 				VPC: aws.VPC{
 					Subnets: []aws.Subnet{
-						{ID: "test-subnet"},
+						{ID: "subnet-1234567890asdfghj"},
 					},
 				},
 				HostedZone: "test-hosted-zone",
@@ -216,7 +217,7 @@ func TestValidatePlatform(t *testing.T) {
 				Region: "us-east-1",
 				VPC: aws.VPC{
 					Subnets: []aws.Subnet{
-						{ID: "test-subnet"},
+						{ID: "subnet-1234567890asdfghj"},
 					},
 				},
 				HostedZone:     "test-hosted-zone",
@@ -229,7 +230,7 @@ func TestValidatePlatform(t *testing.T) {
 				Region: "us-east-1",
 				VPC: aws.VPC{
 					Subnets: []aws.Subnet{
-						{ID: "test-subnet"},
+						{ID: "subnet-1234567890asdfghj"},
 					},
 				},
 				HostedZone:     "test-hosted-zone",
@@ -237,10 +238,365 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			expected: `^test-path\.hostedZoneRole: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified$`,
 		},
+		{
+			name: "valid subnets, empty",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC:    aws.VPC{},
+			},
+		},
+		{
+			name: "valid subnets, no roles assigned",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "subnet-1234567890asdfghj"},
+						{ID: "subnet-asdfghj1234567890"},
+					},
+				},
+			},
+		},
+		{
+			name:    "valid subnets, internal cluster and all required roles assigned",
+			publish: types.InternalPublishingStrategy,
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "valid subnets, external cluster and all required roles assigned",
+			publish: types.ExternalPublishingStrategy,
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneExternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid subnets, some without roles assigned",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+						},
+					},
+				},
+			},
+			expected: `^\[test-path\.vpc\.subnets: Forbidden: either all subnets must be assigned roles or none of the subnets should have roles assigned, test-path\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"subnet-1234567890asdfghj\", Roles:\[\]aws\.SubnetRole\{Type:\"Bootstrap\"\}, aws\.SubnetRole\{Type:\"ClusterNode\"\}\}, aws\.Subnet\{ID:\"subnet-asdfghj1234567890\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: roles \[ControlPlaneInternalLB IngressControllerLB ControlPlaneExternalLB\] must be assigned to at least 1 subnet\}\]$`,
+		},
+		{
+			name: "invalid subnets, invalid subnet IDs",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "subnet-1j"},
+						{ID: "bad-subnet567890"},
+					},
+				},
+			},
+			expected: `^\[test-path\.vpc\.subnets\[0\]\.id: Invalid value: \"subnet-1j\": must be non-empty, start with \"subnet-\", consist only of alphanumeric characters, and must be exactly 24 characters long, test-path\.vpc\.subnets\[1\]\.id: Invalid value: \"bad-subnet567890\": must be non-empty, start with \"subnet-\", consist only of alphanumeric characters, and must be exactly 24 characters long\]$`,
+		},
+		{
+			name: "invalid subnets, duplicate subnet IDs",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{ID: "subnet-1234567890asdfghj"},
+						{ID: "subnet-1234567890asdfghj"},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets\[1\]\.id: Duplicate value: \"subnet-1234567890asdfghj\"$`,
+		},
+		{
+			name: "invalid subnets, unsupported roles assigned",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: "UnsupportedRole"},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets\[0\]\.roles\[0\]\.type: Unsupported value: \"UnsupportedRole\": supported values: \"Bootstrap\", \"ClusterNode\", \"ControlPlaneExternalLB\", \"ControlPlaneInternalLB\", \"EdgeNode\", \"IngressControllerLB\"$`,
+		},
+		{
+			name: "invalid subnets, duplicate roles assigned to a subnet",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneExternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets\[0\]\.roles\[1\]\.type: Duplicate value: \"Bootstrap\"$`,
+		},
+		{
+			name: "invalid subnets, ControlPlaneExternalLB and ControlPlaneInternalLB roles assigned to the same subnet",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneExternalLBSubnetRole},
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets\[1\]\.roles: Forbidden: must not have both ControlPlaneExternalLB and ControlPlaneInternalLB role$`,
+		},
+		{
+			name: "invalid subnets, EdgeNode and other roles assigned to the same subnet",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.EdgeNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneExternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets\[0\]\.roles: Forbidden: must not combine EdgeNode role with any other roles$`,
+		},
+		{
+			name: "invalid subnets, IngressControllerLB roles assigned to more than 10 subnets",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: append(
+						[]aws.Subnet{
+							{
+								ID: "subnet-1234567890asdfghj",
+								Roles: []aws.SubnetRole{
+									{Type: aws.BootstrapNodeSubnetRole},
+									{Type: aws.ClusterNodeSubnetRole},
+								},
+							},
+							{
+								ID: "subnet-asdfghj1234567890",
+								Roles: []aws.SubnetRole{
+									{Type: aws.ControlPlaneInternalLBSubnetRole},
+								},
+							},
+							{
+								ID: "subnet-0fcf8e0392f0910d0",
+								Roles: []aws.SubnetRole{
+									{Type: aws.ControlPlaneExternalLBSubnetRole},
+								},
+							},
+						},
+						func() []aws.Subnet {
+							subnets := []aws.Subnet{}
+							for i := 0; i < 11; i++ {
+								subnets = append(subnets, aws.Subnet{
+									ID: aws.AWSSubnetID(fmt.Sprintf("subnet-asdfghj392f0910d%d", i)),
+									Roles: []aws.SubnetRole{
+										{Type: aws.IngressControllerLBSubnetRole},
+									},
+								})
+							}
+							return subnets
+						}()...,
+					),
+				},
+			},
+			expected: `^test-path\.vpc\.subnets: Forbidden: must not include more than 10 subnets with the IngressControllerLB role$`,
+		},
+		{
+			name:    "invalid subnets, internal cluster and ControlPlaneExternalLB role assigned to a subnet",
+			publish: types.InternalPublishingStrategy,
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-asdfghj1234567890",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneInternalLBSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.ControlPlaneExternalLBSubnetRole},
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets: Forbidden: must not include subnets with the ControlPlaneExternalLB role in a private cluster$`,
+		},
+		{
+			name:    "invalid subnets, internal cluster and missing required roles",
+			publish: types.InternalPublishingStrategy,
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test\-path\.vpc\.subnets\: Invalid value\: \[\]aws\.Subnet\{aws\.Subnet\{ID\:"subnet\-1234567890asdfghj", Roles\:\[\]aws\.SubnetRole\{Type\:"Bootstrap"\}, aws\.SubnetRole\{Type\:"ClusterNode"\}\}, aws\.Subnet\{ID\:"subnet\-0fcf8e0392f0910d0", Roles\:\[\]aws\.SubnetRole\{Type\:"IngressControllerLB"\}\}\}\]\: Roles \[ControlPlaneInternalLB\] must be assigned to at least 1 subnet$`,
+		},
+		{
+			name:    "invalid subnets, external cluster and missing required roles",
+			publish: types.ExternalPublishingStrategy,
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				VPC: aws.VPC{
+					Subnets: []aws.Subnet{
+						{
+							ID: "subnet-1234567890asdfghj",
+							Roles: []aws.SubnetRole{
+								{Type: aws.BootstrapNodeSubnetRole},
+								{Type: aws.ClusterNodeSubnetRole},
+							},
+						},
+						{
+							ID: "subnet-0fcf8e0392f0910d0",
+							Roles: []aws.SubnetRole{
+								{Type: aws.IngressControllerLBSubnetRole},
+							},
+						},
+					},
+				},
+			},
+			expected: `^test-path\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"subnet-1234567890asdfghj\", Roles:\[\]aws\.SubnetRole\{Type:\"Bootstrap\"\}, aws\.SubnetRole\{Type:\"ClusterNode\"\}\}, aws\.Subnet\{ID:\"subnet-0fcf8e0392f0910d0\", Roles:\[\]aws\.SubnetRole\{Type:\"IngressControllerLB\"\}\}\}\}: Roles \[ControlPlaneExternalLB ControlPlaneInternalLB\] must be assigned to at least 1 subnet$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidatePlatform(tc.platform, tc.credMode, field.NewPath("test-path")).ToAggregate()
+			err := ValidatePlatform(tc.platform, tc.publish, tc.credMode, field.NewPath("test-path")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1041,7 +1041,7 @@ func validatePlatform(platform *types.Platform, usingAgentMethod bool, fldPath *
 	}
 	if platform.AWS != nil {
 		validate(aws.Name, platform.AWS, func(f *field.Path) field.ErrorList {
-			return awsvalidation.ValidatePlatform(platform.AWS, c.CredentialsMode, f)
+			return awsvalidation.ValidatePlatform(platform.AWS, c.Publish, c.CredentialsMode, f)
 		})
 	}
 	if platform.Azure != nil {


### PR DESCRIPTION
This include static validations for the vpc.subnets field (no call to AWS API is performed). The validation criteria can be found at jira ticket [0] and enhancement proposal [1]. Summary of validation criteria:

- The subnet IDs must not include duplicates
- There can only be maximum 10 subnets assigned IngressControllerLB role.
- Either all subnets must have roles assigned or none at all.
- For a subnet that has defined roles
  - Roles must be of supported types (i.e. from a set of defined roles)
  - Roles must not be duplicate. This and * check naturally validates that a subnet can only have max 5 roles
  - EdgeNode cannot be combined with any other roles
  - ClusterNode, IngressControllerLB, ControlPlaneExternalLB (if cluster is external), and ControlPlaneInternalLB must be assigned to at least 1 subnet
  - A subnet cannot have both role ControlPlaneExternalLB and ControlPlaneInternalLB *
  - If the cluster is internal, ControlPlaneExternalLB must not be assigned to any subnets.

References:

[0] https://issues.redhat.com/browse/CORS-3869
[1] https://github.com/openshift/enhancements/blob/30f44ee0cd57dc4ba3b72e10c0b8f1614970d0e0/enhancements/installer/aws-lb-subnet-selection.md#installer-validation-rules