### PR TITLE
CORS-3278: Switch IBMCloud to CAPI

### DIFF
--- a/pkg/infrastructure/platform/platform.go
+++ b/pkg/infrastructure/platform/platform.go
@@ -19,9 +19,7 @@ import (
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages/azure"
-	"github.com/openshift/installer/pkg/terraform/stages/ibmcloud"
 	"github.com/openshift/installer/pkg/terraform/stages/ovirt"
-	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
@@ -51,10 +49,7 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 	case gcptypes.Name:
 		return clusterapi.InitializeProvider(gcpcapi.Provider{}), nil
 	case ibmcloudtypes.Name:
-		if types.ClusterAPIFeatureGateEnabled(platform, fg) {
-			return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
-		}
-		return terraform.InitializeProvider(ibmcloud.PlatformStages), nil
+		return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
 	case nutanixtypes.Name:
 		return clusterapi.InitializeProvider(nutanixcapi.Provider{}), nil
 	case powervstypes.Name:

--- a/pkg/infrastructure/platform/platform_altinfra.go
+++ b/pkg/infrastructure/platform/platform_altinfra.go
@@ -16,7 +16,6 @@ import (
 	openstackcapi "github.com/openshift/installer/pkg/infrastructure/openstack/clusterapi"
 	powervscapi "github.com/openshift/installer/pkg/infrastructure/powervs/clusterapi"
 	vspherecapi "github.com/openshift/installer/pkg/infrastructure/vsphere/clusterapi"
-	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/featuregates"
@@ -38,10 +37,7 @@ func ProviderForPlatform(platform string, fg featuregates.FeatureGate) (infrastr
 	case gcptypes.Name:
 		return clusterapi.InitializeProvider(gcpcapi.Provider{}), nil
 	case ibmcloudtypes.Name:
-		if types.ClusterAPIFeatureGateEnabled(platform, fg) {
-			return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
-		}
-		return nil, nil
+		return clusterapi.InitializeProvider(ibmcloudcapi.Provider{}), nil
 	case vspheretypes.Name:
 		return clusterapi.InitializeProvider(vspherecapi.Provider{}), nil
 	case powervstypes.Name:

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -629,12 +629,10 @@ func ClusterAPIFeatureGateEnabled(platform string, fgs featuregates.FeatureGate)
 
 	// Check if CAPI install is enabled for individual platforms.
 	switch platform {
-	case aws.Name, azure.Name, gcp.Name, nutanix.Name, openstack.Name, powervs.Name, vsphere.Name:
+	case aws.Name, azure.Name, gcp.Name, nutanix.Name, openstack.Name, powervs.Name, vsphere.Name, ibmcloud.Name:
 		return true
 	case azure.StackTerraformName, azure.StackCloud.Name():
 		return false
-	case ibmcloud.Name:
-		return fgs.Enabled(features.FeatureGateClusterAPIInstallIBMCloud)
 	default:
 		return false
 	}


### PR DESCRIPTION
Sets IBMCloud to default to using CAPI--not Terraform for installs.