### PR TITLE
CORS-3867: fix CRD descriptor to mention required BootstrapNode role

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4251,7 +4251,7 @@ spec:
                           In this case, the VPC must not contain any other non-cluster subnets without the kubernetes.io/cluster/<cluster-id> tag.
 
                           For manually specified subnet role selection, each subnet must have at least one assigned role,
-                          and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
+                          and the ClusterNode, BootstrapNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
                           However, if the cluster scope is internal, then ControlPlaneExternalLB is not required.
 
                           Subnets must contain unique IDs, and can include no more than 10 subnets with the IngressController role.

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -158,7 +158,7 @@ type VPC struct {
 	// In this case, the VPC must not contain any other non-cluster subnets without the kubernetes.io/cluster/<cluster-id> tag.
 	//
 	// For manually specified subnet role selection, each subnet must have at least one assigned role,
-	// and the ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
+	// and the ClusterNode, BootstrapNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB roles must be assigned to at least one subnet.
 	// However, if the cluster scope is internal, then ControlPlaneExternalLB is not required.
 	//
 	// Subnets must contain unique IDs, and can include no more than 10 subnets with the IngressController role.

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -258,7 +258,7 @@ func validateSubnets(subnets []aws.Subnet, publish types.PublishingStrategy, fld
 			allErrs = append(allErrs, field.Forbidden(fldPath, "must not include subnets with the ControlPlaneExternalLB role in a private cluster"))
 		}
 
-		// ClusterNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB
+		// ClusterNode, BootstrapNode, IngressControllerLB, ControlPlaneExternalLB, and ControlPlaneInternalLB
 		// must be assigned to at least 1 subnet.
 		missingRoles := sets.New[aws.SubnetRoleType]()
 		for rType := range supportedRoles {


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift/installer/pull/9443. In manual role selection, BootstrapNode role is required. This should be reflected in the CRD descriptor (i.e. `openshift-install explain`).