### PR TITLE
AGENT-537: Add agent command to generate certificates

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent/mirror"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/password"
+	"github.com/openshift/installer/pkg/asset/tls"
 )
 
 func newAgentCmd(ctx context.Context) *cobra.Command {
@@ -114,7 +115,23 @@ var (
 		},
 	}
 
-	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget, agentConfigImageTarget, agentUnconfiguredIgnitionTarget}
+	agentCertificatesTarget = target{
+		name: "Agent create certificates",
+		command: &cobra.Command{
+			Use:    "certificates",
+			Short:  "Generates the tls certificates that can be used to create kubeconfig",
+			Args:   cobra.ExactArgs(0),
+			Hidden: true,
+		},
+		assets: []asset.WritableAsset{
+			&tls.KubeAPIServerLBSignerCertKey{},
+			&tls.KubeAPIServerLocalhostSignerCertKey{},
+			&tls.KubeAPIServerServiceNetworkSignerCertKey{},
+			&tls.AdminKubeConfigSignerCertKey{},
+		},
+	}
+
+	agentTargets = []target{agentConfigTarget, agentManifestsTarget, agentImageTarget, agentPXEFilesTarget, agentConfigImageTarget, agentUnconfiguredIgnitionTarget, agentCertificatesTarget}
 )
 
 func newAgentCreateCmd(ctx context.Context) *cobra.Command {

--- a/cmd/openshift-install/testdata/agent/image/assets/tls_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/tls_assets.txt
@@ -1,0 +1,12 @@
+# Verify that the create certificates command generates the tls assets 
+
+exec openshift-install agent create certificates --dir $WORK
+
+exists $WORK/tls/admin-kubeconfig-signer.crt
+exists $WORK/tls/kube-apiserver-lb-signer.crt
+exists $WORK/tls/kube-apiserver-localhost-signer.crt
+exists $WORK/tls/kube-apiserver-service-network-signer.crt
+exists $WORK/tls/admin-kubeconfig-signer.key
+exists $WORK/tls/kube-apiserver-lb-signer.key 
+exists $WORK/tls/kube-apiserver-localhost-signer.key
+exists $WORK/tls/kube-apiserver-service-network-signer.key


### PR DESCRIPTION
Add a new hidden agent-based-installer command to generate tls certificates. This will be used by the agent UI.

```
$ ./bin/openshift-install agent create certificates
INFO Certificates created in: tls 
$ ls tls
admin-kubeconfig-signer.crt  kube-apiserver-lb-signer.crt  kube-apiserver-localhost-signer.crt  kube-apiserver-service-network-signer.crt
admin-kubeconfig-signer.key  kube-apiserver-lb-signer.key  kube-apiserver-localhost-signer.key  kube-apiserver-service-network-signer.key
```

