### PR TITLE
DNM: Testing CIS fix for IBM Terraform provider

### DIFF
--- a/terraform/providers/ibm/go.mod
+++ b/terraform/providers/ibm/go.mod
@@ -228,3 +228,5 @@ exclude (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/client-go v12.0.0+incompatible
 )
+
+replace github.com/IBM-Cloud/terraform-provider-ibm => github.com/cjschaef/terraform-provider-ibm v1.56.0-fix

--- a/terraform/providers/ibm/go.sum
+++ b/terraform/providers/ibm/go.sum
@@ -107,8 +107,6 @@ github.com/IBM-Cloud/power-go-client v1.2.2 h1:VNlzizoG2x06c3nL1ZBILF701QcvXcu6n
 github.com/IBM-Cloud/power-go-client v1.2.2/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
-github.com/IBM-Cloud/terraform-provider-ibm v1.56.0 h1:6dSY3eaN1t4BX6PI6rP+mXDjXL6zXFSkeRFS3sjNoVk=
-github.com/IBM-Cloud/terraform-provider-ibm v1.56.0/go.mod h1:IgrkQqlHazcqkrMReLEVZqlVm4G2Zl1znKVFi4jPeMg=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca/go.mod h1:IjXrnOcTe92Q4pEBHmui3H/GM1hw5Pd0zXA5cw5/iZU=
 github.com/IBM/appconfiguration-go-admin-sdk v0.3.0 h1:OqFxnDxro0JiRwHBKytCcseY2YKD4n87JN1UcaOD4Ss=
@@ -317,6 +315,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyY
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cjschaef/terraform-provider-ibm v1.56.0-fix h1:rvaG2y9S79gMnLw2o1ogznrxzygWTsekA7KJXD3v4+0=
+github.com/cjschaef/terraform-provider-ibm v1.56.0-fix/go.mod h1:IgrkQqlHazcqkrMReLEVZqlVm4G2Zl1znKVFi4jPeMg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=

--- a/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go
+++ b/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go
@@ -468,19 +468,39 @@ func ResourceIBMCISDnsRecordRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set(cisID, crn)
-	d.Set(cisDomainID, *result.Result.ZoneID)
-	d.Set(cisDNSRecordID, *result.Result.ID)
-	d.Set(cisZoneName, *result.Result.ZoneName)
-	d.Set(cisDNSRecordCreatedOn, *result.Result.CreatedOn)
-	d.Set(cisDNSRecordModifiedOn, *result.Result.ModifiedOn)
-	d.Set(cisDNSRecordName, *result.Result.Name)
-	d.Set(cisDNSRecordType, *result.Result.Type)
+	if result.Result.ZoneID != nil {
+		d.Set(cisDomainID, *result.Result.ZoneID)
+	}
+	if result.Result.ID != nil {
+		d.Set(cisDNSRecordID, *result.Result.ID)
+	}
+	if result.Result.ZoneName != nil {
+		d.Set(cisZoneName, *result.Result.ZoneName)
+	}
+	if result.Result.CreatedOn != nil {
+		d.Set(cisDNSRecordCreatedOn, *result.Result.CreatedOn)
+	}
+	if result.Result.ModifiedOn != nil {
+		d.Set(cisDNSRecordModifiedOn, *result.Result.ModifiedOn)
+	}
+	if result.Result.Name != nil {
+		d.Set(cisDNSRecordName, *result.Result.Name)
+	}
+	if result.Result.Type != nil {
+		d.Set(cisDNSRecordType, *result.Result.Type)
+	}
 	if result.Result.Content != nil {
 		d.Set(cisDNSRecordContent, *result.Result.Content)
 	}
-	d.Set(cisDNSRecordProxiable, *result.Result.Proxiable)
-	d.Set(cisDNSRecordProxied, *result.Result.Proxied)
-	d.Set(cisDNSRecordTTL, *result.Result.TTL)
+	if result.Result.Proxiable != nil {
+		d.Set(cisDNSRecordProxiable, *result.Result.Proxiable)
+	}
+	if result.Result.Proxied != nil {
+		d.Set(cisDNSRecordProxied, *result.Result.Proxied)
+	}
+	if result.Result.TTL != nil {
+		d.Set(cisDNSRecordTTL, *result.Result.TTL)
+	}
 	if result.Result.Priority != nil {
 		d.Set(cisDNSRecordPriority, *result.Result.Priority)
 	}

--- a/terraform/providers/ibm/vendor/modules.txt
+++ b/terraform/providers/ibm/vendor/modules.txt
@@ -83,7 +83,7 @@ github.com/IBM-Cloud/power-go-client/power/client/service_instances
 github.com/IBM-Cloud/power-go-client/power/client/storage_types
 github.com/IBM-Cloud/power-go-client/power/client/swagger_spec
 github.com/IBM-Cloud/power-go-client/power/models
-# github.com/IBM-Cloud/terraform-provider-ibm v1.56.0
+# github.com/IBM-Cloud/terraform-provider-ibm v1.56.0 => github.com/cjschaef/terraform-provider-ibm v1.56.0-fix
 ## explicit; go 1.18
 github.com/IBM-Cloud/terraform-provider-ibm
 github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns
@@ -1466,3 +1466,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/portworx/sched-ops v0.0.0-20200831185134-3e8010dc7056 => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
+# github.com/IBM-Cloud/terraform-provider-ibm => github.com/cjschaef/terraform-provider-ibm v1.56.0-fix


### PR DESCRIPTION
DO NOT MERGE: Testing CIS fix for IBM Terraform provider by backporting fix to IBM TF release that supports installer 4.14 release. This change should not merge, as it is a temporary solution to prove this method is viable for older installer and golang versions for IBM TF provider.