### PR TITLE
OCPBUGS-53439: fix inconsistent subnet role name for bootstrap node

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4282,11 +4282,11 @@ spec:
                                   type:
                                     description: |-
                                       Type specifies the type of role (aka function) that the subnet will provide in the cluster.
-                                      Role types include ClusterNode, EdgeNode, Bootstrap, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
+                                      Role types include ClusterNode, EdgeNode, BootstrapNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
                                     enum:
                                     - ClusterNode
                                     - EdgeNode
-                                    - Bootstrap
+                                    - BootstrapNode
                                     - IngressControllerLB
                                     - ControlPlaneExternalLB
                                     - ControlPlaneInternalLB

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -191,7 +191,7 @@ type Subnet struct {
 // SubnetRole specifies the role (aka function) that the subnet will provide in the cluster.
 type SubnetRole struct {
 	// Type specifies the type of role (aka function) that the subnet will provide in the cluster.
-	// Role types include ClusterNode, EdgeNode, Bootstrap, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
+	// Role types include ClusterNode, EdgeNode, BootstrapNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB.
 	//
 	// +required
 	Type SubnetRoleType `json:"type"`
@@ -204,7 +204,7 @@ type SubnetRole struct {
 type AWSSubnetID string // nolint:revive
 
 // SubnetRoleType defines the type of role (aka function) that the subnet will provide in the cluster.
-// +kubebuilder:validation:Enum:="ClusterNode";"EdgeNode";"Bootstrap";"IngressControllerLB";"ControlPlaneExternalLB";"ControlPlaneInternalLB"
+// +kubebuilder:validation:Enum:="ClusterNode";"EdgeNode";"BootstrapNode";"IngressControllerLB";"ControlPlaneExternalLB";"ControlPlaneInternalLB"
 type SubnetRoleType string
 
 const (


### PR DESCRIPTION
Previously, the installer supports role BootstrapNode but the CRD descriptor says Bootstrap.