### PR TITLE
OCPBUGS-53107: Set appropriate KillMode for systemd services

### DIFF
--- a/data/data/agent/systemd/units/agent-add-node.service
+++ b/data/data/agent/systemd/units/agent-add-node.service
@@ -15,7 +15,6 @@ EnvironmentFile=/etc/assisted/rendezvous-host.env
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
 ExecStart=/usr/local/bin/add-node.sh
 
-KillMode=none
 Type=oneshot
 RemainAfterExit=true
 

--- a/data/data/agent/systemd/units/agent-import-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-import-cluster.service.template
@@ -20,7 +20,7 @@ ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
-KillMode=none
+KillMode=mixed
 Type=oneshot
 Restart=on-failure
 RestartSec=30

--- a/data/data/agent/systemd/units/agent-register-cluster.service.template
+++ b/data/data/agent/systemd/units/agent-register-cluster.service.template
@@ -20,7 +20,7 @@ ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
-KillMode=none
+KillMode=mixed
 Type=oneshot
 Restart=on-failure
 RestartSec=30

--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -17,7 +17,7 @@ ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
-KillMode=none
+KillMode=mixed
 Type=oneshot
 Restart=on-failure
 RestartSec=30

--- a/data/data/agent/systemd/units/agent-start-ui.service.template
+++ b/data/data/agent/systemd/units/agent-start-ui.service.template
@@ -19,7 +19,7 @@ ExecStart=/bin/bash -c "AIUI_APP_API_URL=${SERVICE_BASE_URL} podman run --net ho
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
-KillMode=none
+KillMode=mixed
 Type=oneshot
 RemainAfterExit=true
 

--- a/data/data/agent/systemd/units/apply-host-config.service
+++ b/data/data/agent/systemd/units/apply-host-config.service
@@ -18,7 +18,7 @@ ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
-KillMode=none
+KillMode=mixed
 Type=oneshot
 RemainAfterExit=true
 

--- a/data/data/agent/systemd/units/pre-network-manager-config.service
+++ b/data/data/agent/systemd/units/pre-network-manager-config.service
@@ -7,7 +7,6 @@ DefaultDependencies=no
 User=root
 ExecStart=/usr/local/bin/pre-network-manager-config.sh
 TimeoutSec=60
-KillMode=none
 Type=oneshot
 PrivateTmp=true
 RemainAfterExit=no

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -7,7 +7,6 @@ Before=agent-interactive-console.service
 [Service]
 ExecStart=/usr/local/bin/set-hostname.sh
 
-KillMode=none
 Type=oneshot
 RemainAfterExit=true
 

--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -15,7 +15,6 @@ EnvironmentFile=/etc/assisted/rendezvous-host.env
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
 ExecStart=/usr/local/bin/start-cluster-installation.sh
 
-KillMode=none
 Type=oneshot
 RemainAfterExit=true
 

--- a/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
+++ b/data/data/bootstrap/baremetal/systemd/units/extract-machine-os.service
@@ -18,7 +18,6 @@ TimeoutStartSec=20m
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%N.cid
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile=%t/%N.cid
 ExecStopPost=-/bin/rm -f %t/%N.cid
-KillMode=none
 Type=oneshot
 RemainAfterExit=true
 Restart=on-failure


### PR DESCRIPTION
It looks like the practice of setting `KillMode: none` began with podman-generate-systemd, and was copied and pasted into virtually every service. This could cause some weird behaviour when services were stopped.