### PR TITLE
NO-JIRA: OWNERS_ALIASES - Add user as coreos-approvers / coreos-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -134,6 +134,7 @@ aliases:
     - jbtrystram
     - madhu-pillai
     - Johan-Liebert1
+    - tlbueno
   coreos-reviewers:
     - c4rt0
     - cgwalters
@@ -155,6 +156,7 @@ aliases:
     - jbtrystram
     - madhu-pillai
     - Johan-Liebert1
+    - tlbueno
   agent-reviewers:
     - andfasano
     - bfournie


### PR DESCRIPTION
Add a new team member user as coreos-approvers / coreos-reviwers in the OWNERS_ALIASES file