### PR TITLE
OCPBUGS-51378: Change vsphere conversion govmomi err to be clear

### DIFF
--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -48,7 +48,12 @@ func GetFinder(server, username, password string) (*find.Finder, error) {
 			// If bogus authentication is provided in the scenario of AI or assisted
 			// just provide warning message. If this is IPI or UPI validation will
 			// catch and halt on incorrect authentication.
-			localLogger.Warnf("unable to log into vCenter %s, %v", server, err)
+
+			localLogger.Debugf("this can be safely ignored if non-deprecated platform spec fields are used"+
+				"or installing via UPI, Assisted or Agent Installer. "+
+				"Conversion of deprecated platform spec fields cannot continue without vCenter %s access, error: %v",
+				server, err)
+
 			return nil, nil
 		}
 		finder = find.NewFinder(client.Client, true)


### PR DESCRIPTION
This commit changes the govmomi error to be more clear in scenarios of UPI, AI and Assisted.