### PR TITLE
SPLAT-2072: Removed VSphereMultiVCenters feature gate

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6715,9 +6715,8 @@ spec:
                       Deprecated: Use VCenters.Server
                     type: string
                   vcenters:
-                    description: |-
-                      VCenters holds the connection details for services to communicate with vCenter.
-                      Currently only a single vCenter is supported.
+                    description: VCenters holds the connection details for services
+                      to communicate with vCenter.
                     items:
                       description: |-
                         VCenter stores the vCenter connection fields

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	ibmcloudmachines "github.com/openshift/installer/pkg/asset/machines/ibmcloud"
@@ -329,14 +328,7 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 		}
 		cm.Data[cloudProviderConfigDataKey] = powervsConfig
 	case vspheretypes.Name:
-		var vsphereConfig string
-		var err error
-		// When we GA multi vcenter, we should only support yaml generation here.
-		if installConfig.Config.EnabledFeatureGates().Enabled(features.FeatureGateVSphereMultiVCenters) {
-			vsphereConfig, err = vspheremanifests.CloudProviderConfigYaml(clusterID.InfraID, installConfig.Config.Platform.VSphere)
-		} else {
-			vsphereConfig, err = vspheremanifests.CloudProviderConfigIni(clusterID.InfraID, installConfig.Config.Platform.VSphere)
-		}
+		vsphereConfig, err := vspheremanifests.CloudProviderConfigYaml(clusterID.InfraID, installConfig.Config.Platform.VSphere)
 
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -96,23 +96,20 @@ func TestFeatureGates(t *testing.T) {
 			}(),
 		},
 		{
-			name: "vSphere two vcenters is not allowed with Feature Gates disabled",
+			name: "vSphere two vcenters is allowed with default Feature Gates",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"VSphereMultiVCenters=false"}
+				c.FeatureSet = v1.Default
 				c.VSphere = validVSpherePlatform()
 				c.VSphere.VCenters = append(c.VSphere.VCenters, vsphere.VCenter{Server: "additional-vcenter"})
 				return c
 			}(),
-			expected: `^platform.vsphere.vcenters: Forbidden: this field is protected by the VSphereMultiVCenters feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set`,
 		},
 		{
 			name: "vSphere two vcenters is allowed with custom Feature Gate enabled",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"VSphereMultiVCenters=true"}
 				c.VSphere = validVSpherePlatform()
 				c.VSphere.VCenters = append(c.VSphere.VCenters, vsphere.VCenter{Server: "additional-vcenter"})
 				return c

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -128,7 +128,6 @@ type Platform struct {
 	// of vsphere.
 	DiskType DiskType `json:"diskType,omitempty"`
 	// VCenters holds the connection details for services to communicate with vCenter.
-	// Currently only a single vCenter is supported.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=3
 	// +kubebuilder:validation:MinItems=1

--- a/pkg/types/vsphere/validation/featuregates.go
+++ b/pkg/types/vsphere/validation/featuregates.go
@@ -33,11 +33,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 			Field:           field.NewPath("platform", "vsphere", "hosts"),
 		},
 		{
-			FeatureGateName: features.FeatureGateVSphereMultiVCenters,
-			Condition:       len(v.VCenters) > 1,
-			Field:           field.NewPath("platform", "vsphere", "vcenters"),
-		},
-		{
 			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
 			Condition:       multiNetworksFound,
 			Field:           field.NewPath("platform", "vsphere", "failureDomains", "topology", "networks"),


### PR DESCRIPTION
[SPLAT-2072](https://issues.redhat.com//browse/SPLAT-2072)

### Changes
- Removed usage of feature gate VSphereMultiVCenter for multiple vCenter configurations since its now GA.
- Removed legacy ini configuration from installer now that multi vCenter is GA.

### Notes
After a feature gate has been GA in an OCP release, we are supposed to clean up feature gate usage in the next release.  Multi vCenter support GA'd in 4.18, so the intention is to remove the feature gate as part of 4.19.