### PR TITLE
CORS-3919: Add GCP service endpoints to the infrastructure manifest

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3720,21 +3720,50 @@ spec:
                       There must be only one ServiceEndpoint for a service.
                     items:
                       description: |-
-                        ServiceEndpoint stores the configuration for services to
+                        GCPServiceEndpoint store the configuration of a custom url to
                         override existing defaults of GCP Services.
                       properties:
                         name:
                           description: |-
-                            Name is the name of the GCP service.
+                            name is the name of the GCP service whose endpoint is being overridden.
                             This must be provided and cannot be empty.
+
+                            Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
+                            Storage, and TagManager.
+
+                            As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
+                            Service will be directed to the endpoint specified in the url field.
+                          enum:
+                          - Compute
+                          - Container
+                          - CloudResourceManager
+                          - DNS
+                          - File
+                          - IAM
+                          - ServiceUsage
+                          - Storage
+                          - TagManager
                           type: string
                         url:
                           description: |-
-                            URL is fully qualified URI with scheme https, that overrides the default generated
-                            endpoint for a client.
-                            This must be provided and cannot be empty.
-                          pattern: ^https://
+                            url is a fully qualified URI that overrides the default endpoint for a client using the GCP service specified
+                            in the name field.
+                            url is required, must use the scheme https, must not be more than 253 characters in length,
+                            and must be a valid URL according to Go's net/url package (https://pkg.go.dev/net/url#URL)
+
+                            An example of a valid endpoint that overrides the Compute Service: "https://compute-myendpoint1.p.googleapis.com"
+                          maxLength: 253
                           type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid URL
+                            rule: isURL(self)
+                          - message: scheme must be https
+                            rule: 'isURL(self) ? (url(self).getScheme() == "https")
+                              : true'
+                          - message: url must consist only of a scheme and domain.
+                              The url path must be empty.
+                            rule: url(self).getEscapedPath() == "" || url(self).getEscapedPath()
+                              == "/"
                       required:
                       - name
                       - url

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -203,6 +203,13 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 			}
 			config.Status.PlatformStatus.GCP.ResourceTags = resourceTags
 		}
+
+		config.Status.PlatformStatus.GCP.ServiceEndpoints = installConfig.Config.Platform.GCP.ServiceEndpoints
+		sort.Slice(config.Status.PlatformStatus.GCP.ServiceEndpoints, func(i, j int) bool {
+			return config.Status.PlatformStatus.GCP.ServiceEndpoints[i].Name <
+				config.Status.PlatformStatus.GCP.ServiceEndpoints[j].Name
+		})
+
 		// If the user has requested the use of a DNS provisioned by them, then OpenShift needs to
 		// start an in-cluster DNS for the installation to succeed. The user can then configure their
 		// DNS post-install.

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -3,24 +3,8 @@ package gcp
 import (
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/dns"
-)
-
-const (
-	// CloudResourceManagerServiceName is the name and internal key for the cloud resource manager API endpoint.
-	CloudResourceManagerServiceName = "cloudresourcemanager"
-	// ComputeServiceName is the name and internal key for the compute API endpoint.
-	ComputeServiceName = "compute"
-	// DNSServiceName is the name and internal key for the DNS API endpoint.
-	DNSServiceName = "dns"
-	// FileServiceName is the name and internal key for the file API endpoint.
-	FileServiceName = "file"
-	// IAMServiceName is the name and internal key for the IAM API endpoint.
-	IAMServiceName = "iam"
-	// ServiceUsageServiceName is the name and internal key for the service usage API endpoint.
-	ServiceUsageServiceName = "serviceusage"
-	// StorageServiceName is the name and internal key for the storage API endpoint.
-	StorageServiceName = "storage"
 )
 
 // Platform stores all the global configuration that all machinesets
@@ -80,22 +64,7 @@ type Platform struct {
 	// service endpoint of GCP Services.
 	// There must be only one ServiceEndpoint for a service.
 	// +optional
-	ServiceEndpoints []ServiceEndpoint `json:"serviceEndpoints,omitempty"`
-}
-
-// ServiceEndpoint stores the configuration for services to
-// override existing defaults of GCP Services.
-type ServiceEndpoint struct {
-	// Name is the name of the GCP service.
-	// This must be provided and cannot be empty.
-	Name string `json:"name"`
-
-	// URL is fully qualified URI with scheme https, that overrides the default generated
-	// endpoint for a client.
-	// This must be provided and cannot be empty.
-	//
-	// +kubebuilder:validation:Pattern=`^https://`
-	URL string `json:"url"`
+	ServiceEndpoints []configv1.GCPServiceEndpoint `json:"serviceEndpoints,omitempty"`
 }
 
 // UserLabel is a label to apply to GCP resources created for the cluster.

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
@@ -80,13 +81,15 @@ var (
 	userLabelKeyPrefixRegex = regexp.MustCompile(`^(?i)(kubernetes\-io|openshift\-io)`)
 
 	supportedEndpointNames = sets.New(
-		gcp.CloudResourceManagerServiceName,
-		gcp.ComputeServiceName,
-		gcp.DNSServiceName,
-		gcp.FileServiceName,
-		gcp.IAMServiceName,
-		gcp.ServiceUsageServiceName,
-		gcp.StorageServiceName,
+		configv1.GCPServiceEndpointNameCompute,
+		configv1.GCPServiceEndpointNameContainer,
+		configv1.GCPServiceEndpointNameCloudResource,
+		configv1.GCPServiceEndpointNameDNS,
+		configv1.GCPServiceEndpointNameFile,
+		configv1.GCPServiceEndpointNameIAM,
+		configv1.GCPServiceEndpointNameServiceUsage,
+		configv1.GCPServiceEndpointNameStorage,
+		configv1.GCPServiceEndpointNameTagManager,
 	)
 )
 
@@ -175,9 +178,9 @@ func validateLabel(key, value string) error {
 	return nil
 }
 
-func validateServiceEndpoints(endpoints []gcp.ServiceEndpoint, fldPath *field.Path) field.ErrorList {
+func validateServiceEndpoints(endpoints []configv1.GCPServiceEndpoint, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	tracker := map[string]int{}
+	tracker := map[configv1.GCPServiceEndpointName]int{}
 	for idx, e := range endpoints {
 		fldp := fldPath.Index(idx)
 		if !supportedEndpointNames.Has(e.Name) {

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
@@ -157,7 +158,7 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid gcp endpoint blank name",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
 						Name: "",
 						URL:  "https://my-custom-endpoint.example.com/copmute/v1/",
@@ -170,7 +171,7 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid gcp endpoint invalid name",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
 						Name: "badname",
 						URL:  "https://my-custom-endpoint.example.com/copmute/v1/",
@@ -183,13 +184,13 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid gcp endpoint duplicate name",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "https://my-custom-endpoint.example.com/compute/v1/",
 					},
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "https://my-custom-endpoint.example.com/compute/v2/",
 					},
 				},
@@ -200,9 +201,9 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid gcp endpoint url blank",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "",
 					},
 				},
@@ -213,9 +214,9 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid scheme gcp endpoint url",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "http://my-custom-endpoint.example.com/compute/v1/",
 					},
 				},
@@ -226,9 +227,9 @@ func TestValidatePlatform(t *testing.T) {
 			name: "valid gcp endpoint",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "https://my-custom-endpoint.example.com/compute/v1/",
 					},
 				},
@@ -239,9 +240,9 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid gcp endpoint relative path",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "/compute/v1/",
 					},
 				},
@@ -252,9 +253,9 @@ func TestValidatePlatform(t *testing.T) {
 			name: "valid gcp endpoint url no scheme",
 			platform: &gcp.Platform{
 				Region: "us-east1",
-				ServiceEndpoints: []gcp.ServiceEndpoint{
+				ServiceEndpoints: []configv1.GCPServiceEndpoint{
 					{
-						Name: "compute",
+						Name: configv1.GCPServiceEndpointNameCompute,
 						URL:  "my-custom-endpoint.example.com/compute/v1/",
 					},
 				},

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/dns"
-	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -33,9 +32,9 @@ func TestFeatureGates(t *testing.T) {
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.GCP = validGCPPlatform()
-				c.GCP.ServiceEndpoints = []gcp.ServiceEndpoint{
+				c.GCP.ServiceEndpoints = []v1.GCPServiceEndpoint{
 					{
-						Name: gcp.ComputeServiceName,
+						Name: v1.GCPServiceEndpointNameCompute,
 						URL:  "https://compute.googleapis.com",
 					},
 				}


### PR DESCRIPTION
** The manifest will contain the service endpoints originally in the install config. 
** Validation for these service endpoint additions to the manifests will occur.