### PR TITLE
OCPBUGS-54902: Custom-DNS: Update Kubeconfig and Infra CR based on private or public cluster

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -897,7 +897,12 @@ func handleUnreachableAPIServer(ctx context.Context, config *rest.Config) error 
 		return fmt.Errorf("failed to fetch %s: %w", lbConfig.Name(), err)
 	}
 
-	_, ipAddrs, err := lbConfig.ParseDNSDataFromConfig(lbconfig.PublicLoadBalancer)
+	lbType := lbconfig.PublicLoadBalancer
+	if !installConfig.Config.PublicAPI() {
+		lbType = lbconfig.PrivateLoadBalancer
+	}
+
+	_, ipAddrs, err := lbConfig.ParseDNSDataFromConfig(lbType)
 	if err != nil {
 		return fmt.Errorf("failed to parse lbconfig: %w", err)
 	}

--- a/pkg/infrastructure/aws/clusterapi/ignition.go
+++ b/pkg/infrastructure/aws/clusterapi/ignition.go
@@ -71,6 +71,10 @@ func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) (*clusterapi
 			privateIPAddresses = append(privateIPAddresses, *nic.PrivateIpAddress)
 		}
 	}
+	if !in.InstallConfig.Config.PublicAPI() {
+		// For private cluster installs, the API LB IP is the same as the API-Int LB IP
+		publicIPAddresses = privateIPAddresses
+	}
 	logrus.Debugf("AWS: Editing Ignition files to start in-cluster DNS when UserProvisionedDNS is enabled")
 	return clusterapi.EditIgnition(in, awstypes.Name, publicIPAddresses, privateIPAddresses)
 }


### PR DESCRIPTION
Update Kubeconfig with API or API-Int LB IP based on whether the cluster is public or private respectively. This updated Kubeconfig can be used to reach API server from the install host when cutsom-DNS is enabled and there is no external DNS yet.