### PR TITLE
AGENT-537: Run agent installer command to create certificates

### DIFF
--- a/data/data/agent/files/usr/local/bin/set-node-zero.sh
+++ b/data/data/agent/files/usr/local/bin/set-node-zero.sh
@@ -45,6 +45,16 @@ done
 if [ "${IS_NODE_ZERO}" = "true" ]; then
     echo "Node 0 IP ${NODE_ZERO_IP} found on this host" 1>&2
 
+    # Create tls certs, if they don't exist, via the installer command.
+    # This allows the certs to be created at run-time, e.g. when installed via the UI
+    AGENT_TLS_DIR=/opt/agent/tls
+    if [ -z $(ls -A "$AGENT_TLS_DIR") ]; then
+       . /usr/local/bin/release-image.sh
+       IMAGE=$(image_for installer)
+       /usr/bin/podman run --privileged -v /tmp:/assets --rm "${IMAGE}" agent create certificates --dir=/assets
+       cp /tmp/tls/* $AGENT_TLS_DIR
+    fi
+
     NODE0_PATH=/etc/assisted/node0
     mkdir -p "$(dirname "${NODE0_PATH}")"
 


### PR DESCRIPTION
If the agent tls certificates have not been created yet, i.e. when using the agent UI, use the installer command to create the certs prior to running the assisted-service.

Requires https://github.com/openshift/installer/pull/9557