### PR TITLE
OCPBUGS-36553: VSphere: add vips to machinenetwork

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -279,11 +279,12 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 		}
 
 		config.Spec.PlatformSpec.VSphere = vsphereinfra.GetInfraPlatformSpec(installConfig, clusterID.InfraID)
-		if _, exists := cloudproviderconfig.ConfigMap.Data["vsphere.conf"]; exists {
-			cloudProviderConfigMapKey = "vsphere.conf"
+		if cloudproviderconfig.ConfigMap != nil {
+			if _, exists := cloudproviderconfig.ConfigMap.Data["vsphere.conf"]; exists {
+				cloudProviderConfigMapKey = "vsphere.conf"
+			}
 		}
-
-		config.Status.PlatformStatus.VSphere.MachineNetworks = types.MachineNetworksToCIDRs(installConfig.Config.MachineNetwork)
+		config.Status.PlatformStatus.VSphere.MachineNetworks = config.Spec.PlatformSpec.VSphere.MachineNetworks
 	case ovirt.Name:
 		config.Spec.PlatformSpec.Type = configv1.OvirtPlatformType
 		config.Status.PlatformStatus.Ovirt = &configv1.OvirtPlatformStatus{

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -268,8 +268,6 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 		config.Spec.PlatformSpec.VSphere = &configv1.VSpherePlatformSpec{}
 		if len(installConfig.Config.VSphere.APIVIPs) > 0 {
 			config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{
-				APIServerInternalIP:  installConfig.Config.VSphere.APIVIPs[0],
-				IngressIP:            installConfig.Config.VSphere.IngressVIPs[0],
 				APIServerInternalIPs: installConfig.Config.VSphere.APIVIPs,
 				IngressIPs:           installConfig.Config.VSphere.IngressVIPs,
 				LoadBalancer:         installConfig.Config.VSphere.LoadBalancer,

--- a/pkg/asset/manifests/infrastructure_test.go
+++ b/pkg/asset/manifests/infrastructure_test.go
@@ -508,9 +508,6 @@ func (b infraBuildNamespace) withVSphereAPIVIP(vip string) infraOption {
 		b.withVSpherePlatformStatus()(infra)
 		infra.Spec.PlatformSpec.VSphere.APIServerInternalIPs = append(infra.Spec.PlatformSpec.VSphere.APIServerInternalIPs, configv1.IP(vip))
 		infra.Status.PlatformStatus.VSphere.APIServerInternalIPs = append(infra.Status.PlatformStatus.VSphere.APIServerInternalIPs, vip)
-		if infra.Status.PlatformStatus.VSphere.APIServerInternalIP == "" {
-			infra.Status.PlatformStatus.VSphere.APIServerInternalIP = vip
-		}
 	}
 }
 
@@ -520,8 +517,5 @@ func (b infraBuildNamespace) withVSphereIngressVIP(vip string) infraOption {
 		b.withVSpherePlatformStatus()(infra)
 		infra.Spec.PlatformSpec.VSphere.IngressIPs = append(infra.Spec.PlatformSpec.VSphere.IngressIPs, configv1.IP(vip))
 		infra.Status.PlatformStatus.VSphere.IngressIPs = append(infra.Status.PlatformStatus.VSphere.IngressIPs, vip)
-		if infra.Status.PlatformStatus.VSphere.IngressIP == "" {
-			infra.Status.PlatformStatus.VSphere.IngressIP = vip
-		}
 	}
 }

--- a/pkg/asset/manifests/infrastructure_test.go
+++ b/pkg/asset/manifests/infrastructure_test.go
@@ -11,12 +11,23 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/dns"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	nonetypes "github.com/openshift/installer/pkg/types/none"
+	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
+)
+
+const (
+	defaultMachineNetwork = "10.0.0.0/16"
+	ipv6MachineNetwork    = "2001:db8::/32"
+	ipv4APIVIP            = "192.168.1.0"
+	ipv4IngressVIP        = "192.168.222.4"
+	ipv6APIVIP            = "fe80::1"
+	ipv6IngressVIP        = "fe80::2"
 )
 
 func TestGenerateInfrastructure(t *testing.T) {
@@ -110,7 +121,50 @@ func TestGenerateInfrastructure(t *testing.T) {
 				infraBuild.withAWSPlatformStatus(),
 			),
 			expectedFilesGenerated: 1,
-		}}
+		}, {
+			name: "vsphere with VIPs appended to machine networks",
+			installConfig: icBuild.build(
+				icBuild.forVSphere(),
+				icBuild.withMachineNetwork(defaultMachineNetwork),
+				icBuild.withVSphereAPIVIP(ipv4APIVIP),
+				icBuild.withVSphereIngressVIP(ipv4IngressVIP),
+			),
+			expectedInfrastructure: infraBuild.build(
+				infraBuild.forPlatform(configv1.VSpherePlatformType),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(defaultMachineNetwork)),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv4APIVIP+"/32")),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv4IngressVIP+"/32")),
+				infraBuild.withVSphereAPIVIP(ipv4APIVIP),
+				infraBuild.withVSphereIngressVIP(ipv4IngressVIP),
+			),
+			expectedFilesGenerated: 1,
+		}, {
+			name: "dual stack vsphere with VIPs appended to machine networks",
+			installConfig: icBuild.build(
+				icBuild.forVSphere(),
+				icBuild.withMachineNetwork(defaultMachineNetwork),
+				icBuild.withMachineNetwork(ipv6MachineNetwork),
+				icBuild.withVSphereAPIVIP(ipv4APIVIP),
+				icBuild.withVSphereIngressVIP(ipv4IngressVIP),
+				icBuild.withVSphereAPIVIP(ipv6APIVIP),
+				icBuild.withVSphereIngressVIP(ipv6IngressVIP),
+			),
+			expectedInfrastructure: infraBuild.build(
+				infraBuild.forPlatform(configv1.VSpherePlatformType),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(defaultMachineNetwork)),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv6MachineNetwork)),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv4APIVIP+"/32")),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv6APIVIP+"/128")),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv4IngressVIP+"/32")),
+				infraBuild.withVSphereMachineNetworkEntry(configv1.CIDR(ipv6IngressVIP+"/128")),
+				infraBuild.withVSphereAPIVIP(ipv4APIVIP),
+				infraBuild.withVSphereIngressVIP(ipv4IngressVIP),
+				infraBuild.withVSphereAPIVIP(ipv6APIVIP),
+				infraBuild.withVSphereIngressVIP(ipv6IngressVIP),
+			),
+			expectedFilesGenerated: 1,
+		},
+	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			parents := asset.Parents{}
@@ -190,6 +244,26 @@ func (b icBuildNamespace) forNone() icOption {
 	}
 }
 
+func (b icBuildNamespace) forVSphere() icOption {
+	return func(ic *types.InstallConfig) {
+		if ic.Platform.VSphere != nil {
+			return
+		}
+		ic.Platform.VSphere = &vspheretypes.Platform{}
+	}
+}
+
+func (b icBuildNamespace) withMachineNetwork(cidr string) icOption {
+	return func(ic *types.InstallConfig) {
+		b.forVSphere()(ic)
+		if ic.Networking == nil {
+			ic.Networking = &types.Networking{}
+		}
+		mn := types.MachineNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)}
+		ic.Networking.MachineNetwork = append(ic.Networking.MachineNetwork, mn)
+	}
+}
+
 func (b icBuildNamespace) withAWSServiceEndpoint(name, url string) icOption {
 	return func(ic *types.InstallConfig) {
 		b.forAWS()(ic)
@@ -234,6 +308,20 @@ func (b icBuildNamespace) withAWSUserProvisionedDNS(enabled string) icOption {
 			ic.Platform.AWS.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
 			ic.FeatureGates = []string{"AWSClusterHostedDNS=true"}
 		}
+	}
+}
+
+func (b icBuildNamespace) withVSphereAPIVIP(vip string) icOption {
+	return func(ic *types.InstallConfig) {
+		b.forVSphere()(ic)
+		ic.Platform.VSphere.APIVIPs = append(ic.Platform.VSphere.APIVIPs, vip)
+	}
+}
+
+func (b icBuildNamespace) withVSphereIngressVIP(vip string) icOption {
+	return func(ic *types.InstallConfig) {
+		b.forVSphere()(ic)
+		ic.Platform.VSphere.IngressVIPs = append(ic.Platform.VSphere.IngressVIPs, vip)
 	}
 }
 
@@ -383,6 +471,57 @@ func (b infraBuildNamespace) withAWSClusterHostedDNS(enabled string) infraOption
 		}
 		if enabled == "Enabled" {
 			infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.DNSType = configv1.ClusterHostedDNSType
+		}
+	}
+}
+
+func (b infraBuildNamespace) withVSpherePlatformSpec() infraOption {
+	return func(infra *configv1.Infrastructure) {
+		if infra.Spec.PlatformSpec.VSphere != nil {
+			return
+		}
+		infra.Spec.PlatformSpec.VSphere = &configv1.VSpherePlatformSpec{}
+	}
+}
+
+func (b infraBuildNamespace) withVSpherePlatformStatus() infraOption {
+	return func(infra *configv1.Infrastructure) {
+		if infra.Status.PlatformStatus.VSphere != nil {
+			return
+		}
+		infra.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{}
+	}
+}
+
+func (b infraBuildNamespace) withVSphereMachineNetworkEntry(cidr configv1.CIDR) infraOption {
+	return func(infra *configv1.Infrastructure) {
+		b.withVSpherePlatformSpec()(infra)
+		b.withVSpherePlatformStatus()(infra)
+		infra.Spec.PlatformSpec.VSphere.MachineNetworks = append(infra.Spec.PlatformSpec.VSphere.MachineNetworks, cidr)
+		infra.Status.PlatformStatus.VSphere.MachineNetworks = append(infra.Status.PlatformStatus.VSphere.MachineNetworks, cidr)
+	}
+}
+
+func (b infraBuildNamespace) withVSphereAPIVIP(vip string) infraOption {
+	return func(infra *configv1.Infrastructure) {
+		b.withVSpherePlatformSpec()(infra)
+		b.withVSpherePlatformStatus()(infra)
+		infra.Spec.PlatformSpec.VSphere.APIServerInternalIPs = append(infra.Spec.PlatformSpec.VSphere.APIServerInternalIPs, configv1.IP(vip))
+		infra.Status.PlatformStatus.VSphere.APIServerInternalIPs = append(infra.Status.PlatformStatus.VSphere.APIServerInternalIPs, vip)
+		if infra.Status.PlatformStatus.VSphere.APIServerInternalIP == "" {
+			infra.Status.PlatformStatus.VSphere.APIServerInternalIP = vip
+		}
+	}
+}
+
+func (b infraBuildNamespace) withVSphereIngressVIP(vip string) infraOption {
+	return func(infra *configv1.Infrastructure) {
+		b.withVSpherePlatformSpec()(infra)
+		b.withVSpherePlatformStatus()(infra)
+		infra.Spec.PlatformSpec.VSphere.IngressIPs = append(infra.Spec.PlatformSpec.VSphere.IngressIPs, configv1.IP(vip))
+		infra.Status.PlatformStatus.VSphere.IngressIPs = append(infra.Status.PlatformStatus.VSphere.IngressIPs, vip)
+		if infra.Status.PlatformStatus.VSphere.IngressIP == "" {
+			infra.Status.PlatformStatus.VSphere.IngressIP = vip
 		}
 	}
 }

--- a/pkg/asset/manifests/vsphere/infrastructure.go
+++ b/pkg/asset/manifests/vsphere/infrastructure.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	utilsnet "k8s.io/utils/net"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
@@ -75,6 +76,8 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig, clusterID string) *co
 	platformSpec.APIServerInternalIPs = types.StringsToIPs(icPlatformSpec.APIVIPs)
 	platformSpec.IngressIPs = types.StringsToIPs(icPlatformSpec.IngressVIPs)
 	platformSpec.MachineNetworks = types.MachineNetworksToCIDRs(ic.Config.MachineNetwork)
+	platformSpec.MachineNetworks = append(platformSpec.MachineNetworks, vipsToCIDRs(ic.Config.VSphere.APIVIPs)...)
+	platformSpec.MachineNetworks = append(platformSpec.MachineNetworks, vipsToCIDRs(ic.Config.VSphere.IngressVIPs)...)
 
 	if ic.Config.EnabledFeatureGates().Enabled(features.FeatureGateVSphereMultiNetworks) {
 		logrus.Debug("Multi-networks feature gate enabled")
@@ -97,4 +100,17 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig, clusterID string) *co
 		}
 	}
 	return &platformSpec
+}
+
+// vipsToCIDRs takes a single ip address and converts it to CIDR notation.
+func vipsToCIDRs(vips []string) []configv1.CIDR {
+	cidrs := make([]configv1.CIDR, len(vips))
+	for i, vip := range vips {
+		mask := "/32"
+		if utilsnet.IsIPv6String(vip) {
+			mask = "/128"
+		}
+		cidrs[i] = configv1.CIDR(vip + mask)
+	}
+	return cidrs
 }


### PR DESCRIPTION
Appends the ingress and api vips to the machinenetworks in the cluster infrastructure object, because the cluster network operator checks to ensure that the machinenetwork contains those vips. In some edge cases we have seen valid configurations fail when the VIPs appear to be outside the valid range.

Here are some dumps of what the infrastructure manifest looks like (these were captured during unit tests):

## Single Stack

### Spec:

```
    APIServerInternalIPs: ([]v1.IP) (len=1 cap=1) {
     (v1.IP) (len=11) "192.168.1.0"
    },
    IngressIPs: ([]v1.IP) (len=1 cap=1) {
     (v1.IP) (len=13) "192.168.222.4"
    },
    MachineNetworks: ([]v1.CIDR) (len=3 cap=4) {
     (v1.CIDR) (len=11) "10.0.0.0/16",
     (v1.CIDR) (len=14) "192.168.1.0/32",
     (v1.CIDR) (len=16) "192.168.222.4/32"
    }
```

### Status:

```
    APIServerInternalIP: (string) (len=11) "192.168.1.0",
    APIServerInternalIPs: ([]string) (len=1 cap=1) {
     (string) (len=11) "192.168.1.0"
    },
    IngressIP: (string) (len=13) "192.168.222.4",
    IngressIPs: ([]string) (len=1 cap=1) {
     (string) (len=13) "192.168.222.4"
    },
    NodeDNSIP: (string) "",
    LoadBalancer: (*v1.VSpherePlatformLoadBalancer)(<nil>),
    MachineNetworks: ([]v1.CIDR) (len=3 cap=4) {
     (v1.CIDR) (len=11) "10.0.0.0/16",
     (v1.CIDR) (len=14) "192.168.1.0/32",
     (v1.CIDR) (len=16) "192.168.222.4/32"
    }
```

## Dual Stack

### Spec

```
      APIServerInternalIPs: ([]v1.IP) (len=2 cap=2) {
       (v1.IP) (len=11) "192.168.1.0",
       (v1.IP) (len=7) "fe80::1"
      },
      IngressIPs: ([]v1.IP) (len=2 cap=2) {
       (v1.IP) (len=13) "192.168.222.4",
       (v1.IP) (len=7) "fe80::2"
      },
      MachineNetworks: ([]v1.CIDR) (len=6 cap=8) {
       (v1.CIDR) (len=11) "10.0.0.0/16",
       (v1.CIDR) (len=9) "fe80::/10",
       (v1.CIDR) (len=14) "192.168.1.0/32",
       (v1.CIDR) (len=10) "fe80::1/64",
       (v1.CIDR) (len=16) "192.168.222.4/32",
       (v1.CIDR) (len=10) "fe80::2/64"
      }
```

### Status

```
      APIServerInternalIP: (string) (len=11) "192.168.1.0",
      APIServerInternalIPs: ([]string) (len=2 cap=2) {
       (string) (len=11) "192.168.1.0",
       (string) (len=7) "fe80::1"
      },
      IngressIP: (string) (len=13) "192.168.222.4",
      IngressIPs: ([]string) (len=2 cap=2) {
       (string) (len=13) "192.168.222.4",
       (string) (len=7) "fe80::2"
      },
      NodeDNSIP: (string) "",
      LoadBalancer: (*v1.VSpherePlatformLoadBalancer)(<nil>),
      MachineNetworks: ([]v1.CIDR) (len=6 cap=8) {
       (v1.CIDR) (len=11) "10.0.0.0/16",
       (v1.CIDR) (len=9) "fe80::/10",
       (v1.CIDR) (len=14) "192.168.1.0/32",
       (v1.CIDR) (len=10) "fe80::1/64",
       (v1.CIDR) (len=16) "192.168.222.4/32",
       (v1.CIDR) (len=10) "fe80::2/64"
      }
```
/cc @mkowalski @jcpowermac @rvanderp3 