### PR TITLE
SPLAT-2078: Removed VSphereStaticIPs feature gate

### DIFF
--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -67,23 +67,10 @@ func TestFeatureGates(t *testing.T) {
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"VSphereStaticIPs=true"}
 				c.VSphere = validVSpherePlatform()
 				c.VSphere.Hosts = []*vsphere.Host{{Role: "test"}}
 				return c
 			}(),
-		},
-		{
-			name: "vSphere hosts is not allowed with custom Feature Gate disabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.CustomNoUpgrade
-				c.FeatureGates = []string{"VSphereStaticIPs=false"}
-				c.VSphere = validVSpherePlatform()
-				c.VSphere.Hosts = []*vsphere.Host{{Role: "test"}}
-				return c
-			}(),
-			expected: `^platform.vsphere.hosts: Forbidden: this field is protected by the VSphereStaticIPs feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
 			name: "vSphere one vcenter is allowed with default Feature Gates",

--- a/pkg/types/vsphere/validation/featuregates.go
+++ b/pkg/types/vsphere/validation/featuregates.go
@@ -28,11 +28,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 
 	return []featuregates.GatedInstallConfigFeature{
 		{
-			FeatureGateName: features.FeatureGateVSphereStaticIPs,
-			Condition:       len(v.Hosts) > 0,
-			Field:           field.NewPath("platform", "vsphere", "hosts"),
-		},
-		{
 			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
 			Condition:       multiNetworksFound,
 			Field:           field.NewPath("platform", "vsphere", "failureDomains", "topology", "networks"),


### PR DESCRIPTION
[SPLAT-2078](https://issues.redhat.com//browse/SPLAT-2078)

### Changes
- Removed references to VSphereStaticIPs feature gate

Notes
After a feature gate has been GA in an OCP release, we are supposed to clean up feature gate usage in the next release. VSphere static IP support GA'd in 4.16, so the intention is to remove the feature gate as part of 4.19.