### PR TITLE
OCPBUGS-39583: Remove tmp directory used for agent pxe files

### DIFF
--- a/pkg/asset/agent/image/agentpxefiles.go
+++ b/pkg/asset/agent/image/agentpxefiles.go
@@ -68,6 +68,8 @@ func (a *AgentPXEFiles) Generate(dependencies asset.Parents) error {
 
 // PersistToFile writes the PXE assets in the assets folder named pxe.
 func (a *AgentPXEFiles) PersistToFile(directory string) error {
+	defer os.RemoveAll(a.tmpPath)
+
 	// If the imageReader is not set then it means that either one of the AgentPXEFiles
 	// dependencies or the asset itself failed for some reason
 	if a.imageReader == nil {


### PR DESCRIPTION
Remove the tmp directory that is created when running the command: 'openshift-install agent create pxe-files'