### PR TITLE
CORS-3908: Update gcp cloud provider config map to include new endpoints

### DIFF
--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -24,10 +24,17 @@ type global struct {
 	SubnetworkName string `gcfg:"subnetwork-name"`
 
 	NetworkProjectID string `gcfg:"network-project-id"`
+
+	// APIEndpoint is the compute API endpoint to use. If this is blank,
+	// then the default endpoint is used.
+	APIEndpoint string `gcfg:"api-endpoint"`
+	// ContainerAPIEndpoint is the container API endpoint to use. If this is blank,
+	// then the default endpoint is used.
+	ContainerAPIEndpoint string `gcfg:"container-api-endpoint"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet, networkProjectID string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, apiEndpoint, containerAPIEndpoint string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -47,6 +54,10 @@ func CloudProviderConfig(infraID, projectID, subnet, networkProjectID string) (s
 
 			// Used for shared vpc installations,
 			NetworkProjectID: networkProjectID,
+
+			// Used for api endpoint overrides in the cloud provider.
+			APIEndpoint:          apiEndpoint,
+			ContainerAPIEndpoint: containerAPIEndpoint,
 		},
 	}
 
@@ -68,6 +79,8 @@ node-tags       = {{$tag}}
 node-instance-prefix = {{.Global.NodeInstancePrefix}}
 external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
 subnetwork-name = {{.Global.SubnetworkName}}
-{{ if ne .Global.NetworkProjectID "" }}network-project-id = {{.Global.NetworkProjectID}}{{end}}
+{{- if ne .Global.NetworkProjectID "" }}{{"\n"}}network-project-id = {{.Global.NetworkProjectID}}{{ end }}
+{{- if ne .Global.APIEndpoint "" }}{{"\n"}}api-endpoint = {{.Global.APIEndpoint}}{{ end }}
+{{- if ne .Global.ContainerAPIEndpoint "" }}{{"\n"}}container-api-endpoint = {{.Global.ContainerAPIEndpoint}}{{ end }}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -18,9 +18,8 @@ node-instance-prefix = uid
 external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
 
-
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "", "")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }
@@ -39,7 +38,27 @@ subnetwork-name = uid-worker-subnet
 network-project-id = test-network-project-id
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id", "", "")
+	assert.NoError(t, err, "failed to create cloud provider config")
+	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
+}
+
+func TestCloudProviderConfigWithEndpoints(t *testing.T) {
+	expectedConfig := `[global]
+project-id      = test-project-id
+regional        = true
+multizone       = true
+node-tags       = uid-master
+node-tags       = uid-control-plane
+node-tags       = uid-worker
+node-instance-prefix = uid
+external-instance-groups-prefix = uid
+subnetwork-name = uid-worker-subnet
+api-endpoint = compute-testendpoint.p.googleapis.com
+container-api-endpoint = container-testendpoint.p.googleapis.com
+
+`
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "compute-testendpoint.p.googleapis.com", "container-testendpoint.p.googleapis.com")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
** manifests/gcp/cloudproviderconfig: The GCP cloud provider config will now be supplied with the api-endpoint and container-api-endpoint. The GCP Cloud provider (and upstream) can accept a config with the api-endpoint (compute) and container-api-endpoint (container) values to override the endpoints for the services.

** See https://github.com/kubernetes/cloud-provider-gcp/blob/master/providers/gce/gce.go#L231 and https://github.com/kubernetes/cloud-provider-gcp/blob/master/providers/gce/gce.go#L234.