### PR TITLE
OCPBUGS-54615: Don't store tempdir path in asset store

### DIFF
--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -72,11 +72,10 @@ func (a *AgentArtifacts) Generate(ctx context.Context, dependencies asset.Parent
 	kargs := &Kargs{}
 	baseIso := &BaseIso{}
 	agentManifests := &manifests.AgentManifests{}
-	agentClusterInstall := &manifests.AgentClusterInstall{}
 	registriesConf := &mirror.RegistriesConf{}
 	agentconfig := &config.AgentConfig{}
 	agentWorkflow := &workflow.AgentWorkflow{}
-	dependencies.Get(ignition, kargs, baseIso, agentManifests, agentClusterInstall, registriesConf, agentconfig, agentWorkflow)
+	dependencies.Get(ignition, kargs, baseIso, agentManifests, registriesConf, agentconfig, agentWorkflow)
 
 	if err := workflowreport.GetReport(ctx).Stage(workflow.StageAgentArtifacts); err != nil {
 		return err
@@ -93,12 +92,14 @@ func (a *AgentArtifacts) Generate(ctx context.Context, dependencies asset.Parent
 	a.ISOPath = baseIso.File.Filename
 	a.Kargs = kargs.KernelCmdLine()
 	a.MirrorConfig = registriesConf.MirrorConfig
-	a.ExternalPlatformName = agentClusterInstall.GetExternalPlatformName()
 	a.ReleaseImage = agentManifests.ClusterImageSet.Spec.ReleaseImage
 	a.PullSecret = agentManifests.GetPullSecretData()
 
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
+		agentClusterInstall := &manifests.AgentClusterInstall{}
+		dependencies.Get(agentClusterInstall)
+		a.ExternalPlatformName = agentClusterInstall.GetExternalPlatformName()
 		if agentconfig.Config != nil {
 			a.BootArtifactsBaseURL = strings.Trim(agentconfig.Config.BootArtifactsBaseURL, "/")
 			// External platform will always create a minimal ISO
@@ -112,6 +113,7 @@ func (a *AgentArtifacts) Generate(ctx context.Context, dependencies asset.Parent
 	case workflow.AgentWorkflowTypeAddNodes:
 		clusterInfo := &joiner.ClusterInfo{}
 		dependencies.Get(clusterInfo)
+		a.ExternalPlatformName = clusterInfo.ExternalPlatformName
 		if clusterInfo.BootArtifactsBaseURL != "" {
 			a.BootArtifactsBaseURL = strings.Trim(clusterInfo.BootArtifactsBaseURL, "/")
 		}

--- a/pkg/asset/agent/image/agentartifacts.go
+++ b/pkg/asset/agent/image/agentartifacts.go
@@ -40,12 +40,15 @@ const (
 type AgentArtifacts struct {
 	CPUArch              string
 	RendezvousIP         string
-	TmpPath              string
 	IgnitionByte         []byte
 	Kargs                string
 	ISOPath              string
 	BootArtifactsBaseURL string
 	MinimalISO           bool
+	MirrorConfig         types.MirrorConfig
+	ExternalPlatformName string
+	ReleaseImage         string
+	PullSecret           string
 }
 
 // Dependencies returns the assets on which the AgentArtifacts asset depends.
@@ -89,6 +92,10 @@ func (a *AgentArtifacts) Generate(ctx context.Context, dependencies asset.Parent
 	a.IgnitionByte = ignitionByte
 	a.ISOPath = baseIso.File.Filename
 	a.Kargs = kargs.KernelCmdLine()
+	a.MirrorConfig = registriesConf.MirrorConfig
+	a.ExternalPlatformName = agentClusterInstall.GetExternalPlatformName()
+	a.ReleaseImage = agentManifests.ClusterImageSet.Spec.ReleaseImage
+	a.PullSecret = agentManifests.GetPullSecretData()
 
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
@@ -110,25 +117,6 @@ func (a *AgentArtifacts) Generate(ctx context.Context, dependencies asset.Parent
 		}
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
-	}
-
-	var agentTuiFiles []string
-	if agentClusterInstall.GetExternalPlatformName() != agent.ExternalPlatformNameOci {
-		if err := workflowreport.GetReport(ctx).SubStage(workflow.StageAgentArtifactsAgentTUI); err != nil {
-			return err
-		}
-		agentTuiFiles, err = a.fetchAgentTuiFiles(agentManifests.ClusterImageSet.Spec.ReleaseImage, agentManifests.GetPullSecretData(), registriesConf.MirrorConfig)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := workflowreport.GetReport(ctx).SubStage(workflow.StageAgentArtifactsPrepare); err != nil {
-		return err
-	}
-	err = a.prepareAgentArtifacts(a.ISOPath, agentTuiFiles)
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -161,28 +149,50 @@ func (a *AgentArtifacts) fetchAgentTuiFiles(releaseImage string, pullSecret stri
 	return files, nil
 }
 
-func (a *AgentArtifacts) prepareAgentArtifacts(iso string, additionalFiles []string) error {
+// PrepareArtifacts extracts the contents of the ISO to a tempdir.
+func (a *AgentArtifacts) PrepareArtifacts(ctx context.Context, stage workflowreport.StageID) (string, error) {
+	var agentTuiFiles []string
+	var err error
+	if a.ExternalPlatformName != agent.ExternalPlatformNameOci {
+		if err := workflowreport.GetReport(ctx).SubStage(
+			workflowreport.NewStageID(fmt.Sprintf("%s.agent-tui", stage.ID()),
+				"Extracting required artifacts from release payload")); err != nil {
+			return "", err
+		}
+		agentTuiFiles, err = a.fetchAgentTuiFiles(a.ReleaseImage, a.PullSecret, a.MirrorConfig)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if err = workflowreport.GetReport(ctx).SubStage(
+		workflowreport.NewStageID(fmt.Sprintf("%s.prepare", stage.ID()),
+			"Preparing artifacts")); err != nil {
+		return "", err
+	}
+
 	// Create a tmp folder to store all the pieces required to generate the agent artifacts.
 	tmpPath, err := os.MkdirTemp("", "agent")
 	if err != nil {
-		return err
+		return "", err
 	}
-	a.TmpPath = tmpPath
 
-	err = isoeditor.Extract(iso, a.TmpPath)
+	err = isoeditor.Extract(a.ISOPath, tmpPath)
 	if err != nil {
-		return err
+		os.RemoveAll(tmpPath)
+		return "", err
 	}
 
-	err = a.appendAgentFilesToInitrd(additionalFiles)
+	err = a.appendAgentFilesToInitrd(tmpPath, agentTuiFiles)
 	if err != nil {
-		return err
+		os.RemoveAll(tmpPath)
+		return "", err
 	}
 
-	return nil
+	return tmpPath, nil
 }
 
-func (a *AgentArtifacts) appendAgentFilesToInitrd(additionalFiles []string) error {
+func (a *AgentArtifacts) appendAgentFilesToInitrd(tmpPath string, additionalFiles []string) error {
 	ca := NewCpioArchive()
 
 	dstPath := "/agent-files/"
@@ -217,7 +227,7 @@ for i in $(find /agent-files/ -printf "%P\n"); do chcon system_u:object_r:bin_t:
 	}
 
 	// Append the archive to initrd.img
-	initrdImgPath := filepath.Join(a.TmpPath, "images", "pxeboot", "initrd.img")
+	initrdImgPath := filepath.Join(tmpPath, "images", "pxeboot", "initrd.img")
 	initrdImg, err := os.OpenFile(initrdImgPath, os.O_WRONLY|os.O_APPEND, 0)
 	if err != nil {
 		return err

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -69,6 +69,11 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 		return err
 	}
 
+	var err error
+	if a.tmpPath, err = agentArtifacts.PrepareArtifacts(ctx, workflow.StageGenerateISO); err != nil {
+		return err
+	}
+
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		a.platform = agentManifests.AgentClusterInstall.Spec.PlatformType
@@ -88,7 +93,6 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 
 	a.cpuArch = agentArtifacts.CPUArch
 	a.rendezvousIP = agentArtifacts.RendezvousIP
-	a.tmpPath = agentArtifacts.TmpPath
 	a.isoPath = agentArtifacts.ISOPath
 	a.bootArtifactsBaseURL = agentArtifacts.BootArtifactsBaseURL
 	a.minimalISO = agentArtifacts.MinimalISO

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/agent/gencrypto"
 	"github.com/openshift/installer/pkg/asset/agent/joiner"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
@@ -36,7 +37,7 @@ type AgentImage struct {
 	isoPath              string
 	rootFSURL            string
 	bootArtifactsBaseURL string
-	platform             hiveext.PlatformType
+	externalPlatformName string
 	isoFilename          string
 	imageExpiresAt       string
 	minimalISO           bool
@@ -50,8 +51,6 @@ func (a *AgentImage) Dependencies() []asset.Asset {
 		&workflow.AgentWorkflow{},
 		&joiner.ClusterInfo{},
 		&AgentArtifacts{},
-		&manifests.AgentManifests{},
-		&BaseIso{},
 		&gencrypto.AuthConfig{},
 	}
 }
@@ -61,9 +60,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 	agentWorkflow := &workflow.AgentWorkflow{}
 	clusterInfo := &joiner.ClusterInfo{}
 	agentArtifacts := &AgentArtifacts{}
-	agentManifests := &manifests.AgentManifests{}
-	baseIso := &BaseIso{}
-	dependencies.Get(agentArtifacts, agentManifests, baseIso, agentWorkflow, clusterInfo)
+	dependencies.Get(agentArtifacts, agentWorkflow, clusterInfo)
 
 	if err := workflowreport.GetReport(ctx).Stage(workflow.StageGenerateISO); err != nil {
 		return err
@@ -76,14 +73,12 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
-		a.platform = agentManifests.AgentClusterInstall.Spec.PlatformType
 		a.isoFilename = agentISOFilename
 
 	case workflow.AgentWorkflowTypeAddNodes:
 		authConfig := &gencrypto.AuthConfig{}
 		dependencies.Get(authConfig)
 
-		a.platform = clusterInfo.PlatformType
 		a.isoFilename = agentAddNodesISOFilename
 		a.imageExpiresAt = authConfig.AuthTokenExpiry
 
@@ -96,6 +91,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 	a.isoPath = agentArtifacts.ISOPath
 	a.bootArtifactsBaseURL = agentArtifacts.BootArtifactsBaseURL
 	a.minimalISO = agentArtifacts.MinimalISO
+	a.externalPlatformName = agentArtifacts.ExternalPlatformName
 
 	volumeID, err := isoeditor.VolumeIdentifier(a.isoPath)
 	if err != nil {
@@ -110,7 +106,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 			logrus.Debugf("Using custom rootfs URL: %s", a.rootFSURL)
 		} else {
 			// Default to the URL from the RHCOS streams file
-			defaultRootFSURL, err := baseIso.getRootFSURL(ctx, a.cpuArch)
+			defaultRootFSURL, err := getRootFSURL(ctx, a.cpuArch)
 			if err != nil {
 				return err
 			}
@@ -275,8 +271,8 @@ func (a *AgentImage) PersistToFile(directory string) error {
 		return err
 	}
 	// For external platform OCI, add CCM manifests in the openshift directory.
-	if a.platform == hiveext.ExternalPlatformType {
-		logrus.Infof("When using %s oci platform, always make sure CCM manifests were added in the %s directory.", hiveext.ExternalPlatformType, manifests.OpenshiftManifestDir())
+	if a.externalPlatformName == agent.ExternalPlatformNameOci {
+		logrus.Infof("When using %s %s platform, always make sure CCM manifests were added in the %s directory.", hiveext.ExternalPlatformType, a.externalPlatformName, manifests.OpenshiftManifestDir())
 	}
 
 	return nil

--- a/pkg/asset/agent/image/agentpxefiles.go
+++ b/pkg/asset/agent/image/agentpxefiles.go
@@ -46,14 +46,17 @@ func (a *AgentPXEFiles) Dependencies() []asset.Asset {
 }
 
 // Generate generates the image files for PXE asset.
-func (a *AgentPXEFiles) Generate(_ context.Context, dependencies asset.Parents) error {
+func (a *AgentPXEFiles) Generate(ctx context.Context, dependencies asset.Parents) error {
 	agentArtifacts := &AgentArtifacts{}
 	agentWorkflow := &workflow.AgentWorkflow{}
 	dependencies.Get(agentArtifacts, agentWorkflow)
 
-	a.tmpPath = agentArtifacts.TmpPath
-
 	if err := workflowreport.GetReport(ctx).Stage(workflow.StageGeneratePXE); err != nil {
+		return err
+	}
+
+	var err error
+	if a.tmpPath, err = agentArtifacts.PrepareArtifacts(ctx, workflow.StageGeneratePXE); err != nil {
 		return err
 	}
 

--- a/pkg/asset/agent/image/agentpxefiles.go
+++ b/pkg/asset/agent/image/agentpxefiles.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
+	workflowreport "github.com/openshift/installer/pkg/asset/agent/workflow/report"
 	"github.com/openshift/installer/pkg/types"
 )
 
@@ -51,6 +52,10 @@ func (a *AgentPXEFiles) Generate(_ context.Context, dependencies asset.Parents) 
 	dependencies.Get(agentArtifacts, agentWorkflow)
 
 	a.tmpPath = agentArtifacts.TmpPath
+
+	if err := workflowreport.GetReport(ctx).Stage(workflow.StageGeneratePXE); err != nil {
+		return err
+	}
 
 	ignitionContent := &isoeditor.IgnitionContent{Config: agentArtifacts.IgnitionByte}
 	initrdImgPath := filepath.Join(a.tmpPath, "images", "pxeboot", "initrd.img")

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -35,8 +35,8 @@ func (i *BaseIso) Name() string {
 	return "Base ISO Image"
 }
 
-// Fetch RootFS URL using the rhcos.json.
-func (i *BaseIso) getRootFSURL(ctx context.Context, archName string) (string, error) {
+// getRootFSURL fetches the rootfs URL using the rhcos.json.
+func getRootFSURL(ctx context.Context, archName string) (string, error) {
 	metal, err := rhcos.GetMetalArtifact(ctx, archName)
 	if err != nil {
 		return "", err

--- a/pkg/asset/agent/image/kargs.go
+++ b/pkg/asset/agent/image/kargs.go
@@ -36,20 +36,25 @@ func (a *Kargs) Generate(_ context.Context, dependencies asset.Parents) error {
 	agentClusterInstall := &manifests.AgentClusterInstall{}
 	dependencies.Get(agentClusterInstall, agentWorkflow, clusterInfo)
 
+	var externalPlatformName string
+
 	switch agentWorkflow.Workflow {
 	case workflow.AgentWorkflowTypeInstall:
 		a.fips = agentClusterInstall.FIPSEnabled()
-		// Add kernel args for external oci platform
-		if agentClusterInstall.GetExternalPlatformName() == agent.ExternalPlatformNameOci {
-			logrus.Debugf("Added kernel args to enable serial console for %s %s platform", hiveext.ExternalPlatformType, agent.ExternalPlatformNameOci)
-			a.consoleArgs = " console=ttyS0"
-		}
+		externalPlatformName = agentClusterInstall.GetExternalPlatformName()
 
 	case workflow.AgentWorkflowTypeAddNodes:
 		a.fips = clusterInfo.FIPS
+		externalPlatformName = clusterInfo.ExternalPlatformName
 
 	default:
 		return fmt.Errorf("AgentWorkflowType value not supported: %s", agentWorkflow.Workflow)
+	}
+
+	// Add kernel args for external oci platform
+	if externalPlatformName == agent.ExternalPlatformNameOci {
+		logrus.Debugf("Added kernel args to enable serial console for %s %s platform", hiveext.ExternalPlatformType, agent.ExternalPlatformNameOci)
+		a.consoleArgs = " console=ttyS0"
 	}
 
 	return nil

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -67,6 +67,7 @@ type ClusterInfo struct {
 	ImageDigestSources            []types.ImageDigestSource
 	DeprecatedImageContentSources []types.ImageContentSource
 	PlatformType                  hiveext.PlatformType
+	ExternalPlatformName          string
 	SSHKey                        string
 	IgnitionEndpointWorker        *models.IgnitionEndpoint
 	FIPS                          bool
@@ -527,6 +528,9 @@ func (ci *ClusterInfo) retrievePlatformType() error {
 	}
 
 	ci.PlatformType = agent.HivePlatformType(platform)
+	if ci.PlatformType == hiveext.ExternalPlatformType && infra.Spec.PlatformSpec.External != nil {
+		ci.ExternalPlatformName = infra.Spec.PlatformSpec.External.PlatformName
+	}
 	return nil
 }
 

--- a/pkg/asset/agent/workflow/commons.go
+++ b/pkg/asset/agent/workflow/commons.go
@@ -44,10 +44,6 @@ var (
 
 	// StageAgentArtifacts represents the agent artifact stage.
 	StageAgentArtifacts wr.StageID = wr.NewStageID("create-agent-artifacts", "Creating agent artifacts for the final image")
-	// StageAgentArtifactsAgentTUI represents the agent-tui embedding substage.
-	StageAgentArtifactsAgentTUI wr.StageID = wr.NewStageID("create-agent-artifacts.agent-tui", "Extracting required artifacts from release payload")
-	// StageAgentArtifactsPrepare represents the artifacts preparation substage.
-	StageAgentArtifactsPrepare wr.StageID = wr.NewStageID("create-agent-artifacts.prepare", "Preparing artifacts")
 
 	// StageGenerateISO represents the iso assembling stage.
 	StageGenerateISO wr.StageID = wr.NewStageID("generate-iso", "Assembling ISO image")


### PR DESCRIPTION
Even non-writable assets get persisted to the asset store, so don't store values that are only valid for one invocation of the installer. The AgentArtifacts asset only gets regenerated if some of its input changes. This prevented e.g. running both `create image` and `create pxe-files` in the same directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Artifact preparation (ISO extraction and initrd updates) moved to a dedicated preparation step that returns a temporary artifacts path.
  * PXE generation now reports progress as a distinct staged step for clearer build status.
  * External platform name handling consolidated across the agent image pipeline for consistent multi-platform behavior.

* **New Features**
  * Mirror configuration, release image, and pull-secret values are now captured and propagated into artifact preparation.
  * OCI-specific kernel-argument handling unified and applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->