### PR TITLE
OCPBUGS-55193: data/manifests/bootkube/cvo-overrides: Default to eus-4.14

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.14
+  channel: eus-4.14
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
Like 12e711edb2 (#9373), but for 4.14.  Timing on this one has [4.14 leaving the maintenance phase and entering the EUS phase on 2025-05-01][1].  We want 4.14.z that enter `fast-4.14` up through that time to keep being added to `stable-4.14`, but `4.14.z` that enter `fast-4.14` after that date to only be added to `eus-4.14` (and no longer get added to `stable-4.14`), to help folks who don't meet the EUS qualifications stay on releases that they have support for.  Landing this change on 2025-04-28 or so should get us into that position, because 4.14.z built the week of 2025-04-21 through 2025-04-25 would likely be entering `fast-4.14` on the week of 2025-04-28 through 2025-05-02.

[1]: https://access.redhat.com/support/policy/updates/openshift#dates