### PR TITLE
SPLAT-2121: vsphere - if no host group found, append not found

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -226,7 +226,11 @@ func validateHostGroups(validationCtx *validationContext, cluster, hostGroup str
 		}
 	}
 
-	return allErrs
+	// this was originally missed
+	// if we reach here there are no vm-host groups by the name specified
+	// we need to add an error
+
+	return append(allErrs, field.NotFound(fldPath, hostGroup))
 }
 
 func validateVCenterVersion(validationCtx *validationContext, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
This commit adds the missing error if the group
loop does not find a host group with the
defined failure domain hostGroup param.