### PR TITLE
OCPBUGS-52356: IBMCloud: Fix CAPI endpoint overrides

### DIFF
--- a/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
@@ -369,11 +369,19 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 	}
 	logrus.Debugf("bootstrap ignition config upload complete to %s/%s/%s", cosInstanceName, bucketName, ignitionFile)
 
-	ignitionURL := url.URL{
-		Scheme: "https",
-		Host:   cosEndpoint,
-		Path:   fmt.Sprintf("%s/%s", bucketName, ignitionFile),
+	// Build the URL for the ignition config.
+	cosURL, err := url.Parse(cosEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ibmcloud cos url: %s", cosURL)
 	}
+	// Make sure the COS URL has an https scheme, if one isn't already set.
+	if cosURL.Scheme == "" {
+		cosURL.Scheme = "https"
+	}
+	ignitionURL := cosURL.JoinPath(bucketName, ignitionFile)
+	//	Scheme: "https",
+	//	Host:   cosEndpoint,
+	//	Path:   fmt.Sprintf("%s/%s", bucketName, ignitionFile),
 
 	// Build Ignition Config for Secret to direct bootstrap to consume COS Ignition Config.
 	logrus.Debugf("building ignition config data for bootstrap secret")

--- a/pkg/types/ibmcloud/metadata_test.go
+++ b/pkg/types/ibmcloud/metadata_test.go
@@ -1,0 +1,108 @@
+package ibmcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var (
+	regionUSSouth = "us-south"
+
+	cisURL                = "test-cis-url.com"
+	cosURL                = "test-cos-url.com"
+	iamURL                = "test-iam-url.com"
+	globalTaggingURL      = "test-gt-url.com"
+	keyProtectURL         = "test-kp-url.com"
+	resourceControllerURL = "test-rc-url.com"
+	resourceManagerURL    = "test-rm-url.com"
+	vpcURL                = "test-vpc-url.com"
+)
+
+func TestGetRegionAndEndpointsFlag(t *testing.T) {
+	testCases := []struct {
+		name           string
+		region         string
+		endpoints      []configv1.IBMCloudServiceEndpoint
+		expectedResult string
+	}{
+		{
+			name:           "no service endpionts",
+			region:         regionUSSouth,
+			endpoints:      []configv1.IBMCloudServiceEndpoint{},
+			expectedResult: "",
+		},
+		{
+			name:   "ignore iam service endpoint",
+			region: regionUSSouth,
+			endpoints: []configv1.IBMCloudServiceEndpoint{
+				{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  iamURL,
+				},
+			},
+			expectedResult: "",
+		},
+		{
+			name:   "single service endpoint flag",
+			region: regionUSSouth,
+			endpoints: []configv1.IBMCloudServiceEndpoint{
+				{
+					Name: configv1.IBMCloudServiceCOS,
+					URL:  cosURL,
+				},
+			},
+			expectedResult: fmt.Sprintf("%s:%s=%s", regionUSSouth, "cos", cosURL),
+		},
+		{
+			name:   "all supported capi service endpoints flag",
+			region: regionUSSouth,
+			endpoints: []configv1.IBMCloudServiceEndpoint{
+				{
+					Name: configv1.IBMCloudServiceCIS,
+					URL:  cisURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceCOS,
+					URL:  cosURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceIAM,
+					URL:  iamURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceGlobalTagging,
+					URL:  globalTaggingURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceKeyProtect,
+					URL:  keyProtectURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceResourceController,
+					URL:  resourceControllerURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceResourceManager,
+					URL:  resourceManagerURL,
+				},
+				{
+					Name: configv1.IBMCloudServiceVPC,
+					URL:  vpcURL,
+				},
+			},
+			expectedResult: fmt.Sprintf("%s:%s=%s,%s=%s,%s=%s,%s=%s,%s=%s", regionUSSouth, "cos", cosURL, "globaltagging", globalTaggingURL, "rc", resourceControllerURL, "rm", resourceManagerURL, "vpc", vpcURL),
+		},
+	}
+
+	for _, tCase := range testCases {
+		m := Metadata{
+			Region:           tCase.region,
+			ServiceEndpoints: tCase.endpoints,
+		}
+		assert.Equal(t, tCase.expectedResult, m.GetRegionAndEndpointsFlag())
+	}
+}


### PR DESCRIPTION
Fix the endpoint override support for IBM Cloud CAPI and the Ignition URL for bootstrap node during CAPI deployment.

Related: https://issues.redhat.com/browse/OCPBUGS-52356