### PR TITLE
NO-ISSUE: Deduplicate shared IDS to IDMS conversion in installer manifests and imagebased installer

### DIFF
--- a/pkg/asset/imagebased/configimage/imagedigestmirrorset_test.go
+++ b/pkg/asset/imagebased/configimage/imagedigestmirrorset_test.go
@@ -12,6 +12,7 @@ import (
 
 	apicfgv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/mock"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -158,5 +159,5 @@ func imageDigestSources() []types.ImageDigestSource {
 }
 
 func imageDigestMirrorSet() *apicfgv1.ImageDigestMirrorSet {
-	return convertIDSToIDMS(imageDigestSources())
+	return manifests.ConvertImageDigestMirrorSet(imageDigestSources())
 }


### PR DESCRIPTION
This change deduplicates the conversion of the `installconfig.Config.ImageDigestSources` to an `ImageDigestMirrorSet` that is shared between the installer's `manifests` and the `imagebased` installer.

Related PR: https://github.com/openshift/installer/pull/9391