### PR TITLE
[WIP] AGENT-1113: Add interactive disconnected ignition command

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent/image"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
 	"github.com/openshift/installer/pkg/asset/agent/mirror"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 )
@@ -114,7 +115,28 @@ var (
 		},
 	}
 
-	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget, agentConfigImageTarget, agentUnconfiguredIgnitionTarget}
+	agentInteractiveDisconnectedIgnitionTarget = target{
+		name: "Agent interactive disconnected install ignition",
+		command: &cobra.Command{
+			Use:    "interactive-disconnected-ignition",
+			Short:  "Generates the agent ignition required to support the interactive disconnected installation",
+			Args:   cobra.ExactArgs(0),
+			Hidden: true,
+		}, assets: []asset.WritableAsset{
+			&workflow.AgentWorkflowInstallInteractiveDisconnected{},
+			&image.InteractiveDisconnectedIgnition{},
+		},
+	}
+
+	agentTargets = []target{
+		agentConfigTarget,
+		agentManifestsTarget,
+		agentImageTarget,
+		agentPXEFilesTarget,
+		agentConfigImageTarget,
+		agentUnconfiguredIgnitionTarget,
+		agentInteractiveDisconnectedIgnitionTarget,
+	}
 )
 
 func newAgentCreateCmd(ctx context.Context) *cobra.Command {

--- a/pkg/asset/agent/image/interactive_disconnected_ignition.go
+++ b/pkg/asset/agent/image/interactive_disconnected_ignition.go
@@ -1,0 +1,212 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/stream-metadata-go/arch"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent/common"
+	"github.com/openshift/installer/pkg/asset/agent/interactive"
+	"github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
+	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/version"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	interactiveDisconnectedIgnitionFilename = "interactive-disconnected-agent.ign"
+)
+
+// InteractiveDisconnectedIgnition is the asset responsible for generating the
+// ignition file required to support the interactive disconnected setup.
+type InteractiveDisconnectedIgnition struct {
+	Config *igntypes.Config
+	File   *asset.File
+}
+
+// Name returns the human-friendly name of the asset.
+func (i *InteractiveDisconnectedIgnition) Name() string {
+	return "Agent Installer Interactive Disconnected Ignition"
+}
+
+// Dependencies returns the assets on which the current asset depends.
+func (i *InteractiveDisconnectedIgnition) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&workflow.AgentWorkflow{},
+		&interactive.InstallConfig{},
+		&manifests.ClusterImageSet{},
+		&manifests.AgentPullSecret{},
+		&manifests.InfraEnv{},
+		&common.InfraEnvID{},
+	}
+}
+
+// Generate produces an asset used only for the interactive disconnected workflow.
+// In the connected UI, the only mandatory installation detail required is the release version (and architecture).
+// Optionally the user may specify the pull secret, an SSH key or the list of the OLM operators to be installed.
+// All the remaining configuration will be provided by the user subsequently in the disconnected environment,
+// through the assisted UI running on the rendezvous node.
+func (i *InteractiveDisconnectedIgnition) Generate(_ context.Context, dependencies asset.Parents) error {
+	agentWorkflow := &workflow.AgentWorkflow{}
+	interactiveInstallConfig := &interactive.InstallConfig{}
+	clusterImageSet := &manifests.ClusterImageSet{}
+	agentPullSecret := &manifests.AgentPullSecret{}
+	infraEnv := &manifests.InfraEnv{}
+	infraEnvID := &common.InfraEnvID{}
+	dependencies.Get(agentWorkflow, interactiveInstallConfig, clusterImageSet, agentPullSecret, infraEnv, infraEnvID)
+
+	if agentWorkflow.Workflow != workflow.AgentWorkflowTypeInstallInteractiveDisconnected {
+		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
+	}
+
+	// By default, no user is added.
+	config := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+	}
+	// Add the optional ssh key for the "core" user if configured.
+	if interactiveInstallConfig.SSHKey() != "" {
+		config.Passwd = igntypes.Passwd{
+			Users: []igntypes.PasswdUser{
+				{
+					Name: "core",
+					SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
+						igntypes.SSHAuthorizedKey(interactiveInstallConfig.SSHKey()),
+					},
+				},
+			},
+		}
+	}
+
+	// Get the current release architecture and version, to define the complete release image list.
+	openshiftArch, err := i.getCurrentReleaseArch()
+	if err != nil {
+		return err
+	}
+	openshiftVersion, err := version.Version()
+	if err != nil {
+		return err
+	}
+	openShiftReleaseImage := clusterImageSet.Config.Spec.ReleaseImage // Note: in the current workflow it's always equivalent to releaseimage.Image{}.PullSpec
+
+	releaseImageList, err := releaseImageListWithVersion(openShiftReleaseImage, openshiftArch, []string{openshiftArch}, openshiftVersion)
+	if err != nil {
+		return err
+	}
+	// Get the current OS image.
+	osImage, err := getOSImagesInfo(openshiftArch, openshiftVersion, DefaultCoreOSStreamGetter)
+	if err != nil {
+		return err
+	}
+
+	// Prepare (just) the required template input parameters.
+	agentTemplateData := &agentTemplateData{
+		PullSecret:    interactiveInstallConfig.PullSecret(),
+		ReleaseImages: releaseImageList,
+		ReleaseImage:  openShiftReleaseImage,
+		InfraEnvID:    infraEnvID.ID,
+		OSImage:       osImage,
+	}
+
+	// Add the agent files to ignition. The list of files added could be improved,
+	// by skipping those ones not really required for the current workflow.
+	err = bootstrap.AddStorageFiles(&config, "/", "agent/files", agentTemplateData)
+	if err != nil {
+		return err
+	}
+	// Add the required bootstrap files.
+	err = addBootstrapScripts(&config, openShiftReleaseImage)
+	if err != nil {
+		return err
+	}
+	// Add the rendezvous host file. Agent TUI will interact with that file in case
+	// the rendezvous IP wasn't previously configured.
+	rendezvousHostFile := ignition.FileFromString(rendezvousHostEnvPath,
+		"root", 0644,
+		getRendezvousHostEnv("http", interactiveInstallConfig.RendezvousIP(), "", "", agentWorkflow.Workflow))
+	config.Storage.Files = append(config.Storage.Files, rendezvousHostFile)
+	// Add the only required agent manifests.
+	for _, file := range []asset.File{
+		*infraEnv.File,
+		*clusterImageSet.File,
+		*agentPullSecret.File,
+	} {
+		manifestFile := ignition.FileFromBytes(filepath.Join(manifestPath, filepath.Base(file.Filename)),
+			"root", 0600, file.Data)
+		config.Storage.Files = append(config.Storage.Files, manifestFile)
+	}
+
+	// Configure the ignition services.
+	enabledServices := getDefaultEnabledServices()
+	err = bootstrap.AddSystemdUnits(&config, "agent/systemd/units", agentTemplateData, enabledServices)
+	if err != nil {
+		return err
+	}
+	// TBD: Add assisted UI related services.
+
+	// Generate the ignition file.
+	i.Config = &config
+	return i.generateFile()
+}
+
+func (i *InteractiveDisconnectedIgnition) getCurrentReleaseArch() (string, error) {
+	releaseArch, err := version.ReleaseArchitecture()
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(releaseArch, "multi") || strings.Contains(releaseArch, "unknown") {
+		releaseArch = string(version.DefaultArch())
+	}
+	return arch.RpmArch(releaseArch), nil
+}
+
+func (i *InteractiveDisconnectedIgnition) generateFile() error {
+	data, err := ignition.Marshal(i.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal InteractiveDisconnectedIgnition config")
+	}
+	i.File = &asset.File{
+		Filename: interactiveDisconnectedIgnitionFilename,
+		Data:     data,
+	}
+	return nil
+}
+
+// PersistToFile writes the unconfigured ignition in the assets folder.
+func (i *InteractiveDisconnectedIgnition) PersistToFile(directory string) error {
+	if i.File == nil {
+		return errors.New("attempting to persist a InteractiveDisconnectedIgnition that has not been generated")
+	}
+	ignitionFile := filepath.Join(directory, i.File.Filename)
+
+	err := os.WriteFile(ignitionFile, i.File.Data, 0o644) //nolint:gosec // no sensitive info
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("ignition created in: %s", ignitionFile)
+
+	return nil
+}
+
+// Load returns the UnconfiguredIgnition from disk.
+func (*InteractiveDisconnectedIgnition) Load(f asset.FileFetcher) (bool, error) {
+	// The InteractiveDisconnectedIgnition will not be needed by another asset so load is noop.
+	// This is implemented because it is required by WritableAsset
+	return false, nil
+}
+
+// Files returns the files generated by the asset.
+func (*InteractiveDisconnectedIgnition) Files() []*asset.File {
+	// Return empty array because File will never be loaded.
+	return []*asset.File{}
+}

--- a/pkg/asset/agent/image/interactive_disconnected_ignition_test.go
+++ b/pkg/asset/agent/image/interactive_disconnected_ignition_test.go
@@ -1,0 +1,183 @@
+package image
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent/common"
+	"github.com/openshift/installer/pkg/asset/agent/interactive"
+	"github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/agent/workflow"
+)
+
+func TestInteractiveDisconnectedIgnition_Generate(t *testing.T) {
+	skipTestIfnmstatectlIsMissing(t)
+
+	workingDirectory, err := os.Getwd()
+	assert.NoError(t, err)
+	err = os.Chdir(path.Join(workingDirectory, "../../../../data"))
+	assert.NoError(t, err)
+
+	cases := []struct {
+		name             string
+		deps             []asset.Asset
+		expectedError    string
+		expectedFiles    []string
+		expectedServices map[string]bool
+	}{
+		{
+			name: "unsupported workflow",
+			deps: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				&interactive.InstallConfig{},
+				&manifests.ClusterImageSet{},
+				&manifests.AgentPullSecret{},
+				&manifests.InfraEnv{},
+				&common.InfraEnvID{},
+			},
+			expectedError: "AgentWorkflowType value not supported: install",
+		},
+		{
+			name: "default",
+			deps: interactiveDefaultAssets(),
+
+			expectedFiles:    interactiveExpectedFiles(),
+			expectedServices: interactiveExpectedServices(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parents := asset.Parents{}
+			parents.Add(tc.deps...)
+
+			asset := &InteractiveDisconnectedIgnition{}
+			err := asset.Generate(context.Background(), parents)
+
+			if tc.expectedError != "" {
+				assert.Equal(t, tc.expectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assertExpectedFiles(t, asset.Config, tc.expectedFiles, nil)
+				assertServiceEnabled(t, asset.Config, tc.expectedServices)
+			}
+		})
+	}
+}
+
+func interactiveDefaultAssets() []asset.Asset {
+	return []asset.Asset{
+		&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstallInteractiveDisconnected},
+		&interactive.InstallConfig{},
+		&manifests.ClusterImageSet{
+			Config: &v1.ClusterImageSet{
+				Spec: v1.ClusterImageSetSpec{
+					ReleaseImage: "registry.ci.openshift.org/ocp/release:4.99",
+				},
+			},
+			File: &asset.File{
+				Filename: "cluster-image-set.yaml",
+				Data:     []byte("cluster-image-set.yaml"),
+			},
+		},
+		&manifests.AgentPullSecret{
+			File: &asset.File{
+				Filename: "pull-secret.yaml",
+				Data:     []byte("pull-secret.yaml"),
+			},
+		},
+		&manifests.InfraEnv{
+			File: &asset.File{
+				Filename: "infraenv.yaml",
+				Data:     []byte("infraenv.yaml"),
+			},
+		},
+		&common.InfraEnvID{},
+	}
+}
+
+func interactiveExpectedServices() map[string]bool {
+	return map[string]bool{
+		// enabled services
+		"agent.service":                             true,
+		"agent-interactive-console.service":         true,
+		"agent-interactive-console-serial@.service": true,
+		"agent-import-cluster.service":              true,
+		"agent-register-cluster.service":            true,
+		"agent-register-infraenv.service":           true,
+
+		"assisted-service-db.service":  true,
+		"assisted-service-pod.service": true,
+		"assisted-service.service":     true,
+
+		"install-status.service":     true,
+		"iscsistart.service":         true,
+		"iscsiadm.service":           true,
+		"node-zero.service":          true,
+		"oci-eval-user-data.service": true,
+		"selinux.service":            true,
+		"set-hostname.service":       true,
+
+		// disabled services
+		"agent-add-node.service":             false,
+		"agent-auth-token-status.service":    false,
+		"agent-check-config-image.service":   false,
+		"apply-host-config.service":          false,
+		"load-config-iso@.service":           false,
+		"pre-network-manager-config.service": false,
+		"start-cluster-installation.service": false,
+	}
+}
+
+func interactiveExpectedFiles() []string {
+	return []string{
+		"/etc/issue",
+
+		"/etc/assisted/agent-installer.env",
+		"/etc/assisted/rendezvous-host.env",
+
+		"/etc/assisted/manifests/cluster-image-set.yaml",
+		"/etc/assisted/manifests/infraenv.yaml",
+		"/etc/assisted/manifests/pull-secret.yaml",
+
+		"/etc/containers/containers.conf",
+		"/etc/motd.d/10-agent-installer",
+		"/etc/multipath.conf",
+		"/etc/NetworkManager/conf.d/clientid.conf",
+		"/etc/systemd/system.conf.d/10-default-env.conf",
+		"/etc/udev/rules.d/80-agent-config-image.rules",
+
+		"/root/assisted.te",
+		"/root/.docker/config.json",
+
+		"/usr/local/bin/add-node.sh",
+		"/usr/local/bin/agent-auth-token-status.sh",
+		"/usr/local/bin/agent-config-image-wait.sh",
+		"/usr/local/bin/agent-gather",
+		"/usr/local/bin/bootstrap-service-record.sh",
+		"/usr/local/bin/common.sh",
+		"/usr/local/bin/extract-agent.sh",
+		"/usr/local/bin/get-container-images.sh",
+		"/usr/local/bin/install-status.sh",
+		"/usr/local/bin/issue_status.sh",
+		"/usr/local/bin/load-config-iso.sh",
+		"/usr/local/bin/oci-eval-user-data.sh",
+		"/usr/local/bin/release-image.sh",
+		"/usr/local/bin/release-image-download.sh",
+		"/usr/local/bin/set-hostname.sh",
+		"/usr/local/bin/set-node-zero.sh",
+		"/usr/local/bin/start-agent.sh",
+		"/usr/local/bin/start-cluster-installation.sh",
+		"/usr/local/bin/wait-for-assisted-service.sh",
+
+		"/usr/local/share/assisted-service/assisted-db.env",
+		"/usr/local/share/assisted-service/assisted-service.env",
+		"/usr/local/share/assisted-service/images.env",
+		"/usr/local/share/start-cluster/start-cluster.env",
+	}
+}

--- a/pkg/asset/agent/interactive/install_config.go
+++ b/pkg/asset/agent/interactive/install_config.go
@@ -1,0 +1,124 @@
+package interactive
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+var (
+	interactiveInstallConfigFilename = "interactive-install-config.yaml"
+
+	defaultPullSecret = `{"auths":{"":{"auth":"dXNlcjpwYXNz"}}}` //nolint:gosec // no sensitive info
+)
+
+// InstallConfig defines the default setting for the cluster
+// when using the interfactive disconnected workflow.
+type InstallConfig struct {
+	config Config
+}
+
+// Config is used to read the content of the configuration file.
+type Config struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	RendezvousIP string   `json:"rendezvousIP,omitempty"`
+	SSHKey       string   `json:"sshKey,omitempty"`
+	PullSecret   string   `json:"pullSecret,omitempty"`
+	Operators    []string `json:"operators,omitempty"`
+}
+
+var _ asset.WritableAsset = (*InstallConfig)(nil)
+
+// Name returns the human-friendly name of the asset.
+func (ic *InstallConfig) Name() string {
+	return "Agent Installer Interactive InstallConfig"
+}
+
+// Dependencies returns all of the dependencies directly needed to generate
+// the asset.
+func (*InstallConfig) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+// Generate generates the InteractiveInstallConfig.
+func (ic *InstallConfig) Generate(ctx context.Context, dependencies asset.Parents) error {
+	return nil
+}
+
+// Files is not used for this asset.
+func (*InstallConfig) Files() []*asset.File {
+	return []*asset.File{}
+}
+
+// Load returns the config asset from the disk.
+func (ic *InstallConfig) Load(f asset.FileFetcher) (bool, error) {
+	file, err := f.FetchByName(interactiveInstallConfigFilename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to load %s file: %w", interactiveInstallConfigFilename, err)
+	}
+
+	config := Config{}
+	if err = yaml.Unmarshal(file.Data, &config); err != nil {
+		return false, fmt.Errorf("failed to unmarshal %s: %w", interactiveInstallConfigFilename, err)
+	}
+	ic.config = config
+
+	if err = ic.finish(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (*InstallConfig) finish() error {
+	allErrs := field.ErrorList{}
+
+	// TODO: validations
+
+	return allErrs.ToAggregate()
+}
+
+// ClusterName returns the cluster name.
+func (*InstallConfig) ClusterName() string {
+	return "generic-cluster"
+}
+
+// ClusterNamespace returns the cluster namespace.
+func (*InstallConfig) ClusterNamespace() string {
+	return "generic"
+}
+
+// PullSecret returns the pull-secret if configured,
+// otherwise a dummy (but valid) one.
+func (ic *InstallConfig) PullSecret() string {
+	pullSecret := defaultPullSecret
+	if ic.config.PullSecret != "" {
+		pullSecret = ic.config.PullSecret
+	}
+	return pullSecret
+}
+
+// SSHKey return the configure ssh key.
+func (ic *InstallConfig) SSHKey() string {
+	return ic.config.SSHKey
+}
+
+// RendezvousIP returns the configured rendezvous IP.
+func (ic *InstallConfig) RendezvousIP() string {
+	return ic.config.RendezvousIP
+}
+
+// Operators returns the list of OLM operators to be installed.
+func (ic *InstallConfig) Operators() []string {
+	return ic.config.Operators
+}

--- a/pkg/asset/agent/manifests/agentpullsecret.go
+++ b/pkg/asset/agent/manifests/agentpullsecret.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/asset/agent/interactive"
 	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/validate"
@@ -47,6 +48,7 @@ func (*AgentPullSecret) Dependencies() []asset.Asset {
 		&workflow.AgentWorkflow{},
 		&joiner.ClusterInfo{},
 		&agent.OptionalInstallConfig{},
+		&interactive.InstallConfig{},
 	}
 }
 
@@ -55,6 +57,7 @@ func (a *AgentPullSecret) Generate(_ context.Context, dependencies asset.Parents
 	agentWorkflow := &workflow.AgentWorkflow{}
 	installConfig := &agent.OptionalInstallConfig{}
 	clusterInfo := &joiner.ClusterInfo{}
+	interactiveInstallConfig := &interactive.InstallConfig{}
 	dependencies.Get(agentWorkflow, installConfig, clusterInfo)
 
 	switch agentWorkflow.Workflow {
@@ -65,6 +68,9 @@ func (a *AgentPullSecret) Generate(_ context.Context, dependencies asset.Parents
 
 	case workflow.AgentWorkflowTypeAddNodes:
 		a.generateSecret(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.PullSecret)
+
+	case workflow.AgentWorkflowTypeInstallInteractiveDisconnected:
+		a.generateSecret(interactiveInstallConfig.ClusterName(), interactiveInstallConfig.ClusterNamespace(), interactiveInstallConfig.PullSecret())
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)

--- a/pkg/asset/agent/manifests/clusterimageset.go
+++ b/pkg/asset/agent/manifests/clusterimageset.go
@@ -57,7 +57,7 @@ func (a *ClusterImageSet) Generate(ctx context.Context, dependencies asset.Paren
 	dependencies.Get(releaseImage, installConfig, agentWorkflow, clusterInfo)
 
 	switch agentWorkflow.Workflow {
-	case workflow.AgentWorkflowTypeInstall:
+	case workflow.AgentWorkflowTypeInstall, workflow.AgentWorkflowTypeInstallInteractiveDisconnected:
 		currentVersion, err := version.Version()
 		if err != nil {
 			return err

--- a/pkg/asset/agent/workflow/agentworkflowinstallinteractivedisconnected.go
+++ b/pkg/asset/agent/workflow/agentworkflowinstallinteractivedisconnected.go
@@ -1,0 +1,31 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+// AgentWorkflowInstallInteractiveDisconnected is meant just to define
+// the add nodes workflow.
+type AgentWorkflowInstallInteractiveDisconnected struct {
+	AgentWorkflow
+}
+
+var _ asset.WritableAsset = (*AgentWorkflowInstallInteractiveDisconnected)(nil)
+
+// Name returns a human friendly name for the asset.
+func (*AgentWorkflowInstallInteractiveDisconnected) Name() string {
+	return "Agent Workflow Install Interactive Disconnected"
+}
+
+// Generate generates the AgentWorkflow asset.
+func (a *AgentWorkflowInstallInteractiveDisconnected) Generate(_ context.Context, dependencies asset.Parents) error {
+	a.Workflow = AgentWorkflowTypeInstallInteractiveDisconnected
+	a.File = &asset.File{
+		Filename: agentWorkflowFilename,
+		Data:     []byte(a.Workflow),
+	}
+
+	return nil
+}

--- a/pkg/asset/agent/workflow/commons.go
+++ b/pkg/asset/agent/workflow/commons.go
@@ -11,6 +11,11 @@ const (
 	AgentWorkflowTypeInstall AgentWorkflowType = "install"
 	// AgentWorkflowTypeAddNodes identifies the add nodes workflow.
 	AgentWorkflowTypeAddNodes AgentWorkflowType = "addnodes"
+	// AgentWorkflowTypeInstallInteractiveDisconnected identifies a specific kind of
+	// disconnected install workflow. The installation details will be provided through
+	// a dedicated UI running on the rendezvous node, and in addition no external registry
+	// will be required for an air-gapped deployment.
+	AgentWorkflowTypeInstallInteractiveDisconnected = "install-interactive-disconnected"
 
 	agentWorkflowFilename = ".agentworkflow"
 )


### PR DESCRIPTION
This patch adds a new (not public) preliminary version of the command to generate the ignition file required to support the interactive disconnected (registry-free) workflow. The ignition produced will be used by the builder script to generate the enhanced ISO image containing all the required OpenShift images.

A follow-up patch will add also the required integration tests, and the integration with the assisted UI.
(note: given the current work in progress also in the other epics, no effort has been done to reduce the code duplication with the `unconfigured-ignition` and `ignition` assets. Once the workflow/approach will be consolidated, a refactoring PR will follow up to clean it up better)

Required by:
* https://github.com/openshift/appliance/pull/335

Related to:
* https://github.com/openshift/agent-installer-utils/pull/38
* https://github.com/openshift-assisted/assisted-installer-ui/pull/2789