### PR TITLE
OCPBUGS-54606: convert OVNKubernetes networkType to correct format

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -96,10 +96,13 @@ func convertNetworking(config *types.InstallConfig) {
 		netconf.NetworkType = netconf.DeprecatedType
 	}
 
-	// Recognize the OpenShiftSDN network plugin name regardless of capitalization, for
+	// Recognize the network plugin name regardless of capitalization, for
 	// backward compatibility
-	if strings.ToLower(netconf.NetworkType) == strings.ToLower(string(operv1.NetworkTypeOpenShiftSDN)) {
+	if strings.EqualFold(netconf.NetworkType, string(operv1.NetworkTypeOpenShiftSDN)) {
 		netconf.NetworkType = string(operv1.NetworkTypeOpenShiftSDN)
+	}
+	if strings.EqualFold(netconf.NetworkType, string(operv1.NetworkTypeOVNKubernetes)) {
+		netconf.NetworkType = string(operv1.NetworkTypeOVNKubernetes)
 	}
 
 	// Convert hostSubnetLength to hostPrefix

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -175,6 +175,25 @@ func TestConvertInstallConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "OVNKubernetes spelling",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Networking: &types.Networking{
+					NetworkType: "OVNkubernetes",
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Networking: &types.Networking{
+					NetworkType: "OVNKubernetes",
+				},
+			},
+		},
+		{
 			name: "deprecated OpenStack LbFloatingIP",
 			config: &types.InstallConfig{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
The installer is quite lenient about case sensitivity of networkType values. We do have existing logic to convert this field value to the correct format [[0]](https://github.com/openshift/installer/blob/7867e67e84f38f33016c1506764770982cfee503/pkg/types/conversion/installconfig.go#L99-L103.). That only applies to OpenShiftSDN.

This PR extends that logic to handle OVNKubernetes.