### PR TITLE
CORS-3278: IBMCloud: Add DestroyBootstrap for leftover CAPI resources

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ cloud.google.com/go/monitoring v1.21.2 h1:FChwVtClH19E7pJ+e0xUhJPGksctZNVOk2UhMm
 cloud.google.com/go/monitoring v1.21.2/go.mod h1:hS3pXvaG8KgWTSz+dAdyzPrGUYmi2Q+WFX8g2hqVEZU=
 cloud.google.com/go/storage v1.43.0 h1:CcxnSohZwizt4LCzQHWvBf1/kvtHUn7gk9QERXPyXFs=
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/AlecAivazis/survey/v2 v2.3.5 h1:A8cYupsAZkjaUmhtTYv3sSqc7LO5mp1XDfqe5E/9wRQ=
 github.com/AlecAivazis/survey/v2 v2.3.5/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
@@ -106,6 +108,12 @@ github.com/IBM/vpc-go-sdk v0.65.0 h1:wCOm4pPdrsPnnHlpLHrqntLdzEmyjafK5BfZdke/ntI
 github.com/IBM/vpc-go-sdk v0.65.0/go.mod h1:VL7sy61ybg6tvA60SepoQx7TFe20m7JyNUt+se2tHP4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
+github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -197,6 +205,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RSSp2Om9lubZpiMgVbvn39bsUmW9U5h0twqc=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -217,6 +227,10 @@ github.com/containers/image/v5 v5.31.0 h1:eDFVlz5XaYICxe9dXpf23htEKvyosgkl62mJlI
 github.com/containers/image/v5 v5.31.0/go.mod h1:5QfOqSackPkSbF7Qxc1DnVNnPJKQ+KWLkfEfDpK590Q=
 github.com/containers/storage v1.54.0 h1:xwYAlf6n9OnIlURQLLg3FYHbO74fQ/2W2N6EtQEUM4I=
 github.com/containers/storage v1.54.0/go.mod h1:PlMOoinRrBSnhYODLxt4EXl0nmJt+X0kjG0Xdt9fMTw=
+github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
+github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
+github.com/coredns/corefile-migration v1.0.25 h1:/XexFhM8FFlFLTS/zKNEWgIZ8Gl5GaWrHsMarGj/PRQ=
+github.com/coredns/corefile-migration v1.0.25/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
 github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb h1:rmqyI19j3Z/74bIRhuC59RB442rXUazKNueVpfJPxg4=
 github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb/go.mod h1:rcFZM3uxVvdyNmsAV2jopgPD1cs5SPWJWU5dOz2LUnw=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
@@ -246,6 +260,8 @@ github.com/digitalocean/go-libvirt v0.0.0-20240220204746-fcabe97a6eed h1:pDXysiX
 github.com/digitalocean/go-libvirt v0.0.0-20240220204746-fcabe97a6eed/go.mod h1:isF7ghADfbC01gQx4vZnIOrxXT5RXLG81y+UCb5XSwc=
 github.com/diskfs/go-diskfs v1.4.0 h1:MAybY6TPD+fmhY+a2qFhmdvMeIKvCqlgh4QIc1uCmBs=
 github.com/diskfs/go-diskfs v1.4.0/go.mod h1:G8cyy+ngM+3yKlqjweMmtqvE+TxsnIo1xumbJX1AeLg=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -468,6 +484,9 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/h2non/filetype v1.0.12 h1:yHCsIe0y2cvbDARtJhGBTD2ecvqMSTvlIcph9En/Zao=
 github.com/h2non/filetype v1.0.12/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
@@ -500,6 +519,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
+github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
@@ -603,6 +624,7 @@ github.com/microsoftgraph/msgraph-sdk-go v0.59.0 h1:gS/rWZVpQGT3gaR01MWTaH85cISj
 github.com/microsoftgraph/msgraph-sdk-go v0.59.0/go.mod h1:RBrQLknmiglNeL5QarizkazPxs10ONHY/CUtNK9bzkI=
 github.com/microsoftgraph/msgraph-sdk-go-core v0.34.1 h1:tGDR/Je5mnf4Kn01w8/5HyywPL07JonFfe6Ip0w7a08=
 github.com/microsoftgraph/msgraph-sdk-go-core v0.34.1/go.mod h1:28uAIh5Oa9x4yfiKCrjTbG+1hikkf82jEzSKb7gC+Dg=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -612,6 +634,7 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
@@ -762,6 +785,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
@@ -772,6 +797,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
+github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
@@ -850,12 +877,19 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 h1:TT4fX+n
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0/go.mod h1:L7UH0GbB0p47T4Rri3uHjbpCFYrVrwc1I25QhNPiGK8=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=
 go.opentelemetry.io/otel v1.29.0/go.mod h1:N/WtXPs1CNCUEx+Agz5uouwCba+i+bJGFicT8SR4NP8=
+go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0/go.mod h1:s75jGIWA9OfCMzF0xr+ZgfrB5FEbbV7UuYo32ahUiFI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 h1:qFffATk0X+HD+f1Z8lswGiOQYKHRlzfmdJm0wEaVrFA=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0/go.mod h1:MOiCmryaYtc+V0Ei+Tx9o5S1ZjA7kzLucuVuyzBZloQ=
 go.opentelemetry.io/otel/metric v1.29.0 h1:vPf/HFWTNkPu1aYeIsc98l4ktOQaL6LeSoeV2g+8YLc=
 go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=
 go.opentelemetry.io/otel/sdk v1.29.0 h1:vkqKjk7gwhS8VaWb0POZKmIEDimRCMsopNYnriHyryo=
 go.opentelemetry.io/otel/sdk v1.29.0/go.mod h1:pM8Dx5WKnvxLCb+8lG1PRNIDxu9g9b9g59Qr7hfAAok=
 go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt39JTi4=
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
+go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
+go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
@@ -1157,6 +1191,8 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 libvirt.org/go/libvirtxml v1.10002.0 h1:6bc7BZcTd/X/RSKc/YE6y5ZpGXoDdhRYuP5qPdB+LzI=
 libvirt.org/go/libvirtxml v1.10002.0/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.9.5 h1:68164Q201Y5ANVkhyrOZenoMbfL2SEBjVYZs/ihhSro=
 sigs.k8s.io/cluster-api v1.9.5/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
 sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1-0.20241026111253-5b4f7c1acb52 h1:HoQrHMmOCFdY4QwnxYU8LkaQSKPelekGh8S1V52rXL4=

--- a/pkg/asset/installconfig/ibmcloud/ibmcloud.go
+++ b/pkg/asset/installconfig/ibmcloud/ibmcloud.go
@@ -116,9 +116,19 @@ func selectRegion(regions map[string]string) (string, error) {
 	return selectedRegion, nil
 }
 
+// BootstrapSecurityGroupName creates a VPC Security Group name using the provided InfraID and bootstrap SG name suffix.
+func BootstrapSecurityGroupName(infraID string) string {
+	return fmt.Sprintf("%s-%s", infraID, BootstrapSGNameSuffix)
+}
+
 // COSInstanceName creates a COS Instance name based on provided InfraID.
 func COSInstanceName(infraID string) string {
 	return fmt.Sprintf("%s-cos", infraID)
+}
+
+// VPCName creates a VPC name based on provided InfraID.
+func VPCName(infraID string) string {
+	return fmt.Sprintf("%s-vpc", infraID)
 }
 
 // VSIImageCOSBucketName creates a COS Bucket name for the VSI Image, based on provided InfraID.

--- a/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
+++ b/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
@@ -48,6 +48,21 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
+// AttachFloatingIP mocks base method.
+func (m *MockAPI) AttachFloatingIP(ctx context.Context, instanceName, instanceID, region, resourceGroupName string) (*vpcv1.FloatingIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachFloatingIP", ctx, instanceName, instanceID, region, resourceGroupName)
+	ret0, _ := ret[0].(*vpcv1.FloatingIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AttachFloatingIP indicates an expected call of AttachFloatingIP.
+func (mr *MockAPIMockRecorder) AttachFloatingIP(ctx, instanceName, instanceID, region, resourceGroupName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachFloatingIP", reflect.TypeOf((*MockAPI)(nil).AttachFloatingIP), ctx, instanceName, instanceID, region, resourceGroupName)
+}
+
 // CreateCISDNSRecord mocks base method.
 func (m *MockAPI) CreateCISDNSRecord(ctx context.Context, cisInstanceCRN, zoneID, recordName, cname string) error {
 	m.ctrl.T.Helper()
@@ -128,7 +143,7 @@ func (m *MockAPI) CreateDNSServicesPermittedNetwork(ctx context.Context, dnsInst
 }
 
 // CreateDNSServicesPermittedNetwork indicates an expected call of CreateDNSServicesPermittedNetwork.
-func (mr *MockAPIMockRecorder) CreateDNSServicesPermittedNetwork(ctx, dnsInstanceID, dnsZoneID, vpcCRN interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateDNSServicesPermittedNetwork(ctx, dnsInstanceID, dnsZoneID, vpcCRN any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDNSServicesPermittedNetwork", reflect.TypeOf((*MockAPI)(nil).CreateDNSServicesPermittedNetwork), ctx, dnsInstanceID, dnsZoneID, vpcCRN)
 }
@@ -159,6 +174,90 @@ func (m *MockAPI) CreateResourceGroup(ctx context.Context, rgName string) error 
 func (mr *MockAPIMockRecorder) CreateResourceGroup(ctx, rgName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceGroup", reflect.TypeOf((*MockAPI)(nil).CreateResourceGroup), ctx, rgName)
+}
+
+// DeleteCOSBucket mocks base method.
+func (m *MockAPI) DeleteCOSBucket(ctx context.Context, cosInstanceID, bucketName, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCOSBucket", ctx, cosInstanceID, bucketName, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCOSBucket indicates an expected call of DeleteCOSBucket.
+func (mr *MockAPIMockRecorder) DeleteCOSBucket(ctx, cosInstanceID, bucketName, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCOSBucket", reflect.TypeOf((*MockAPI)(nil).DeleteCOSBucket), ctx, cosInstanceID, bucketName, region)
+}
+
+// DeleteCOSInstance mocks base method.
+func (m *MockAPI) DeleteCOSInstance(ctx context.Context, cosInstanceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCOSInstance", ctx, cosInstanceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCOSInstance indicates an expected call of DeleteCOSInstance.
+func (mr *MockAPIMockRecorder) DeleteCOSInstance(ctx, cosInstanceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCOSInstance", reflect.TypeOf((*MockAPI)(nil).DeleteCOSInstance), ctx, cosInstanceID)
+}
+
+// DeleteCOSObject mocks base method.
+func (m *MockAPI) DeleteCOSObject(ctx context.Context, cosInstanceID, bucketName, objectKey, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCOSObject", ctx, cosInstanceID, bucketName, objectKey, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCOSObject indicates an expected call of DeleteCOSObject.
+func (mr *MockAPIMockRecorder) DeleteCOSObject(ctx, cosInstanceID, bucketName, objectKey, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCOSObject", reflect.TypeOf((*MockAPI)(nil).DeleteCOSObject), ctx, cosInstanceID, bucketName, objectKey, region)
+}
+
+// DeleteFloatingIP mocks base method.
+func (m *MockAPI) DeleteFloatingIP(ctx context.Context, floatingIPID, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFloatingIP", ctx, floatingIPID, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteFloatingIP indicates an expected call of DeleteFloatingIP.
+func (mr *MockAPIMockRecorder) DeleteFloatingIP(ctx, floatingIPID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFloatingIP", reflect.TypeOf((*MockAPI)(nil).DeleteFloatingIP), ctx, floatingIPID, region)
+}
+
+// DeleteSecurityGroup mocks base method.
+func (m *MockAPI) DeleteSecurityGroup(ctx context.Context, securityGroupID, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSecurityGroup", ctx, securityGroupID, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSecurityGroup indicates an expected call of DeleteSecurityGroup.
+func (mr *MockAPIMockRecorder) DeleteSecurityGroup(ctx, securityGroupID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockAPI)(nil).DeleteSecurityGroup), ctx, securityGroupID, region)
+}
+
+// DeleteSecurityGroupTargetBinding mocks base method.
+func (m *MockAPI) DeleteSecurityGroupTargetBinding(ctx context.Context, securityGroupID, targetID, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSecurityGroupTargetBinding", ctx, securityGroupID, targetID, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSecurityGroupTargetBinding indicates an expected call of DeleteSecurityGroupTargetBinding.
+func (mr *MockAPIMockRecorder) DeleteSecurityGroupTargetBinding(ctx, securityGroupID, targetID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroupTargetBinding", reflect.TypeOf((*MockAPI)(nil).DeleteSecurityGroupTargetBinding), ctx, securityGroupID, targetID, region)
 }
 
 // GetAPIKey mocks base method.
@@ -355,6 +454,21 @@ func (mr *MockAPIMockRecorder) GetEncryptionKey(ctx, keyCRN any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncryptionKey", reflect.TypeOf((*MockAPI)(nil).GetEncryptionKey), ctx, keyCRN)
 }
 
+// GetFloatingIPByName mocks base method.
+func (m *MockAPI) GetFloatingIPByName(ctx context.Context, floatingIPName, region string) (*vpcv1.FloatingIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFloatingIPByName", ctx, floatingIPName, region)
+	ret0, _ := ret[0].(*vpcv1.FloatingIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFloatingIPByName indicates an expected call of GetFloatingIPByName.
+func (mr *MockAPIMockRecorder) GetFloatingIPByName(ctx, floatingIPName, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatingIPByName", reflect.TypeOf((*MockAPI)(nil).GetFloatingIPByName), ctx, floatingIPName, region)
+}
+
 // GetIBMCloudRegions mocks base method.
 func (m *MockAPI) GetIBMCloudRegions(ctx context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
@@ -365,7 +479,7 @@ func (m *MockAPI) GetIBMCloudRegions(ctx context.Context) (map[string]string, er
 }
 
 // GetIBMCloudRegions indicates an expected call of GetIBMCloudRegions.
-func (mr *MockAPIMockRecorder) GetIBMCloudRegions(ctx interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetIBMCloudRegions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIBMCloudRegions", reflect.TypeOf((*MockAPI)(nil).GetIBMCloudRegions), ctx)
 }
@@ -428,6 +542,21 @@ func (m *MockAPI) GetSSHKeyByPublicKey(ctx context.Context, publicKey string) (*
 func (mr *MockAPIMockRecorder) GetSSHKeyByPublicKey(ctx, publicKey any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHKeyByPublicKey", reflect.TypeOf((*MockAPI)(nil).GetSSHKeyByPublicKey), ctx, publicKey)
+}
+
+// GetSecurityGroupByName mocks base method.
+func (m *MockAPI) GetSecurityGroupByName(ctx context.Context, sgName, vpcID, region string) (*vpcv1.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecurityGroupByName", ctx, sgName, vpcID, region)
+	ret0, _ := ret[0].(*vpcv1.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecurityGroupByName indicates an expected call of GetSecurityGroupByName.
+func (mr *MockAPIMockRecorder) GetSecurityGroupByName(ctx, sgName, vpcID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupByName", reflect.TypeOf((*MockAPI)(nil).GetSecurityGroupByName), ctx, sgName, vpcID, region)
 }
 
 // GetSubnet mocks base method.
@@ -520,6 +649,21 @@ func (mr *MockAPIMockRecorder) GetVPCs(ctx, region any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCs", reflect.TypeOf((*MockAPI)(nil).GetVPCs), ctx, region)
 }
 
+// GetVSI mocks base method.
+func (m *MockAPI) GetVSI(ctx context.Context, instanceID, region string) (*vpcv1.Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVSI", ctx, instanceID, region)
+	ret0, _ := ret[0].(*vpcv1.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVSI indicates an expected call of GetVSI.
+func (mr *MockAPIMockRecorder) GetVSI(ctx, instanceID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVSI", reflect.TypeOf((*MockAPI)(nil).GetVSI), ctx, instanceID, region)
+}
+
 // GetVSIProfiles mocks base method.
 func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
 	m.ctrl.T.Helper()
@@ -533,6 +677,36 @@ func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, 
 func (mr *MockAPIMockRecorder) GetVSIProfiles(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVSIProfiles", reflect.TypeOf((*MockAPI)(nil).GetVSIProfiles), ctx)
+}
+
+// ListCOSBuckets mocks base method.
+func (m *MockAPI) ListCOSBuckets(ctx context.Context, cosInstanceID, region string) (*s3.ListBucketsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCOSBuckets", ctx, cosInstanceID, region)
+	ret0, _ := ret[0].(*s3.ListBucketsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCOSBuckets indicates an expected call of ListCOSBuckets.
+func (mr *MockAPIMockRecorder) ListCOSBuckets(ctx, cosInstanceID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCOSBuckets", reflect.TypeOf((*MockAPI)(nil).ListCOSBuckets), ctx, cosInstanceID, region)
+}
+
+// ListCOSObjects mocks base method.
+func (m *MockAPI) ListCOSObjects(ctx context.Context, cosInstanceID, bucketName, region string) (*s3.ListObjectsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCOSObjects", ctx, cosInstanceID, bucketName, region)
+	ret0, _ := ret[0].(*s3.ListObjectsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCOSObjects indicates an expected call of ListCOSObjects.
+func (mr *MockAPIMockRecorder) ListCOSObjects(ctx, cosInstanceID, bucketName, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCOSObjects", reflect.TypeOf((*MockAPI)(nil).ListCOSObjects), ctx, cosInstanceID, bucketName, region)
 }
 
 // SetVPCServiceURLForRegion mocks base method.

--- a/pkg/asset/manifests/ibmcloud/cluster.go
+++ b/pkg/asset/manifests/ibmcloud/cluster.go
@@ -45,7 +45,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	}
 	vpcName := platform.GetVPCName()
 	if vpcName == "" {
-		vpcName = fmt.Sprintf("%s-vpc", clusterID.InfraID)
+		vpcName = ibmcloudic.VPCName(clusterID.InfraID)
 	}
 
 	// NOTE(cjschaef): Add support to use existing Image details, rather than always creating a new VPC Custom Image.

--- a/pkg/infrastructure/ibmcloud/clusterapi/bootstrap.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/bootstrap.go
@@ -1,0 +1,104 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/sirupsen/logrus"
+
+	ibmcloudic "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
+	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
+)
+
+func cleanupIgnitionCOSBucket(ctx context.Context, client ibmcloudic.API, instanceID string, bucketName string, region string) error {
+	// First, check whether the bucket exists.
+	bucketDetails, err := client.GetCOSBucketByName(ctx, instanceID, bucketName, region)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed checking for ignition bucket: %w", err)
+	case bucketDetails == nil:
+		logrus.Debugf("ignition bucket not found, skipping cleanup")
+		return nil
+	default:
+		logrus.Debugf("found ignition bucket %s", *bucketDetails.Name)
+	}
+
+	// Buckets need to be empty to complete deletion, remove all objects in the bucket.
+	cosObjectsDetails, err := client.ListCOSObjects(ctx, instanceID, bucketName, region)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed collecting objects in ignition bucket: %w", err)
+	case cosObjectsDetails == nil:
+		logrus.Debugf("ignition bucket appears to be empty %s", *bucketDetails.Name)
+	default:
+		for _, object := range cosObjectsDetails.Contents {
+			if object.Key == nil {
+				return fmt.Errorf("cos object has no key in ignition bucket")
+			}
+			logrus.Debugf("deleting cos object %s in ignition bucket", *object.Key)
+			if err = client.DeleteCOSObject(ctx, instanceID, bucketName, *object.Key, region); err != nil {
+				return fmt.Errorf("failed to delete object %s in ignition bucket: %w", *object.Key, err)
+			}
+		}
+	}
+
+	// Finally, delete the bucket itself.
+	logrus.Debugf("deleting ignition bucket %s", bucketName)
+	if err = client.DeleteCOSBucket(ctx, instanceID, bucketName, region); err != nil {
+		return fmt.Errorf("failed to delete ignition cos bucket: %w", err)
+	}
+	return nil
+}
+
+func cleanupBootstrapSecurityGroup(ctx context.Context, client ibmcloudic.API, vpcID string, securityGroupName string, region string) error {
+	sgDetails, err := client.GetSecurityGroupByName(ctx, securityGroupName, vpcID, region)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed retrieving security group as %s for destroy bootstrap: %w", securityGroupName, err)
+	case sgDetails != nil:
+		// After finding the bootstrap SG, check if we have to detach the bootstrap network interface (which should be the only attached target) from the SG first.
+		logrus.Debugf("checking bootstrap network interface of bootstrap instance for bootstrap security group %s", *sgDetails.ID)
+		for _, target := range sgDetails.Targets {
+			// Check if the target is a SG Network Interface reference type first, then default to the generic SG target.
+			networkInterfaceTarget, ok := target.(*vpcv1.SecurityGroupTargetReferenceNetworkInterfaceReferenceTargetContext)
+			switch {
+			case ok:
+				logrus.Debugf("removing bootstrap network interface: %s", *networkInterfaceTarget.ID)
+				if err = client.DeleteSecurityGroupTargetBinding(ctx, *sgDetails.ID, *networkInterfaceTarget.ID, region); err != nil {
+					return fmt.Errorf("failed to detach bootstrap network interface %s from bootstrap security group %s: %w", *networkInterfaceTarget.ID, *sgDetails.ID, err)
+				}
+				logrus.Debugf("removed bootstrap network interface %s from bootstrap security group %s", *networkInterfaceTarget.ID, *sgDetails.ID)
+			case reflect.TypeOf(target).String() == ibmcloudtypes.IBMCloudInfrastructureSecurityGroupTargetReference:
+				targetReference := target.(*vpcv1.SecurityGroupTargetReference)
+				switch {
+				case targetReference.ResourceType != nil && *targetReference.ResourceType == vpcv1.SecurityGroupTargetReferenceBareMetalServerNetworkInterfaceReferenceTargetContextResourceTypeNetworkInterfaceConst:
+					logrus.Debugf("removing bootstrap generic network interface: %s", *targetReference.ID)
+					if err = client.DeleteSecurityGroupTargetBinding(ctx, *sgDetails.ID, *targetReference.ID, region); err != nil {
+						return fmt.Errorf("failed to detach bootstrap generic network interface %s from bootstrap security group %s: %w", *targetReference.ID, *sgDetails.ID, err)
+					}
+					logrus.Debugf("removed bootstrap generic network interface %s from bootstrap security group %s", *targetReference.ID, *sgDetails.ID)
+				default:
+					targetReferenceType := ""
+					if targetReference.ResourceType != nil {
+						targetReferenceType = *targetReference.ResourceType
+					}
+					return fmt.Errorf("unexpected targetReference %s=%s", *targetReference.ID, targetReferenceType)
+				}
+			default:
+				return fmt.Errorf("unexpected target attached to bootstrap security group %s=%s", *sgDetails.ID, reflect.TypeOf(target).String())
+			}
+		}
+
+		logrus.Debugf("deleting bootstrap security group: %s=%s", *sgDetails.ID, securityGroupName)
+		err = client.DeleteSecurityGroup(ctx, *sgDetails.ID, region)
+		if err != nil {
+			return fmt.Errorf("failed to delete bootstrap security group %s: %w", *sgDetails.ID, err)
+		}
+		logrus.Debugf("deleted bootstrap security group: %s", *sgDetails.ID)
+	default:
+		logrus.Debugf("no bootstrap security group found for the cluster as %s, skipping security group cleanup", securityGroupName)
+	}
+	return nil
+}

--- a/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/ibmcloud/clusterapi/clusterapi.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	capibmcloud "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api/util/patch"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -27,8 +28,10 @@ import (
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 )
 
+var _ clusterapi.BootstrapDestroyer = (*Provider)(nil)
 var _ clusterapi.IgnitionProvider = (*Provider)(nil)
 var _ clusterapi.PreProvider = (*Provider)(nil)
+var _ clusterapi.PostProvider = (*Provider)(nil)
 var _ clusterapi.Provider = (*Provider)(nil)
 var _ clusterapi.Timeouts = (*Provider)(nil)
 
@@ -294,6 +297,67 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 	return nil
 }
 
+// PostProvision is called once Infrastructure provisioning is completed, including machines.
+func (p Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisionInput) error {
+	// If the cluster is Public/External, attach a floating IP to the bootstrap node for debugging purposes. It will need to be cleaned up during bootstrap destroy however.
+
+	if in.InstallConfig.Config.Publish == types.InternalPublishingStrategy {
+		logrus.Debugf("no post provisioning required for internal clusters")
+		return nil
+	}
+
+	metadata := ibmcloudic.NewMetadata(in.InstallConfig.Config)
+	client, err := metadata.Client()
+	if err != nil {
+		return fmt.Errorf("failed creating IBM Cloud client in PostProvision: %w", err)
+	}
+
+	// Collect the bootstrap machine from the provider.
+	ibmcloudMachine := &capibmcloud.IBMVPCMachine{}
+	key := crclient.ObjectKey{
+		Name:      capiutils.GenerateBoostrapMachineName(in.InfraID),
+		Namespace: capiutils.Namespace,
+	}
+	logrus.Debugf("PostProvision: machineKey = %+v", key)
+	if err = in.Client.Get(ctx, key, ibmcloudMachine); err != nil {
+		return fmt.Errorf("failed to get ibmcloud bootstrap machine in PostProvision: %w", err)
+	}
+
+	resourceGroupName := in.InfraID
+	if in.InstallConfig.Config.Platform.IBMCloud.ResourceGroupName != "" {
+		resourceGroupName = in.InstallConfig.Config.Platform.IBMCloud.ResourceGroupName
+	}
+	logrus.Debugf("collected resource group name %s for floating ip", resourceGroupName)
+
+	// Attach a new VPC Floating IP resource to the bootstrap machine.
+	logrus.Debugf("creating floating ip for bootstrap machine")
+	floatingIPDetails, err := client.AttachFloatingIP(ctx, ibmcloudMachine.Name, ibmcloudMachine.Status.InstanceID, in.InstallConfig.Config.Platform.IBMCloud.Region, resourceGroupName)
+	if err != nil {
+		return fmt.Errorf("failed to attaching floating ip to bootstrap machine: %w", err)
+	}
+
+	// Create patch helper to update the bootstrap machine addresses.
+	patchHelper, err := patch.NewHelper(ibmcloudMachine, in.Client)
+	if err != nil {
+		return fmt.Errorf("failed creating patch helper to update machine addresses")
+	}
+
+	// Update the bootstrap machine's external address with the new floating IP address.
+	ibmcloudMachine.Status.Addresses = append(ibmcloudMachine.Status.Addresses, corev1.NodeAddress{
+		Address: *floatingIPDetails.Address,
+		Type:    corev1.NodeExternalIP,
+	})
+
+	// Patch the bootstrap machine.
+	if err = patchHelper.Patch(ctx, ibmcloudMachine); err != nil {
+		return fmt.Errorf("failed to patch bootstrap machine with floating ip address: %w", err)
+	}
+
+	logrus.Debugf("floating ip attached to bootstrap machine at %s", *floatingIPDetails.Address)
+
+	return nil
+}
+
 func leftInContext(ctx context.Context) time.Duration {
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -402,4 +466,113 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 	}
 
 	return ignSecrets, nil
+}
+
+// DestroyBootstrap destroys the remaining temporary bootstrap resources.
+func (p Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapDestroyInput) error {
+	// Currently expect the Bootstrap Node will be deleted via CAPI (along with its LB Pool Members).
+	// Remaining IBM Cloud Resources that need to be cleaned up:
+	// 1. COS Bucket for temporary bootstrap Ignition Config.
+	// 2. Potentially the COS Instance, if no other Buckets exist (specifically the Bucket for VSI Image).
+	// 3. Bootstrap Security Group.
+	// 4. Bootstrap Floating IP (if one was created, for External/Public clusters).
+	// 5. TBD - Bootstrap Machine's LoadBalancerPoolMembers (check whether this cleanup is required here or elsewhere).
+
+	logrus.Infof("bootstrap destroy ibmcloud resource cleanup")
+	// Setup IBM Cloud Client.
+	client, err := ibmcloudic.NewClient(in.Metadata.IBMCloud.ServiceEndpoints)
+	if err != nil {
+		return fmt.Errorf("failed creating IBM Cloud client during destroy bootstrap: %w", err)
+	}
+	infraID := in.Metadata.InfraID
+	region := in.Metadata.IBMCloud.Region
+	bootstrapMachineName := capiutils.GenerateBoostrapMachineName(infraID)
+	logrus.Debugf("bootstrap destroy cleanup resources for %s", infraID)
+
+	// Cleanup COS Bucket for bootstrap Ignition Config
+	cosInstanceName := ibmcloudic.COSInstanceName(infraID)
+	bucketName := ibmcloudbootstrap.GetIgnitionBucketName(infraID)
+	// Get COS Instance ID
+	logrus.Debugf("bootstrap destroy check cos resources for %s/%s", cosInstanceName, bucketName)
+	cosInstanceDetails, err := client.GetCOSInstanceByName(ctx, cosInstanceName)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed retrieving cos instance for destroy bootstrap: %w", err)
+	case cosInstanceDetails != nil:
+		err = cleanupIgnitionCOSBucket(ctx, client, *cosInstanceDetails.ID, bucketName, region)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup bootstrap ignition cos bucket %s: %w", bucketName, err)
+		}
+		logrus.Debugf("cleaned up bootstrap ignition cos bucket: %s/%s", *cosInstanceDetails.ID, bucketName)
+	default:
+		logrus.Debugf("no cos instance found for the cluster as %s, skipping ignition bucket cleanup", cosInstanceName)
+	}
+
+	// If there are no additional Buckets within the COS Instance (specifically the Bucket used for the VSI Image), cleanup the COS Instance as well.
+	logrus.Debugf("checking whether cos instance should be cleaned up as well: %s", *cosInstanceDetails.ID)
+	cosBucketsOutput, err := client.ListCOSBuckets(ctx, *cosInstanceDetails.ID, region)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed listing cos buckets in cos instance %s: %w", *cosInstanceDetails.ID, err)
+	case cosBucketsOutput == nil || len(cosBucketsOutput.Buckets) == 0:
+		logrus.Debugf("no remaining buckets in cos instance %s, attempting to cleanup instance", *cosInstanceDetails.ID)
+		err := client.DeleteCOSInstance(ctx, *cosInstanceDetails.ID)
+		if err != nil {
+			return fmt.Errorf("failed to delete empty cos instance %s: %w", *cosInstanceDetails.ID, err)
+		}
+	case len(cosBucketsOutput.Buckets) == 1 && cosBucketsOutput.Buckets[0].Name != nil && *cosBucketsOutput.Buckets[0].Name == bucketName:
+		logrus.Debugf("bootstrap ignition cos bucket %s still listed in cos instance, proceeding to cleanup cos instance: %s", bucketName, *cosInstanceDetails.ID)
+		err := client.DeleteCOSInstance(ctx, *cosInstanceDetails.ID)
+		if err != nil {
+			return fmt.Errorf("failed to delete cos instance %s, with single bucket %s: %w", *cosInstanceDetails.ID, bucketName, err)
+		}
+	default:
+		logrus.Debugf("cos instance contains additional buckets, skipping cos instance %s cleanup", *cosInstanceDetails.ID)
+	}
+
+	// Cleanup the Security Group for the Bootstrap node.
+	vpcName := in.Metadata.IBMCloud.VPC
+	// If VPC name is empty, it was auto-generated from the InfraID (not a pre-existing VPC for BYON support).
+	if vpcName == "" {
+		vpcName = ibmcloudic.VPCName(infraID)
+	}
+
+	logrus.Debugf("bootstrap destroy checking for vpc %s", vpcName)
+	var vpcResourceNotFoundError *ibmcloudic.VPCResourceNotFoundError
+	vpcDetails, err := client.GetVPCByName(ctx, vpcName)
+	if err != nil {
+		if errors.As(err, &vpcResourceNotFoundError) {
+			return fmt.Errorf("no vpc found for the cluster as %s, unable to complete cleanup", vpcName)
+		}
+		return fmt.Errorf("failed retrieving vpc for destroy bootstrap: %w", err)
+	}
+
+	bootstrapSGName := ibmcloudic.BootstrapSecurityGroupName(infraID)
+	logrus.Debugf("cleaning up bootstrap security group %s", bootstrapSGName)
+	if err = cleanupBootstrapSecurityGroup(ctx, client, *vpcDetails.ID, bootstrapSGName, region); err != nil {
+		return fmt.Errorf("failed to cleanup boostrap security group %s: %w", bootstrapSGName, err)
+	}
+
+	// Cleanup the Floating IP for the Bootstrap node, if this is an External/Public cluster.
+	logrus.Debugf("checking for cleanup of floating ip %s", bootstrapMachineName)
+	floatingIPDetails, err := client.GetFloatingIPByName(ctx, bootstrapMachineName, region)
+	switch {
+	case err != nil:
+		// If this isn't a Not Found error (it is okay if it doesn't exist), return the unexpected error.
+		if !errors.As(err, &vpcResourceNotFoundError) {
+			return fmt.Errorf("failed checking for existing bootstrap floating ip: %w", err)
+		}
+		logrus.Debugf("no bootstrap floating ip found for cleanup, skipping")
+	case floatingIPDetails != nil:
+		logrus.Debugf("found bootstrap floating ip for cleanup: %s=%s", *floatingIPDetails.Name, *floatingIPDetails.ID)
+		err = client.DeleteFloatingIP(ctx, *floatingIPDetails.ID, region)
+		if err != nil {
+			return fmt.Errorf("failed deleting bootstrap floating ip: %w", err)
+		}
+	default:
+		logrus.Debugf("no bootstrap floating ip found for cleanup, skipping")
+	}
+
+	logrus.Infof("destroy bootstrap cleanup completed")
+	return nil
 }

--- a/pkg/types/ibmcloud/platform.go
+++ b/pkg/types/ibmcloud/platform.go
@@ -46,6 +46,9 @@ const (
 
 	// IBMCloudServiceVPCVar is the variable name used by the IBM Cloud Terraform Provider to override the VPC endpoint.
 	IBMCloudServiceVPCVar string = "IBMCLOUD_IS_NG_API_ENDPOINT"
+
+	// IBMCloudInfrastructureSecurityGroupTargetReference is the name of a generic IBM Cloud Infrastructure Security Group target.
+	IBMCloudInfrastructureSecurityGroupTargetReference string = "*vpcv1.SecurityGroupTargetReference"
 )
 
 var (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2582,10 +2582,13 @@ sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/util/annotations
 sigs.k8s.io/cluster-api/util/certs
+sigs.k8s.io/cluster-api/util/conditions
+sigs.k8s.io/cluster-api/util/conditions/v1beta2
 sigs.k8s.io/cluster-api/util/contract
 sigs.k8s.io/cluster-api/util/conversion
 sigs.k8s.io/cluster-api/util/kubeconfig
 sigs.k8s.io/cluster-api/util/labels/format
+sigs.k8s.io/cluster-api/util/patch
 sigs.k8s.io/cluster-api/util/secret
 sigs.k8s.io/cluster-api/util/topology
 # sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1-0.20241026111253-5b4f7c1acb52

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/doc.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package conditions implements condition utilities.
+package conditions

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/getter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/getter.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// Getter interface defines methods that a Cluster API object should implement in order to
+// use the conditions package for getting conditions.
+type Getter interface {
+	client.Object
+
+	// GetConditions returns the list of conditions for a cluster API object.
+	GetConditions() clusterv1.Conditions
+}
+
+// Get returns the condition with the given type, if the condition does not exist,
+// it returns nil.
+func Get(from Getter, t clusterv1.ConditionType) *clusterv1.Condition {
+	conditions := from.GetConditions()
+	if conditions == nil {
+		return nil
+	}
+
+	for _, condition := range conditions {
+		if condition.Type == t {
+			return &condition
+		}
+	}
+	return nil
+}
+
+// Has returns true if a condition with the given type exists.
+func Has(from Getter, t clusterv1.ConditionType) bool {
+	return Get(from, t) != nil
+}
+
+// IsTrue is true if the condition with the given type is True, otherwise it returns false
+// if the condition is not True or if the condition does not exist (is nil).
+func IsTrue(from Getter, t clusterv1.ConditionType) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == corev1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse is true if the condition with the given type is False, otherwise it returns false
+// if the condition is not False or if the condition does not exist (is nil).
+func IsFalse(from Getter, t clusterv1.ConditionType) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == corev1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown is true if the condition with the given type is Unknown or if the condition
+// does not exist (is nil).
+func IsUnknown(from Getter, t clusterv1.ConditionType) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == corev1.ConditionUnknown
+	}
+	return true
+}
+
+// GetReason returns a nil safe string of Reason for the condition with the given type.
+func GetReason(from Getter, t clusterv1.ConditionType) string {
+	if c := Get(from, t); c != nil {
+		return c.Reason
+	}
+	return ""
+}
+
+// GetMessage returns a nil safe string of Message.
+func GetMessage(from Getter, t clusterv1.ConditionType) string {
+	if c := Get(from, t); c != nil {
+		return c.Message
+	}
+	return ""
+}
+
+// GetSeverity returns the condition Severity or nil if the condition
+// does not exist (is nil).
+func GetSeverity(from Getter, t clusterv1.ConditionType) *clusterv1.ConditionSeverity {
+	if c := Get(from, t); c != nil {
+		return &c.Severity
+	}
+	return nil
+}
+
+// GetLastTransitionTime returns the condition Severity or nil if the condition
+// does not exist (is nil).
+func GetLastTransitionTime(from Getter, t clusterv1.ConditionType) *metav1.Time {
+	if c := Get(from, t); c != nil {
+		return &c.LastTransitionTime
+	}
+	return nil
+}
+
+// summary returns a Ready condition with the summary of all the conditions existing
+// on an object. If the object does not have other conditions, no summary condition is generated.
+// NOTE: The resulting Ready condition will have positive polarity; the conditions we are starting from might have positive or negative polarity.
+func summary(from Getter, options ...MergeOption) *clusterv1.Condition {
+	conditions := from.GetConditions()
+
+	mergeOpt := &mergeOptions{}
+	for _, o := range options {
+		o(mergeOpt)
+	}
+
+	// Identifies the conditions in scope for the Summary by taking all the existing conditions except Ready,
+	// or, if a list of conditions types is specified, only the conditions the condition in that list.
+	conditionsInScope := make([]localizedCondition, 0, len(conditions))
+	for i := range conditions {
+		c := conditions[i]
+		if c.Type == clusterv1.ReadyCondition {
+			continue
+		}
+
+		if mergeOpt.conditionTypes != nil {
+			found := false
+			for _, t := range mergeOpt.conditionTypes {
+				if c.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		// Keep track of the polarity of the condition we are starting from.
+		polarity := PositivePolarity
+		for _, t := range mergeOpt.negativeConditionTypes {
+			if c.Type == t {
+				polarity = NegativePolarity
+				break
+			}
+		}
+
+		conditionsInScope = append(conditionsInScope, localizedCondition{
+			Condition: &c,
+			Polarity:  polarity,
+			Getter:    from,
+		})
+	}
+
+	// If it is required to add a step counter only if a subset of condition exists, check if the conditions
+	// in scope are included in this subset or not.
+	if mergeOpt.addStepCounterIfOnlyConditionTypes != nil {
+		for _, c := range conditionsInScope {
+			found := false
+			for _, t := range mergeOpt.addStepCounterIfOnlyConditionTypes {
+				if c.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				mergeOpt.addStepCounter = false
+				break
+			}
+		}
+	}
+
+	// If it is required to add a step counter, determine the total number of conditions defaulting
+	// to the selected conditions or, if defined, to the total number of conditions type to be considered.
+	if mergeOpt.addStepCounter {
+		mergeOpt.stepCounter = len(conditionsInScope)
+		if mergeOpt.conditionTypes != nil {
+			mergeOpt.stepCounter = len(mergeOpt.conditionTypes)
+		}
+		if mergeOpt.addStepCounterIfOnlyConditionTypes != nil {
+			mergeOpt.stepCounter = len(mergeOpt.addStepCounterIfOnlyConditionTypes)
+		}
+	}
+
+	return merge(conditionsInScope, clusterv1.ReadyCondition, mergeOpt)
+}
+
+// mirrorOptions allows to set options for the mirror operation.
+type mirrorOptions struct {
+	fallbackTo       *bool
+	fallbackReason   string
+	fallbackSeverity clusterv1.ConditionSeverity
+	fallbackMessage  string
+}
+
+// MirrorOptions defines an option for mirroring conditions.
+type MirrorOptions func(*mirrorOptions)
+
+// WithFallbackValue specify a fallback value to use in case the mirrored condition does not exist;
+// in case the fallbackValue is false, given values for reason, severity and message will be used.
+func WithFallbackValue(fallbackValue bool, reason string, severity clusterv1.ConditionSeverity, message string) MirrorOptions {
+	return func(c *mirrorOptions) {
+		c.fallbackTo = &fallbackValue
+		c.fallbackReason = reason
+		c.fallbackSeverity = severity
+		c.fallbackMessage = message
+	}
+}
+
+// mirror mirrors the Ready condition from a dependent object into the target condition;
+// if the Ready condition does not exist in the source object, no target conditions is generated.
+// NOTE: Considering that we are mirroring Ready conditions with positive polarity, also the resulting condition will have positive polarity.
+func mirror(from Getter, targetCondition clusterv1.ConditionType, options ...MirrorOptions) *clusterv1.Condition {
+	mirrorOpt := &mirrorOptions{}
+	for _, o := range options {
+		o(mirrorOpt)
+	}
+
+	condition := Get(from, clusterv1.ReadyCondition)
+
+	if mirrorOpt.fallbackTo != nil && condition == nil {
+		switch *mirrorOpt.fallbackTo {
+		case true:
+			condition = TrueCondition(targetCondition)
+		case false:
+			condition = FalseCondition(targetCondition, mirrorOpt.fallbackReason, mirrorOpt.fallbackSeverity, mirrorOpt.fallbackMessage)
+		}
+	}
+
+	if condition != nil {
+		condition.Type = targetCondition
+	}
+
+	return condition
+}
+
+// Aggregates all the Ready condition from a list of dependent objects into the target object;
+// if the Ready condition does not exist in one of the source object, the object is excluded from
+// the aggregation; if none of the source object have ready condition, no target conditions is generated.
+// NOTE: Considering that we are aggregating Ready conditions with positive polarity, also the resulting condition will have positive polarity.
+func aggregate(from []Getter, targetCondition clusterv1.ConditionType, options ...MergeOption) *clusterv1.Condition {
+	conditionsInScope := make([]localizedCondition, 0, len(from))
+	for i := range from {
+		condition := Get(from[i], clusterv1.ReadyCondition)
+
+		conditionsInScope = append(conditionsInScope, localizedCondition{
+			Condition: condition,
+			Polarity:  PositivePolarity,
+			Getter:    from[i],
+		})
+	}
+
+	mergeOpt := &mergeOptions{
+		addStepCounter: true,
+		stepCounter:    len(from),
+	}
+	for _, o := range options {
+		o(mergeOpt)
+	}
+	return merge(conditionsInScope, targetCondition, mergeOpt)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/matcher.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/matcher.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// MatchConditions returns a custom matcher to check equality of clusterv1.Conditions.
+func MatchConditions(expected clusterv1.Conditions) types.GomegaMatcher {
+	return &matchConditions{
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	expected clusterv1.Conditions
+}
+
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := []interface{}{}
+	for _, condition := range m.expected {
+		elems = append(elems, MatchCondition(condition))
+	}
+
+	return gomega.ConsistOf(elems...).Match(actual)
+}
+
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchCondition returns a custom matcher to check equality of clusterv1.Condition.
+func MatchCondition(expected clusterv1.Condition) types.GomegaMatcher {
+	return &matchCondition{
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	expected clusterv1.Condition
+}
+
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(clusterv1.Condition)
+	if !ok {
+		return false, fmt.Errorf("actual should be of type Condition")
+	}
+
+	ok, err = gomega.Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Severity).Match(actualCondition.Severity)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return ok, err
+	}
+
+	return ok, err
+}
+
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/matchers.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/matchers.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"errors"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// HaveSameStateOf matches a condition to have the same state of another.
+func HaveSameStateOf(expected *clusterv1.Condition) types.GomegaMatcher {
+	return &conditionMatcher{
+		Expected: expected,
+	}
+}
+
+type conditionMatcher struct {
+	Expected *clusterv1.Condition
+}
+
+func (matcher *conditionMatcher) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(*clusterv1.Condition)
+	if !ok {
+		return false, errors.New("value should be a condition")
+	}
+
+	return HasSameState(actualCondition, matcher.Expected), nil
+}
+
+func (matcher *conditionMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have the same state of", matcher.Expected)
+}
+func (matcher *conditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have the same state of", matcher.Expected)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/merge.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/merge.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+type conditionPolarity string
+
+const (
+	// PositivePolarity describe a condition with positive polarity (Status=True good).
+	PositivePolarity conditionPolarity = "Positive"
+
+	// NegativePolarity describe a condition with negative polarity (Status=False good).
+	NegativePolarity conditionPolarity = "Negative"
+)
+
+// localizedCondition defines a condition with the information of the object the conditions
+// was originated from.
+type localizedCondition struct {
+	*clusterv1.Condition
+	Polarity conditionPolarity
+	Getter
+}
+
+// merge a list of condition into a single one.
+// This operation is designed to ensure visibility of the most relevant conditions for defining the
+// operational state of a component. E.g. If there is one error in the condition list, this one takes
+// priority over the other conditions and it is should be reflected in the target condition.
+//
+// More specifically:
+// 1. Conditions are grouped by status, severity
+// 2. The resulting condition groups are sorted according to the following priority:
+//   - P0 - Status=False - PositivePolarity |  Status=True  - NegativePolarity, Severity=Error
+//   - P1 - Status=False - PositivePolarity |  Status=True  - NegativePolarity, Severity=Warning
+//   - P2 - Status=False - PositivePolarity |  Status=True  - NegativePolarity, Severity=Info
+//   - P3 - Status=True  - PositivePolarity |  Status=False - NegativePolarity
+//   - P4 - Status=Unknown
+//
+// 3. The group with highest priority is used to determine status, severity and other info of the target condition.
+//
+// Please note that the last operation includes also the task of computing the Reason and the Message for the target
+// condition; in order to complete such task some trade-off should be made, because there is no a golden rule
+// for summarizing many Reason/Message into single Reason/Message.
+// mergeOptions allows the user to adapt this process to the specific needs by exposing a set of merge strategies.
+// NOTE: Target condition will have positive polarity.
+func merge(conditions []localizedCondition, targetCondition clusterv1.ConditionType, options *mergeOptions) *clusterv1.Condition {
+	g := getConditionGroups(conditions)
+	if len(g) == 0 {
+		return nil
+	}
+
+	if g.TopGroup().status == corev1.ConditionTrue {
+		return TrueCondition(targetCondition)
+	}
+
+	targetReason := getReason(g, options)
+	targetMessage := getMessage(g, options)
+	if g.TopGroup().status == corev1.ConditionFalse {
+		return FalseCondition(targetCondition, targetReason, g.TopGroup().severity, targetMessage)
+	}
+	return UnknownCondition(targetCondition, targetReason, targetMessage)
+}
+
+// getConditionGroups groups a list of conditions according to status, severity values.
+// Additionally, the resulting groups are sorted by mergePriority.
+func getConditionGroups(conditions []localizedCondition) conditionGroups {
+	groups := conditionGroups{}
+
+	for _, condition := range conditions {
+		if condition.Condition == nil {
+			continue
+		}
+
+		added := false
+
+		// Identify the groupStatus the condition belongs to.
+		// NOTE: status for the conditions with negative polarity is "negated" so it is possible
+		// to merge conditions with different polarity (conditionGroup is always using positive polarity).
+		groupStatus := condition.Status
+		if condition.Polarity == NegativePolarity {
+			switch groupStatus {
+			case corev1.ConditionFalse:
+				groupStatus = corev1.ConditionTrue
+			case corev1.ConditionTrue:
+				groupStatus = corev1.ConditionFalse
+			case corev1.ConditionUnknown:
+				groupStatus = corev1.ConditionUnknown
+			}
+		}
+		for i := range groups {
+			if groups[i].status == groupStatus && groups[i].severity == condition.Severity {
+				groups[i].conditions = append(groups[i].conditions, condition)
+				added = true
+				break
+			}
+		}
+		if !added {
+			groups = append(groups, conditionGroup{
+				conditions: []localizedCondition{condition},
+				status:     groupStatus,
+				severity:   condition.Severity,
+			})
+		}
+	}
+
+	// sort groups by priority
+	sort.Sort(groups)
+
+	// sorts conditions in the TopGroup so we ensure predictable result for merge strategies.
+	// condition are sorted using the same lexicographic order used by Set; in case two conditions
+	// have the same type, condition are sorted using according to the alphabetical order of the source object name.
+	if len(groups) > 0 {
+		sort.Slice(groups[0].conditions, func(i, j int) bool {
+			a := groups[0].conditions[i]
+			b := groups[0].conditions[j]
+			if a.Type != b.Type {
+				return lexicographicLess(a.Condition, b.Condition)
+			}
+			return a.GetName() < b.GetName()
+		})
+	}
+
+	return groups
+}
+
+// conditionGroups provides supports for grouping a list of conditions to be
+// merged into a single condition. ConditionGroups can be sorted by mergePriority.
+type conditionGroups []conditionGroup
+
+func (g conditionGroups) Len() int {
+	return len(g)
+}
+
+func (g conditionGroups) Less(i, j int) bool {
+	return g[i].mergePriority() < g[j].mergePriority()
+}
+
+func (g conditionGroups) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+// TopGroup returns the condition group with the highest mergePriority.
+func (g conditionGroups) TopGroup() *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	return &g[0]
+}
+
+// TrueGroup returns the condition group with status True, if any.
+// Note: conditionGroup is always using positive polarity; the conditions in the group might have positive or negative polarity.
+func (g conditionGroups) TrueGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionTrue, clusterv1.ConditionSeverityNone)
+}
+
+// ErrorGroup returns the condition group with status False and severity Error, if any.
+// Note: conditionGroup is always using positive polarity; the conditions in the group might have positive or negative polarity.
+func (g conditionGroups) ErrorGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, clusterv1.ConditionSeverityError)
+}
+
+// WarningGroup returns the condition group with status False and severity Warning, if any.
+// Note: conditionGroup is always using positive polarity; the conditions in the group might have positive or negative polarity.
+func (g conditionGroups) WarningGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, clusterv1.ConditionSeverityWarning)
+}
+
+func (g conditionGroups) getByStatusAndSeverity(status corev1.ConditionStatus, severity clusterv1.ConditionSeverity) *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	for _, group := range g {
+		if group.status == status && group.severity == severity {
+			return &group
+		}
+	}
+	return nil
+}
+
+// conditionGroup define a group of conditions with the same status and severity,
+// and thus with the same priority when merging into a Ready condition.
+// Note: conditionGroup is always using positive polarity; the conditions in the group might have positive or negative polarity.
+type conditionGroup struct {
+	status     corev1.ConditionStatus
+	severity   clusterv1.ConditionSeverity
+	conditions []localizedCondition
+}
+
+// mergePriority provides a priority value for the status and severity tuple that identifies this
+// condition group. The mergePriority value allows an easier sorting of conditions groups.
+// Note: conditionGroup is always using positive polarity.
+func (g conditionGroup) mergePriority() int {
+	switch g.status {
+	case corev1.ConditionFalse:
+		switch g.severity {
+		case clusterv1.ConditionSeverityError:
+			return 0
+		case clusterv1.ConditionSeverityWarning:
+			return 1
+		case clusterv1.ConditionSeverityInfo:
+			return 2
+		}
+	case corev1.ConditionTrue:
+		return 3
+	case corev1.ConditionUnknown:
+		return 4
+	}
+
+	// this should never happen
+	return 99
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/merge_strategies.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/merge_strategies.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+	"strings"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// mergeOptions allows to set strategies for merging a set of conditions into a single condition,
+// and more specifically for computing the target Reason and the target Message.
+type mergeOptions struct {
+	conditionTypes                     []clusterv1.ConditionType
+	negativeConditionTypes             []clusterv1.ConditionType
+	addSourceRef                       bool
+	addStepCounter                     bool
+	addStepCounterIfOnlyConditionTypes []clusterv1.ConditionType
+	stepCounter                        int
+}
+
+// MergeOption defines an option for computing a summary of conditions.
+type MergeOption func(*mergeOptions)
+
+// WithConditions instructs merge about the condition types to consider when doing a merge operation;
+// if this option is not specified, all the conditions (excepts Ready) will be considered. This is required,
+// so we can provide some guarantees about the semantic of the target condition without worrying about
+// side effects if someone or something adds custom conditions to the objects.
+//
+// NOTE: The order of conditions types defines the priority for determining the Reason and Message for the
+// target condition.
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithConditions(t ...clusterv1.ConditionType) MergeOption {
+	return func(c *mergeOptions) {
+		c.conditionTypes = t
+	}
+}
+
+// WithNegativePolarityConditions instruct merge about which conditions should be considered having negative polarity.
+// IMPORTANT: this must be a subset of WithConditions.
+func WithNegativePolarityConditions(t ...clusterv1.ConditionType) MergeOption {
+	return func(c *mergeOptions) {
+		c.negativeConditionTypes = t
+	}
+}
+
+// WithStepCounter instructs merge to add a "x of y completed" string to the message,
+// where x is the number of conditions with Status=true and y is the number of conditions in scope.
+func WithStepCounter() MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounter = true
+	}
+}
+
+// WithStepCounterIf adds a step counter if the value is true.
+// This can be used e.g. to add a step counter only if the object is not being deleted.
+//
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithStepCounterIf(value bool) MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounter = value
+	}
+}
+
+// WithStepCounterIfOnly ensure a step counter is show only if a subset of condition exists.
+// This applies for example on Machines, where we want to use
+// the step counter notation while provisioning the machine, but then we want to move away from this notation
+// as soon as the machine is provisioned and e.g. a Machine health check condition is generated
+//
+// IMPORTANT: This options requires WithStepCounter or WithStepCounterIf to be set.
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithStepCounterIfOnly(t ...clusterv1.ConditionType) MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounterIfOnlyConditionTypes = t
+	}
+}
+
+// AddSourceRef instructs merge to add info about the originating object to the target Reason.
+func AddSourceRef() MergeOption {
+	return func(c *mergeOptions) {
+		c.addSourceRef = true
+	}
+}
+
+// getReason returns the reason to be applied to the condition resulting by merging a set of condition groups.
+// The reason is computed according to the given mergeOptions.
+func getReason(groups conditionGroups, options *mergeOptions) string {
+	return getFirstReason(groups, options.conditionTypes, options.addSourceRef)
+}
+
+// getFirstReason returns the first reason from the ordered list of conditions in the top group.
+// If required, the reason gets localized with the source object reference.
+func getFirstReason(g conditionGroups, order []clusterv1.ConditionType, addSourceRef bool) string {
+	if condition := getFirstCondition(g, order); condition != nil {
+		reason := condition.Reason
+		if addSourceRef {
+			return localizeReason(reason, condition.Getter)
+		}
+		return reason
+	}
+	return ""
+}
+
+// localizeReason adds info about the originating object to the target Reason.
+func localizeReason(reason string, from Getter) string {
+	if strings.Contains(reason, "@") {
+		return reason
+	}
+	return fmt.Sprintf("%s @ %s/%s", reason, from.GetObjectKind().GroupVersionKind().Kind, from.GetName())
+}
+
+// getMessage returns the message to be applied to the condition resulting by merging a set of condition groups.
+// The message is computed according to the given mergeOptions, but in case of errors or warning a
+// summary of existing errors is automatically added.
+func getMessage(groups conditionGroups, options *mergeOptions) string {
+	if options.addStepCounter {
+		return getStepCounterMessage(groups, options.stepCounter)
+	}
+
+	return getFirstMessage(groups, options.conditionTypes)
+}
+
+// getStepCounterMessage returns a message "x of y completed", where x is the number of conditions
+// with Status=true and y is the number passed to this method.
+func getStepCounterMessage(groups conditionGroups, to int) string {
+	ct := 0
+	if trueGroup := groups.TrueGroup(); trueGroup != nil {
+		ct = len(trueGroup.conditions)
+	}
+	return fmt.Sprintf("%d of %d completed", ct, to)
+}
+
+// getFirstMessage returns the message from the ordered list of conditions in the top group.
+func getFirstMessage(groups conditionGroups, order []clusterv1.ConditionType) string {
+	if condition := getFirstCondition(groups, order); condition != nil {
+		return condition.Message
+	}
+	return ""
+}
+
+// getFirstCondition returns a first condition from the ordered list of conditions in the top group.
+func getFirstCondition(g conditionGroups, priority []clusterv1.ConditionType) *localizedCondition {
+	topGroup := g.TopGroup()
+	if topGroup == nil {
+		return nil
+	}
+
+	switch len(topGroup.conditions) {
+	case 0:
+		return nil
+	case 1:
+		return &topGroup.conditions[0]
+	default:
+		for _, p := range priority {
+			for _, c := range topGroup.conditions {
+				if c.Type == p {
+					return &c
+				}
+			}
+		}
+		return &topGroup.conditions[0]
+	}
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/patch.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/patch.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// Patch defines a list of operations to change a list of conditions into another.
+type Patch []PatchOperation
+
+// PatchOperation define an operation that changes a single condition.
+type PatchOperation struct {
+	Before *clusterv1.Condition
+	After  *clusterv1.Condition
+	Op     PatchOperationType
+}
+
+// PatchOperationType defines patch operation types.
+type PatchOperationType string
+
+const (
+	// AddConditionPatch defines an add condition patch operation.
+	AddConditionPatch PatchOperationType = "Add"
+
+	// ChangeConditionPatch defines an change condition patch operation.
+	ChangeConditionPatch PatchOperationType = "Change"
+
+	// RemoveConditionPatch defines a remove condition patch operation.
+	RemoveConditionPatch PatchOperationType = "Remove"
+)
+
+// NewPatch returns the Patch required to align source conditions to after conditions.
+func NewPatch(before Getter, after Getter) (Patch, error) {
+	var patch Patch
+
+	if util.IsNil(before) {
+		return nil, errors.New("error creating patch: before object is nil")
+	}
+	if util.IsNil(after) {
+		return nil, errors.New("error creating patch: after object is nil")
+	}
+
+	// Identify AddCondition and ModifyCondition changes.
+	targetConditions := after.GetConditions()
+	for i := range targetConditions {
+		targetCondition := targetConditions[i]
+		currentCondition := Get(before, targetCondition.Type)
+		if currentCondition == nil {
+			patch = append(patch, PatchOperation{Op: AddConditionPatch, After: &targetCondition})
+			continue
+		}
+
+		if !reflect.DeepEqual(&targetCondition, currentCondition) {
+			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, After: &targetCondition, Before: currentCondition})
+		}
+	}
+
+	// Identify RemoveCondition changes.
+	baseConditions := before.GetConditions()
+	for i := range baseConditions {
+		baseCondition := baseConditions[i]
+		targetCondition := Get(after, baseCondition.Type)
+		if targetCondition == nil {
+			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Before: &baseCondition})
+		}
+	}
+	return patch, nil
+}
+
+// applyOptions allows to set strategies for patch apply.
+type applyOptions struct {
+	ownedConditions []clusterv1.ConditionType
+	forceOverwrite  bool
+}
+
+func (o *applyOptions) isOwnedCondition(t clusterv1.ConditionType) bool {
+	for _, i := range o.ownedConditions {
+		if i == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyOption defines an option for applying a condition patch.
+type ApplyOption func(*applyOptions)
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+func WithOwnedConditions(t ...clusterv1.ConditionType) ApplyOption {
+	return func(c *applyOptions) {
+		c.ownedConditions = t
+	}
+}
+
+// WithForceOverwrite In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+func WithForceOverwrite(v bool) ApplyOption {
+	return func(c *applyOptions) {
+		c.forceOverwrite = v
+	}
+}
+
+// Apply executes a three-way merge of a list of Patch.
+// When merge conflicts are detected (latest deviated from before in an incompatible way), an error is returned.
+func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
+	if p.IsZero() {
+		return nil
+	}
+
+	if util.IsNil(latest) {
+		return errors.New("error patching conditions: latest object was nil")
+	}
+
+	applyOpt := &applyOptions{}
+	for _, o := range options {
+		if util.IsNil(o) {
+			return errors.New("error patching conditions: ApplyOption was nil")
+		}
+		o(applyOpt)
+	}
+
+	for _, conditionPatch := range p {
+		switch conditionPatch.Op {
+		case AddConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
+			// If the condition is already on latest, check if latest and after agree on the change; if not, this is a conflict.
+			if latestCondition := Get(latest, conditionPatch.After.Type); latestCondition != nil {
+				// If latest and after agree on the change, then it is a conflict.
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// otherwise, the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// If the condition does not exists on the latest, add the new after condition.
+			Set(latest, conditionPatch.After)
+
+		case ChangeConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
+			latestCondition := Get(latest, conditionPatch.After.Type)
+
+			// If the condition does not exist anymore on the latest, this is a conflict.
+			if latestCondition == nil {
+				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+			}
+
+			// If the condition on the latest is different from the base condition, check if
+			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
+			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// Otherwise the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// Otherwise apply the new after condition.
+			Set(latest, conditionPatch.After)
+
+		case RemoveConditionPatch:
+			// If the conditions is owned, always keep the after value (condition should be deleted).
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.Before.Type) {
+				Delete(latest, conditionPatch.Before.Type)
+				continue
+			}
+
+			// If the condition is still on the latest, check if it is changed in the meantime;
+			// if so then this is a conflict.
+			if latestCondition := Get(latest, conditionPatch.Before.Type); latestCondition != nil {
+				if !HasSameState(latestCondition, conditionPatch.Before) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+				}
+			}
+			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.
+			Delete(latest, conditionPatch.Before.Type)
+		}
+	}
+	return nil
+}
+
+// IsZero returns true if the patch is nil or has no changes.
+func (p Patch) IsZero() bool {
+	if p == nil {
+		return true
+	}
+	return len(p) == 0
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/setter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/setter.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// Setter interface defines methods that a Cluster API object should implement in order to
+// use the conditions package for setting conditions.
+type Setter interface {
+	Getter
+	SetConditions(clusterv1.Conditions)
+}
+
+// Set sets the given condition.
+//
+// NOTE: If a condition already exists, the LastTransitionTime is updated only if a change is detected
+// in any of the following fields: Status, Reason, Severity and Message.
+func Set(to Setter, condition *clusterv1.Condition) {
+	if to == nil || condition == nil {
+		return
+	}
+
+	// Check if the new conditions already exists, and change it only if there is a status
+	// transition (otherwise we should preserve the current last transition time)-
+	conditions := to.GetConditions()
+	exists := false
+	for i := range conditions {
+		existingCondition := conditions[i]
+		if existingCondition.Type == condition.Type {
+			exists = true
+			if !HasSameState(&existingCondition, condition) {
+				condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+				conditions[i] = *condition
+				break
+			}
+			condition.LastTransitionTime = existingCondition.LastTransitionTime
+			break
+		}
+	}
+
+	// If the condition does not exist, add it, setting the transition time only if not already set
+	if !exists {
+		if condition.LastTransitionTime.IsZero() {
+			condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+		}
+		conditions = append(conditions, *condition)
+	}
+
+	// Sorts conditions for convenience of the consumer, i.e. kubectl.
+	sort.Slice(conditions, func(i, j int) bool {
+		return lexicographicLess(&conditions[i], &conditions[j])
+	})
+
+	to.SetConditions(conditions)
+}
+
+// SetWithCustomLastTransitionTime is similar to Set function which sets the given condition but following changes for LastTransitionTime.
+//
+//  1. if the condition of the specified type already exists (all fields of the existing condition are updated to
+//     new condition, LastTransitionTime is set to current time if unset and new status differs from the old status)
+//  2. if a condition of the specified type does not exist (LastTransitionTime is set to current time if unset, and newCondition is appended)
+func SetWithCustomLastTransitionTime(to Setter, condition *clusterv1.Condition) {
+	if to == nil || condition == nil {
+		return
+	}
+
+	// Check if the new conditions already exists, and change it only if there is a status
+	// transition (otherwise we should preserve the current last transition time)-
+	conditions := to.GetConditions()
+	exists := false
+	for i := range conditions {
+		existingCondition := conditions[i]
+		if existingCondition.Type == condition.Type {
+			exists = true
+			if !HasSameState(&existingCondition, condition) {
+				if existingCondition.Status != condition.Status {
+					if condition.LastTransitionTime.IsZero() {
+						condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+					}
+				} else {
+					condition.LastTransitionTime = existingCondition.LastTransitionTime
+				}
+				conditions[i] = *condition
+			}
+			break
+		}
+	}
+
+	// If the condition does not exist, add it, setting the transition time only if not already set
+	if !exists {
+		if condition.LastTransitionTime.IsZero() {
+			condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+		}
+		conditions = append(conditions, *condition)
+	}
+
+	// Sorts conditions for convenience of the consumer, i.e. kubectl.
+	sort.Slice(conditions, func(i, j int) bool {
+		return lexicographicLess(&conditions[i], &conditions[j])
+	})
+
+	to.SetConditions(conditions)
+}
+
+// TrueCondition returns a condition with Status=True and the given type.
+func TrueCondition(t clusterv1.ConditionType) *clusterv1.Condition {
+	return &clusterv1.Condition{
+		Type:   t,
+		Status: corev1.ConditionTrue,
+	}
+}
+
+// TrueConditionWithNegativePolarity returns a condition with negative polarity, Status=True and the given type (Status=True has a negative meaning).
+func TrueConditionWithNegativePolarity(t clusterv1.ConditionType, reason string, severity clusterv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) *clusterv1.Condition {
+	return &clusterv1.Condition{
+		Type:     t,
+		Status:   corev1.ConditionTrue,
+		Reason:   reason,
+		Severity: severity,
+		Message:  fmt.Sprintf(messageFormat, messageArgs...),
+	}
+}
+
+// FalseCondition returns a condition with Status=False and the given type.
+func FalseCondition(t clusterv1.ConditionType, reason string, severity clusterv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) *clusterv1.Condition {
+	return &clusterv1.Condition{
+		Type:     t,
+		Status:   corev1.ConditionFalse,
+		Reason:   reason,
+		Severity: severity,
+		Message:  fmt.Sprintf(messageFormat, messageArgs...),
+	}
+}
+
+// FalseConditionWithNegativePolarity returns a condition with negative polarity, Status=false and the given type (Status=False has a positive meaning).
+func FalseConditionWithNegativePolarity(t clusterv1.ConditionType) *clusterv1.Condition {
+	return &clusterv1.Condition{
+		Type:   t,
+		Status: corev1.ConditionFalse,
+	}
+}
+
+// UnknownCondition returns a condition with Status=Unknown and the given type.
+func UnknownCondition(t clusterv1.ConditionType, reason string, messageFormat string, messageArgs ...interface{}) *clusterv1.Condition {
+	return &clusterv1.Condition{
+		Type:    t,
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: fmt.Sprintf(messageFormat, messageArgs...),
+	}
+}
+
+// MarkTrue sets Status=True for the condition with the given type.
+func MarkTrue(to Setter, t clusterv1.ConditionType) {
+	Set(to, TrueCondition(t))
+}
+
+// MarkTrueWithNegativePolarity sets Status=True for a condition with negative polarity and the given type (Status=True has a negative meaning).
+func MarkTrueWithNegativePolarity(to Setter, t clusterv1.ConditionType, reason string, severity clusterv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) {
+	Set(to, TrueConditionWithNegativePolarity(t, reason, severity, messageFormat, messageArgs...))
+}
+
+// MarkUnknown sets Status=Unknown for the condition with the given type.
+func MarkUnknown(to Setter, t clusterv1.ConditionType, reason, messageFormat string, messageArgs ...interface{}) {
+	Set(to, UnknownCondition(t, reason, messageFormat, messageArgs...))
+}
+
+// MarkFalse sets Status=False for the condition with the given type.
+func MarkFalse(to Setter, t clusterv1.ConditionType, reason string, severity clusterv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) {
+	Set(to, FalseCondition(t, reason, severity, messageFormat, messageArgs...))
+}
+
+// MarkFalseWithNegativePolarity sets Status=False for a condition with negative polarity and the given type (Status=False has a positive meaning).
+func MarkFalseWithNegativePolarity(to Setter, t clusterv1.ConditionType) {
+	Set(to, FalseConditionWithNegativePolarity(t))
+}
+
+// SetSummary sets a Ready condition with the summary of all the conditions existing
+// on an object. If the object does not have other conditions, no summary condition is generated.
+func SetSummary(to Setter, options ...MergeOption) {
+	Set(to, summary(to, options...))
+}
+
+// SetMirror creates a new condition by mirroring the Ready condition from a dependent object;
+// if the Ready condition does not exist in the source object, no target conditions is generated.
+func SetMirror(to Setter, targetCondition clusterv1.ConditionType, from Getter, options ...MirrorOptions) {
+	Set(to, mirror(from, targetCondition, options...))
+}
+
+// SetAggregate creates a new condition with the aggregation of all the Ready condition
+// from a list of dependent objects; if the Ready condition does not exist in one of the source object,
+// the object is excluded from the aggregation; if none of the source object have ready condition,
+// no target conditions is generated.
+func SetAggregate(to Setter, targetCondition clusterv1.ConditionType, from []Getter, options ...MergeOption) {
+	Set(to, aggregate(from, targetCondition, options...))
+}
+
+// Delete deletes the condition with the given type.
+func Delete(to Setter, t clusterv1.ConditionType) {
+	if to == nil {
+		return
+	}
+
+	conditions := to.GetConditions()
+	newConditions := make(clusterv1.Conditions, 0, len(conditions))
+	for _, condition := range conditions {
+		if condition.Type != t {
+			newConditions = append(newConditions, condition)
+		}
+	}
+	to.SetConditions(newConditions)
+}
+
+// lexicographicLess returns true if a condition is less than another in regard to
+// the order of conditions designed for convenience of the consumer, i.e. kubectl.
+// According to this order the Ready condition always goes first, followed by all the other
+// conditions sorted by Type.
+func lexicographicLess(i, j *clusterv1.Condition) bool {
+	if i == nil {
+		return true
+	}
+	if j == nil {
+		return false
+	}
+	return (i.Type == clusterv1.ReadyCondition || i.Type < j.Type) && j.Type != clusterv1.ReadyCondition
+}
+
+// HasSameState returns true if a condition has the same state of another; state is defined
+// by the union of following fields: Type, Status, Reason, Severity and Message (it excludes LastTransitionTime).
+func HasSameState(i, j *clusterv1.Condition) bool {
+	if i == nil || j == nil {
+		return i == j
+	}
+	return i.Type == j.Type &&
+		i.Status == j.Status &&
+		i.Reason == j.Reason &&
+		i.Severity == j.Severity &&
+		i.Message == j.Message
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/unstructured.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/unstructured.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// UnstructuredGetter return a Getter object that can read conditions from an Unstructured object.
+// Important. This method should be used only with types implementing Cluster API conditions.
+func UnstructuredGetter(u *unstructured.Unstructured) Getter {
+	return &unstructuredWrapper{Unstructured: u}
+}
+
+// UnstructuredSetter return a Setter object that can set conditions from an Unstructured object.
+// Important. This method should be used only with types implementing Cluster API conditions.
+func UnstructuredSetter(u *unstructured.Unstructured) Setter {
+	return &unstructuredWrapper{Unstructured: u}
+}
+
+type unstructuredWrapper struct {
+	*unstructured.Unstructured
+}
+
+// GetConditions returns the list of conditions from an Unstructured object.
+//
+// NOTE: Due to the constraints of JSON-unmarshal, this operation is to be considered best effort.
+// In more details:
+//   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
+//   - It's not possible to detect if the object has an empty condition list or if it does not implement conditions;
+//     in both cases the operation returns an empty slice is returned.
+//   - If the object doesn't implement conditions on under status as defined in Cluster API,
+//     JSON-unmarshal matches incoming object keys to the keys; this can lead to conditions values partially set.
+func (c *unstructuredWrapper) GetConditions() clusterv1.Conditions {
+	conditions := clusterv1.Conditions{}
+	if err := util.UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "conditions"); err != nil {
+		return nil
+	}
+	return conditions
+}
+
+// SetConditions set the conditions into an Unstructured object.
+//
+// NOTE: Due to the constraints of JSON-unmarshal, this operation is to be considered best effort.
+// In more details:
+//   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
+//   - It's not possible to detect if the object has an empty condition list or if it does not implement conditions;
+//     in both cases the operation returns an empty slice is returned.
+func (c *unstructuredWrapper) SetConditions(conditions clusterv1.Conditions) {
+	v := make([]interface{}, 0, len(conditions))
+	for i := range conditions {
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&conditions[i])
+		if err != nil {
+			log.Log.Error(err, "Failed to convert Condition to unstructured map. This error shouldn't have occurred, please file an issue.", "groupVersionKind", c.GroupVersionKind(), "name", c.GetName(), "namespace", c.GetNamespace())
+			continue
+		}
+		v = append(v, m)
+	}
+	// unstructured.SetNestedField returns an error only if value cannot be set because one of
+	// the nesting levels is not a map[string]interface{}; this is not the case so the error should never happen here.
+	err := unstructured.SetNestedField(c.Unstructured.Object, v, "status", "conditions")
+	if err != nil {
+		log.Log.Error(err, "Failed to set Conditions on unstructured object. This error shouldn't have occurred, please file an issue.", "groupVersionKind", c.GroupVersionKind(), "name", c.GetName(), "namespace", c.GetNamespace())
+	}
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/aggregate.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/aggregate.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// AggregateOption is some configuration that modifies options for a aggregate call.
+type AggregateOption interface {
+	// ApplyToAggregate applies this configuration to the given aggregate options.
+	ApplyToAggregate(option *AggregateOptions)
+}
+
+// AggregateOptions allows to set options for the aggregate operation.
+type AggregateOptions struct {
+	mergeStrategy                  MergeStrategy
+	targetConditionType            string
+	negativePolarityConditionTypes []string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *AggregateOptions) ApplyOptions(opts []AggregateOption) *AggregateOptions {
+	for _, opt := range opts {
+		opt.ApplyToAggregate(o)
+	}
+	return o
+}
+
+// NewAggregateCondition aggregates a condition from a list of objects; the given condition must have positive polarity;
+// if the given condition does not exist in one of the source objects, missing conditions are considered Unknown, reason NotYetReported.
+//
+// If the source conditions type has negative polarity, it should be indicated with the NegativePolarityConditionTypes option;
+// in this case NegativePolarityConditionTypes must match the sourceConditionType, and by default also the resulting condition
+// will have negative polarity.
+//
+// By default, the Aggregate condition has the same type of the source condition, but this can be changed by using
+// the TargetConditionType option.
+//
+// Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option.
+func NewAggregateCondition[T Getter](sourceObjs []T, sourceConditionType string, opts ...AggregateOption) (*metav1.Condition, error) {
+	if len(sourceObjs) == 0 {
+		return nil, errors.New("sourceObjs can't be empty")
+	}
+
+	aggregateOpt := &AggregateOptions{
+		targetConditionType: sourceConditionType,
+	}
+	aggregateOpt.ApplyOptions(opts)
+
+	if len(aggregateOpt.negativePolarityConditionTypes) != 0 && (aggregateOpt.negativePolarityConditionTypes[0] != sourceConditionType || len(aggregateOpt.negativePolarityConditionTypes) > 1) {
+		return nil, errors.Errorf("negativePolarityConditionTypes can only be set to [%q]", sourceConditionType)
+	}
+
+	if aggregateOpt.mergeStrategy == nil {
+		// Note: If mergeStrategy is not explicitly set, target condition has negative polarity if source condition has negative polarity
+		targetConditionHasPositivePolarity := !sets.New[string](aggregateOpt.negativePolarityConditionTypes...).Has(sourceConditionType)
+		aggregateOpt.mergeStrategy = DefaultMergeStrategy(TargetConditionHasPositivePolarity(targetConditionHasPositivePolarity), GetPriorityFunc(GetDefaultMergePriorityFunc(aggregateOpt.negativePolarityConditionTypes...)))
+	}
+
+	conditionsInScope := make([]ConditionWithOwnerInfo, 0, len(sourceObjs))
+	for _, obj := range sourceObjs {
+		conditions := getConditionsWithOwnerInfo(obj)
+
+		// Drops all the conditions not in scope for the merge operation
+		hasConditionType := false
+		for _, condition := range conditions {
+			if condition.Type != sourceConditionType {
+				continue
+			}
+			conditionsInScope = append(conditionsInScope, condition)
+			hasConditionType = true
+			break
+		}
+
+		// Add the expected conditions if it does not exist, so we are compliant with K8s guidelines
+		// (all missing conditions should be considered unknown).
+		if !hasConditionType {
+			conditionOwner := getConditionOwnerInfo(obj)
+
+			conditionsInScope = append(conditionsInScope, ConditionWithOwnerInfo{
+				OwnerResource: conditionOwner,
+				Condition: metav1.Condition{
+					Type:    sourceConditionType,
+					Status:  metav1.ConditionUnknown,
+					Reason:  NotYetReportedReason,
+					Message: fmt.Sprintf("Condition %s not yet reported", sourceConditionType),
+					// NOTE: LastTransitionTime and ObservedGeneration are not relevant for merge.
+				},
+			})
+		}
+	}
+
+	status, reason, message, err := aggregateOpt.mergeStrategy.Merge(conditionsInScope, []string{sourceConditionType})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &metav1.Condition{
+		Type:    aggregateOpt.targetConditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}
+
+	return c, err
+}
+
+// SetAggregateCondition is a convenience method that calls NewAggregateCondition to create an aggregate condition from the source objects,
+// and then calls Set to add the new condition to the target object.
+func SetAggregateCondition[T Getter](sourceObjs []T, targetObj Setter, conditionType string, opts ...AggregateOption) error {
+	aggregateCondition, err := NewAggregateCondition(sourceObjs, conditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *aggregateCondition)
+	return nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/doc.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/doc.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1beta2 implements utils for metav1.Conditions that will be used starting with the v1beta2 API.
+//
+// Please note that in order to make this change while respecting API deprecation rules, it is required
+// to go through a phased approach:
+// - Phase 1. metav1.Conditions will be added into v1beta1 API types under the Status.V1Beta2.Conditions struct (clusterv1.Conditions will remain in Status.Conditions)
+// - Phase 2. when introducing v1beta2 API types:
+//   - clusterv1.Conditions will be moved from Status.Conditions to Status.Deprecated.V1Beta1.Conditions
+//   - metav1.Conditions will be moved from Status.V1Beta2.Conditions to Status.Conditions
+//
+// - Phase 3. when removing v1beta1 API types, Status.Deprecated will be dropped.
+//
+// Please see the proposal https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+//
+// In order to make this transition easier both for CAPI and other projects using this package,
+// utils automatically adapt to handle objects at different stage of the transition.
+package v1beta2

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/getter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/getter.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// TODO: Move to the API package.
+const (
+	// NoReasonReported identifies a clusterv1.Condition that reports no reason.
+	NoReasonReported = "NoReasonReported"
+)
+
+// Getter interface defines methods that an API object should implement in order to
+// use the conditions package for getting conditions.
+type Getter interface {
+	// GetV1Beta2Conditions returns the list of conditions for a cluster API object.
+	// Note: GetV1Beta2Conditions will be renamed to GetConditions in a later stage of the transition to V1Beta2.
+	GetV1Beta2Conditions() []metav1.Condition
+}
+
+// Get returns a condition from the object implementing the Getter interface.
+//
+// Please note that Get does not support reading conditions from unstructured objects nor from API types not implementing
+// the Getter interface. Eventually, users can implement wrappers on those types implementing this interface and
+// taking care of aligning the condition format if necessary.
+func Get(sourceObj Getter, sourceConditionType string) *metav1.Condition {
+	// if obj is nil, the requested condition does not exist.
+	if util.IsNil(sourceObj) {
+		return nil
+	}
+
+	// Otherwise get the requested condition.
+	return meta.FindStatusCondition(sourceObj.GetV1Beta2Conditions(), sourceConditionType)
+}
+
+// Has returns true if a condition with the given type exists.
+func Has(from Getter, conditionType string) bool {
+	return Get(from, conditionType) != nil
+}
+
+// IsTrue is true if the condition with the given type is True, otherwise it returns false
+// if the condition is not True or if the condition does not exist (is nil).
+func IsTrue(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse is true if the condition with the given type is False, otherwise it returns false
+// if the condition is not False or if the condition does not exist (is nil).
+func IsFalse(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown is true if the condition with the given type is Unknown or if the condition
+// does not exist (is nil).
+func IsUnknown(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionUnknown
+	}
+	return true
+}
+
+// UnstructuredGetAll returns conditions from an Unstructured object.
+//
+// UnstructuredGetAll supports retrieving conditions from objects at different stages of the transition from
+// clusterv1.conditions to the metav1.Condition type:
+//   - Objects with clusterv1.Conditions in status.conditions; in this case a best effort conversion
+//     to metav1.Condition is performed, just enough to allow surfacing a condition from a provider object with Mirror
+//   - Objects with metav1.Condition in status.v1beta2.conditions
+//   - Objects with metav1.Condition in status.conditions
+func UnstructuredGetAll(sourceObj runtime.Unstructured) ([]metav1.Condition, error) {
+	if util.IsNil(sourceObj) {
+		return nil, errors.New("sourceObj is nil")
+	}
+
+	ownerInfo := getConditionOwnerInfo(sourceObj)
+
+	value, exists, err := unstructured.NestedFieldNoCopy(sourceObj.UnstructuredContent(), "status", "v1beta2", "conditions")
+	if exists && err == nil {
+		if conditions, ok := value.([]interface{}); ok {
+			r, err := convertFromUnstructuredConditions(conditions)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to convert status.v1beta2.conditions from %s to []metav1.Condition", ownerInfo.Kind)
+			}
+			return r, nil
+		}
+	}
+
+	value, exists, err = unstructured.NestedFieldNoCopy(sourceObj.UnstructuredContent(), "status", "conditions")
+	if exists && err == nil {
+		if conditions, ok := value.([]interface{}); ok {
+			r, err := convertFromUnstructuredConditions(conditions)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to convert status.conditions from %s to []metav1.Condition", ownerInfo.Kind)
+			}
+			return r, nil
+		}
+	}
+
+	// With unstructured, it is not possible to detect if conditions are not set if the type is wrongly defined.
+	// This methods assume condition are not set.
+	return nil, nil
+}
+
+// UnstructuredGet returns a condition from an Unstructured object.
+//
+// UnstructuredGet supports retrieving conditions from objects at different stages of the transition from
+// clusterv1.conditions to the metav1.Condition type:
+//   - Objects with clusterv1.Conditions in status.conditions; in this case a best effort conversion
+//     to metav1.Condition is performed, just enough to allow surfacing a condition from a provider object with Mirror
+//   - Objects with metav1.Condition in status.v1beta2.conditions
+//   - Objects with metav1.Condition in status.conditions
+func UnstructuredGet(sourceObj runtime.Unstructured, sourceConditionType string) (*metav1.Condition, error) {
+	r, err := UnstructuredGetAll(sourceObj)
+	if err != nil {
+		return nil, err
+	}
+	return meta.FindStatusCondition(r, sourceConditionType), nil
+}
+
+// convertFromUnstructuredConditions converts []interface{} to []metav1.Condition; this operation must account for
+// objects which are not transitioning to metav1.Condition, or not yet fully transitioned, and thus a best
+// effort conversion of values to metav1.Condition is performed.
+func convertFromUnstructuredConditions(conditions []interface{}) ([]metav1.Condition, error) {
+	if conditions == nil {
+		return nil, nil
+	}
+
+	convertedConditions := make([]metav1.Condition, 0, len(conditions))
+	for _, c := range conditions {
+		cMap, ok := c.(map[string]interface{})
+		if !ok || cMap == nil {
+			continue
+		}
+
+		var conditionType string
+		if v, ok := cMap["type"]; ok {
+			conditionType = v.(string)
+		}
+
+		var status string
+		if v, ok := cMap["status"]; ok {
+			status = v.(string)
+		}
+
+		var observedGeneration int64
+		if v, ok := cMap["observedGeneration"]; ok {
+			observedGeneration = v.(int64)
+		}
+
+		var lastTransitionTime metav1.Time
+		if v, ok := cMap["lastTransitionTime"]; ok && v != nil && v.(string) != "" {
+			if err := lastTransitionTime.UnmarshalQueryParameter(v.(string)); err != nil {
+				return nil, errors.Wrapf(err, "failed to unmarshal lastTransitionTime value: %s", v)
+			}
+		}
+
+		var reason string
+		if v, ok := cMap["reason"]; ok {
+			reason = v.(string)
+		}
+
+		var message string
+		if v, ok := cMap["message"]; ok {
+			message = v.(string)
+		}
+
+		c := metav1.Condition{
+			Type:               conditionType,
+			Status:             metav1.ConditionStatus(status),
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: lastTransitionTime,
+			Reason:             reason,
+			Message:            message,
+		}
+		if err := validateAndFixConvertedCondition(&c); err != nil {
+			return nil, err
+		}
+
+		convertedConditions = append(convertedConditions, c)
+	}
+	return convertedConditions, nil
+}
+
+// validateAndFixConvertedCondition validates and fixes a clusterv1.Condition converted to a metav1.Condition.
+// this operation assumes conditions have been set using Cluster API condition utils;
+// also, only a few, minimal rules are enforced, just enough to allow surfacing a condition from a providers object with Mirror.
+func validateAndFixConvertedCondition(c *metav1.Condition) error {
+	if c.Type == "" {
+		return errors.New("type must be set for all conditions")
+	}
+	if c.Status == "" {
+		return errors.Errorf("status must be set for the %s condition", c.Type)
+	}
+	switch c.Status {
+	case metav1.ConditionFalse, metav1.ConditionTrue, metav1.ConditionUnknown:
+		break
+	default:
+		return errors.Errorf("status for the %s condition must be one of %s, %s, %s", c.Type, metav1.ConditionTrue, metav1.ConditionFalse, metav1.ConditionUnknown)
+	}
+	if c.Reason == "" {
+		c.Reason = NoReasonReported
+	}
+
+	// NOTE: Empty LastTransitionTime is tolerated because it will be set when assigning the newly generated mirror condition to an object.
+	// NOTE: Other metav1.Condition validations rules, e.g. regex, are not enforced at this stage; they will be enforced by the API server at a later stage.
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/matcher.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/matcher.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IgnoreLastTransitionTime instructs MatchConditions and MatchCondition to ignore the LastTransitionTime field.
+type IgnoreLastTransitionTime bool
+
+// ApplyMatch applies this configuration to the given Match options.
+func (f IgnoreLastTransitionTime) ApplyMatch(opts *MatchOptions) {
+	opts.ignoreLastTransitionTime = bool(f)
+}
+
+// MatchOption is some configuration that modifies options for a match call.
+type MatchOption interface {
+	// ApplyMatch applies this configuration to the given match options.
+	ApplyMatch(option *MatchOptions)
+}
+
+// MatchOptions allows to set options for the match operation.
+type MatchOptions struct {
+	ignoreLastTransitionTime bool
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *MatchOptions) ApplyOptions(opts []MatchOption) *MatchOptions {
+	for _, opt := range opts {
+		opt.ApplyMatch(o)
+	}
+	return o
+}
+
+// MatchConditions returns a custom matcher to check equality of []metav1.Condition.
+func MatchConditions(expected []metav1.Condition, opts ...MatchOption) types.GomegaMatcher {
+	return &matchConditions{
+		opts:     opts,
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	opts     []MatchOption
+	expected []metav1.Condition
+}
+
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := []interface{}{}
+	for _, condition := range m.expected {
+		elems = append(elems, MatchCondition(condition, m.opts...))
+	}
+
+	return gomega.ConsistOf(elems...).Match(actual)
+}
+
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchCondition returns a custom matcher to check equality of metav1.Condition.
+func MatchCondition(expected metav1.Condition, opts ...MatchOption) types.GomegaMatcher {
+	return &matchCondition{
+		opts:     opts,
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	opts     []MatchOption
+	expected metav1.Condition
+}
+
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	matchOpt := &MatchOptions{
+		ignoreLastTransitionTime: false,
+	}
+	matchOpt.ApplyOptions(m.opts)
+
+	actualCondition, ok := actual.(metav1.Condition)
+	if !ok {
+		return false, fmt.Errorf("actual should be of type metav1.Condition")
+	}
+
+	ok, err = gomega.Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.ObservedGeneration).Match(actualCondition.ObservedGeneration)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return ok, err
+	}
+
+	if !matchOpt.ignoreLastTransitionTime {
+		ok, err = gomega.BeTemporally("==", m.expected.LastTransitionTime.Time).Match(actualCondition.LastTransitionTime.Time)
+		if !ok {
+			return ok, err
+		}
+	}
+
+	return ok, err
+}
+
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/merge_strategies.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/merge_strategies.go
@@ -1,0 +1,646 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gobuffalo/flect"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// ConditionWithOwnerInfo is a wrapper around metav1.Condition with additional ConditionOwnerInfo.
+// These infos can be used when generating the message resulting from the merge operation.
+type ConditionWithOwnerInfo struct {
+	OwnerResource ConditionOwnerInfo
+	metav1.Condition
+}
+
+// ConditionOwnerInfo contains infos about the object that owns the condition.
+type ConditionOwnerInfo struct {
+	Kind                  string
+	Name                  string
+	IsControlPlaneMachine bool
+}
+
+// String returns a string representation of the ConditionOwnerInfo.
+func (o ConditionOwnerInfo) String() string {
+	return fmt.Sprintf("%s %s", o.Kind, o.Name)
+}
+
+// MergeStrategy defines a strategy used to merge conditions during the aggregate or summary operation.
+type MergeStrategy interface {
+	// Merge passed in conditions.
+	//
+	// It is up to the caller to ensure that all the expected conditions exist (e.g. by adding new conditions with status Unknown).
+	// Conditions passed in must be of the given conditionTypes (other condition types must be discarded).
+	//
+	// The list of conditionTypes has an implicit order; it is up to the implementation of merge to use this info or not.
+	Merge(conditions []ConditionWithOwnerInfo, conditionTypes []string) (status metav1.ConditionStatus, reason, message string, err error)
+}
+
+// DefaultMergeStrategyOption is some configuration that modifies the DefaultMergeStrategy behaviour.
+type DefaultMergeStrategyOption interface {
+	// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+	ApplyToDefaultMergeStrategy(option *DefaultMergeStrategyOptions)
+}
+
+// DefaultMergeStrategyOptions allows to set options for the DefaultMergeStrategy behaviour.
+type DefaultMergeStrategyOptions struct {
+	getPriorityFunc                    func(condition metav1.Condition) MergePriority
+	targetConditionHasPositivePolarity bool
+	computeReasonFunc                  func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+	summaryMessageTransformFunc        func([]string) []string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *DefaultMergeStrategyOptions) ApplyOptions(opts []DefaultMergeStrategyOption) *DefaultMergeStrategyOptions {
+	for _, opt := range opts {
+		opt.ApplyToDefaultMergeStrategy(o)
+	}
+	return o
+}
+
+// DefaultMergeStrategy returns the default merge strategy.
+//
+// Use the GetPriorityFunc option to customize how the MergePriority for a given condition is computed.
+// If not specified, conditions are considered issues or not if not to their normal state given the polarity
+// (e.g. a positive polarity condition is considered to be reporting an issue when status is false,
+// otherwise the condition is considered to be reporting an info unless status is unknown).
+//
+// Use the TargetConditionHasPositivePolarity to define the polarity of the condition returned by the DefaultMergeStrategy.
+// If not specified, the generate condition will have positive polarity (status true = good).
+//
+// Use the ComputeReasonFunc to customize how the reason for the resulting condition will be computed.
+// If not specified, generic reasons will be used.
+func DefaultMergeStrategy(opts ...DefaultMergeStrategyOption) MergeStrategy {
+	strategyOpt := &DefaultMergeStrategyOptions{
+		targetConditionHasPositivePolarity: true,
+		computeReasonFunc:                  GetDefaultComputeMergeReasonFunc(issuesReportedReason, unknownReportedReason, infoReportedReason), // NOTE: when no specific reason are provided, generic ones are used.
+		getPriorityFunc:                    GetDefaultMergePriorityFunc(),
+		summaryMessageTransformFunc:        nil,
+	}
+	strategyOpt.ApplyOptions(opts)
+
+	return &defaultMergeStrategy{
+		getPriorityFunc:                    strategyOpt.getPriorityFunc,
+		computeReasonFunc:                  strategyOpt.computeReasonFunc,
+		targetConditionHasPositivePolarity: strategyOpt.targetConditionHasPositivePolarity,
+		summaryMessageTransformFunc:        strategyOpt.summaryMessageTransformFunc,
+	}
+}
+
+// GetDefaultMergePriorityFunc returns the merge priority for each condition.
+// It assigns following priority values to conditions:
+// - issues: conditions with positive polarity (normal True) and status False or conditions with negative polarity (normal False) and status True.
+// - unknown: conditions with status unknown.
+// - info: conditions with positive polarity (normal True) and status True or conditions with negative polarity (normal False) and status False.
+func GetDefaultMergePriorityFunc(negativePolarityConditionTypes ...string) func(condition metav1.Condition) MergePriority {
+	negativePolarityConditionTypesSet := sets.New[string](negativePolarityConditionTypes...)
+	return func(condition metav1.Condition) MergePriority {
+		switch condition.Status {
+		case metav1.ConditionTrue:
+			if negativePolarityConditionTypesSet.Has(condition.Type) {
+				return IssueMergePriority
+			}
+			return InfoMergePriority
+		case metav1.ConditionFalse:
+			if negativePolarityConditionTypesSet.Has(condition.Type) {
+				return InfoMergePriority
+			}
+			return IssueMergePriority
+		case metav1.ConditionUnknown:
+			return UnknownMergePriority
+		}
+
+		// Note: this should never happen. In case, those conditions are considered like conditions with unknown status.
+		return UnknownMergePriority
+	}
+}
+
+// MergePriority defines the priority for a condition during a merge operation.
+type MergePriority uint8
+
+const (
+	// IssueMergePriority is the merge priority used by GetDefaultMergePriority in case the condition state is considered an issue.
+	IssueMergePriority MergePriority = iota
+
+	// UnknownMergePriority is the merge priority used by GetDefaultMergePriority in case of unknown conditions.
+	UnknownMergePriority
+
+	// InfoMergePriority is the merge priority used by GetDefaultMergePriority in case the condition state is not considered an issue.
+	InfoMergePriority
+)
+
+// GetDefaultComputeMergeReasonFunc return a function picking one of the three reasons in input depending on
+// the status of the conditions being merged.
+func GetDefaultComputeMergeReasonFunc(issueReason, unknownReason, infoReason string) func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string {
+	return func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, _ []ConditionWithOwnerInfo) string {
+		switch {
+		case len(issueConditions) > 0:
+			return issueReason
+		case len(unknownConditions) > 0:
+			return unknownReason
+		default:
+			// Note: This func can assume that there is at least one condition, so this branch is equivalent to len(infoReason) > 0,
+			// and it makes the linter happy.
+			return infoReason
+		}
+	}
+}
+
+const (
+	// issuesReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting issues.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	issuesReportedReason = "IssuesReported"
+
+	// unknownReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting unknown.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	unknownReportedReason = "UnknownReported"
+
+	// infoReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting info.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	infoReportedReason = "InfoReported"
+)
+
+// defaultMergeStrategy defines the default merge strategy for Cluster API conditions.
+type defaultMergeStrategy struct {
+	getPriorityFunc                    func(condition metav1.Condition) MergePriority
+	targetConditionHasPositivePolarity bool
+	computeReasonFunc                  func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+	summaryMessageTransformFunc        func([]string) []string
+}
+
+// Merge all conditions in input based on a strategy that surfaces issues first, then unknown conditions, then info (if none of issues and unknown condition exists).
+// - issues: conditions with positive polarity (normal True) and status False or conditions with negative polarity (normal False) and status True.
+// - unknown: conditions with status unknown.
+// - info: conditions with positive polarity (normal True) and status True or conditions with negative polarity (normal False) and status False.
+func (d *defaultMergeStrategy) Merge(conditions []ConditionWithOwnerInfo, conditionTypes []string) (status metav1.ConditionStatus, reason, message string, err error) {
+	if len(conditions) == 0 {
+		return "", "", "", errors.New("can't merge an empty list of conditions")
+	}
+
+	if d.getPriorityFunc == nil {
+		return "", "", "", errors.New("can't merge without a getPriority func")
+	}
+
+	// Infer which operation is calling this func, so it is possible to use different strategies for computing the message for the target condition.
+	// - When merge should consider a single condition type, we can assume this func is called within an aggregate operation
+	//   (Aggregate should merge the same condition across many objects)
+	isAggregateOperation := len(conditionTypes) == 1
+
+	// - Otherwise we can assume this func is called within a summary operation
+	//   (Summary should merge different conditions from the same object)
+	isSummaryOperation := !isAggregateOperation
+
+	// sortConditions the relevance defined by the users (the order of condition types), LastTransition time (older first).
+	sortConditions(conditions, conditionTypes)
+
+	issueConditions, unknownConditions, infoConditions := splitConditionsByPriority(conditions, d.getPriorityFunc)
+
+	// Compute the status for the target condition:
+	// Note: This function always returns a condition with positive polarity.
+	// - if there are issues, use false
+	// - else if there are unknown, use unknown
+	// - else if there are info, use true
+	switch {
+	case len(issueConditions) > 0:
+		if d.targetConditionHasPositivePolarity {
+			status = metav1.ConditionFalse
+		} else {
+			status = metav1.ConditionTrue
+		}
+	case len(unknownConditions) > 0:
+		status = metav1.ConditionUnknown
+	case len(infoConditions) > 0:
+		if d.targetConditionHasPositivePolarity {
+			status = metav1.ConditionTrue
+		} else {
+			status = metav1.ConditionFalse
+		}
+	default:
+		// NOTE: this is already handled above, but repeating also here for better readability.
+		return "", "", "", errors.New("can't merge an empty list of conditions")
+	}
+
+	// Compute the reason for the target condition:
+	// - In case there is only one condition in the top group, use the reason from this condition
+	// - In case there are more than one condition in the top group, use a generic reason (for the target group)
+	reason = d.computeReasonFunc(issueConditions, unknownConditions, infoConditions)
+
+	// Compute the message for the target condition, which is optimized for the operation being performed.
+
+	// When performing the summary operation, usually we are merging a small set of conditions from the same object,
+	// Considering the small number of conditions, involved it is acceptable/preferred to provide as much detail
+	// as possible about the messages from the conditions being merged.
+	//
+	// Accordingly, the resulting message is composed by all the messages from conditions classified as issues/unknown;
+	// messages from conditions classified as info are included only if there are no issues/unknown.
+	//
+	// e.g. Condition-B (False): Message-B; Condition-!C (True): Message-!C; Condition-A (Unknown): Message-A
+	//
+	// When including messages from conditions, they are sorted by issue/unknown and by the implicit order of condition types
+	// provided by the user (it is considered as order of relevance).
+	if isSummaryOperation {
+		message = summaryMessage(conditions, d, status)
+	}
+
+	// When performing the aggregate operation, we are merging one single condition from potentially many objects.
+	// Considering the high number of conditions involved, the messages from the conditions being merged must be filtered/summarized
+	// using rules designed to surface the most important issues.
+	//
+	// Accordingly, the resulting message is composed by only three messages from conditions classified as issues/unknown;
+	// instead three messages from conditions classified as info are included only if there are no issues/unknown.
+	//
+	// Three criteria are used to pick the messages to be shown
+	// - Messages for control plane machines always go first
+	// - Messages for issues always go before messages for unknown, info messages goes last
+	// - The number of objects reporting the same message determine the order used to pick within the messages in the same bucket
+	//
+	// For each message it is reported a list of max 3 objects reporting the message; if more objects are reporting the same
+	// message, the number of those objects is surfaced.
+	//
+	// e.g. (False): Message-1 from obj0, obj1, obj2 and 2 more Objects
+	//
+	// If there are other objects - objects not included in the list above - reporting issues/unknown (or info there no issues/unknown),
+	// the number of those objects is surfaced.
+	//
+	// e.g. ...; 2 more Objects with issues; 1 more Objects with unknown status
+	//
+	if isAggregateOperation {
+		n := 3
+		messages := []string{}
+
+		// Get max n issue/unknown messages, decrement n, and track if there are other objects reporting issues/unknown not included in the messages.
+		if len(issueConditions) > 0 || len(unknownConditions) > 0 {
+			issueMessages := aggregateMessages(append(issueConditions, unknownConditions...), &n, false, d.getPriorityFunc, map[MergePriority]string{IssueMergePriority: "with other issues", UnknownMergePriority: "with status unknown"})
+			messages = append(messages, issueMessages...)
+		}
+
+		// Only if there are no issue or unknown,
+		// Get max n info messages, decrement n, and track if there are other objects reporting info not included in the messages.
+		if len(issueConditions) == 0 && len(unknownConditions) == 0 && len(infoConditions) > 0 {
+			infoMessages := aggregateMessages(infoConditions, &n, true, d.getPriorityFunc, map[MergePriority]string{InfoMergePriority: "with additional info"})
+			messages = append(messages, infoMessages...)
+		}
+
+		message = strings.Join(messages, "\n")
+	}
+
+	return status, reason, message, nil
+}
+
+// sortConditions by condition types order, LastTransitionTime
+// (the order of relevance defined by the users, the oldest first).
+func sortConditions(conditions []ConditionWithOwnerInfo, orderedConditionTypes []string) {
+	conditionOrder := make(map[string]int, len(orderedConditionTypes))
+	for i, conditionType := range orderedConditionTypes {
+		conditionOrder[conditionType] = i
+	}
+
+	sort.SliceStable(conditions, func(i, j int) bool {
+		// Sort by condition order (user defined, useful when computing summary of different conditions from the same object)
+		return conditionOrder[conditions[i].Type] < conditionOrder[conditions[j].Type] ||
+			// If same condition order, sort by last transition time (useful when computing aggregation of the same conditions from different objects)
+			(conditionOrder[conditions[i].Type] == conditionOrder[conditions[j].Type] && conditions[i].LastTransitionTime.Before(&conditions[j].LastTransitionTime))
+	})
+}
+
+// splitConditionsByPriority split conditions in 3 groups:
+// - conditions representing an issue.
+// - conditions with status unknown.
+// - conditions representing an info.
+// NOTE: The order of conditions is preserved in each group.
+func splitConditionsByPriority(conditions []ConditionWithOwnerInfo, getPriority func(condition metav1.Condition) MergePriority) (issueConditions, unknownConditions, infoConditions []ConditionWithOwnerInfo) {
+	for _, condition := range conditions {
+		switch getPriority(condition.Condition) {
+		case IssueMergePriority:
+			issueConditions = append(issueConditions, condition)
+		case UnknownMergePriority:
+			unknownConditions = append(unknownConditions, condition)
+		case InfoMergePriority:
+			infoConditions = append(infoConditions, condition)
+		}
+	}
+	return issueConditions, unknownConditions, infoConditions
+}
+
+// summaryMessage returns message for the summary operation.
+func summaryMessage(conditions []ConditionWithOwnerInfo, d *defaultMergeStrategy, status metav1.ConditionStatus) string {
+	messages := []string{}
+
+	// Note: use conditions because we want to preserve the order of relevance defined by the users (the order of condition types).
+	for _, condition := range conditions {
+		priority := d.getPriorityFunc(condition.Condition)
+		if priority == InfoMergePriority {
+			// Drop info messages when we are surfacing issues or unknown.
+			if status != metav1.ConditionTrue {
+				continue
+			}
+			// Drop info conditions with empty messages.
+			if condition.Message == "" {
+				continue
+			}
+		}
+
+		m := fmt.Sprintf("* %s:", condition.Type)
+		if condition.Message != "" {
+			m += indentIfMultiline(condition.Message)
+		} else {
+			m += fmt.Sprintf(" %s", condition.Reason)
+		}
+		messages = append(messages, m)
+	}
+
+	if d.summaryMessageTransformFunc != nil {
+		messages = d.summaryMessageTransformFunc(messages)
+	}
+
+	return strings.Join(messages, "\n")
+}
+
+// aggregateMessages returns messages for the aggregate operation.
+func aggregateMessages(conditions []ConditionWithOwnerInfo, n *int, dropEmpty bool, getPriority func(condition metav1.Condition) MergePriority, otherMessages map[MergePriority]string) (messages []string) {
+	// create a map with all the messages and the list of objects reporting the same message.
+	messageObjMap := map[string]map[string][]string{}
+	messagePriorityMap := map[string]MergePriority{}
+	messageMustGoFirst := map[string]bool{}
+	cpMachines := sets.Set[string]{}
+	for _, condition := range conditions {
+		if dropEmpty && condition.Message == "" {
+			continue
+		}
+
+		// Keep track of the message and the list of objects it applies to.
+		m := condition.Message
+		if _, ok := messageObjMap[condition.OwnerResource.Kind]; !ok {
+			messageObjMap[condition.OwnerResource.Kind] = map[string][]string{}
+		}
+		messageObjMap[condition.OwnerResource.Kind][m] = append(messageObjMap[condition.OwnerResource.Kind][m], condition.OwnerResource.Name)
+
+		// Keep track of CP machines
+		if condition.OwnerResource.IsControlPlaneMachine {
+			cpMachines.Insert(condition.OwnerResource.Name)
+		}
+
+		// Keep track of the priority of the message.
+		// In case the same message exists with different priorities, the highest according to issue/unknown/info applies.
+		currentPriority, ok := messagePriorityMap[m]
+		newPriority := getPriority(condition.Condition)
+		switch {
+		case !ok:
+			messagePriorityMap[m] = newPriority
+		case currentPriority == IssueMergePriority:
+			// No-op, issue is already the highest priority.
+		case currentPriority == UnknownMergePriority:
+			// If current priority is unknown, use new one only if higher.
+			if newPriority == IssueMergePriority {
+				messagePriorityMap[m] = newPriority
+			}
+		case currentPriority == InfoMergePriority:
+			// if current priority is info, new one can be equal or higher, use it.
+			messagePriorityMap[m] = newPriority
+		}
+
+		// Keep track if this message belongs to control plane machines, and thus it should go first.
+		// Note: it is enough that on object is a control plane machine to move the message as first.
+		first, ok := messageMustGoFirst[m]
+		if !ok || !first {
+			if condition.OwnerResource.IsControlPlaneMachine {
+				messageMustGoFirst[m] = true
+			}
+		}
+	}
+
+	// Gets the objects kind (with a stable order).
+	kinds := make([]string, 0, len(messageObjMap))
+	for kind := range messageObjMap {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+
+	// Aggregate messages for each object kind.
+	for _, kind := range kinds {
+		kindPlural := flect.Pluralize(kind)
+		messageObjMapForKind := messageObjMap[kind]
+
+		// compute the order of messages according to:
+		// - message should go first (e.g. it applies to a control plane machine)
+		// - message priority (e.g. first issues, then unknown)
+		// - the number of objects reporting the same message.
+		// Note: The list of object names is used as a secondary criteria to sort messages with the same number of objects.
+		messageIndex := make([]string, 0, len(messageObjMapForKind))
+		for m := range messageObjMapForKind {
+			messageIndex = append(messageIndex, m)
+		}
+
+		sort.SliceStable(messageIndex, func(i, j int) bool {
+			return sortMessage(messageIndex[i], messageIndex[j], messageMustGoFirst, messagePriorityMap, messageObjMapForKind)
+		})
+
+		// Pick the first n messages, decrement n.
+		// For each message, add up to three objects; if more add the number of the remaining objects with the same message.
+		// Count the number of objects reporting messages not included in the above.
+		// Note: we are showing up to three objects because usually control plane has 3 machines, and we want to show all issues
+		// to control plane machines if any,
+		others := map[MergePriority]int{}
+		for _, m := range messageIndex {
+			if *n == 0 {
+				others[messagePriorityMap[m]] += len(messageObjMapForKind[m])
+				continue
+			}
+
+			msg := ""
+			allObjects := messageObjMapForKind[m]
+			sort.Slice(allObjects, func(i, j int) bool {
+				return sortObj(allObjects[i], allObjects[j], cpMachines)
+			})
+			switch {
+			case len(allObjects) == 0:
+				// This should never happen, entry in the map exists only when an object reports a message.
+			case len(allObjects) == 1:
+				msg += fmt.Sprintf("* %s %s:", kind, strings.Join(allObjects, ", "))
+			case len(allObjects) <= 3:
+				msg += fmt.Sprintf("* %s %s:", kindPlural, strings.Join(allObjects, ", "))
+			default:
+				msg += fmt.Sprintf("* %s %s, ... (%d more):", kindPlural, strings.Join(allObjects[:3], ", "), len(allObjects)-3)
+			}
+			msg += indentIfMultiline(m)
+
+			messages = append(messages, msg)
+			*n--
+		}
+
+		for _, p := range []MergePriority{IssueMergePriority, UnknownMergePriority, InfoMergePriority} {
+			other, ok := others[p]
+			if !ok {
+				continue
+			}
+
+			otherMessage, ok := otherMessages[p]
+			if !ok {
+				continue
+			}
+			if other == 1 {
+				messages = append(messages, fmt.Sprintf("And %d %s %s", other, kind, otherMessage))
+			}
+			if other > 1 {
+				messages = append(messages, fmt.Sprintf("And %d %s %s", other, kindPlural, otherMessage))
+			}
+		}
+	}
+
+	return messages
+}
+
+func sortMessage(i, j string, messageMustGoFirst map[string]bool, messagePriorityMap map[string]MergePriority, messageObjMapForKind map[string][]string) bool {
+	if messageMustGoFirst[i] && !messageMustGoFirst[j] {
+		return true
+	}
+	if !messageMustGoFirst[i] && messageMustGoFirst[j] {
+		return false
+	}
+
+	if messagePriorityMap[i] < messagePriorityMap[j] {
+		return true
+	}
+	if messagePriorityMap[i] > messagePriorityMap[j] {
+		return false
+	}
+
+	if len(messageObjMapForKind[i]) > len(messageObjMapForKind[j]) {
+		return true
+	}
+	if len(messageObjMapForKind[i]) < len(messageObjMapForKind[j]) {
+		return false
+	}
+
+	return strings.Join(messageObjMapForKind[i], ",") < strings.Join(messageObjMapForKind[j], ",")
+}
+
+func sortObj(i, j string, cpMachines sets.Set[string]) bool {
+	if cpMachines.Has(i) && !cpMachines.Has(j) {
+		return true
+	}
+	if !cpMachines.Has(i) && cpMachines.Has(j) {
+		return false
+	}
+	return i < j
+}
+
+var re = regexp.MustCompile(`\s*\*\s+`)
+
+func indentIfMultiline(m string) string {
+	msg := ""
+	// If it is a multiline string or if it start with a bullet, indent the message.
+	if strings.Contains(m, "\n") || re.MatchString(m) {
+		msg += "\n"
+
+		// Split the message in lines, and add a prefix; prefix can be
+		// "  " when indenting a line starting in a bullet
+		// "  * " when indenting a line starting without a bullet (indent + add a bullet)
+		// "    " when indenting a line starting with a bullet, but other lines required adding a bullet
+		lines := strings.Split(m, "\n")
+		prefix := "  "
+		hasLinesWithoutBullet := false
+		for i := range lines {
+			if !re.MatchString(lines[i]) {
+				hasLinesWithoutBullet = true
+				break
+			}
+		}
+		for i, l := range lines {
+			prefix := prefix
+			if hasLinesWithoutBullet {
+				if !re.MatchString(lines[i]) {
+					prefix += "* "
+				} else {
+					prefix += "  "
+				}
+			}
+			lines[i] = prefix + l
+		}
+		msg += strings.Join(lines, "\n")
+	} else {
+		msg += " " + m
+	}
+	return msg
+}
+
+// getConditionsWithOwnerInfo return all the conditions from an object each one with the corresponding ConditionOwnerInfo.
+func getConditionsWithOwnerInfo(obj Getter) []ConditionWithOwnerInfo {
+	ret := make([]ConditionWithOwnerInfo, 0, 10)
+	conditions := obj.GetV1Beta2Conditions()
+	ownerInfo := getConditionOwnerInfo(obj)
+	for _, condition := range conditions {
+		ret = append(ret, ConditionWithOwnerInfo{
+			OwnerResource: ownerInfo,
+			Condition:     condition,
+		})
+	}
+	return ret
+}
+
+// getConditionOwnerInfo return the ConditionOwnerInfo for the given object.
+// Note: Given that controller runtime often does not set typeMeta for objects,
+// in case kind is missing we are falling back to the type name, which in most cases
+// is the same as kind.
+func getConditionOwnerInfo(obj any) ConditionOwnerInfo {
+	var kind, name string
+	var isControlPlaneMachine bool
+	if runtimeObject, ok := obj.(runtime.Object); ok {
+		kind = runtimeObject.GetObjectKind().GroupVersionKind().Kind
+	}
+
+	if kind == "" {
+		t := reflect.TypeOf(obj)
+		if t.Kind() == reflect.Pointer {
+			kind = t.Elem().Name()
+		} else {
+			kind = t.Name()
+		}
+	}
+
+	if objMeta, ok := obj.(objectWithNameAndLabels); ok {
+		name = objMeta.GetName()
+		if kind == "Machine" {
+			_, isControlPlaneMachine = objMeta.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		}
+	}
+
+	return ConditionOwnerInfo{
+		Kind:                  kind,
+		Name:                  name,
+		IsControlPlaneMachine: isControlPlaneMachine,
+	}
+}
+
+// objectWithNameAndLabels is a subset of metav1.Object.
+type objectWithNameAndLabels interface {
+	GetName() string
+	GetLabels() map[string]string
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/mirror.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/mirror.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NotYetReportedReason is set on missing conditions generated during mirror, aggregate or summary operations.
+// Missing conditions are generated during the above operations when an expected condition does not exist on a object.
+// TODO: Move to the API package.
+const NotYetReportedReason = "NotYetReported"
+
+// MirrorOption is some configuration that modifies options for a mirror call.
+type MirrorOption interface {
+	// ApplyToMirror applies this configuration to the given mirror options.
+	ApplyToMirror(*MirrorOptions)
+}
+
+// MirrorOptions allows to set options for the mirror operation.
+type MirrorOptions struct {
+	targetConditionType string
+	fallbackStatus      metav1.ConditionStatus
+	fallbackReason      string
+	fallbackMessage     string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *MirrorOptions) ApplyOptions(opts []MirrorOption) *MirrorOptions {
+	for _, opt := range opts {
+		opt.ApplyToMirror(o)
+	}
+	return o
+}
+
+// NewMirrorCondition create a mirror of the given condition from obj; if the given condition does not exist in the source obj,
+// the condition specified in the FallbackCondition is used; if this option is not set, a new condition with status Unknown
+// and reason NotYetReported is created.
+//
+// By default, the Mirror condition has the same type as the source condition, but this can be changed by using
+// the TargetConditionType option.
+func NewMirrorCondition(sourceObj Getter, sourceConditionType string, opts ...MirrorOption) *metav1.Condition {
+	condition := Get(sourceObj, sourceConditionType)
+
+	return newMirrorCondition(condition, sourceConditionType, opts)
+}
+
+func newMirrorCondition(sourceCondition *metav1.Condition, sourceConditionType string, opts []MirrorOption) *metav1.Condition {
+	mirrorOpt := &MirrorOptions{
+		targetConditionType: sourceConditionType,
+	}
+	mirrorOpt.ApplyOptions(opts)
+
+	if sourceCondition != nil {
+		return &metav1.Condition{
+			Type:   mirrorOpt.targetConditionType,
+			Status: sourceCondition.Status,
+			// NOTE: we are preserving the original transition time (when the underlying condition changed)
+			LastTransitionTime: sourceCondition.LastTransitionTime,
+			Reason:             sourceCondition.Reason,
+			Message:            sourceCondition.Message,
+			// NOTE: ObservedGeneration will be set when this condition is added to an object by calling Set
+			// (also preserving ObservedGeneration from the source object will be confusing when the mirror conditions shows up in the target object).
+		}
+	}
+
+	if mirrorOpt.fallbackStatus != "" {
+		return &metav1.Condition{
+			Type:    mirrorOpt.targetConditionType,
+			Status:  mirrorOpt.fallbackStatus,
+			Reason:  mirrorOpt.fallbackReason,
+			Message: mirrorOpt.fallbackMessage,
+			// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+		}
+	}
+
+	return &metav1.Condition{
+		Type:    mirrorOpt.targetConditionType,
+		Status:  metav1.ConditionUnknown,
+		Reason:  NotYetReportedReason,
+		Message: fmt.Sprintf("Condition %s not yet reported", sourceConditionType),
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}
+}
+
+// SetMirrorCondition is a convenience method that calls NewMirrorCondition to create a mirror condition from the source object,
+// and then calls Set to add the new condition to the target object.
+func SetMirrorCondition(sourceObj Getter, targetObj Setter, sourceConditionType string, opts ...MirrorOption) {
+	mirrorCondition := NewMirrorCondition(sourceObj, sourceConditionType, opts...)
+	Set(targetObj, *mirrorCondition)
+}
+
+// NewMirrorConditionFromUnstructured is a convenience method create a mirror of the given condition from the unstructured source obj.
+// It combines, UnstructuredGet, NewMirrorCondition (most specifically it uses only the logic to
+// create a mirror condition).
+func NewMirrorConditionFromUnstructured(sourceObj runtime.Unstructured, sourceConditionType string, opts ...MirrorOption) (*metav1.Condition, error) {
+	condition, err := UnstructuredGet(sourceObj, sourceConditionType)
+	if err != nil {
+		return nil, err
+	}
+	return newMirrorCondition(condition, sourceConditionType, opts), nil
+}
+
+// SetMirrorConditionFromUnstructured is a convenience method that mirror of the given condition from the unstructured source obj
+// into the target object. It combines, NewMirrorConditionFromUnstructured, and Set.
+func SetMirrorConditionFromUnstructured(sourceObj runtime.Unstructured, targetObj Setter, sourceConditionType string, opts ...MirrorOption) error {
+	condition, err := NewMirrorConditionFromUnstructured(sourceObj, sourceConditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *condition)
+	return nil
+}
+
+// BoolToStatus converts a bool to either metav1.ConditionTrue or metav1.ConditionFalse.
+func BoolToStatus(status bool) metav1.ConditionStatus {
+	if status {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/options.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/options.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// ConditionSortFunc defines the sort order when conditions are assigned to an object.
+type ConditionSortFunc func(i, j metav1.Condition) bool
+
+// ApplyToSet applies this configuration to the given Set options.
+func (f ConditionSortFunc) ApplyToSet(opts *SetOptions) {
+	opts.conditionSortFunc = f
+}
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ConditionSortFunc) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.conditionSortFunc = f
+}
+
+// TargetConditionType allows to specify the type of new mirror or aggregate conditions.
+type TargetConditionType string
+
+// ApplyToMirror applies this configuration to the given mirror options.
+func (t TargetConditionType) ApplyToMirror(opts *MirrorOptions) {
+	opts.targetConditionType = string(t)
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t TargetConditionType) ApplyToAggregate(opts *AggregateOptions) {
+	opts.targetConditionType = string(t)
+}
+
+// FallbackCondition defines the condition that should be returned by mirror if the source condition
+// does not exist.
+type FallbackCondition struct {
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// ApplyToMirror applies this configuration to the given mirror options.
+func (f FallbackCondition) ApplyToMirror(opts *MirrorOptions) {
+	opts.fallbackStatus = f.Status
+	opts.fallbackReason = f.Reason
+	opts.fallbackMessage = f.Message
+}
+
+// ForConditionTypes allows to define the set of conditions in scope for a summary operation.
+// Please note that condition types have an implicit order that can be used by the summary operation to determine relevance of the different conditions.
+type ForConditionTypes []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t ForConditionTypes) ApplyToSummary(opts *SummaryOptions) {
+	opts.conditionTypes = t
+}
+
+// NegativePolarityConditionTypes allows to define polarity for some of the conditions in scope for a summary or an aggregate operation.
+type NegativePolarityConditionTypes []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t NegativePolarityConditionTypes) ApplyToSummary(opts *SummaryOptions) {
+	opts.negativePolarityConditionTypes = t
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t NegativePolarityConditionTypes) ApplyToAggregate(opts *AggregateOptions) {
+	opts.negativePolarityConditionTypes = t
+}
+
+// IgnoreTypesIfMissing allows to define conditions types that should be ignored (not defaulted to unknown) when performing a summary operation.
+type IgnoreTypesIfMissing []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t IgnoreTypesIfMissing) ApplyToSummary(opts *SummaryOptions) {
+	opts.ignoreTypesIfMissing = t
+}
+
+// OverrideConditions allows to override conditions read from the source object only for the scope of a summary operation.
+// The condition on the source object will preserve the original value.
+type OverrideConditions []ConditionWithOwnerInfo
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t OverrideConditions) ApplyToSummary(opts *SummaryOptions) {
+	opts.overrideConditions = t
+}
+
+// CustomMergeStrategy allows to define a custom merge strategy when creating new summary or aggregate conditions.
+type CustomMergeStrategy struct {
+	MergeStrategy
+}
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t CustomMergeStrategy) ApplyToSummary(opts *SummaryOptions) {
+	opts.mergeStrategy = t
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t CustomMergeStrategy) ApplyToAggregate(opts *AggregateOptions) {
+	opts.mergeStrategy = t
+}
+
+// OwnedConditionTypes allows to define condition types owned by the controller when performing patch apply.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type OwnedConditionTypes []string
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (o OwnedConditionTypes) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.ownedConditionTypes = o
+}
+
+// ForceOverwrite instructs patch apply to always use the value provided by the controller (no matter of what value exists currently).
+type ForceOverwrite bool
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ForceOverwrite) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.forceOverwrite = bool(f)
+}
+
+// GetPriorityFunc defines priority of a given condition when processed by the DefaultMergeStrategy.
+// Note: The return value must be one of IssueMergePriority, UnknownMergePriority, InfoMergePriority.
+type GetPriorityFunc func(condition metav1.Condition) MergePriority
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f GetPriorityFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.getPriorityFunc = f
+}
+
+// TargetConditionHasPositivePolarity defines the polarity of the condition returned by the DefaultMergeStrategy.
+type TargetConditionHasPositivePolarity bool
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (t TargetConditionHasPositivePolarity) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.targetConditionHasPositivePolarity = bool(t)
+}
+
+// ComputeReasonFunc defines a function to be used when computing the reason of the condition returned by the DefaultMergeStrategy.
+type ComputeReasonFunc func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f ComputeReasonFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.computeReasonFunc = f
+}
+
+// SummaryMessageTransformFunc defines a function to be used when computing the message for a summary condition returned by the DefaultMergeStrategy.
+type SummaryMessageTransformFunc func([]string) []string
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f SummaryMessageTransformFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.summaryMessageTransformFunc = f
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/patch.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/patch.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// Patch defines a list of operations to change a list of conditions into another.
+type Patch []PatchOperation
+
+// PatchOperation defines an operation that changes a single condition.
+type PatchOperation struct {
+	Before *metav1.Condition
+	After  *metav1.Condition
+	Op     PatchOperationType
+}
+
+// PatchOperationType defines a condition patch operation type.
+type PatchOperationType string
+
+const (
+	// AddConditionPatch defines an add condition patch operation.
+	AddConditionPatch PatchOperationType = "Add"
+
+	// ChangeConditionPatch defines an change condition patch operation.
+	ChangeConditionPatch PatchOperationType = "Change"
+
+	// RemoveConditionPatch defines a remove condition patch operation.
+	RemoveConditionPatch PatchOperationType = "Remove"
+)
+
+// NewPatch returns the Patch required to align source conditions to after conditions.
+func NewPatch(before, after Getter) (Patch, error) {
+	var patch Patch
+
+	if util.IsNil(before) {
+		return nil, errors.New("error creating patch: before object is nil")
+	}
+	beforeConditions := before.GetV1Beta2Conditions()
+
+	if util.IsNil(after) {
+		return nil, errors.New("error creating patch: after object is nil")
+	}
+	afterConditions := after.GetV1Beta2Conditions()
+
+	// Identify AddCondition and ModifyCondition changes.
+	for i := range afterConditions {
+		afterCondition := afterConditions[i]
+		beforeCondition := meta.FindStatusCondition(beforeConditions, afterCondition.Type)
+		if beforeCondition == nil {
+			patch = append(patch, PatchOperation{Op: AddConditionPatch, After: &afterCondition})
+			continue
+		}
+
+		if !reflect.DeepEqual(&afterCondition, beforeCondition) {
+			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, After: &afterCondition, Before: beforeCondition})
+		}
+	}
+
+	// Identify RemoveCondition changes.
+	for i := range beforeConditions {
+		beforeCondition := beforeConditions[i]
+		afterCondition := meta.FindStatusCondition(afterConditions, beforeCondition.Type)
+		if afterCondition == nil {
+			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Before: &beforeCondition})
+		}
+	}
+	return patch, nil
+}
+
+// PatchApplyOption is some configuration that modifies options for a patch apply call.
+type PatchApplyOption interface {
+	// ApplyToPatchApply applies this configuration to the given patch apply options.
+	ApplyToPatchApply(option *PatchApplyOptions)
+}
+
+// PatchApplyOptions allows to set strategies for patch apply.
+type PatchApplyOptions struct {
+	ownedConditionTypes []string
+	forceOverwrite      bool
+	conditionSortFunc   ConditionSortFunc
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *PatchApplyOptions) ApplyOptions(opts []PatchApplyOption) *PatchApplyOptions {
+	for _, opt := range opts {
+		if util.IsNil(opt) {
+			continue
+		}
+		opt.ApplyToPatchApply(o)
+	}
+	return o
+}
+
+func (o *PatchApplyOptions) isOwnedConditionType(conditionType string) bool {
+	for _, i := range o.ownedConditionTypes {
+		if i == conditionType {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply executes a three-way merge of a list of Patch.
+// When merge conflicts are detected (latest deviated from before in an incompatible way), an error is returned.
+func (p Patch) Apply(latest Setter, opts ...PatchApplyOption) error {
+	if p.IsZero() {
+		return nil
+	}
+
+	if util.IsNil(latest) {
+		return errors.New("error patching conditions: latest object is nil")
+	}
+	latestConditions := latest.GetV1Beta2Conditions()
+
+	applyOpt := &PatchApplyOptions{
+		// By default, sort conditions by the default condition order: available and ready always first, deleting and paused always last, all the other conditions in alphabetical order.
+		conditionSortFunc: defaultSortLessFunc,
+	}
+	applyOpt.ApplyOptions(opts)
+
+	for _, conditionPatch := range p {
+		switch conditionPatch.Op {
+		case AddConditionPatch:
+			// If the condition is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
+				setStatusCondition(&latestConditions, *conditionPatch.After)
+				continue
+			}
+
+			// If the condition is already on latest, check if latest and after agree on the change; if not, this is a conflict.
+			if latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.After.Type); latestCondition != nil {
+				// If latest and after disagree on the change, then it is a conflict
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// otherwise, the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// If the condition does not exists on the latest, add the new after condition.
+			setStatusCondition(&latestConditions, *conditionPatch.After)
+
+		case ChangeConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
+				setStatusCondition(&latestConditions, *conditionPatch.After)
+				continue
+			}
+
+			latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.After.Type)
+
+			// If the condition does not exist anymore on the latest, this is a conflict.
+			if latestCondition == nil {
+				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+			}
+
+			// If the condition on the latest is different from the base condition, check if
+			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
+			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// Otherwise the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// Otherwise apply the new after condition.
+			setStatusCondition(&latestConditions, *conditionPatch.After)
+
+		case RemoveConditionPatch:
+			// If latestConditions is nil or empty, nothing to remove.
+			if len(latestConditions) == 0 {
+				continue
+			}
+
+			// If the conditions is owned, always keep the after value (condition should be deleted).
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.Before.Type) {
+				meta.RemoveStatusCondition(&latestConditions, conditionPatch.Before.Type)
+				continue
+			}
+
+			// If the condition is still on the latest, check if it is changed in the meantime;
+			// if so then this is a conflict.
+			if latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.Before.Type); latestCondition != nil {
+				if !HasSameState(latestCondition, conditionPatch.Before) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+				}
+			}
+			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.
+			meta.RemoveStatusCondition(&latestConditions, conditionPatch.Before.Type)
+		}
+	}
+
+	if applyOpt.conditionSortFunc != nil {
+		sort.SliceStable(latestConditions, func(i, j int) bool {
+			return applyOpt.conditionSortFunc(latestConditions[i], latestConditions[j])
+		})
+	}
+
+	latest.SetV1Beta2Conditions(latestConditions)
+	return nil
+}
+
+// IsZero returns true if the patch is nil or has no changes.
+func (p Patch) IsZero() bool {
+	if p == nil {
+		return true
+	}
+	return len(p) == 0
+}
+
+// HasSameState returns true if a condition has the same state of another; state is defined
+// by the union of following fields: Type, Status, Reason, ObservedGeneration and Message (it excludes LastTransitionTime).
+func HasSameState(i, j *metav1.Condition) bool {
+	return i.Type == j.Type &&
+		i.Status == j.Status &&
+		i.ObservedGeneration == j.ObservedGeneration &&
+		i.Reason == j.Reason &&
+		i.Message == j.Message
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/setter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/setter.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// Setter interface defines methods that a Cluster API object should implement in order to
+// use the conditions package for setting conditions.
+type Setter interface {
+	Getter
+
+	// SetV1Beta2Conditions sets conditions for an API object.
+	// Note: SetV1Beta2Conditions will be renamed to SetConditions in a later stage of the transition to V1Beta2.
+	SetV1Beta2Conditions([]metav1.Condition)
+}
+
+// SetOption is some configuration that modifies options for a Set request.
+type SetOption interface {
+	// ApplyToSet applies this configuration to the given Set options.
+	ApplyToSet(option *SetOptions)
+}
+
+// SetOptions allows to define options for the set operation.
+type SetOptions struct {
+	conditionSortFunc ConditionSortFunc
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *SetOptions) ApplyOptions(opts []SetOption) *SetOptions {
+	for _, opt := range opts {
+		opt.ApplyToSet(o)
+	}
+	return o
+}
+
+// Set a condition on the given object implementing the Setter interface; if the object is nil, the operation is a no-op.
+//
+// When setting a condition:
+// - condition.ObservedGeneration will be set to object.Metadata.Generation if targetObj is a metav1.Object.
+// - If the condition does not exist and condition.LastTransitionTime is not set, time.Now is used.
+// - If the condition already exists, condition.Status is changing and condition.LastTransitionTime is not set, time.Now is used.
+// - If the condition already exists, condition.Status is NOT changing, all the fields can be changed except for condition.LastTransitionTime.
+//
+// Additionally, Set enforces a default condition order (Available and Ready fist, everything else in alphabetical order),
+// but this can be changed by using the ConditionSortFunc option.
+//
+// Please note that Set does not support setting conditions to an unstructured object nor to API types not implementing
+// the Setter interface. Eventually, users can implement wrappers on those types implementing this interface and
+// taking care of aligning the condition format if necessary.
+func Set(targetObj Setter, condition metav1.Condition, opts ...SetOption) {
+	if util.IsNil(targetObj) {
+		return
+	}
+
+	setOpt := &SetOptions{
+		// By default, sort conditions by the default condition order: available and ready always first, deleting and paused always last, all the other conditions in alphabetical order.
+		conditionSortFunc: defaultSortLessFunc,
+	}
+	setOpt.ApplyOptions(opts)
+
+	if objMeta, ok := targetObj.(metav1.Object); ok {
+		condition.ObservedGeneration = objMeta.GetGeneration()
+	}
+
+	conditions := targetObj.GetV1Beta2Conditions()
+	if changed := setStatusCondition(&conditions, condition); !changed {
+		return
+	}
+
+	if setOpt.conditionSortFunc != nil {
+		sort.SliceStable(conditions, func(i, j int) bool {
+			return setOpt.conditionSortFunc(conditions[i], conditions[j])
+		})
+	}
+
+	targetObj.SetV1Beta2Conditions(conditions)
+}
+
+func setStatusCondition(conditions *[]metav1.Condition, condition metav1.Condition) bool {
+	// Truncate last transition time to seconds.
+	// This prevents inconsistencies from what we have in objects in memory and what Marshal/Unmarshal
+	// will do while the data is sent to/read from the API server.
+	if condition.LastTransitionTime.IsZero() {
+		condition.LastTransitionTime = metav1.Now()
+	}
+	condition.LastTransitionTime.Time = condition.LastTransitionTime.Truncate(1 * time.Second)
+	return meta.SetStatusCondition(conditions, condition)
+}
+
+// Delete deletes the condition with the given type.
+func Delete(to Setter, conditionType string) {
+	if to == nil {
+		return
+	}
+
+	conditions := to.GetV1Beta2Conditions()
+	newConditions := make([]metav1.Condition, 0, len(conditions)-1)
+	for _, condition := range conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+	to.SetV1Beta2Conditions(newConditions)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/sort.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/sort.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var orderMap = map[string]int{}
+
+func init() {
+	for i, c := range order {
+		orderMap[c] = i
+	}
+}
+
+// defaultSortLessFunc returns true if a condition is less than another with regards to the
+// order of conditions designed for convenience of the consumer, i.e. kubectl get.
+// According to this order the Available and the Ready condition always goes first, Deleting and Paused always goes last,
+// and all the other conditions are sorted by Type.
+func defaultSortLessFunc(i, j metav1.Condition) bool {
+	fi, oki := orderMap[i.Type]
+	if !oki {
+		fi = orderMap[readinessAndAvailabilityGates]
+	}
+	fj, okj := orderMap[j.Type]
+	if !okj {
+		fj = orderMap[readinessAndAvailabilityGates]
+	}
+	return fi < fj ||
+		(fi == fj && i.Type < j.Type)
+}
+
+// The order array below leads to the following condition ordering:
+//
+// | Condition                      | Cluster | KCP | MD | MS | MP | Machine |
+// |--------------------------------|---------|-----|:---|----|----|---------|
+// | -- Availability conditions --  |         |     |    |    |    |         |
+// | Available                      | x       | x   | x  |    | x  | x       |
+// | Ready                          |         |     |    |    |    | x       |
+// | UpToDate                       |         |     |    |    |    | x       |
+// | RemoteConnectionProbe          | x       |     |    |    |    |         |
+// | BootstrapConfigReady           |         |     |    |    | x  | x       |
+// | InfrastructureReady            | x       |     |    |    | x  | x       |
+// | ControlPlaneInitialized        | x       |     |    |    |    |         |
+// | ControlPlaneAvailable          | x       |     |    |    |    |         |
+// | WorkersAvailable               | x       |     |    |    |    |         |
+// | CertificatesAvailable          |         | x   |    |    |    |         |
+// | Initialized                    |         | x   |    |    |    |         |
+// | EtcdClusterHealthy             |         | x   |    |    |    |         |
+// | ControlPlaneComponentsHealthy  |         | x   |    |    |    |         |
+// | NodeHealthy                    |         |     |    |    |    | x       |
+// | NodeReady                      |         |     |    |    |    | x       |
+// | EtcdPodHealthy                 |         |     |    |    |    | x       |
+// | EtcdMemberHealthy              |         |     |    |    |    | x       |
+// | APIServerPodHealthy            |         |     |    |    |    | x       |
+// | ControllerManagerPodHealthy    |         |     |    |    |    | x       |
+// | SchedulerPodHealthy            |         |     |    |    |    | x       |
+// | HealthCheckSucceeded           |         |     |    |    |    | x       |
+// | OwnerRemediated                |         |     |    |    |    | x       |
+// | -- Operations --               |         |     |    |    |    |         |
+// | TopologyReconciled             | x       |     |    |    |    |         |
+// | RollingOut                     | x       | x   | x  |    | x  |         |
+// | Remediating                    | x       | x   | x  | x  | x  |         |
+// | ScalingDown                    | x       | x   | x  | x  | x  |         |
+// | ScalingUp                      | x       | x   | x  | x  | x  |         |
+// | -- Aggregated from Machines -- |         |     |    |    |    |         |
+// | MachinesReady                  |         | x   | x  | x  | x  |         |
+// | ControlPlaneMachinesReady      | x       |     |    |    |    |         |
+// | WorkerMachinesReady            | x       |     |    |    |    |         |
+// | MachinesUpToDate               |         | x   | x  | x  | x  |         |
+// | ControlPlaneMachinesUpToDate   | x       |     |    |    |    |         |
+// | WorkerMachinesUpToDate         | x       |     |    |    |    |         |
+// | -- From other controllers --   |         |     |    |    |    |         |
+// | Readiness/Availability gates   | x       |     |    |    |    | x       |
+// | -- Misc --                     |         |     |    |    |    |         |
+// | Paused                         | x       | x   | x  | x  | x  | x       |
+// | Deleting                       | x       | x   | x  | x  | x  | x       |
+// .
+var order = []string{
+	clusterv1.AvailableV1Beta2Condition,
+	clusterv1.ReadyV1Beta2Condition,
+	clusterv1.MachineUpToDateV1Beta2Condition,
+	clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
+	clusterv1.BootstrapConfigReadyV1Beta2Condition,
+	clusterv1.InfrastructureReadyV1Beta2Condition,
+	clusterv1.ClusterControlPlaneInitializedV1Beta2Condition,
+	clusterv1.ClusterControlPlaneAvailableV1Beta2Condition,
+	clusterv1.ClusterWorkersAvailableV1Beta2Condition,
+	kubeadmControlPlaneCertificatesAvailableV1Beta2Condition,
+	kubeadmControlPlaneInitializedV1Beta2Condition,
+	kubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition,
+	kubeadmControlPlaneControlPlaneComponentsHealthyV1Beta2Condition,
+	clusterv1.MachineNodeHealthyV1Beta2Condition,
+	clusterv1.MachineNodeReadyV1Beta2Condition,
+	kubeadmControlPlaneMachineEtcdPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineAPIServerPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineControllerManagerPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineSchedulerPodHealthyV1Beta2Condition,
+	clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+	clusterv1.MachineOwnerRemediatedV1Beta2Condition,
+	clusterv1.ClusterTopologyReconciledV1Beta2Condition,
+	clusterv1.RollingOutV1Beta2Condition,
+	clusterv1.RemediatingV1Beta2Condition,
+	clusterv1.ScalingDownV1Beta2Condition,
+	clusterv1.ScalingUpV1Beta2Condition,
+	clusterv1.MachinesReadyV1Beta2Condition,
+	clusterv1.ClusterControlPlaneMachinesReadyV1Beta2Condition,
+	clusterv1.ClusterWorkerMachinesReadyV1Beta2Condition,
+	clusterv1.MachinesUpToDateV1Beta2Condition,
+	clusterv1.ClusterControlPlaneMachinesUpToDateV1Beta2Condition,
+	clusterv1.ClusterWorkerMachinesUpToDateV1Beta2Condition,
+	readinessAndAvailabilityGates,
+	clusterv1.PausedV1Beta2Condition,
+	clusterv1.DeletingV1Beta2Condition,
+}
+
+// Constants defining a placeholder for readiness and availability gates.
+const (
+	readinessAndAvailabilityGates = ""
+)
+
+// Constants inlined for ordering (we want to avoid importing the KCP API package).
+const (
+	kubeadmControlPlaneCertificatesAvailableV1Beta2Condition              = "CertificatesAvailable"
+	kubeadmControlPlaneInitializedV1Beta2Condition                        = "Initialized"
+	kubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition                 = "EtcdClusterHealthy"
+	kubeadmControlPlaneControlPlaneComponentsHealthyV1Beta2Condition      = "ControlPlaneComponentsHealthy"
+	kubeadmControlPlaneMachineAPIServerPodHealthyV1Beta2Condition         = "APIServerPodHealthy"
+	kubeadmControlPlaneMachineControllerManagerPodHealthyV1Beta2Condition = "ControllerManagerPodHealthy"
+	kubeadmControlPlaneMachineSchedulerPodHealthyV1Beta2Condition         = "SchedulerPodHealthy"
+	kubeadmControlPlaneMachineEtcdPodHealthyV1Beta2Condition              = "EtcdPodHealthy"
+	kubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition           = "EtcdMemberHealthy"
+)

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/summary.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/summary.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// SummaryOption is some configuration that modifies options for a summary call.
+type SummaryOption interface {
+	// ApplyToSummary applies this configuration to the given summary options.
+	ApplyToSummary(*SummaryOptions)
+}
+
+// SummaryOptions allows to set options for the summary operation.
+type SummaryOptions struct {
+	mergeStrategy                  MergeStrategy
+	conditionTypes                 []string
+	negativePolarityConditionTypes []string
+	ignoreTypesIfMissing           []string
+	overrideConditions             []ConditionWithOwnerInfo
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *SummaryOptions) ApplyOptions(opts []SummaryOption) *SummaryOptions {
+	for _, opt := range opts {
+		opt.ApplyToSummary(o)
+	}
+	return o
+}
+
+// NewSummaryCondition creates a new condition by summarizing a set of conditions from an object; the list of
+// types of the conditions to be summarized must be provided with the ForConditionTypes option;
+// conditions types with negative polarity, should be indicated with the NegativePolarityConditionTypes option.
+//
+// If any of the condition in scope does not exist in the source object, missing conditions are considered Unknown, reason NotYetReported.
+// Use the IgnoreTypesIfMissing to exclude types from this option.
+//
+// Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option or
+// to add a step counter to the generated message by using the StepCounter option.
+func NewSummaryCondition(sourceObj Getter, targetConditionType string, opts ...SummaryOption) (*metav1.Condition, error) {
+	summarizeOpt := &SummaryOptions{}
+	summarizeOpt.ApplyOptions(opts)
+	if summarizeOpt.mergeStrategy == nil {
+		// Note. Summary always assume the target condition type has positive polarity.
+		summarizeOpt.mergeStrategy = DefaultMergeStrategy(GetPriorityFunc(GetDefaultMergePriorityFunc(summarizeOpt.negativePolarityConditionTypes...)))
+	}
+
+	if len(summarizeOpt.conditionTypes) == 0 {
+		return nil, errors.New("option ForConditionTypes not provided or empty")
+	}
+
+	for _, conditionType := range summarizeOpt.conditionTypes {
+		if conditionType == targetConditionType {
+			return nil, errors.Errorf("option ForConditionTypes cannot include %s (target condition type)", targetConditionType)
+		}
+	}
+
+	expectedConditionTypes := sets.New[string](summarizeOpt.conditionTypes...)
+	ignoreTypesIfMissing := sets.New[string](summarizeOpt.ignoreTypesIfMissing...)
+	existingConditionTypes := sets.New[string]()
+
+	conditions := getConditionsWithOwnerInfo(sourceObj)
+
+	conditionsByType := map[string]ConditionWithOwnerInfo{}
+	for _, c := range conditions {
+		conditionsByType[c.Type] = c
+	}
+	overrideConditionsByType := map[string]ConditionWithOwnerInfo{}
+	for _, c := range summarizeOpt.overrideConditions {
+		if _, ok := overrideConditionsByType[c.Type]; ok {
+			return nil, errors.Errorf("override condition %s specified multiple times", c.Type)
+		}
+
+		overrideConditionsByType[c.Type] = c
+
+		if _, ok := conditionsByType[c.Type]; !ok {
+			return nil, errors.Errorf("override condition %s must exist in source object", c.Type)
+		}
+	}
+
+	conditionsInScope := make([]ConditionWithOwnerInfo, 0, len(expectedConditionTypes))
+	for _, condition := range conditions {
+		// Drops all the conditions not in scope for the merge operation
+		if !expectedConditionTypes.Has(condition.Type) {
+			continue
+		}
+
+		if overrideCondition, ok := overrideConditionsByType[condition.Type]; ok {
+			conditionsInScope = append(conditionsInScope, overrideCondition)
+		} else {
+			conditionsInScope = append(conditionsInScope, condition)
+		}
+
+		existingConditionTypes.Insert(condition.Type)
+	}
+
+	// Add the expected conditions which do not exist, so we are compliant with K8s guidelines
+	// (all missing conditions should be considered unknown).
+
+	diff := expectedConditionTypes.Difference(existingConditionTypes).Difference(ignoreTypesIfMissing).UnsortedList()
+	if len(diff) > 0 {
+		conditionOwner := getConditionOwnerInfo(sourceObj)
+
+		for _, c := range diff {
+			conditionsInScope = append(conditionsInScope, ConditionWithOwnerInfo{
+				OwnerResource: conditionOwner,
+				Condition: metav1.Condition{
+					Type:    c,
+					Status:  metav1.ConditionUnknown,
+					Reason:  NotYetReportedReason,
+					Message: "Condition not yet reported",
+					// NOTE: LastTransitionTime and ObservedGeneration are not relevant for merge.
+				},
+			})
+		}
+	}
+
+	if len(conditionsInScope) == 0 {
+		return nil, errors.New("summary can't be performed when the list of conditions to be summarized is empty")
+	}
+
+	status, reason, message, err := summarizeOpt.mergeStrategy.Merge(conditionsInScope, summarizeOpt.conditionTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &metav1.Condition{
+		Type:    targetConditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}, nil
+}
+
+// SetSummaryCondition is a convenience method that calls NewSummaryCondition to create a summary condition from the source object,
+// and then calls Set to add the new condition to the target object.
+func SetSummaryCondition(sourceObj Getter, targetObj Setter, targetConditionType string, opts ...SummaryOption) error {
+	summaryCondition, err := NewSummaryCondition(sourceObj, targetConditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *summaryCondition)
+	return nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/patch/doc.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/patch/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package patch implements patch utilities.
+package patch

--- a/vendor/sigs.k8s.io/cluster-api/util/patch/options.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/patch/options.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+// Option is some configuration that modifies options for a patch request.
+type Option interface {
+	// ApplyToHelper applies this configuration to the given Helper options.
+	ApplyToHelper(*HelperOptions)
+}
+
+// HelperOptions contains options for patch options.
+type HelperOptions struct {
+	// IncludeStatusObservedGeneration sets the status.observedGeneration field
+	// on the incoming object to match metadata.generation, only if there is a change.
+	IncludeStatusObservedGeneration bool
+
+	// ForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+	// This option should only ever be set in controller managing the object being patched.
+	ForceOverwriteConditions bool
+
+	// OwnedConditions defines condition types owned by the controller.
+	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	OwnedConditions []clusterv1.ConditionType
+
+	// OwnedV1Beta2Conditions defines condition types owned by the controller.
+	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	OwnedV1Beta2Conditions []string
+
+	// Metav1ConditionsFields allows to override the path for the field hosting []metav1.Condition.
+	// Please note that the default value for this option is inferred from the object struct.
+	// This means, that if the correct path cannot be detected, this option has to be specified. One example
+	// is if you pass a wrapper to unstructured.
+	// The override for this option is considered only if the object implements the v1beta2conditions.Setter interface.
+	Metav1ConditionsFieldPath []string
+
+	// Clusterv1ConditionsFieldPath allows to override the path for the field hosting clusterv1.Conditions.
+	// Please note that the default value for this option is inferred from the object struct.
+	// This means, that if the correct path cannot be detected, this option has to be specified. One example
+	// is if you pass a wrapper to unstructured.
+	// The override for this option is considered only if the object implements the conditions.Setter interface.
+	Clusterv1ConditionsFieldPath []string
+}
+
+// WithForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+// This option should only ever be set in controller managing the object being patched.
+type WithForceOverwriteConditions struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithForceOverwriteConditions) ApplyToHelper(in *HelperOptions) {
+	in.ForceOverwriteConditions = true
+}
+
+// WithStatusObservedGeneration sets the status.observedGeneration field
+// on the incoming object to match metadata.generation, only if there is a change.
+type WithStatusObservedGeneration struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
+	in.IncludeStatusObservedGeneration = true
+}
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type WithOwnedConditions struct {
+	Conditions []clusterv1.ConditionType
+}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithOwnedConditions) ApplyToHelper(in *HelperOptions) {
+	in.OwnedConditions = w.Conditions
+}
+
+// WithOwnedV1Beta2Conditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type WithOwnedV1Beta2Conditions struct {
+	Conditions []string
+}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithOwnedV1Beta2Conditions) ApplyToHelper(in *HelperOptions) {
+	in.OwnedV1Beta2Conditions = w.Conditions
+}
+
+// Metav1ConditionsFieldPath allows to override the path for the field hosting []metav1.Condition.
+// Please note that the default value for this option is inferred from the object struct.
+// The override for this option is considered only if the object implements the v1beta2conditions.Setter interface.
+type Metav1ConditionsFieldPath []string
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w Metav1ConditionsFieldPath) ApplyToHelper(in *HelperOptions) {
+	in.Metav1ConditionsFieldPath = w
+}
+
+// Clusterv1ConditionsFieldPath allows to override the path for the field hosting clusterv1.Conditions.
+// Please note that the default value for this option is inferred from the object struct.
+// The override for this option is considered only if the object implements the conditions.Setter interface.
+type Clusterv1ConditionsFieldPath []string
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w Clusterv1ConditionsFieldPath) ApplyToHelper(in *HelperOptions) {
+	in.Clusterv1ConditionsFieldPath = w
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/patch/patch.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/patch/patch.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
+)
+
+// Helper is a utility for ensuring the proper patching of objects.
+type Helper struct {
+	client       client.Client
+	gvk          schema.GroupVersionKind
+	beforeObject client.Object
+	before       *unstructured.Unstructured
+	after        *unstructured.Unstructured
+	changes      sets.Set[string]
+
+	metav1ConditionsFieldPath    []string
+	clusterv1ConditionsFieldPath []string
+}
+
+// NewHelper returns an initialized Helper. Use NewHelper before changing
+// obj. After changing obj use Helper.Patch to persist your changes.
+//
+// Please note that patch helper implements a custom handling for objects implementing
+// the condition.Setter interface or the v1beta2conditions.Setter interface.
+//
+// It is also possible to implement wrappers for object not implementing those interfaces;
+// in case those objects have custom conditions types the wrapper should take care of conversions.
+// Additionally, if the conditions are not in the canonical place defined by the proposal for
+// improving status in Cluster API conditions, locations of the condition field must be
+// provided explicitly by using Metav1ConditionsFieldPath and Clusterv1ConditionsFieldPath options
+// during the Patch call.
+func NewHelper(obj client.Object, crClient client.Client) (*Helper, error) {
+	// Return early if the object is nil.
+	if util.IsNil(obj) {
+		return nil, errors.New("failed to create patch helper: object is nil")
+	}
+
+	// Get the GroupVersionKind of the object,
+	// used to validate against later on.
+	gvk, err := apiutil.GVKForObject(obj, crClient.Scheme())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create patch helper for object %s", klog.KObj(obj))
+	}
+
+	// Identify location of the condition fields according to the canonical place defined by the proposal for
+	// improving status in Cluster API conditions.
+	metav1ConditionsFieldPath, clusterv1ConditionsFieldPath, err := identifyConditionsFieldsPath(obj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to identify condition fields for object %s", klog.KObj(obj))
+	}
+
+	return &Helper{
+		client:                       crClient,
+		gvk:                          gvk,
+		beforeObject:                 obj.DeepCopyObject().(client.Object),
+		metav1ConditionsFieldPath:    metav1ConditionsFieldPath,
+		clusterv1ConditionsFieldPath: clusterv1ConditionsFieldPath,
+	}, nil
+}
+
+// Patch will attempt to patch the given object, including its status.
+func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) error {
+	// Return early if the object is nil.
+	if util.IsNil(obj) {
+		return errors.Errorf("failed to patch %s %s: modified object is nil", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+
+	// Get the GroupVersionKind of the object that we want to patch.
+	gvk, err := apiutil.GVKForObject(obj, h.client.Scheme())
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch %s %s", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+	if gvk != h.gvk {
+		return errors.Errorf("failed to patch %s %s: unmatched GroupVersionKind, expected %q got %q", h.gvk.Kind, klog.KObj(h.beforeObject), h.gvk, gvk)
+	}
+
+	// Calculate the options.
+	options := &HelperOptions{}
+	for _, opt := range opts {
+		opt.ApplyToHelper(options)
+	}
+
+	// If condition field path override have been provided, propagate them to the helper for usage in various places of this func.
+	if len(options.Clusterv1ConditionsFieldPath) > 0 {
+		h.clusterv1ConditionsFieldPath = options.Clusterv1ConditionsFieldPath
+	}
+	if len(options.Metav1ConditionsFieldPath) > 0 {
+		h.metav1ConditionsFieldPath = options.Metav1ConditionsFieldPath
+	}
+
+	// Check if the object satisfies the Cluster API contract setter interfaces; if not, ignore condition field path entirely.
+	if _, canInterfaceConditions := obj.(conditions.Setter); !canInterfaceConditions {
+		h.clusterv1ConditionsFieldPath = nil
+	}
+	if _, canInterfaceV1Beta2Conditions := obj.(v1beta2conditions.Setter); !canInterfaceV1Beta2Conditions {
+		h.metav1ConditionsFieldPath = nil
+	}
+
+	// Convert the before object to unstructured.
+	h.before, err = toUnstructured(h.beforeObject, gvk)
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch %s %s: failed to convert before object to Unstructured", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+
+	// Convert the after object to unstructured.
+	h.after, err = toUnstructured(obj, gvk)
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch %s %s: failed to convert after object to Unstructured", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+
+	// Determine if the object has status.
+	if unstructuredHasStatus(h.after) {
+		if options.IncludeStatusObservedGeneration {
+			// Set status.observedGeneration if we're asked to do so.
+			if err := unstructured.SetNestedField(h.after.Object, h.after.GetGeneration(), "status", "observedGeneration"); err != nil {
+				return errors.Wrapf(err, "failed to patch %s %s: failed to set .status.observedGeneration", h.gvk.Kind, klog.KObj(h.beforeObject))
+			}
+
+			// Restore the changes back to the original object.
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(h.after.Object, obj); err != nil {
+				return errors.Wrapf(err, "failed to patch %s %s: failed to converted object from Unstructured", h.gvk.Kind, klog.KObj(h.beforeObject))
+			}
+		}
+	}
+
+	// Calculate and store the top-level field changes (e.g. "metadata", "spec", "status") we have before/after.
+	h.changes, err = h.calculateChanges(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch %s %s", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+
+	// Issue patches and return errors in an aggregate.
+	var errs []error
+	// Patch the conditions first.
+	//
+	// Given that we pass in metadata.resourceVersion to perform a 3-way-merge conflict resolution,
+	// patching conditions first avoids an extra loop if spec or status patch succeeds first
+	// given that causes the resourceVersion to mutate.
+	if err := h.patchStatusConditions(ctx, obj, options.ForceOverwriteConditions, options.OwnedConditions, options.OwnedV1Beta2Conditions); err != nil {
+		errs = append(errs, err)
+	}
+	// Then proceed to patch the rest of the object.
+	if err := h.patch(ctx, obj); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := h.patchStatus(ctx, obj); err != nil {
+		if !(apierrors.IsNotFound(err) && !obj.GetDeletionTimestamp().IsZero() && len(obj.GetFinalizers()) == 0) {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Wrapf(kerrors.NewAggregate(errs), "failed to patch %s %s", h.gvk.Kind, klog.KObj(h.beforeObject))
+	}
+	return nil
+}
+
+// patch issues a patch for metadata and spec.
+func (h *Helper) patch(ctx context.Context, obj client.Object) error {
+	if !h.shouldPatch(specPatch) {
+		return nil
+	}
+	beforeObject, afterObject, err := h.calculatePatch(obj, specPatch)
+	if err != nil {
+		return err
+	}
+	return h.client.Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+}
+
+// patchStatus issues a patch if the status has changed.
+func (h *Helper) patchStatus(ctx context.Context, obj client.Object) error {
+	if !h.shouldPatch(statusPatch) {
+		return nil
+	}
+	beforeObject, afterObject, err := h.calculatePatch(obj, statusPatch)
+	if err != nil {
+		return err
+	}
+	return h.client.Status().Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+}
+
+// patchStatusConditions issues a patch if there are any changes to the conditions slice under
+// the status subresource. This is a special case and it's handled separately given that
+// we allow different controllers to act on conditions of the same object.
+//
+// This method has an internal backoff loop. When a conflict is detected, the method
+// asks the Client for the a new version of the object we're trying to patch.
+//
+// Condition changes are then applied to the latest version of the object, and if there are
+// no unresolvable conflicts, the patch is sent again.
+func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []clusterv1.ConditionType, ownedV1beta2Conditions []string) error {
+	// Nothing to do if the object doesn't have conditions (doesn't have conditions identified as needing a special treatment).
+	if len(h.clusterv1ConditionsFieldPath) == 0 && len(h.metav1ConditionsFieldPath) == 0 {
+		return nil
+	}
+
+	// If the object has clusterv1 conditions, create a function applying corresponding changes if any.
+	var clusterv1ApplyPatch func(client.Object) error
+	if len(h.clusterv1ConditionsFieldPath) > 0 {
+		// Make sure our before/after objects satisfy the proper interface before continuing.
+		//
+		// NOTE: The checks and error below are done so that we don't panic if any of the objects don't satisfy the
+		// interface any longer, although this shouldn't happen because we already check when creating the patcher.
+		before, ok := h.beforeObject.(conditions.Getter)
+		if !ok {
+			return errors.Errorf("%s %s doesn't satisfy conditions.Getter, cannot patch", h.gvk.Kind, klog.KObj(h.beforeObject))
+		}
+		after, ok := obj.(conditions.Getter)
+		if !ok {
+			return errors.Errorf("%s %s doesn't satisfy conditions.Getter, cannot compute patch", h.gvk.Kind, klog.KObj(obj))
+		}
+
+		diff, err := conditions.NewPatch(
+			before,
+			after,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "%s %s can not be patched", h.gvk.Kind, klog.KObj(before))
+		}
+		if !diff.IsZero() {
+			clusterv1ApplyPatch = func(latest client.Object) error {
+				latestSetter, ok := latest.(conditions.Setter)
+				if !ok {
+					return errors.Errorf("%s %s doesn't satisfy conditions.Setter, cannot apply patch", h.gvk.Kind, klog.KObj(latest))
+				}
+
+				return diff.Apply(latestSetter, conditions.WithForceOverwrite(forceOverwrite), conditions.WithOwnedConditions(ownedConditions...))
+			}
+		}
+	}
+
+	// If the object has metav1 conditions, create a function applying corresponding changes if any.
+	var metav1ApplyPatch func(client.Object) error
+	if len(h.metav1ConditionsFieldPath) > 0 {
+		// Make sure our before/after objects satisfy the proper interface before continuing.
+		//
+		// NOTE: The checks and error below are done so that we don't panic if any of the objects don't satisfy the
+		// interface any longer, although this shouldn't happen because we already check when creating the patcher.
+		before, ok := h.beforeObject.(v1beta2conditions.Getter)
+		if !ok {
+			return errors.Errorf("%s %s doesn't satisfy v1beta2conditions.Getter, cannot patch", h.gvk.Kind, klog.KObj(h.beforeObject))
+		}
+		after, ok := obj.(v1beta2conditions.Getter)
+		if !ok {
+			return errors.Errorf("%s %s doesn't satisfy v1beta2conditions.Getter, cannot compute patch", h.gvk.Kind, klog.KObj(obj))
+		}
+
+		diff, err := v1beta2conditions.NewPatch(
+			before,
+			after,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "%s %s can not be patched", h.gvk.Kind, klog.KObj(h.beforeObject))
+		}
+
+		if !diff.IsZero() {
+			metav1ApplyPatch = func(latest client.Object) error {
+				latestSetter, ok := latest.(v1beta2conditions.Setter)
+				if !ok {
+					return errors.Errorf("%s %s doesn't satisfy conditions.Setter, cannot apply patch", h.gvk.Kind, klog.KObj(latest))
+				}
+
+				return diff.Apply(latestSetter, v1beta2conditions.ForceOverwrite(forceOverwrite), v1beta2conditions.OwnedConditionTypes(ownedV1beta2Conditions))
+			}
+		}
+	}
+
+	// No changes to apply, return early.
+	if clusterv1ApplyPatch == nil && metav1ApplyPatch == nil {
+		return nil
+	}
+
+	// Make a copy of the object and store the key used if we have conflicts.
+	key := client.ObjectKeyFromObject(obj)
+
+	// Define and start a backoff loop to handle conflicts
+	// between controllers working on the same object.
+	//
+	// This has been copied from https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/controller/controller_utils.go#L86-L88.
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Jitter:   1.0,
+	}
+
+	// Start the backoff loop and return errors if any.
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		latest, ok := h.beforeObject.DeepCopyObject().(client.Object)
+		if !ok {
+			return false, errors.Errorf("%s %s doesn't satisfy client.Object, cannot patch", h.gvk.Kind, klog.KObj(h.beforeObject))
+		}
+
+		// Get a new copy of the object.
+		if err := h.client.Get(ctx, key, latest); err != nil {
+			return false, err
+		}
+
+		// Create the condition patch before merging conditions.
+		conditionsPatch := client.MergeFromWithOptions(latest.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
+
+		// Set the condition patch previously created on the new object.
+		if clusterv1ApplyPatch != nil {
+			if err := clusterv1ApplyPatch(latest); err != nil {
+				return false, err
+			}
+		}
+		if metav1ApplyPatch != nil {
+			if err := metav1ApplyPatch(latest); err != nil {
+				return false, err
+			}
+		}
+
+		// Issue the patch.
+		err := h.client.Status().Patch(ctx, latest, conditionsPatch)
+		switch {
+		case apierrors.IsConflict(err):
+			// Requeue.
+			return false, nil
+		case err != nil:
+			return false, err
+		default:
+			return true, nil
+		}
+	})
+}
+
+// calculatePatch returns the before/after objects to be given in a controller-runtime patch, scoped down to the absolute necessary.
+func (h *Helper) calculatePatch(afterObj client.Object, focus patchType) (client.Object, client.Object, error) {
+	// Get a shallow unsafe copy of the before/after object in unstructured form.
+	before := unsafeUnstructuredCopy(h.before, focus, h.clusterv1ConditionsFieldPath, h.metav1ConditionsFieldPath)
+	after := unsafeUnstructuredCopy(h.after, focus, h.clusterv1ConditionsFieldPath, h.metav1ConditionsFieldPath)
+
+	// We've now applied all modifications to local unstructured objects,
+	// make copies of the original objects and convert them back.
+	beforeObj := h.beforeObject.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(before.Object, beforeObj); err != nil {
+		return nil, nil, err
+	}
+	afterObj = afterObj.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(after.Object, afterObj); err != nil {
+		return nil, nil, err
+	}
+	return beforeObj, afterObj, nil
+}
+
+func (h *Helper) shouldPatch(focus patchType) bool {
+	if focus == specPatch {
+		// If we're looking to patch anything other than status,
+		// return true if the changes map has any fields after removing `status`.
+		return h.changes.Clone().Delete("status").Len() > 0
+	}
+	return h.changes.Has(string(focus))
+}
+
+// calculate changes tries to build a patch from the before/after objects we have
+// and store in a map which top-level fields (e.g. `metadata`, `spec`, `status`, etc.) have changed.
+func (h *Helper) calculateChanges(after client.Object) (sets.Set[string], error) {
+	// Calculate patch data.
+	patch := client.MergeFrom(h.beforeObject)
+	diff, err := patch.Data(after)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to calculate patch data")
+	}
+
+	// Unmarshal patch data into a local map.
+	patchDiff := map[string]interface{}{}
+	if err := json.Unmarshal(diff, &patchDiff); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal patch data into a map")
+	}
+
+	// Return the map.
+	res := sets.New[string]()
+	for key := range patchDiff {
+		res.Insert(key)
+	}
+	return res, nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/patch/utils.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/patch/utils.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+type patchType string
+
+const (
+	specPatch   patchType = "spec"
+	statusPatch patchType = "status"
+)
+
+var (
+	preserveUnstructuredKeys = map[string]bool{
+		"kind":       true,
+		"apiVersion": true,
+		"metadata":   true,
+	}
+)
+
+func unstructuredHasStatus(u *unstructured.Unstructured) bool {
+	_, ok := u.Object["status"]
+	return ok
+}
+
+// toUnstructured converts an object to Unstructured.
+// We have to pass in a gvk as we can't rely on GVK being set in a runtime.Object.
+func toUnstructured(obj runtime.Object, gvk schema.GroupVersionKind) (*unstructured.Unstructured, error) {
+	// If the incoming object is already unstructured, perform a deep copy first
+	// otherwise DefaultUnstructuredConverter ends up returning the inner map without
+	// making a copy.
+	if _, ok := obj.(runtime.Unstructured); ok {
+		obj = obj.DeepCopyObject()
+	}
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: rawMap}
+	u.SetGroupVersionKind(gvk)
+
+	return u, nil
+}
+
+// unsafeUnstructuredCopy returns a shallow copy of the unstructured object given as input.
+// It copies the common fields such as `kind`, `apiVersion`, `metadata` and the patchType specified.
+//
+// It's not safe to modify any of the keys in the returned unstructured object, the result should be treated as read-only.
+func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, clusterv1ConditionsFieldPath, metav1ConditionsFieldPath []string) *unstructured.Unstructured {
+	// Create the return focused-unstructured object with a preallocated map.
+	res := &unstructured.Unstructured{Object: make(map[string]interface{}, len(obj.Object))}
+
+	// Ranges over the keys of the unstructured object, think of this as the very top level of an object
+	// when submitting a yaml to kubectl or a client.
+	// These would be keys like `apiVersion`, `kind`, `metadata`, `spec`, `status`, etc.
+	for key := range obj.Object {
+		value := obj.Object[key]
+
+		preserve := false
+		switch focus {
+		case specPatch:
+			// For what we define as `spec` fields, we should preserve everything
+			// that's not `status`.
+			preserve = key != string(statusPatch)
+		case statusPatch:
+			// For status, only preserve the status fields.
+			preserve = key == string(focus)
+		}
+
+		// Perform a shallow copy only for the keys we're interested in,
+		// or the ones that should be always preserved (like metadata).
+		if preserve || preserveUnstructuredKeys[key] {
+			res.Object[key] = value
+		}
+	}
+
+	// If we've determined that new or old condition must be set,
+	// when dealing with the status patch, remove corresponding sub-fields from the object.
+	// NOTE: Removing conditions sub-fields changes the incoming object! This is safe because the condition patch
+	// doesn't use the unstructured fields, and it runs before any other patch.
+	//
+	// If we want to be 100% safe, we could make a copy of the incoming object before modifying it, although
+	// copies have a high cpu and high memory usage, therefore we intentionally choose to avoid extra copies
+	// given that the ordering of operations and safety is handled internally by the patch helper.
+	if focus == statusPatch {
+		if len(clusterv1ConditionsFieldPath) > 0 {
+			unstructured.RemoveNestedField(res.Object, clusterv1ConditionsFieldPath...)
+		}
+		if len(metav1ConditionsFieldPath) > 0 {
+			unstructured.RemoveNestedField(res.Object, metav1ConditionsFieldPath...)
+		}
+	}
+
+	return res
+}
+
+var (
+	clusterv1ConditionsType = reflect.TypeOf(clusterv1.Conditions{})
+	metav1ConditionsType    = reflect.TypeOf([]metav1.Condition{})
+)
+
+func identifyConditionsFieldsPath(obj runtime.Object) ([]string, []string, error) {
+	if obj == nil {
+		return nil, nil, errors.New("cannot identify conditions on a nil object")
+	}
+
+	ptr := reflect.ValueOf(obj)
+	if ptr.Kind() != reflect.Pointer {
+		return nil, nil, errors.New("cannot identify conditions on a object that is not a pointer")
+	}
+
+	elem := ptr.Elem()
+	if !elem.IsValid() {
+		return nil, nil, errors.New("obj must be a valid value (non zero value of its type)")
+	}
+
+	statusField := elem.FieldByName("Status")
+	if statusField == (reflect.Value{}) {
+		return nil, nil, nil
+	}
+
+	// NOTE: Given that we allow providers to migrate at different speed, it is required to support objects at the different stage of the transition from clusterv1.conditions to metav1.conditions.
+	// In order to handle this, it is required to identify where conditions are supported (metav1 or clusterv1 and where they are located.
+
+	var metav1ConditionsFields []string
+	var clusterv1ConditionsFields []string
+
+	if v1beta2Field := statusField.FieldByName("V1Beta2"); v1beta2Field != (reflect.Value{}) {
+		if v1beta2Field.Kind() != reflect.Pointer {
+			return nil, nil, errors.New("obj.status.v1beta2 must be a pointer")
+		}
+
+		v1beta2Elem := v1beta2Field.Elem()
+		if !v1beta2Elem.IsValid() {
+			// If the field is a zero value of its type, we can't further investigate type struct.
+			// We assume the type is implemented according to transition guidelines
+			metav1ConditionsFields = []string{"status", "v1beta2", "conditions"}
+		} else {
+			if conditionField := v1beta2Elem.FieldByName("Conditions"); conditionField != (reflect.Value{}) {
+				metav1ConditionsFields = []string{"status", "v1beta2", "conditions"}
+			}
+		}
+	}
+
+	if conditionField := statusField.FieldByName("Conditions"); conditionField != (reflect.Value{}) {
+		if conditionField.Type() == metav1ConditionsType {
+			metav1ConditionsFields = []string{"status", "conditions"}
+		}
+		if conditionField.Type() == clusterv1ConditionsType {
+			clusterv1ConditionsFields = []string{"status", "conditions"}
+		}
+	}
+
+	if deprecatedField := statusField.FieldByName("Deprecated"); deprecatedField != (reflect.Value{}) {
+		if deprecatedField.Kind() != reflect.Pointer {
+			return nil, nil, errors.New("obj.status.deprecated must be a pointer")
+		}
+
+		deprecatedElem := deprecatedField.Elem()
+		if !deprecatedElem.IsValid() {
+			// If the field is a zero value of its type, we can't further investigate type struct.
+			// We assume the type is implemented according to transition guidelines
+			clusterv1ConditionsFields = []string{"status", "deprecated", "v1beta1", "conditions"}
+		} else {
+			if v1Beta1Field := deprecatedElem.FieldByName("V1Beta1"); deprecatedField != (reflect.Value{}) {
+				if v1Beta1Field.Kind() != reflect.Pointer {
+					return nil, nil, errors.New("obj.status.deprecated.v1beta1 must be a pointer")
+				}
+
+				v1Beta1Elem := v1Beta1Field.Elem()
+				if !v1Beta1Elem.IsValid() {
+					// If the field is a zero value of its type, we can't further investigate type struct.
+					// We assume the type is implemented according to transition guidelines
+					clusterv1ConditionsFields = []string{"status", "deprecated", "v1beta1", "conditions"}
+				} else {
+					if conditionField := v1Beta1Elem.FieldByName("Conditions"); conditionField != (reflect.Value{}) {
+						clusterv1ConditionsFields = []string{"status", "deprecated", "v1beta1", "conditions"}
+					}
+				}
+			}
+		}
+	}
+
+	return metav1ConditionsFields, clusterv1ConditionsFields, nil
+}


### PR DESCRIPTION
Add DestroyBootstrap support for IBM Cloud VPC, to cleanup the remaining resources used during bootstrapping during CAPI deployment. Attach a floating IP to bootstrap node for public clusters during post provision.