### PR TITLE
CORS-3886: azure: Set use managed identity to false

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -32,16 +32,9 @@ func (params CloudProviderConfig) JSON() (string, error) {
 
 	config := config{
 		authConfig: authConfig{
-			Cloud:                       params.CloudName.Name(),
-			TenantID:                    params.TenantID,
-			SubscriptionID:              params.SubscriptionID,
-			UseManagedIdentityExtension: true,
-			// The cloud provider needs the clientID which is only known after terraform has run.
-			// When left empty, the existing managed identity on the VM will be used.
-			// By leaving it empty, we don't have to create the identity before running the installer.
-			// We only need to know that there will be one assigned to the VM, and we control this.
-			// ref: https://github.com/kubernetes/kubernetes/blob/4b7c607ba47928a7be77fadef1550d6498397a4c/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go#L69
-			UserAssignedIdentityID: "",
+			Cloud:          params.CloudName.Name(),
+			TenantID:       params.TenantID,
+			SubscriptionID: params.SubscriptionID,
 		},
 		ResourceGroup:     params.ResourceGroupName,
 		Location:          params.GroupLocation,
@@ -64,13 +57,8 @@ func (params CloudProviderConfig) JSON() (string, error) {
 		ExcludeMasterFromStandardLB: &excludeMasterFromStandardLB,
 	}
 
-	if params.ARO {
-		config.authConfig.UseManagedIdentityExtension = false
-	}
-
 	if params.CloudName == azure.StackCloud {
 		config.authConfig.ResourceManagerEndpoint = params.ResourceManagerEndpoint
-		config.authConfig.UseManagedIdentityExtension = false
 		config.LoadBalancerSku = "basic"
 		config.UseInstanceMetadata = false
 	}

--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -29,7 +29,7 @@ func TestCloudProviderConfig(t *testing.T) {
 	"aadClientSecret": "",
 	"aadClientCertPath": "",
 	"aadClientCertPassword": "",
-	"useManagedIdentityExtension": true,
+	"useManagedIdentityExtension": false,
 	"userAssignedIdentityID": "",
 	"subscriptionId": "subID",
 	"resourceGroup": "clusterid-rg",


### PR DESCRIPTION
Setting the use managed identity extension to false considering installer does not rely on this for now.