### PR TITLE
OCPBUGS-53307: Insert openstack repo in openstack ci image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,9 +1,9 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.ci.openshift.org/ocp/4.17:installer-terraform-providers as providers
+FROM registry.ci.openshift.org/ocp/4.19:installer-terraform-providers as providers
 # We copy from the -artifacts images because they are statically linked
-FROM registry.ci.openshift.org/ocp/4.17:installer-kube-apiserver-artifacts AS kas-artifacts
-FROM registry.ci.openshift.org/ocp/4.17:installer-etcd-artifacts AS etcd-artifacts
+FROM registry.ci.openshift.org/ocp/4.19:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.19:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -19,14 +19,17 @@ RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
 	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.17:cli AS cli
+FROM registry.ci.openshift.org/ocp/4.19:cli AS cli
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi/openstack /var/lib/openshift-install/upi
 COPY --from=builder /go/src/github.com/openshift/installer/docs/user/openstack /var/lib/openshift-install/docs
 COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-manifests.sh /go/src/github.com/openshift/installer/scripts/openstack/manifest-tests /var/lib/openshift-install/manifest-tests
+
+# In CI, install the openstack repositories
+RUN curl http://base-openstack-4-19.ocp.svc >/etc/yum.repos.art/ci/base-4-19-rhel-9-openstack-17-rpms.repo || true
 
 # Install Dependendencies for tests
 RUN yum update -y && \


### PR DESCRIPTION
Since https://github.com/openshift/release/pull/62602 merged, the openstack repo is not available by default. This ensures the openstack ci image gets the additional repo installed.