### PR TITLE
OCPBUGS-54305: Power VS: Get permitted network from user

### DIFF
--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -26,6 +26,7 @@ import (
 type baseDomain struct {
 	BaseDomain string
 	Publish    types.PublishingStrategy
+	PowerVSVPC string
 }
 
 var _ asset.Asset = (*baseDomain)(nil)
@@ -93,6 +94,15 @@ func (a *baseDomain) Generate(ctx context.Context, parents asset.Parents) error 
 		}
 		a.BaseDomain = zone.Name
 		a.Publish = zone.Publish
+		if zone.Publish == types.InternalPublishingStrategy {
+			a.PowerVSVPC, err = powervsconfig.GetVPC(
+				platform.PowerVS.PowerVSResourceGroup,
+				platform.PowerVS.Region,
+			)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	default:
 		//Do nothing

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -101,6 +101,9 @@ func (a *InstallConfig) Generate(ctx context.Context, parents asset.Parents) err
 	a.Config.BareMetal = platform.BareMetal
 	a.Config.Ovirt = platform.Ovirt
 	a.Config.PowerVS = platform.PowerVS
+	if a.Config.PowerVS != nil && baseDomain.PowerVSVPC != "" {
+		a.Config.PowerVS.VPC = baseDomain.PowerVSVPC
+	}
 	a.Config.PowerVC = platform.PowerVC
 	a.Config.Nutanix = platform.Nutanix
 

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 	sshPublicKey := &sshPublicKey{}
-	baseDomain := &baseDomain{"test-domain", types.ExternalPublishingStrategy}
+	baseDomain := &baseDomain{"test-domain", types.ExternalPublishingStrategy, ""}
 	clusterName := &clusterName{"test-cluster"}
 	pullSecret := &pullSecret{`{"auths":{"example.com":{"auth":"authorization value"}}}`}
 	platform := &platform{

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -52,6 +52,7 @@ type API interface {
 	GetPublicGatewayByVPC(ctx context.Context, vpcName string) (*vpcv1.PublicGateway, error)
 	SetVPCServiceURLForRegion(ctx context.Context, region string) error
 	GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error)
+	GetVPCsInResourceGroup(ctx context.Context, resourceGroupID string, region string) ([]vpcv1.VPC, error)
 	GetVPCSubnets(ctx context.Context, vpcID string) ([]vpcv1.Subnet, error)
 
 	// TG
@@ -831,7 +832,27 @@ func (c *Client) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error
 		return nil, fmt.Errorf("failed to set vpc api service url: %w", err)
 	}
 
-	vpcs, _, err := c.vpcAPI.ListVpcs(c.vpcAPI.NewListVpcsOptions())
+	vpcs, _, err := c.vpcAPI.ListVpcsWithContext(ctx, c.vpcAPI.NewListVpcsOptions())
+	if err != nil {
+		return nil, err
+	}
+
+	return vpcs.Vpcs, nil
+}
+
+// GetVPCsInResourceGroup gets all VPCs in a region filtered by resource group ID.
+func (c *Client) GetVPCsInResourceGroup(ctx context.Context, resourceGroupID string, region string) ([]vpcv1.VPC, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	err := c.SetVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set vpc api service url: %w", err)
+	}
+
+	listVpcsOptions := c.vpcAPI.NewListVpcsOptions()
+	listVpcsOptions.SetResourceGroupID(resourceGroupID)
+	vpcs, _, err := c.vpcAPI.ListVpcsWithContext(ctx, listVpcsOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -841,10 +862,13 @@ func (c *Client) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error
 
 // ListResourceGroups returns a list of resource groups.
 func (c *Client) ListResourceGroups(ctx context.Context) (*resourcemanagerv2.ResourceGroupList, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
 	listResourceGroupsOptions := c.managementAPI.NewListResourceGroupsOptions()
 	listResourceGroupsOptions.AccountID = &c.BXCli.User.Account
 
-	resourceGroups, _, err := c.managementAPI.ListResourceGroups(listResourceGroupsOptions)
+	resourceGroups, _, err := c.managementAPI.ListResourceGroupsWithContext(ctx, listResourceGroupsOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/powervs/dns.go
+++ b/pkg/asset/installconfig/powervs/dns.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 
 	"github.com/openshift/installer/pkg/types"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 )
 
 // Zone represents a DNS Zone
@@ -75,4 +76,73 @@ func GetDNSZone() (*Zone, error) {
 	}
 
 	return optionToZoneMap[zoneChoice], nil
+}
+
+// GetVPC returns a VPC name chosen by survey from those available in the resource group.
+func GetVPC(resourceGroup string, region string) (string, error) {
+	client, err := NewClient()
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	// Resolve the VPC region from the PowerVS region.
+	vpcRegion, err := powervstypes.VPCRegionForPowerVSRegion(region)
+	if err != nil {
+		return "", fmt.Errorf("could not determine VPC region for PowerVS region %q: %w", region, err)
+	}
+
+	// Resolve the resource group name to its ID.
+	resourceGroups, err := client.ListResourceGroups(ctx)
+	if err != nil {
+		return "", fmt.Errorf("could not list resource groups: %w", err)
+	}
+	resourceGroupID := ""
+	for _, rg := range resourceGroups.Resources {
+		if rg.Name != nil && *rg.Name == resourceGroup {
+			resourceGroupID = *rg.ID
+			break
+		}
+	}
+	if resourceGroupID == "" {
+		return "", fmt.Errorf("resource group %q not found", resourceGroup)
+	}
+
+	vpcs, err := client.GetVPCsInResourceGroup(ctx, resourceGroupID, vpcRegion)
+	if err != nil {
+		return "", fmt.Errorf("could not retrieve VPCs: %w", err)
+	}
+	if len(vpcs) == 0 {
+		return "", fmt.Errorf("no VPCs found in resource group %q (VPC region %q)", resourceGroup, vpcRegion)
+	}
+
+	vpcNames := make([]string, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		if vpc.Name != nil {
+			vpcNames = append(vpcNames, *vpc.Name)
+		}
+	}
+	sort.Strings(vpcNames)
+
+	var vpcChoice string
+	if err := survey.AskOne(&survey.Select{
+		Message: "VPC",
+		Help:    "The VPC to use for the internal cluster. Must be in the same resource group as the PowerVS workspace.",
+		Options: vpcNames,
+	},
+		&vpcChoice,
+		survey.WithValidator(func(ans interface{}) error {
+			choice := ans.(core.OptionAnswer).Value
+			i := sort.SearchStrings(vpcNames, choice)
+			if i == len(vpcNames) || vpcNames[i] != choice {
+				return fmt.Errorf("invalid VPC %q", choice)
+			}
+			return nil
+		}),
+	); err != nil {
+		return "", fmt.Errorf("failed UserInput: %w", err)
+	}
+
+	return vpcChoice, nil
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -415,6 +415,21 @@ func (mr *MockAPIMockRecorder) GetVPCs(ctx, region any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCs", reflect.TypeOf((*MockAPI)(nil).GetVPCs), ctx, region)
 }
 
+// GetVPCsInResourceGroup mocks base method.
+func (m *MockAPI) GetVPCsInResourceGroup(ctx context.Context, resourceGroupID string, region string) ([]vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCsInResourceGroup", ctx, resourceGroupID, region)
+	ret0, _ := ret[0].([]vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCsInResourceGroup indicates an expected call of GetVPCsInResourceGroup.
+func (mr *MockAPIMockRecorder) GetVPCsInResourceGroup(ctx, resourceGroupID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCsInResourceGroup", reflect.TypeOf((*MockAPI)(nil).GetVPCsInResourceGroup), ctx, resourceGroupID, region)
+}
+
 // ListResourceGroups mocks base method.
 func (m *MockAPI) ListResourceGroups(ctx context.Context) (*resourcemanagerv2.ResourceGroupList, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Obtain the DNS zone's permitted network through the install-config survey for an internal publishing strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PowerVS installations using internal publishing can now select a VPC during configuration.
  * Available VPCs are retrieved by region and resource group, sorted, and presented for selection.
  * The selected VPC is automatically applied to the PowerVS platform configuration before validation.
* **Bug Fixes**
  * Improved error handling when VPC lookup fails or no VPCs are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->