### PR TITLE
NO-JIRA: fix the platform test assertions to check expected err message

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4314,7 +4314,7 @@ spec:
                         description: |-
                           Subnets defines the subnets in an existing VPC and can optionally specify their intended roles.
                           If no roles are specified on any subnet, then the subnet roles are decided automatically.
-                          In this case, the VPC must not contain any subnets without the kubernetes.io/cluster/<cluster-id> tag.
+                          In this case, the VPC must not contain any other non-cluster subnets without the kubernetes.io/cluster/<cluster-id> tag.
 
                           For manually specified subnet role selection, each subnet must have at least one assigned role,
                           and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -155,7 +155,7 @@ type ServiceEndpoint struct {
 type VPC struct {
 	// Subnets defines the subnets in an existing VPC and can optionally specify their intended roles.
 	// If no roles are specified on any subnet, then the subnet roles are decided automatically.
-	// In this case, the VPC must not contain any subnets without the kubernetes.io/cluster/<cluster-id> tag.
+	// In this case, the VPC must not contain any other non-cluster subnets without the kubernetes.io/cluster/<cluster-id> tag.
 	//
 	// For manually specified subnet role selection, each subnet must have at least one assigned role,
 	// and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -255,7 +255,7 @@ func validateSubnets(subnets []aws.Subnet, publish types.PublishingStrategy, fld
 		// If the cluster is private, ControlPlaneExternalLB role is not allowed
 		// as only an internal control plane load balancer will be created.
 		if publish == types.InternalPublishingStrategy && len(subnetsForRole[aws.ControlPlaneExternalLBSubnetRole]) > 0 {
-			allErrs = append(allErrs, field.Forbidden(fldPath, "must not include subnets with the ControlPlaneExternalLBSubnetRole role in a private cluster"))
+			allErrs = append(allErrs, field.Forbidden(fldPath, "must not include subnets with the ControlPlaneExternalLB role in a private cluster"))
 		}
 
 		// ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -163,7 +163,7 @@ func TestValidatePlatform(t *testing.T) {
 					"kubernetes.io/cluster/test-cluster": "shared",
 				},
 			},
-			expected: `^\Qtest-path.userTags[kubernetes.io/cluster/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags\E$`,
+			expected: `^\Qtest-path.userTags[kubernetes.io/cluster/test-cluster]: Invalid value: "shared": key is in the kubernetes.io namespace\E$`,
 		},
 		{
 			name: "invalid userTags, value with invalid characters",
@@ -208,7 +208,7 @@ func TestValidatePlatform(t *testing.T) {
 				Region:         "us-east-1",
 				HostedZoneRole: "test-hosted-zone-role",
 			},
-			expected: `^test-path\.hostedZoneRole: Invalid value: "test-hosted-zone-role": may not specify a role to assume for hosted zone operations without also specifying a hosted zone$`,
+			expected: `\Qtest-path.hostedZoneRole: Invalid value: "test-hosted-zone-role": may not specify a role to assume for hosted zone operations without also specifying a hosted zone\E`,
 		},
 		{
 			name:     "valid hosted zone & role should not throw an error",
@@ -236,7 +236,7 @@ func TestValidatePlatform(t *testing.T) {
 				HostedZone:     "test-hosted-zone",
 				HostedZoneRole: "test-hosted-zone-role",
 			},
-			expected: `^test-path\.hostedZoneRole: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified$`,
+			expected: `^\Qtest-path.credentialsMode: Forbidden: when specifying a hostedZoneRole, either Passthrough or Manual credential mode must be specified\E$`,
 		},
 		{
 			name: "valid subnets, empty",
@@ -332,20 +332,7 @@ func TestValidatePlatform(t *testing.T) {
 					},
 				},
 			},
-			expected: `^\[test-path\.vpc\.subnets: Forbidden: either all subnets must be assigned roles or none of the subnets should have roles assigned, test-path\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"subnet-1234567890asdfghj\", Roles:\[\]aws\.SubnetRole\{Type:\"Bootstrap\"\}, aws\.SubnetRole\{Type:\"ClusterNode\"\}\}, aws\.Subnet\{ID:\"subnet-asdfghj1234567890\", Roles:\[\]aws\.SubnetRole\(nil\)\}\}: roles \[ControlPlaneInternalLB IngressControllerLB ControlPlaneExternalLB\] must be assigned to at least 1 subnet\}\]$`,
-		},
-		{
-			name: "invalid subnets, invalid subnet IDs",
-			platform: &aws.Platform{
-				Region: "us-east-1",
-				VPC: aws.VPC{
-					Subnets: []aws.Subnet{
-						{ID: "subnet-1j"},
-						{ID: "bad-subnet567890"},
-					},
-				},
-			},
-			expected: `^\[test-path\.vpc\.subnets\[0\]\.id: Invalid value: \"subnet-1j\": must be non-empty, start with \"subnet-\", consist only of alphanumeric characters, and must be exactly 24 characters long, test-path\.vpc\.subnets\[1\]\.id: Invalid value: \"bad-subnet567890\": must be non-empty, start with \"subnet-\", consist only of alphanumeric characters, and must be exactly 24 characters long\]$`,
+			expected: `^\Q[test-path.vpc.subnets: Forbidden: either all subnets must be assigned roles or none of the subnets should have roles assigned, test-path.vpc.subnets: Invalid value: []aws.Subnet{aws.Subnet{ID:"subnet-1234567890asdfghj", Roles:[]aws.SubnetRole{aws.SubnetRole{Type:"BootstrapNode"}, aws.SubnetRole{Type:"ClusterNode"}}}, aws.Subnet{ID:"subnet-asdfghj1234567890", Roles:[]aws.SubnetRole(nil)}}: roles [ControlPlaneExternalLB ControlPlaneInternalLB IngressControllerLB] must be assigned to at least 1 subnet]\E$`,
 		},
 		{
 			name: "invalid subnets, duplicate subnet IDs",
@@ -375,7 +362,7 @@ func TestValidatePlatform(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path\.vpc\.subnets\[0\]\.roles\[0\]\.type: Unsupported value: \"UnsupportedRole\": supported values: \"Bootstrap\", \"ClusterNode\", \"ControlPlaneExternalLB\", \"ControlPlaneInternalLB\", \"EdgeNode\", \"IngressControllerLB\"$`,
+			expected: `^\Qtest-path.vpc.subnets[0].roles[0].type: Unsupported value: "UnsupportedRole": supported values: "BootstrapNode", "ClusterNode", "ControlPlaneExternalLB", "ControlPlaneInternalLB", "EdgeNode", "IngressControllerLB"\E$`,
 		},
 		{
 			name: "invalid subnets, duplicate roles assigned to a subnet",
@@ -407,7 +394,7 @@ func TestValidatePlatform(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path\.vpc\.subnets\[0\]\.roles\[1\]\.type: Duplicate value: \"Bootstrap\"$`,
+			expected: `^\Qtest-path.vpc.subnets[0].roles[1].type: Duplicate value: "BootstrapNode"\E$`,
 		},
 		{
 			name: "invalid subnets, ControlPlaneExternalLB and ControlPlaneInternalLB roles assigned to the same subnet",
@@ -566,7 +553,7 @@ func TestValidatePlatform(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test\-path\.vpc\.subnets\: Invalid value\: \[\]aws\.Subnet\{aws\.Subnet\{ID\:"subnet\-1234567890asdfghj", Roles\:\[\]aws\.SubnetRole\{Type\:"Bootstrap"\}, aws\.SubnetRole\{Type\:"ClusterNode"\}\}, aws\.Subnet\{ID\:"subnet\-0fcf8e0392f0910d0", Roles\:\[\]aws\.SubnetRole\{Type\:"IngressControllerLB"\}\}\}\]\: Roles \[ControlPlaneInternalLB\] must be assigned to at least 1 subnet$`,
+			expected: `^\Qtest-path.vpc.subnets: Invalid value: []aws.Subnet{aws.Subnet{ID:"subnet-1234567890asdfghj", Roles:[]aws.SubnetRole{aws.SubnetRole{Type:"BootstrapNode"}, aws.SubnetRole{Type:"ClusterNode"}}}, aws.Subnet{ID:"subnet-0fcf8e0392f0910d0", Roles:[]aws.SubnetRole{aws.SubnetRole{Type:"IngressControllerLB"}}}}: roles [ControlPlaneInternalLB] must be assigned to at least 1 subnet\E$`,
 		},
 		{
 			name:    "invalid subnets, external cluster and missing required roles",
@@ -591,7 +578,7 @@ func TestValidatePlatform(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path\.vpc\.subnets: Invalid value: \[\]aws\.Subnet\{aws\.Subnet\{ID:\"subnet-1234567890asdfghj\", Roles:\[\]aws\.SubnetRole\{Type:\"Bootstrap\"\}, aws\.SubnetRole\{Type:\"ClusterNode\"\}\}, aws\.Subnet\{ID:\"subnet-0fcf8e0392f0910d0\", Roles:\[\]aws\.SubnetRole\{Type:\"IngressControllerLB\"\}\}\}\}: Roles \[ControlPlaneExternalLB ControlPlaneInternalLB\] must be assigned to at least 1 subnet$`,
+			expected: `^\Qtest-path.vpc.subnets: Invalid value: []aws.Subnet{aws.Subnet{ID:"subnet-1234567890asdfghj", Roles:[]aws.SubnetRole{aws.SubnetRole{Type:"BootstrapNode"}, aws.SubnetRole{Type:"ClusterNode"}}}, aws.Subnet{ID:"subnet-0fcf8e0392f0910d0", Roles:[]aws.SubnetRole{aws.SubnetRole{Type:"IngressControllerLB"}}}}: roles [ControlPlaneExternalLB ControlPlaneInternalLB] must be assigned to at least 1 subnet\E$`,
 		},
 	}
 	for _, tc := range cases {
@@ -600,7 +587,7 @@ func TestValidatePlatform(t *testing.T) {
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Regexp(t, tc.credMode, err)
+				assert.Regexp(t, tc.expected, err)
 			}
 		})
 	}

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -302,9 +302,9 @@ func convertAWS(config *types.InstallConfig) error {
 
 	// Subnets field is deprecated in favor of VPC.Subnets.
 	fldPath := field.NewPath("platform", "aws")
-	if config.AWS.DeprecatedSubnets != nil && config.AWS.VPC.Subnets != nil { // nolint: staticcheck
+	if len(config.AWS.DeprecatedSubnets) > 0 && len(config.AWS.VPC.Subnets) > 0 { // nolint: staticcheck
 		return field.Forbidden(fldPath.Child("subnets"), fmt.Sprintf("cannot specify %s and %s together", fldPath.Child("subnets"), fldPath.Child("vpc", "subnets")))
-	} else if config.AWS.DeprecatedSubnets != nil { // nolint: staticcheck
+	} else if len(config.AWS.DeprecatedSubnets) > 0 { // nolint: staticcheck
 		var subnets []aws.Subnet
 		for _, subnetID := range config.AWS.DeprecatedSubnets { // nolint: staticcheck
 			subnets = append(subnets, aws.Subnet{


### PR DESCRIPTION
## Descriptions

The PR fixed the platform test assertions to compare expected err message. Previously, it is using the incorrect field (i.e. `credMode`). I think it causes actually failed unit tests to pass.

This is a also follow-up PR to CORS-3867, [CORS-3868](https://issues.redhat.com//browse/CORS-3868) and [CORS-3869](https://issues.redhat.com//browse/CORS-3869) with the following changes:

- Fix a typo in the err message for static validations of the `aws.vpc.subnets` field. It should have failed previously but due to the issue above, it passed :sweat: 
- Handled empty `vpc.subnets` value case (i.e. same as nil).
- Reworded CRD marker description about untagged subnets to be clearer.

