### PR TITLE
CORS-3883: Remove user-assigned identity from ARM template

### DIFF
--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -58,7 +58,6 @@
     "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
-    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
@@ -120,12 +119,6 @@
       "type" : "Microsoft.Compute/virtualMachines",
       "name" : "[variables('vmName')]",
       "location" : "[variables('location')]",
-      "identity" : {
-        "type" : "userAssigned",
-        "userAssignedIdentities" : {
-          "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
-        }
-      },
       "dependsOn" : [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -80,7 +80,6 @@
     "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
-    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
     "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
@@ -132,12 +131,6 @@
       },
       "name" : "[variables('vmNames')[copyIndex()]]",
       "location" : "[variables('location')]",
-      "identity" : {
-        "type" : "userAssigned",
-        "userAssignedIdentities" : {
-          "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
-        }
-      },
       "dependsOn" : [
         "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"
       ],

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -65,7 +65,6 @@
     "nodeSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('nodeSubnetName'))]",
     "infraLoadBalancerName" : "[parameters('baseName')]",
     "sshKeyPath" : "/home/capi/.ssh/authorized_keys",
-    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
     "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
@@ -117,12 +116,6 @@
               "location" : "[variables('location')]",
               "tags" : {
                 "kubernetes.io-cluster-ffranzupi": "owned"
-              },
-              "identity" : {
-                "type" : "userAssigned",
-                "userAssignedIdentities" : {
-                  "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
-                }
               },
               "dependsOn" : [
                 "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"


### PR DESCRIPTION
For UPI, user-assigned identity attached on each node is also not required, remove it.