### PR TITLE
[release-4.17] OCPBUGS-43708: RendezvousIP should never be proxied

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
@@ -7,10 +7,15 @@ stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
 exists $WORK/agent.x86_64.iso
 exists $WORK/auth/kubeconfig
 exists $WORK/auth/kubeadmin-password
+isocmp agent.x86_64.iso /etc/systemd/system.conf.d/10-default-env.conf expected/10-default-env.conf
 
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
+proxy:
+  httpProxy: http://192.168.111.1:8215
+  httpsProxy: http://192.168.111.1:8215
+  noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
 controlPlane: 
   name: master
   replicas: 3
@@ -44,3 +49,9 @@ metadata:
   name: ostest
   namespace: cluster0
 rendezvousIP: 192.168.111.20
+
+-- expected/10-default-env.conf --
+[Manager]
+DefaultEnvironment=HTTP_PROXY="http://192.168.111.1:8215"
+DefaultEnvironment=HTTPS_PROXY="http://192.168.111.1:8215"
+DefaultEnvironment=NO_PROXY="172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24"

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -76,7 +76,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:
@@ -135,7 +135,7 @@ spec:
   proxy:
     httpProxy: http://192.168.111.1:8215
     httpsProxy: http://192.168.111.1:8215
-    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.0/24
   pullSecretRef:
     name: ostest-pull-secret
   sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=

--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -14,6 +14,10 @@ existsInIso agent.x86_64.iso /etc/assisted/manifests/pull-secret.yaml
 -- install-config.yaml --
 apiVersion: v1
 baseDomain: test.metalkube.org
+proxy:
+  httpProxy: http://192.168.111.1:8215
+  httpsProxy: http://192.168.111.1:8215
+  noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org
 controlPlane: 
   name: master
   replicas: 1
@@ -69,6 +73,10 @@ spec:
   platformType: None
   provisionRequirements:
     controlPlaneAgents: 1
+  proxy:
+    httpProxy: http://192.168.111.1:8215
+    httpsProxy: http://192.168.111.1:8215
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 status:
   debugInfo:
@@ -124,6 +132,10 @@ spec:
   nmStateConfigLabelSelector:
     matchLabels:
       infraenvs.agent-install.openshift.io: ostest
+  proxy:
+    httpProxy: http://192.168.111.1:8215
+    httpsProxy: http://192.168.111.1:8215
+    noProxy: 172.22.0.0/24,virthost.ostest.test.metalkube.org,192.168.111.20
   pullSecretRef:
     name: ostest-pull-secret
   sshAuthorizedKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -234,7 +234,7 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 				rendezvousIP = agentConfig.Config.RendezvousIP
 			}
 
-			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy, rendezvousIP))
+			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig.Config.Proxy, &installConfig.Config.Networking.MachineNetwork, rendezvousIP))
 		}
 
 		if installConfig.Config.Platform.BareMetal != nil {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"context"
+	"net"
 	"os"
 	"testing"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 	"github.com/openshift/installer/pkg/asset/mock"
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	externaltype "github.com/openshift/installer/pkg/types/external"
 )
@@ -38,11 +40,18 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 		installConfigOverrides: `{"fips":true}`,
 	})
 
+	_, machineNetCidr, _ := net.ParseCIDR("192.168.122.0/16") //nolint:errcheck
+	machineNetwork := []types.MachineNetworkEntry{
+		{
+			CIDR: ipnet.IPNet{IPNet: *machineNetCidr},
+		},
+	}
+
 	installConfigWithProxy := getValidOptionalInstallConfig()
-	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, ""))
+	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, &machineNetwork, "192.168.122.2"))
 
 	goodProxyACI := getGoodACI()
-	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"))
+	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, &machineNetwork, "192.168.122.2"))
 
 	goodACIDualStackVIPs := getGoodACIDualStack()
 	goodACIDualStackVIPs.Spec.APIVIPs = []string{"192.168.122.10", "2001:db8:1111:2222:ffff:ffff:ffff:cafe"}

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -39,10 +39,10 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	})
 
 	installConfigWithProxy := getValidOptionalInstallConfig()
-	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy))
+	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, ""))
 
 	goodProxyACI := getGoodACI()
-	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy))
+	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"))
 
 	goodACIDualStackVIPs := getGoodACIDualStack()
 	goodACIDualStackVIPs.Spec.APIVIPs = []string{"192.168.122.10", "2001:db8:1111:2222:ffff:ffff:ffff:cafe"}
@@ -141,6 +141,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				&agent.OptionalInstallConfig{},
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedError: "missing configuration or manifest file",
 		},
@@ -150,6 +151,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfig(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACI,
 		},
@@ -159,6 +161,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithoutNetworkType,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACI,
 		},
@@ -168,6 +171,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithFIPS,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodFIPSACI,
 		},
@@ -177,6 +181,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithProxy,
 				&agentconfig.AgentHosts{},
+				getValidAgentConfig(),
 			},
 			expectedConfig: goodProxyACI,
 		},
@@ -186,6 +191,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigDualStack(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: getGoodACIDualStack(),
 		},
@@ -195,6 +201,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigDualStackDualVIPs(),
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodACIDualStackVIPs,
 		},
@@ -204,6 +211,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithCapabilities,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodCapabilitiesACI,
 		},
@@ -213,6 +221,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithNetworkOverride,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodNetworkOverrideACI,
 		},
@@ -222,6 +231,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWithCPUPartitioning,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodCPUPartitioningACI,
 		},
@@ -231,6 +241,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWExternalPlatform,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodExternalPlatformACI,
 		},
@@ -240,6 +251,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				installConfigWExternalOCIPlatform,
 				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodExternalOCIPlatformACI,
 		},
@@ -249,6 +261,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
 				getValidOptionalInstallConfigWithProvisioning(),
 				getAgentHostsWithBMCConfig(),
+				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodBaremetalPlatformBMCACI,
 		},

--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/types"
@@ -19,11 +21,20 @@ func getPullSecretName(clusterName string) string {
 	return clusterName + "-pull-secret"
 }
 
-func getProxy(proxy *types.Proxy) *aiv1beta1.Proxy {
+func getProxy(proxy *types.Proxy, rendezvousIP string) *aiv1beta1.Proxy {
+	// if proxy set add the rendezvousIP to noproxy
+	noProxy := proxy.NoProxy
+	if (proxy.HTTPProxy != "" || proxy.HTTPSProxy != "") && rendezvousIP != "" {
+		if noProxy == "" {
+			noProxy = rendezvousIP
+		} else {
+			noProxy = fmt.Sprintf("%s,%s", noProxy, rendezvousIP)
+		}
+	}
 	return &aiv1beta1.Proxy{
 		HTTPProxy:  proxy.HTTPProxy,
 		HTTPSProxy: proxy.HTTPSProxy,
-		NoProxy:    proxy.NoProxy,
+		NoProxy:    noProxy,
 	}
 }
 

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -65,7 +65,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		if installConfig.Config != nil {
-			err := i.generateManifest(installConfig.ClusterName(), installConfig.ClusterNamespace(), installConfig.Config.SSHKey, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy, string(installConfig.Config.ControlPlane.Architecture), rendezvousIP)
+			err := i.generateManifest(installConfig.ClusterName(), installConfig.ClusterNamespace(), installConfig.Config.SSHKey, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy, string(installConfig.Config.ControlPlane.Architecture), &installConfig.Config.Networking.MachineNetwork, rendezvousIP)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 		}
 
 	case workflow.AgentWorkflowTypeAddNodes:
-		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.UserCaBundle, clusterInfo.Proxy, clusterInfo.Architecture, rendezvousIP)
+		err := i.generateManifest(clusterInfo.ClusterName, clusterInfo.Namespace, clusterInfo.SSHKey, clusterInfo.UserCaBundle, clusterInfo.Proxy, clusterInfo.Architecture, nil, rendezvousIP)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (i *InfraEnv) Generate(_ context.Context, dependencies asset.Parents) error
 	return i.finish()
 }
 
-func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, additionalTrustBundle string, proxy *types.Proxy, architecture, rendezvousIP string) error {
+func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, additionalTrustBundle string, proxy *types.Proxy, architecture string, machineNetwork *[]types.MachineNetworkEntry, rendezvousIP string) error {
 	infraEnv := &aiv1beta1.InfraEnv{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "InfraEnv",
@@ -122,7 +122,7 @@ func (i *InfraEnv) generateManifest(clusterName, clusterNamespace, sshKey, addit
 		infraEnv.Spec.AdditionalTrustBundle = additionalTrustBundle
 	}
 	if proxy != nil {
-		infraEnv.Spec.Proxy = getProxy(proxy, rendezvousIP)
+		infraEnv.Spec.Proxy = getProxy(proxy, machineNetwork, rendezvousIP)
 	}
 
 	i.Config = infraEnv

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -91,7 +91,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 					Namespace: getProxyValidOptionalInstallConfig().ClusterNamespace(),
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
-					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy),
+					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"),
 					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig().ClusterName()),
@@ -124,7 +124,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 					Namespace: getProxyValidOptionalInstallConfig().ClusterNamespace(),
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
-					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy),
+					Proxy:            getProxy(getProxyValidOptionalInstallConfig().Config.Proxy, "192.168.122.2"),
 					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig().ClusterName()),

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -242,6 +242,12 @@ func getValidAgentConfig() *agentconfig.AgentConfig {
 	}
 }
 
+func getValidAgentConfigProxy() *agentconfig.AgentConfig {
+	agentConfig := getValidAgentConfig()
+	agentConfig.Config.RendezvousIP = "10.10.11.1"
+	return agentConfig
+}
+
 func getValidAgentHostsConfig() *agentconfig.AgentHosts {
 	return &agentconfig.AgentHosts{
 		Hosts: []agenttypes.Host{


### PR DESCRIPTION
Backport of https://github.com/openshift/installer/pull/9083 and https://github.com/openshift/installer/pull/9153