### PR TITLE
OCPBUGS-52203: Find GCP KMS keys

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -15,11 +15,13 @@ import (
 	dns "google.golang.org/api/dns/v1"
 	"google.golang.org/api/googleapi"
 	iam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/serviceusage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	gcpconsts "github.com/openshift/installer/pkg/constants/gcp"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
 //go:generate mockgen -source=./client.go -destination=./mock/gcpclient_generated.go -package=mock
@@ -54,7 +56,7 @@ type API interface {
 	ValidateServiceAccountHasPermissions(ctx context.Context, project string, permissions []string) (bool, error)
 	GetProjectTags(ctx context.Context, projectID string) (sets.Set[string], error)
 	GetNamespacedTagValue(ctx context.Context, tagNamespacedName string) (*cloudresourcemanager.TagValue, error)
-	GetKeyRing(ctx context.Context, keyRingName string) (*kmspb.KeyRing, error)
+	GetKeyRing(ctx context.Context, kmsKeyRef *gcptypes.KMSKeyReference) (*kmspb.KeyRing, error)
 }
 
 // Client makes calls to the GCP API.
@@ -585,16 +587,32 @@ func (c *Client) getKeyManagementClient(ctx context.Context) (*kms.KeyManagement
 }
 
 // GetKeyRing returns the key ring associated with the key name (if found).
-func (c *Client) GetKeyRing(ctx context.Context, keyRingName string) (*kmspb.KeyRing, error) {
+func (c *Client) GetKeyRing(ctx context.Context, kmsKeyRef *gcptypes.KMSKeyReference) (*kmspb.KeyRing, error) {
 	kmsClient, err := c.getKeyManagementClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("key ring client creation failed: %w", err)
 	}
 
-	req := &kmspb.GetKeyRingRequest{Name: keyRingName}
-	resp, err := kmsClient.GetKeyRing(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find key ring %s", keyRingName)
+	keyRingName := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", kmsKeyRef.ProjectID, kmsKeyRef.Location, kmsKeyRef.KeyRing)
+	listReq := &kmspb.ListKeyRingsRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", kmsKeyRef.ProjectID, kmsKeyRef.Location),
 	}
-	return resp, nil
+
+	// OCPBUGS-52203:  GetKeyRingRequest{Name: keyRingName} should work but the resource name (above) is not found.
+	// The cloudkms.keyRings.list permission is required for this operation.
+	listItr := kmsClient.ListKeyRings(ctx, listReq)
+	for {
+		resp, err := listItr.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to iterate through list of kms keyrings: %w", err)
+		}
+
+		re := resp
+		if re.Name == keyRingName {
+			return re, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find kms key ring with name %s", keyRingName)
 }

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	gcp "github.com/openshift/installer/pkg/types/gcp"
 	gomock "go.uber.org/mock/gomock"
 	google "golang.org/x/oauth2/google"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v3"
@@ -121,18 +122,18 @@ func (mr *MockAPIMockRecorder) GetImage(ctx, name, project any) *gomock.Call {
 }
 
 // GetKeyRing mocks base method.
-func (m *MockAPI) GetKeyRing(ctx context.Context, keyRingName string) (*kmspb.KeyRing, error) {
+func (m *MockAPI) GetKeyRing(ctx context.Context, kmsKeyRef *gcp.KMSKeyReference) (*kmspb.KeyRing, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKeyRing", ctx, keyRingName)
+	ret := m.ctrl.Call(m, "GetKeyRing", ctx, kmsKeyRef)
 	ret0, _ := ret[0].(*kmspb.KeyRing)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetKeyRing indicates an expected call of GetKeyRing.
-func (mr *MockAPIMockRecorder) GetKeyRing(ctx, keyRingName interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetKeyRing(ctx, kmsKeyRef any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyRing", reflect.TypeOf((*MockAPI)(nil).GetKeyRing), ctx, keyRingName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyRing", reflect.TypeOf((*MockAPI)(nil).GetKeyRing), ctx, kmsKeyRef)
 }
 
 // GetMachineType mocks base method.

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -738,7 +738,7 @@ func validatePlatformKMSKeys(client API, ic *types.InstallConfig, fieldPath *fie
 	cp := ic.ControlPlane
 	validatedControlPlaneKey := false
 	if cp != nil && cp.Platform.GCP != nil && cp.Platform.GCP.EncryptionKey != nil && cp.Platform.GCP.EncryptionKey.KMSKey != nil {
-		if _, err := client.GetKeyRing(context.TODO(), cp.Platform.GCP.OSDisk.EncryptionKey.KMSKey.KeyRing); err != nil {
+		if _, err := client.GetKeyRing(context.TODO(), cp.Platform.GCP.OSDisk.EncryptionKey.KMSKey); err != nil {
 			return append(allErrs, field.Invalid(fieldPath.Child("controlPlane").Child("encryptionKey").Child("kmsKey").Child("keyRing"),
 				cp.Platform.GCP.OSDisk.EncryptionKey.KMSKey.KeyRing,
 				err.Error(),
@@ -750,7 +750,7 @@ func validatePlatformKMSKeys(client API, ic *types.InstallConfig, fieldPath *fie
 	validatedComputeKeys := false
 	for _, mp := range ic.Compute {
 		if mp.Platform.GCP != nil && mp.Platform.GCP.EncryptionKey != nil && mp.Platform.GCP.EncryptionKey.KMSKey != nil {
-			if _, err := client.GetKeyRing(context.TODO(), mp.Platform.GCP.OSDisk.EncryptionKey.KMSKey.KeyRing); err != nil {
+			if _, err := client.GetKeyRing(context.TODO(), mp.Platform.GCP.OSDisk.EncryptionKey.KMSKey); err != nil {
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("compute").Child("encryptionKey").Child("kmsKey").Child("keyRing"),
 					mp.Platform.GCP.OSDisk.EncryptionKey.KMSKey.KeyRing,
 					err.Error(),
@@ -763,7 +763,7 @@ func validatePlatformKMSKeys(client API, ic *types.InstallConfig, fieldPath *fie
 
 	defaultMp := ic.GCP.DefaultMachinePlatform
 	if defaultMp != nil && defaultMp.EncryptionKey != nil && defaultMp.EncryptionKey.KMSKey != nil {
-		if _, err := client.GetKeyRing(context.TODO(), defaultMp.EncryptionKey.KMSKey.KeyRing); err != nil {
+		if _, err := client.GetKeyRing(context.TODO(), defaultMp.EncryptionKey.KMSKey); err != nil {
 			if validatedControlPlaneKey && (validatedComputeKeys && len(allErrs) == 0) {
 				logrus.Warn("defaultMachinePool.encryptionKey.KMSKey.KeyRing is not valid, but compute and control plane key rings are valid")
 			} else {


### PR DESCRIPTION
** The gcp validation and client in the installconfig asset was not able to find the KMS key ring. This was including keys with global and regional locations. 
** The key rings should be serachable via the GetKeyRingRequest struct, but the resource name projects/*/locations/*/keyRings/* was not finding any key rings. 
** The user must have the cloudkms.keyRings.list permission to list the key rings.