### PR TITLE
CORS-3883:  remove SystemAssigned ID

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -183,28 +183,6 @@ spec:
                           and assigned to the VM
                           Identity can only be set for control-plane nodes.
                         properties:
-                          systemAssignedIdentityRole:
-                            description: |-
-                              SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.
-                              SystemAssignedIdentity is an experimental feature which may be enabled with the MachineAPIMigration
-                              feature gate and may only be assigned on control-plane nodes.
-                            properties:
-                              definitionID:
-                                description: |-
-                                  DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role.
-                                  Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-                                type: string
-                              name:
-                                description: |-
-                                  Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID.
-                                  If not specified, a random UUID will be generated.
-                                type: string
-                              scope:
-                                description: |-
-                                  Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance.
-                                  If not specified, the scope will be the subscription.
-                                type: string
-                            type: object
                           type:
                             description: Type specifies the type of identity to be
                               used.
@@ -1419,28 +1397,6 @@ spec:
                             and assigned to the VM
                             Identity can only be set for control-plane nodes.
                           properties:
-                            systemAssignedIdentityRole:
-                              description: |-
-                                SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.
-                                SystemAssignedIdentity is an experimental feature which may be enabled with the MachineAPIMigration
-                                feature gate and may only be assigned on control-plane nodes.
-                              properties:
-                                definitionID:
-                                  description: |-
-                                    DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role.
-                                    Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID.
-                                    If not specified, a random UUID will be generated.
-                                  type: string
-                                scope:
-                                  description: |-
-                                    Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance.
-                                    If not specified, the scope will be the subscription.
-                                  type: string
-                              type: object
                             type:
                               description: Type specifies the type of identity to
                                 be used.
@@ -2594,28 +2550,6 @@ spec:
                           and assigned to the VM
                           Identity can only be set for control-plane nodes.
                         properties:
-                          systemAssignedIdentityRole:
-                            description: |-
-                              SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.
-                              SystemAssignedIdentity is an experimental feature which may be enabled with the MachineAPIMigration
-                              feature gate and may only be assigned on control-plane nodes.
-                            properties:
-                              definitionID:
-                                description: |-
-                                  DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role.
-                                  Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-                                type: string
-                              name:
-                                description: |-
-                                  Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID.
-                                  If not specified, a random UUID will be generated.
-                                type: string
-                              scope:
-                                description: |-
-                                  Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance.
-                                  If not specified, the scope will be the subscription.
-                                type: string
-                            type: object
                           type:
                             description: Type specifies the type of identity to be
                               used.
@@ -4279,28 +4213,6 @@ spec:
                           and assigned to the VM
                           Identity can only be set for control-plane nodes.
                         properties:
-                          systemAssignedIdentityRole:
-                            description: |-
-                              SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.
-                              SystemAssignedIdentity is an experimental feature which may be enabled with the MachineAPIMigration
-                              feature gate and may only be assigned on control-plane nodes.
-                            properties:
-                              definitionID:
-                                description: |-
-                                  DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role.
-                                  Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-                                type: string
-                              name:
-                                description: |-
-                                  Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID.
-                                  If not specified, a random UUID will be generated.
-                                type: string
-                              scope:
-                                description: |-
-                                  Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance.
-                                  If not specified, the scope will be the subscription.
-                                type: string
-                            type: object
                           type:
                             description: Type specifies the type of identity to be
                               used.

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -175,9 +175,8 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, in *Machi
 						AcceleratedNetworking: ptr.To(mpool.VMNetworkingType == string(azure.VMnetworkingTypeAccelerated) || mpool.VMNetworkingType == string(azure.AcceleratedNetworkingEnabled)),
 					},
 				},
-				Identity:                   mpool.Identity.Type,
-				UserAssignedIdentities:     userAssignedIdentities,
-				SystemAssignedIdentityRole: mpool.Identity.SystemAssignedIdentityRole,
+				Identity:               mpool.Identity.Type,
+				UserAssignedIdentities: userAssignedIdentities,
 			},
 		}
 		azureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))
@@ -234,7 +233,6 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, in *Machi
 			SecurityProfile:            securityProfile,
 			Identity:                   mpool.Identity.Type,
 			UserAssignedIdentities:     userAssignedIdentities,
-			SystemAssignedIdentityRole: mpool.Identity.SystemAssignedIdentityRole,
 		},
 	}
 	bootstrapAzureMachine.SetGroupVersionKind(capz.GroupVersion.WithKind("AzureMachine"))

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -240,12 +240,6 @@ type VMIdentity struct {
 	// Supplying more than one user-assigned identity is an experimental feature
 	// which may be enabled with the MachineAPIMigration feature gate.
 	UserAssignedIdentities []UserAssignedIdentity `json:"userAssignedIdentities"`
-
-	// SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.
-	// SystemAssignedIdentity is an experimental feature which may be enabled with the MachineAPIMigration
-	// feature gate and may only be assigned on control-plane nodes.
-	// +optional
-	SystemAssignedIdentityRole *capz.SystemAssignedIdentityRole `json:"systemAssignedIdentityRole,omitempty"`
 }
 
 // UserAssignedIdentity contains the fields that comprise a user-assigned identity.

--- a/pkg/types/azure/validation/featuregates.go
+++ b/pkg/types/azure/validation/featuregates.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 
 	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
@@ -15,16 +14,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 	cp := c.ControlPlane.Platform
 	defMp := c.Platform.Azure.DefaultMachinePlatform
 	return []featuregates.GatedInstallConfigFeature{
-		{
-			FeatureGateName: features.FeatureGateMachineAPIMigration,
-			Condition:       cp.Azure != nil && cp.Azure.Identity != nil && cp.Azure.Identity.Type == capz.VMIdentitySystemAssigned,
-			Field:           field.NewPath("controlPlane", "azure", "identity", "systemAssignedIdentityRole"),
-		},
-		{
-			FeatureGateName: features.FeatureGateMachineAPIMigration,
-			Condition:       defMp != nil && defMp.Identity != nil && defMp.Identity.Type == capz.VMIdentitySystemAssigned,
-			Field:           field.NewPath("platform", "azure", "defaultMachinePlatform", "identity", "systemAssignedIdentityRole"),
-		},
 		{
 			FeatureGateName: features.FeatureGateMachineAPIMigration,
 			Condition:       cp.Azure != nil && cp.Azure.Identity != nil && cp.Azure.Identity.UserAssignedIdentities != nil && len(cp.Azure.Identity.UserAssignedIdentities) > 1,

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -631,40 +631,22 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path.identity.type: Unsupported value: "unrecognized": supported values: "None", "SystemAssigned", "UserAssigned"$`,
+			expected: `^test-path.identity.type: Unsupported value: "unrecognized": supported values: "None", "UserAssigned"$`,
 		},
 		{
-			name:          "azure VM system-assigned identity name must be a valid UUID",
+			name:          "azure VM SystemAssignedIdentity is not allowed",
 			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{
 				Name: "",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
 						Identity: &azure.VMIdentity{
-							Type: capz.VMIdentitySystemAssigned,
-							SystemAssignedIdentityRole: &capz.SystemAssignedIdentityRole{
-								Name: "not valid",
-							},
+							Type: "SystemAssigned",
 						},
 					},
 				},
 			},
-			expected: `^test-path.identity.systemAssignedIdentityRole.name: Invalid value: "not valid": name must be a valid UUID, please provide a valid UUID or leave name black to have one generated for you$`,
-		},
-		{
-			name:          "azure VM system-assigned identity cannot be used on compute nodes",
-			azurePlatform: azure.PublicCloud,
-			pool: &types.MachinePool{
-				Name: "worker",
-				Platform: types.MachinePoolPlatform{
-					Azure: &azure.MachinePool{
-						Identity: &azure.VMIdentity{
-							Type: capz.VMIdentitySystemAssigned,
-						},
-					},
-				},
-			},
-			expected: `^test-path.identity.type: Invalid value: "SystemAssigned": only user-assigned identities are supported for compute nodes$`,
+			expected: `^test-path.identity.type: Unsupported value: "SystemAssigned": supported values: "None", "UserAssigned"$`,
 		},
 		{
 			name:          "azure VM identity cannot mismatch type and field",
@@ -674,13 +656,13 @@ func TestValidateMachinePool(t *testing.T) {
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
 						Identity: &azure.VMIdentity{
-							Type:                   capz.VMIdentitySystemAssigned,
+							Type:                   capz.VMIdentityNone,
 							UserAssignedIdentities: []azure.UserAssignedIdentity{},
 						},
 					},
 				},
 			},
-			expected: `^test-path.identity.type: Invalid value: "SystemAssigned": userAssignedIdentities may only be used with type: UserAssigned$`,
+			expected: `^test-path.identity.type: Invalid value: "None": userAssignedIdentities may only be used with type: UserAssigned$`,
 		},
 		{
 			name:          "azure VM identity must have user assigned identities when type==UserAssigned",

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -116,39 +116,6 @@ func TestFeatureGates(t *testing.T) {
 			}(),
 		},
 		{
-			name: "Azure system-assigned identities (control plane) requires MachineAPIMigration feature gate",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.AWS = nil // validInstallConfig defaults to AWS
-				c.Azure = &azure.Platform{}
-				c.ControlPlane.Platform.Azure = &azure.MachinePool{
-					Identity: &azure.VMIdentity{
-						Type:                       capz.VMIdentitySystemAssigned,
-						SystemAssignedIdentityRole: &capz.SystemAssignedIdentityRole{},
-					},
-				}
-				return c
-			}(),
-			expected: `^controlPlane.azure.identity.systemAssignedIdentityRole: Forbidden: this field is protected by the MachineAPIMigration feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set`,
-		},
-		{
-			name: "Azure system-assigned identities (default platform) requires MachineAPIMigration feature gate",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.AWS = nil // validInstallConfig defaults to AWS
-				c.Azure = &azure.Platform{
-					DefaultMachinePlatform: &azure.MachinePool{
-						Identity: &azure.VMIdentity{
-							Type:                       capz.VMIdentitySystemAssigned,
-							SystemAssignedIdentityRole: &capz.SystemAssignedIdentityRole{},
-						},
-					},
-				}
-				return c
-			}(),
-			expected: `^platform.azure.defaultMachinePlatform.identity.systemAssignedIdentityRole: Forbidden: this field is protected by the MachineAPIMigration feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set`,
-		},
-		{
 			name: "Azure user-assigned identities (control plane) > 1 requires MachineAPIMigration feature gate",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
SystemAssigned Identities are not supported in any capacity in MAPZ. Due to that they were feature gated for future CAPZ->MAPZ transition. The CAPZ Identity API creates further issues in that, the value to be used for name/scope is unclear and when deleting clusters the role assignment of the identity is leaked.

No users have asked for this functionality, so lets remove it to reduce our complexity and load.