### PR TITLE
OCPBUGS-54260: vsphere-fix convert if only provided name

### DIFF
--- a/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
+++ b/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
@@ -45,7 +45,7 @@ func StartSimulator(setVersionToSupported bool) (*simulator.Server, error) {
 	}
 
 	model.Folder = 1
-	model.Datacenter = 2
+	model.Datacenter = 5
 	model.OpaqueNetwork = 1
 	err := model.Create()
 	if err != nil {


### PR DESCRIPTION
In 4.12 and prior versions of the installer
allowed non-pathed names of vCenter objects.
In 4.13+ that is no longer allowed and absolute full paths are required.
This change is causing issues with ACM/Hive. The
only resolution (not ideal) is to connect
to vCenter and determine from potentially only the objects name to determine the absolute full path.

If there is no available connection to vCenter in the case of AI or Agent installer this fails back to
only merging paths.

Move existing functions from private to public
to assist hive - reducing copy and paste.