### PR TITLE
OCPEDGE-1707: Add Disable Certificate Verification API

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -71,6 +71,8 @@ spec:
                       properties:
                         address:
                           type: string
+                        disableCertificateVerification:
+                          type: boolean
                         hostName:
                           type: string
                         password:
@@ -79,6 +81,7 @@ spec:
                           type: string
                       required:
                       - address
+                      - disableCertificateVerification
                       - password
                       - username
                       type: object
@@ -1384,6 +1387,8 @@ spec:
                         properties:
                           address:
                             type: string
+                          disableCertificateVerification:
+                            type: boolean
                           hostName:
                             type: string
                           password:
@@ -1392,6 +1397,7 @@ spec:
                             type: string
                         required:
                         - address
+                        - disableCertificateVerification
                         - password
                         - username
                         type: object
@@ -2636,6 +2642,8 @@ spec:
                       properties:
                         address:
                           type: string
+                        disableCertificateVerification:
+                          type: boolean
                         hostName:
                           type: string
                         password:
@@ -2644,6 +2652,7 @@ spec:
                           type: string
                       required:
                       - address
+                      - disableCertificateVerification
                       - password
                       - username
                       type: object

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -71,8 +71,15 @@ spec:
                       properties:
                         address:
                           type: string
-                        disableCertificateVerification:
-                          type: boolean
+                        certificateVerification:
+                          default: Enabled
+                          description: |-
+                            CertificateVerification Defines whether ssl certificate verification is required or not.
+                            If omitted, the platform chooses a default, that default is enabled.
+                          enum:
+                          - Enabled
+                          - Disabled
+                          type: string
                         hostName:
                           type: string
                         password:
@@ -81,7 +88,6 @@ spec:
                           type: string
                       required:
                       - address
-                      - disableCertificateVerification
                       - password
                       - username
                       type: object
@@ -1387,8 +1393,15 @@ spec:
                         properties:
                           address:
                             type: string
-                          disableCertificateVerification:
-                            type: boolean
+                          certificateVerification:
+                            default: Enabled
+                            description: |-
+                              CertificateVerification Defines whether ssl certificate verification is required or not.
+                              If omitted, the platform chooses a default, that default is enabled.
+                            enum:
+                            - Enabled
+                            - Disabled
+                            type: string
                           hostName:
                             type: string
                           password:
@@ -1397,7 +1410,6 @@ spec:
                             type: string
                         required:
                         - address
-                        - disableCertificateVerification
                         - password
                         - username
                         type: object
@@ -2642,8 +2654,15 @@ spec:
                       properties:
                         address:
                           type: string
-                        disableCertificateVerification:
-                          type: boolean
+                        certificateVerification:
+                          default: Enabled
+                          description: |-
+                            CertificateVerification Defines whether ssl certificate verification is required or not.
+                            If omitted, the platform chooses a default, that default is enabled.
+                          enum:
+                          - Enabled
+                          - Disabled
+                          type: string
                         hostName:
                           type: string
                         password:
@@ -2652,7 +2671,6 @@ spec:
                           type: string
                       required:
                       - address
-                      - disableCertificateVerification
                       - password
                       - username
                       type: object

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -160,8 +160,9 @@ type Fencing struct {
 
 // Credential stores the information about a baremetal host's management controller.
 type Credential struct {
-	HostName string `json:"hostName,omitempty" validate:"required,uniqueField"`
-	Username string `json:"username" validate:"required"`
-	Password string `json:"password" validate:"required"`
-	Address  string `json:"address" validate:"required,uniqueField"`
+	HostName                       string `json:"hostName,omitempty" validate:"required,uniqueField"`
+	Username                       string `json:"username" validate:"required"`
+	Password                       string `json:"password" validate:"required"`
+	Address                        string `json:"address" validate:"required,uniqueField"`
+	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
 }

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -158,11 +158,26 @@ type Fencing struct {
 	Credentials []*Credential `json:"credentials,omitempty"`
 }
 
+// CertificateVerificationPolicy represents the options for CertificateVerification .
+type CertificateVerificationPolicy string
+
+const (
+	// CertificateVerificationEnabled enables ssl certificate verification.
+	CertificateVerificationEnabled CertificateVerificationPolicy = "Enabled"
+	// CertificateVerificationDisabled disables ssl certificate verification.
+	CertificateVerificationDisabled CertificateVerificationPolicy = "Disabled"
+)
+
 // Credential stores the information about a baremetal host's management controller.
 type Credential struct {
-	HostName                       string `json:"hostName,omitempty" validate:"required,uniqueField"`
-	Username                       string `json:"username" validate:"required"`
-	Password                       string `json:"password" validate:"required"`
-	Address                        string `json:"address" validate:"required,uniqueField"`
-	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
+	HostName string `json:"hostName,omitempty" validate:"required,uniqueField"`
+	Username string `json:"username" validate:"required"`
+	Password string `json:"password" validate:"required"`
+	Address  string `json:"address" validate:"required,uniqueField"`
+	// CertificateVerification Defines whether ssl certificate verification is required or not.
+	// If omitted, the platform chooses a default, that default is enabled.
+	// +kubebuilder:default:="Enabled"
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	CertificateVerification CertificateVerificationPolicy `json:"certificateVerification,omitempty"`
 }

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2824,8 +2824,9 @@ func TestValidateTNF(t *testing.T) {
 		},
 		{
 			config: installConfig().
+				PlatformBMWithHosts().
 				MachinePoolCP(machinePool().
-					Credential(c1().DisableCertificateVerification(true), c2())).
+					Credential(c1().CertificateVerification(types.CertificateVerificationDisabled), c2())).
 				CpReplicas(2).
 				build(),
 			name:     "valid_with_disabled_cert_verification",
@@ -3026,8 +3027,8 @@ func (hb *credentialBuilder) BMCPassword(value string) *credentialBuilder {
 	return hb
 }
 
-func (hb *credentialBuilder) DisableCertificateVerification(value bool) *credentialBuilder {
-	hb.Credential.DisableCertificateVerification = value
+func (hb *credentialBuilder) CertificateVerification(value types.CertificateVerificationPolicy) *credentialBuilder {
+	hb.Credential.CertificateVerification = value
 	return hb
 }
 

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2825,6 +2825,15 @@ func TestValidateTNF(t *testing.T) {
 		{
 			config: installConfig().
 				MachinePoolCP(machinePool().
+					Credential(c1().DisableCertificateVerification(true), c2())).
+				CpReplicas(2).
+				build(),
+			name:     "valid_with_disabled_cert_verification",
+			expected: "",
+		},
+		{
+			config: installConfig().
+				MachinePoolCP(machinePool().
 					Credential(c1(), c2(), c3())).
 				CpReplicas(2).build(),
 			name:     "invalid_number_of_credentials_for_dual_replica",
@@ -3014,6 +3023,11 @@ func (hb *credentialBuilder) BMCUsername(value string) *credentialBuilder {
 
 func (hb *credentialBuilder) BMCPassword(value string) *credentialBuilder {
 	hb.Credential.Password = value
+	return hb
+}
+
+func (hb *credentialBuilder) DisableCertificateVerification(value bool) *credentialBuilder {
+	hb.Credential.DisableCertificateVerification = value
 	return hb
 }
 


### PR DESCRIPTION
Adding an API to disable SSL certification, one use case for this being relevant  is a customer setting up redfish fencing on their internal network.