### PR TITLE
OCPBUGS-50637: Remove error logging when determining image arch

### DIFF
--- a/pkg/asset/agent/common.go
+++ b/pkg/asset/agent/common.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
@@ -100,7 +101,9 @@ func DetermineReleaseImageArch(pullSecret, pullSpec string) (string, error) {
 
 	releaseArch, err := ExecuteOC(pullSecret, getReleaseArch)
 	if err != nil {
-		logrus.Errorf("Release Image arch could not be found: %s", err)
+		if strings.Contains(err.Error(), "unable to read image") {
+			logrus.Debugf("Could not get release image to check architecture in a disconnected setup")
+		}
 		return "", err
 	}
 	logrus.Debugf("Release Image arch is: %s", releaseArch)


### PR DESCRIPTION
In a disconnected environment the check for image architecture generates an error message since the icsp info is not checked, even though the image create succeeds. This has caused multiple customer cases to be generated.