### PR TITLE
OCPBUGS-51171: aws: add ec2:ReplaceRoute permission

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -256,6 +256,8 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:CreateVpcEndpoint",
 		"ec2:ModifySubnetAttribute",
 		"ec2:ModifyVpcAttribute",
+		// Needed by CAPA to update outdated routes
+		"ec2:ReplaceRoute",
 	},
 	// Permissions required for deleting network resources
 	PermissionDeleteNetworking: {


### PR DESCRIPTION
When the installer manages/creates VPC, it might need to update outdated routes in the route table. For example, see issue [0].

Note: in the case of byo (unmanaged) VPC, CAPA does not reconcile the route table, thus not requiring the permissions [1].

References

[0] https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1413
[1] https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/4e912b4e4d1f855abf9b5194acaf9f31b5763c57/pkg/cloud/services/network/routetables.go#L43-L44