### PR TITLE
OCPBUGS-54319: oci-eval-user-data uses dmidecode which is not supported on ppc64le or s390x

### DIFF
--- a/data/data/agent/files/usr/local/bin/oci-eval-user-data.sh
+++ b/data/data/agent/files/usr/local/bin/oci-eval-user-data.sh
@@ -2,6 +2,13 @@
 
 set -euxo pipefail
 
+# dmidecode is not available on ppc64le/s390x
+if [ "$(arch)" == "ppc64le" ] || [ "$(arch)" == "s390x" ] 
+then
+    echo "Non OCI architecture... exiting early"
+    exit 0
+fi
+
 chassis_asset_tag="$(dmidecode --string chassis-asset-tag)"
 if [ "${chassis_asset_tag}" != "OracleCloud.com" ]
 then


### PR DESCRIPTION
added a short-circuit 