### PR TITLE
NO-JIRA: openstack: Replace ansible.netcommon.ipaddr filter

### DIFF
--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -110,8 +110,8 @@
     shell: |
       python -c 'import yaml
       path = "inventory.yaml"
-      ipv4 = "{{ item.ip_address|ipv4 }}"
-      ipv6 = "{{ item.ip_address|ipv6 }}"
+      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
+      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
       if ipv4 != "False":
         key = "os_apiVIP"
         ip = ipv4
@@ -129,8 +129,8 @@
     shell: |
       python -c 'import yaml
       path = "inventory.yaml"
-      ipv4 = "{{ item.ip_address|ipv4 }}"
-      ipv6 = "{{ item.ip_address|ipv6 }}"
+      ipv4 = "{{ item.ip_address|ansible.utils.ipv4 }}"
+      ipv6 = "{{ item.ip_address|ansible.utils.ipv6 }}"
       if ipv4 != "False":
         key = "os_ingressVIP"
         ip = ipv4


### PR DESCRIPTION
Per [1], this is deprecated.

[1] https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/ipaddr_filter.html

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
