### PR TITLE
OCPBUGS-51350: PowerVS: Extra network routes for disconnected install

### DIFF
--- a/pkg/asset/machines/machineconfig/routes.go
+++ b/pkg/asset/machines/machineconfig/routes.go
@@ -1,0 +1,87 @@
+package machineconfig
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	ignutil "github.com/coreos/ignition/v2/config/util"
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/installer/pkg/asset/ignition"
+)
+
+// ForExtraRoutes adds network routes that may be necessary for Disconnected deploy.
+func ForExtraRoutes(role string, cidrs []string, network string) (*mcfgv1.MachineConfig, error) {
+	serviceUnit, err := createExtraRoutesUnit(cidrs, network)
+	if err != nil {
+		return nil, err
+	}
+
+	ignConfig := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+		Systemd: igntypes.Systemd{
+			Units: []igntypes.Unit{
+				{
+					Contents: &serviceUnit,
+					Name:     fmt.Sprintf("99-%s-routes.service", role),
+					Enabled:  ignutil.BoolToPtr(true),
+				},
+			},
+		},
+	}
+
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-routes", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: rawExt,
+		},
+	}, nil
+}
+
+func createExtraRoutesUnit(destCidrs []string, network string) (string, error) {
+	if len(destCidrs) == 0 {
+		return "", fmt.Errorf("destination CIDRs provided are empty")
+	}
+	_, ipnet, err := net.ParseCIDR(network)
+	if err != nil {
+		return "", err
+	}
+	gateway, err := cidr.Host(ipnet, 1)
+	if err != nil {
+		return "", err
+	}
+	cmds := ""
+	for _, cidr := range destCidrs {
+		cmds += fmt.Sprintf("ExecStart=/usr/sbin/ip route add %s via %s\n", cidr, gateway)
+	}
+	unit := `[Unit]
+Description=Add routes
+After=ovs-configuration.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+%s
+[Install]
+WantedBy=network-online.target
+`
+	return fmt.Sprintf(unit, cmds), nil
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -568,6 +568,12 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 				return errors.Wrap(err, "failed to create ignition for custom NTP for master machines")
 			}
 			machineConfigs = append(machineConfigs, ignChrony)
+
+			ignRoutes, err := machineconfig.ForExtraRoutes("master", powervsdefaults.DefaultExtraRoutes(), ic.MachineNetwork[0].CIDR.String())
+			if err != nil {
+				return errors.Wrap(err, "failed to create ignition for extra routes for master machines")
+			}
+			machineConfigs = append(machineConfigs, ignRoutes)
 		}
 	}
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -358,6 +358,12 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 					return errors.Wrap(err, "failed to create ignition for custom NTP for worker machines")
 				}
 				machineConfigs = append(machineConfigs, ignChrony)
+
+				ignRoutes, err := machineconfig.ForExtraRoutes("worker", powervsdefaults.DefaultExtraRoutes(), ic.MachineNetwork[0].CIDR.String())
+				if err != nil {
+					return errors.Wrap(err, "failed to create ignition for extra routes for worker machines")
+				}
+				machineConfigs = append(machineConfigs, ignRoutes)
 			}
 		}
 		// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.

--- a/pkg/types/powervs/defaults/platform.go
+++ b/pkg/types/powervs/defaults/platform.go
@@ -30,3 +30,8 @@ func SetPlatformDefaults(p *powervs.Platform) {
 	// MustParseCIDR parses a CIDR from its string representation. If the parse fails, the function will panic.
 	DefaultMachineCIDR = ipnet.MustParseCIDR(fmt.Sprintf("192.168.%d.0/24", subnet))
 }
+
+// DefaultExtraRoutes returns the default network routes necessary for disconnected install on PowerVS.
+func DefaultExtraRoutes() []string {
+	return []string{"166.8.0.0/14", "161.26.0.0/16"}
+}


### PR DESCRIPTION
When SNAT is disabled (for disconnected setup), there must be some extra routes set up on the VMs for them to be able to reach private API endpoints (eg. PowerVS, NTP) for the installer itself and other runtime components to work as intended.

This PR proposes an additional ignition manifest (`99-[master|worker]-routes`) to do just that on PowerVS.

Rebooting a master and a worker of the installed cluster has also been tested, and CO's get degrated temporarily (as expected), but it's been verified that they all recover once the rebooted node is back to `Ready` state.