### PR TITLE
OCPBUGS-53453: IBMCloud: Move to IBM TF openshift fork

### DIFF
--- a/terraform/providers/ibm/go.mod
+++ b/terraform/providers/ibm/go.mod
@@ -243,3 +243,6 @@ exclude (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/client-go v12.0.0+incompatible
 )
+
+// NOTE(cjschaef): To align with installer's golang version and since the provider has a very restrictive golang version, override to use the forked repository, which maintains unique branches based on golang version and provider release
+replace github.com/IBM-Cloud/terraform-provider-ibm => github.com/openshift/terraform-provider-ibm v1.70.2-0.20250321144105-7e769934732a

--- a/terraform/providers/ibm/go.sum
+++ b/terraform/providers/ibm/go.sum
@@ -122,8 +122,6 @@ github.com/IBM-Cloud/power-go-client v1.8.1 h1:tx1aPJmIQrNru1MD1VHGNasGx3eRIs0zz
 github.com/IBM-Cloud/power-go-client v1.8.1/go.mod h1:N4RxrsMUvBQjSQ/qPk0iMZ8zK+fZPRTnHi/gTaASw0g=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
-github.com/IBM-Cloud/terraform-provider-ibm v1.70.1 h1:MRFyRnCQAigOTSsRMGOVTAKbLUlM13mT1Orn0mG5+oA=
-github.com/IBM-Cloud/terraform-provider-ibm v1.70.1/go.mod h1:rqOLrsof2gpbIANRNINcKpY5LEpeE91an0MGztiFB+g=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca/go.mod h1:IjXrnOcTe92Q4pEBHmui3H/GM1hw5Pd0zXA5cw5/iZU=
 github.com/IBM/appconfiguration-go-admin-sdk v0.3.0 h1:OqFxnDxro0JiRwHBKytCcseY2YKD4n87JN1UcaOD4Ss=
@@ -1404,6 +1402,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mo
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
 github.com/openshift/client-go v0.0.0-20230324103026-3f1513df25e0 h1:ftAVjdiw4/Bnav0Fvw9mxoa0kU1lGK8GKRn28eja8Ik=
 github.com/openshift/client-go v0.0.0-20230324103026-3f1513df25e0/go.mod h1:8jtoeGR9UNGacP00O4WBeSFY3WaP7t0gkm9NZOSSWmg=
+github.com/openshift/terraform-provider-ibm v1.70.2-0.20250321144105-7e769934732a h1:OqBpxPNNmI7ei0mliwSLGqo1PJjKFKnS2ax84jxohr0=
+github.com/openshift/terraform-provider-ibm v1.70.2-0.20250321144105-7e769934732a/go.mod h1:rqOLrsof2gpbIANRNINcKpY5LEpeE91an0MGztiFB+g=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/data_source_ibm_cis_dns_records.go
+++ b/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/data_source_ibm_cis_dns_records.go
@@ -206,7 +206,9 @@ func dataSourceIBMCISDNSRecordsRead(d *schema.ResourceData, meta interface{}) er
 		record := map[string]interface{}{}
 		record["id"] = flex.ConvertCisToTfThreeVar(*instance.ID, zoneID, crn)
 		record[cisDNSRecordID] = *instance.ID
-		record[cisZoneName] = *instance.ZoneName
+		if instance.ZoneName != nil {
+			record[cisZoneName] = *instance.ZoneName
+		}
 		record[cisDNSRecordCreatedOn] = *instance.CreatedOn
 		record[cisDNSRecordModifiedOn] = *instance.ModifiedOn
 		record[cisDNSRecordName] = *instance.Name
@@ -221,7 +223,11 @@ func dataSourceIBMCISDNSRecordsRead(d *schema.ResourceData, meta interface{}) er
 		record[cisDNSRecordProxied] = *instance.Proxied
 		record[cisDNSRecordTTL] = *instance.TTL
 		if instance.Data != nil {
-			d.Set(cisDNSRecordData, flattenData(instance.Data, *instance.ZoneName))
+			zoneName := ""
+			if instance.ZoneName != nil {
+				zoneName = *instance.ZoneName
+			}
+			d.Set(cisDNSRecordData, flattenData(instance.Data, zoneName))
 		}
 
 		records = append(records, record)

--- a/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go
+++ b/terraform/providers/ibm/vendor/github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go
@@ -468,9 +468,13 @@ func ResourceIBMCISDnsRecordRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set(cisID, crn)
-	d.Set(cisDomainID, *result.Result.ZoneID)
+	if result.Result.ZoneID != nil {
+		d.Set(cisDomainID, *result.Result.ZoneID)
+	}
 	d.Set(cisDNSRecordID, *result.Result.ID)
-	d.Set(cisZoneName, *result.Result.ZoneName)
+	if result.Result.ZoneName != nil {
+		d.Set(cisZoneName, *result.Result.ZoneName)
+	}
 	d.Set(cisDNSRecordCreatedOn, *result.Result.CreatedOn)
 	d.Set(cisDNSRecordModifiedOn, *result.Result.ModifiedOn)
 	d.Set(cisDNSRecordName, *result.Result.Name)
@@ -485,7 +489,11 @@ func ResourceIBMCISDnsRecordRead(d *schema.ResourceData, meta interface{}) error
 		d.Set(cisDNSRecordPriority, *result.Result.Priority)
 	}
 	if result.Result.Data != nil {
-		d.Set(cisDNSRecordData, flattenData(result.Result.Data, *result.Result.ZoneName))
+		zoneName := ""
+		if result.Result.ZoneName != nil {
+			zoneName = *result.Result.ZoneName
+		}
+		d.Set(cisDNSRecordData, flattenData(result.Result.Data, zoneName))
 	}
 	return nil
 }
@@ -906,7 +914,7 @@ func flattenData(inVal interface{}, zone string) map[string]string {
 	}
 	for k, v := range inVal.(map[string]interface{}) {
 		strValue := fmt.Sprintf("%v", v)
-		if k == "name" {
+		if k == "name" && zone != "" {
 			strValue = strings.Replace(strValue, "."+zone, "", -1)
 		}
 		outVal[k] = strValue

--- a/terraform/providers/ibm/vendor/modules.txt
+++ b/terraform/providers/ibm/vendor/modules.txt
@@ -91,7 +91,7 @@ github.com/IBM-Cloud/power-go-client/power/client/storage_types
 github.com/IBM-Cloud/power-go-client/power/client/swagger_spec
 github.com/IBM-Cloud/power-go-client/power/client/workspaces
 github.com/IBM-Cloud/power-go-client/power/models
-# github.com/IBM-Cloud/terraform-provider-ibm v1.70.1
+# github.com/IBM-Cloud/terraform-provider-ibm v1.70.1 => github.com/openshift/terraform-provider-ibm v1.70.2-0.20250321144105-7e769934732a
 ## explicit; go 1.22.4
 github.com/IBM-Cloud/terraform-provider-ibm
 github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns
@@ -1586,3 +1586,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/portworx/sched-ops v0.0.0-20200831185134-3e8010dc7056 => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
+# github.com/IBM-Cloud/terraform-provider-ibm => github.com/openshift/terraform-provider-ibm v1.70.2-0.20250321144105-7e769934732a


### PR DESCRIPTION
Use the openshift org fork of IBM Cloud Terraform provider to pick up the fix for CIS API changes. This bump cannot be directly backported due to golang version requirements by the TF provider.

Related: https://issues.redhat.com/browse/OCPBUGS-53453
Related: https://issues.redhat.com/browse/OCPBUGS-53258