### PR TITLE
NO-JIRA: bootstrap: add CLUSTER_PROFILE_ANNOTATION variable to auth-api bootstrapping stage

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -136,6 +136,8 @@ then
 
 	rm --recursive --force auth-api-bootstrap
 
+	CLUSTER_PROFILE_ANNOTATION="self-managed-high-availability"
+
 	bootkube_podman_run \
 		--name auth-api-render \
 		--volume "$PWD:/assets:z" \


### PR DESCRIPTION
This should resolve https://github.com/openshift/installer/pull/9424#discussion_r1967214153

I haven't been able to identify any permafailing nightlies to signal that this variable definition being missing is causing nightly failures, but I do have a slack thread open with TRT here: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1740402125911299