### PR TITLE
OCPBUGS-39146: Validate sgdisk partition start in image based installer config

### DIFF
--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -345,6 +345,118 @@ coreosInstallerArgs:
 			expectedFound: true,
 			expectedError: "",
 		},
+		{
+			name: "valid-extraPartitionStart-zero",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "0"
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
+		{
+			name: "valid-extraPartitionStart-empty-prefix",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "10M"
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
+		{
+			name: "valid-extraPartitionStart-with-prefix",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "+10M"
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
+		{
+			name: "invalid-extraPartitionStart-empty-suffix",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "-10"
+`,
+
+			expectedFound: false,
+			expectedError: "invalid Image-based Installation ISO Config: ExtraPartitionStart: Invalid value: \"-10\": partition start must be '0' or match pattern [+-]?<number>[KMGTP]",
+		},
+		{
+			name: "invalid-extraPartitionStart-invalid-suffix",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "-10L"
+`,
+
+			expectedFound: false,
+			expectedError: "invalid Image-based Installation ISO Config: ExtraPartitionStart: Invalid value: \"-10L\": partition start must be '0' or match pattern [+-]?<number>[KMGTP]",
+		},
+		{
+			name: "invalid-extraPartitionStart-random-string",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: "invalid"
+`,
+
+			expectedFound: false,
+			expectedError: "invalid Image-based Installation ISO Config: ExtraPartitionStart: Invalid value: \"invalid\": partition start must be '0' or match pattern [+-]?<number>[KMGTP]",
+		},
+		{
+			name: "invalid-extraPartitionStart-empty-string",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+extraPartitionStart: ""
+`,
+
+			expectedFound: false,
+			expectedError: "invalid Image-based Installation ISO Config: ExtraPartitionStart: Required value: partition start sector cannot be empty",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This change adds a validation for the [sgdisk](https://linux.die.net/man/8/sgdisk) partition start sector in the image based installer config.

According to sgdisk's man page: 
> Both start and end sectors can be specified in absolute terms as sector numbers or as positions measured in kibibytes (K), mebibytes (M), gibibytes (G), tebibytes (T), or pebibytes (P); for instance, 40M specifies a position 40MiB from the start of the disk. You can specify locations relative to the start or end of the specified default range by preceding the number by a '+' or '-' symbol, as in +2G to specify a point 2GiB after the default start sector, or -200M to specify a point 200MiB before the last available sector. A start or end value of 0 specifies the default value, which is the start of the largest available block for the start sector and the end of the same block for the end sector. 