### PR TITLE
OCPEDGE-1635: Set default values for arbiter

### DIFF
--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -68,6 +68,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 	c.ControlPlane.Name = "master"
 	SetMachinePoolDefaults(c.ControlPlane, c.Platform.Name())
 
+	if c.Arbiter != nil {
+		c.Arbiter.Name = "arbiter"
+		SetMachinePoolDefaults(c.Arbiter, c.Platform.Name())
+	}
+
 	defaultComputePoolUndefined := true
 	for _, compute := range c.Compute {
 		if compute.Name == types.MachinePoolComputeRoleName {

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -201,6 +201,17 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 			expected: defaultInstallConfig(),
 		},
 		{
+			name: "arbiter present",
+			config: &types.InstallConfig{
+				Arbiter: &types.MachinePool{},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Arbiter = defaultMachinePoolWithReplicaCount("arbiter", 0)
+				return c
+			}(),
+		},
+		{
 			name: "Compute present",
 			config: &types.InstallConfig{
 				Compute: []types.MachinePool{{Name: "worker"}},

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -8,7 +8,7 @@ import (
 // SetMachinePoolDefaults sets the defaults for the machine pool.
 func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	defaultReplicaCount := int64(3)
-	if p.Name == types.MachinePoolEdgeRoleName {
+	if p.Name == types.MachinePoolEdgeRoleName || p.Name == types.MachinePoolArbiterRoleName {
 		defaultReplicaCount = 0
 	}
 	if p.Replicas == nil {

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/installer/pkg/types"
 )
 
-func defaultMachinePool(name string) *types.MachinePool {
-	repCount := int64(3)
+func defaultMachinePoolWithReplicaCount(name string, replicaCount int) *types.MachinePool {
+	repCount := int64(replicaCount)
 	return &types.MachinePool{
 		Name:           name,
 		Replicas:       &repCount,
@@ -18,11 +18,12 @@ func defaultMachinePool(name string) *types.MachinePool {
 	}
 }
 
+func defaultMachinePool(name string) *types.MachinePool {
+	return defaultMachinePoolWithReplicaCount(name, 3)
+}
+
 func defaultEdgeMachinePool(name string) *types.MachinePool {
-	pool := defaultMachinePool(name)
-	defaultEdgeReplicaCount := int64(0)
-	pool.Replicas = &defaultEdgeReplicaCount
-	return pool
+	return defaultMachinePoolWithReplicaCount(name, 0)
 }
 
 func TestSetMahcinePoolDefaults(t *testing.T) {
@@ -42,6 +43,16 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 			name:     "empty",
 			pool:     &types.MachinePool{Replicas: &defaultEdgeReplicaCount},
 			expected: defaultEdgeMachinePool(""),
+		},
+		{
+			name:     "edge",
+			pool:     &types.MachinePool{Name: "edge"},
+			expected: defaultEdgeMachinePool("edge"),
+		},
+		{
+			name:     "arbiter",
+			pool:     &types.MachinePool{Name: "arbiter"},
+			expected: defaultMachinePoolWithReplicaCount("arbiter", 0),
 		},
 		{
 			name:     "default",


### PR DESCRIPTION
If arbiter is set in the install config, then we want to set it's default values.