### PR TITLE
NO-JIRA: Update SCOS 4.19 bootimage metadata to 9.0.20250411-0

### DIFF
--- a/data/data/coreos/scos.json
+++ b/data/data/coreos/scos.json
@@ -1,106 +1,106 @@
 {
   "stream": "c9s",
   "metadata": {
-    "last-modified": "2025-02-26T04:24:24Z",
-    "generator": "plume cosa2stream 7550a58"
+    "last-modified": "2025-04-13T06:43:09Z",
+    "generator": "plume cosa2stream 677fe26"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-aws.aarch64.vmdk.gz",
-                "sha256": "0be493536b94d4eeb992ef9734a33e40396722c5ab756534bfc1f142fd944581",
-                "uncompressed-sha256": "b78dad1413cf0d4cb741c5fdaab7bc8399b71823a619ebf54842413fb8aff59b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-aws.aarch64.vmdk.gz",
+                "sha256": "442fad1380595e977de8c4c51df40cc350b3148a5123ed9003f40c0a1ce80d34",
+                "uncompressed-sha256": "e94f60a63f09859355c6db938334f8ddcbd0b310678adee858393e16ba607443"
               }
             }
           }
         },
         "azure": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-azure.aarch64.vhd.gz",
-                "sha256": "1abfd72dfae75bdb483e1650e83e768bff6cc9d56da125a9412729357b3558b1",
-                "uncompressed-sha256": "66b9c9732b052daa504af82bdb88f918993880d7641e1f742399b01cf1a67eb9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-azure.aarch64.vhd.gz",
+                "sha256": "ebfb71b4bf44102939bab1568f511b92a80453eb5978d34ed1b4cd85ababc033",
+                "uncompressed-sha256": "7c2c1e33eb97550ccf27340816fd6bc2d8520eb0406dfa9f2dc23c84a2a15616"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-gcp.aarch64.tar.gz",
-                "sha256": "cce1454bfab11c9522e3ee93ae6bd4375acfc3e25ac378da00aea71ddc0e63d9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-gcp.aarch64.tar.gz",
+                "sha256": "a36a83ceefe7672896752ecdb0963bd4ec314c16ac1cefacba4f6780721b5986"
               }
             }
           }
         },
         "metal": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-metal4k.aarch64.raw.gz",
-                "sha256": "73bd6f4ad5ef74d04179d72450abd52361f8693aab24857e874ae174320131dd",
-                "uncompressed-sha256": "0d01080059747fc739b9f43794f599b8685fd47bf5692d7fae3e7cb73e150643"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-metal4k.aarch64.raw.gz",
+                "sha256": "11d6b5618b5d757b4c97c9d013e6a1af7c02b627695e542d7e244ea7d3bf66a3",
+                "uncompressed-sha256": "586d6baeea6df5c83d4a0b3784d540d3fecf5c8a3a15e6eefb5809c9b6c46ae3"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-live-iso.aarch64.iso",
-                "sha256": "7f97f5ed49feffd19031f8b8a333a8c8719d67b8d693faf583385989f4aafc48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-live-iso.aarch64.iso",
+                "sha256": "dd5423590af176154260223135004f3156d8ef42ef4e9c5095380ce78591aee8"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-live-kernel.aarch64",
-                "sha256": "73d0c7dcf82536705ae37aa7ce540832fc359f84df696f098b62df70171cb3d5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-live-kernel.aarch64",
+                "sha256": "dd3f53587209e11af89f62c01d2c37fa34a15ed2f53ec0bbded0867c8a5c9b69"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-live-initramfs.aarch64.img",
-                "sha256": "1b59ebd36663d49df2ba8fedc63fa78a1fa4d423e30225abdaa27f868eefe473"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-live-initramfs.aarch64.img",
+                "sha256": "785ecb10395688fe7b90567a0d5918d41504b6f09c8a729bb94d44ccc2fe9bb9"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-live-rootfs.aarch64.img",
-                "sha256": "7723ae7e55bb41e50e97aa34d4cbc1f2beb1931eac9b44dfac0e20de1c9b9f9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-live-rootfs.aarch64.img",
+                "sha256": "d08c0173f7ae6337cedbc1e37799399c05180b30382ea000ec90aba4eead091e"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-metal.aarch64.raw.gz",
-                "sha256": "10168560ec85f5bc139ddaf4805a52d9a83c8c17d967a9a26c4775a8ea395291",
-                "uncompressed-sha256": "82e1bec35d3b1e36c689bc08956d3d0512e682e591624ec3d5f40fc2f12f8929"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-metal.aarch64.raw.gz",
+                "sha256": "722fef9886c25000987d91cadbd260b76f1d79158f1bdec6c10a86f3c4515ea0",
+                "uncompressed-sha256": "83441b8b901922efc84684daddbaf526d66f341a140d3b0e76da478f2f54c254"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-openstack.aarch64.qcow2.gz",
-                "sha256": "15c14e6885cefc8fff7934f8712b0cbb3cd76f3aaaa977f1c7df1b77373efee5",
-                "uncompressed-sha256": "e1c2c89e48d55b53b698c4773632cd055ecc9ba87a6fd996e9f810902ff1172b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-openstack.aarch64.qcow2.gz",
+                "sha256": "980e0f0dd0b04c83599891b0de00dd1f750d62c528a64fa6e96c91ac6c38cd15",
+                "uncompressed-sha256": "65d137612c60d4345b2cddadde07b9b0dd4ca54219b1c1c5095e35f30e57d0e3"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/aarch64/scos-9.0.20250222-0-qemu.aarch64.qcow2.gz",
-                "sha256": "21e9a63e97c2aa7bcaa4a1dd900c1391d1e898e83b041712bcb712db6d227175",
-                "uncompressed-sha256": "95e8d7783952008e1c49dd3f09c3c1d7a288bedc22ec77df62db9a8a155aad93"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/aarch64/scos-9.0.20250411-0-qemu.aarch64.qcow2.gz",
+                "sha256": "1cfd328d58a0921be6c330547425777b3aa789aca79ab360dfa05e2c3d8e7f11",
+                "uncompressed-sha256": "0335247110b52894bace25b078a31f08ba6bac888e642c1d2a601ee46b2e9461"
               }
             }
           }
@@ -110,101 +110,101 @@
         "aws": {
           "regions": {
             "us-east-1": {
-              "release": "9.0.20250222-0",
-              "image": "ami-082388db78fd51051"
+              "release": "9.0.20250411-0",
+              "image": "ami-05bd1746e1db29705"
             },
             "us-gov-west-1": {
-              "release": "9.0.20250222-0",
-              "image": "ami-03ec74361443bcb6a"
+              "release": "9.0.20250411-0",
+              "image": "ami-00c8aee5563f2d5bc"
             }
           }
         },
         "gcp": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "project": "rhcos-cloud",
-          "name": "scos-9-0-20250222-0-gcp-aarch64"
+          "name": "scos-9-0-20250411-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.0.20250222-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/scos-9.0.20250222-0-azure.aarch64.vhd"
+          "release": "9.0.20250411-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/scos-9.0.20250411-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-metal4k.ppc64le.raw.gz",
-                "sha256": "6c9b094339138ad218564bc20414aaf45ca2080a5775de95f48422c68c7c67da",
-                "uncompressed-sha256": "45f787ec10a942653f3be3b2a7ec955ed4c0ab6901b05f323ad55679d65d0340"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-metal4k.ppc64le.raw.gz",
+                "sha256": "08dbc88150552f14d111b7c4e6fc07228d4b89a6c1c44270e999dfda9bd2aa29",
+                "uncompressed-sha256": "53ac7f8801059254d2c295b38afa877df60194581a570598f188844f815502e5"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-live-iso.ppc64le.iso",
-                "sha256": "3ba7eb06cc6d16faa817309a38bb5f3463e07e84137d4be03a48b66f904ae816"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-live-iso.ppc64le.iso",
+                "sha256": "55504e553b705ae385887b9a0b8d4a12290cf47362d808ce94580bd5b0f5946e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-live-kernel.ppc64le",
-                "sha256": "24b744acab3b8c087b89965a9430804035e6c8056f28d6926037e858445804d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-live-kernel.ppc64le",
+                "sha256": "08b56fb733e189b308322933c3bab918d3ada299f2474df225cb8da49420c263"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-live-initramfs.ppc64le.img",
-                "sha256": "1d8754540688296b1afe208aed530b9bbc90f1ba1fc17a9b3406f98cabac2fbf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-live-initramfs.ppc64le.img",
+                "sha256": "89529aba4071eab4256916d63c78e5223e5477c9f43ccf6513b2d647cbdb77c6"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-live-rootfs.ppc64le.img",
-                "sha256": "8a55fe870ea942195d46f607435170dc2462be473e52bddeeefd5eea04ecb6f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-live-rootfs.ppc64le.img",
+                "sha256": "c7e010c3ab9e8d6e8a7ba7180cec245560404b609724c76d5b0e01aabd6a157e"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-metal.ppc64le.raw.gz",
-                "sha256": "02d48a45104b29d6b81ca1225a3f41f58bb52d9de6dda74f1e47a37857e14595",
-                "uncompressed-sha256": "95bb601dae2b753aacd0c98ad953264fc60bce6c68254829b4b6d369e92c3829"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-metal.ppc64le.raw.gz",
+                "sha256": "ea5fc0c3a3b93159d276eda682f2417f96f36e71782972a34fc66e8206b88d9d",
+                "uncompressed-sha256": "1187ba1f65606d3581ab7db3112719375ca041b981bbbc2f8a730a8b59d7fe20"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "f9defb421698789f107895676fbf47a2c9f037a173990c3cacddccb4cbd0bc1f",
-                "uncompressed-sha256": "e94b50b29097584e76a2f4b7bc855f4f1f6e56e9101687cfa15fd35bb7a7ca53"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "97c2f7868dca81a5be6eec9bdafb17500dff2c81e876dec96c35b42c159d15e2",
+                "uncompressed-sha256": "e3acae44c81bd4acd694f2e76c1e0a95d7a3f308ced65176db302ab6851310ad"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-powervs.ppc64le.ova.gz",
-                "sha256": "5a0066ddb291b3f15fd3d418a8606bdc7f7e6c7c128a27315fd0a4ba8719951d",
-                "uncompressed-sha256": "d7783fafd1ce84b88e271a04ada6c4ed0dca4e147a6707de96f3398220deb942"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-powervs.ppc64le.ova.gz",
+                "sha256": "8e7762c35d1afc7b3a0fce37744de6d69525a43903d5d2badcce9ec9c1fb074a",
+                "uncompressed-sha256": "d86209753a0420e04dd053aea69e1f720cca7e59a3e4b84e26d0cd9a18be81c5"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/ppc64le/scos-9.0.20250222-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "6cb368f10a6b73a3ff728f29e93c761f7c5c345eb4790ea24f8241d7aa303986",
-                "uncompressed-sha256": "5551ac0f3fac4b1923db5b0a9427c1e6a7c3c71e63df28fefa63958b6e78f6f3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/ppc64le/scos-9.0.20250411-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "4e3533586c297de2784ea307c8292615295122298f19fef46b82f271f61321e0",
+                "uncompressed-sha256": "aa7114d958a481bef7aa4a7c986f660cc51da0302f2bb39be3daa2c23b9d9604"
               }
             }
           }
@@ -214,10 +214,10 @@
         "powervs": {
           "regions": {
             "us-east": {
-              "release": "9.0.20250222-0",
-              "object": "scos-9-0-20250222-0-ppc64le-powervs.ova.gz",
+              "release": "9.0.20250411-0",
+              "object": "scos-9-0-20250411-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/scos-9-0-20250222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/scos-9-0-20250411-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -226,88 +226,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "9da9330ab1d7965e37f2f306eea35e3d524bc6b1e36b98b6ba53971977bcef4d",
-                "uncompressed-sha256": "46b44463efc5259867532a6086d82ad210c3ccd213f09cde9abb3240541c5301"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "71db632bfb694c7c9c5f73346a2754da0ba327a9fd62f8a5a20a7c0aa1067440",
+                "uncompressed-sha256": "2b548dd28b700283eab05fc5efcae2d81963cc6ee1508ad51a9285ffd49d0840"
               }
             }
           }
         },
         "metal": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-metal4k.s390x.raw.gz",
-                "sha256": "c2a6c17db51c7719d6f6147c4ad7cad2b0155d59bfe2da093a85fc823abdab66",
-                "uncompressed-sha256": "2999cfcd7dac7e15f831e95887f1d65f28cc5636318d5a34afbb27aa19a93368"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-metal4k.s390x.raw.gz",
+                "sha256": "af262c60752f22c059ecdcf548ff443efc09369d7373b6d9dd56f70d12f76605",
+                "uncompressed-sha256": "324e1de7246383493320e14f786d883295639512cac6698b06221a73db02d514"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-live-iso.s390x.iso",
-                "sha256": "ce49ed167ec62bb5ef62b13a9c87ac20b1ba4f502fb4cc9cd2d9be7c38be57bc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-live-iso.s390x.iso",
+                "sha256": "fe0a315d27f12d074d7ccd86e972a3cbfed6d01510c8cb2792491bdbb1823761"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-live-kernel.s390x",
-                "sha256": "05e870274a553ef50b73066aef77cbf7cc7bc73f0d67e036cf9557849533a767"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-live-kernel.s390x",
+                "sha256": "7a8fe3df673287728ee031e59f58abefb8e7175df61454a2a1724744a5b4f94b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-live-initramfs.s390x.img",
-                "sha256": "dcbed2df7234ddb4f741c6f4ae64628baa630a9b851011f37c0991f99098ccde"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-live-initramfs.s390x.img",
+                "sha256": "575c6cf13b5b7ce02c59881593fcea3f5ab94a1d4367d85f19657b198418cd9f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-live-rootfs.s390x.img",
-                "sha256": "112a5e40554409b561ebd092a3db0cccc406a3cccf2a946b3571f18e76038ca7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-live-rootfs.s390x.img",
+                "sha256": "1210747be83a5f6bc0276366995ee8aa96525386e028702cf83048c18c6ca772"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-metal.s390x.raw.gz",
-                "sha256": "286d0e14d59e386ca5dcfb7b13a5d783f215e9e35ae6458bb7c97385ef6cb03a",
-                "uncompressed-sha256": "4d8da47531436f9126d1b2296d144e511a08a474d8a0dc39b6e653bcc2eac0f5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-metal.s390x.raw.gz",
+                "sha256": "ba67f11c6ae8900b2377aab650f84da6cd52e8a6f0f5c0f736a68ee8a3062509",
+                "uncompressed-sha256": "27e490988fa1506dda7652dfd957e2b5115ccbb17bafde03df6da3e250bd842e"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-openstack.s390x.qcow2.gz",
-                "sha256": "ecd22ab04d3b73f073c219fdb787e598278bd47dd00ff62dd8e84469eba1481a",
-                "uncompressed-sha256": "dcd9e521fff67f26203d41e5332efbcff7f22a11f05a639687e794dfe93974f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-openstack.s390x.qcow2.gz",
+                "sha256": "5dd2a09c9b75ea4f1f0b5d9fee636831d7e2e734618adb5713b696938277c847",
+                "uncompressed-sha256": "19c67c712b72f8da9b0c7a4393ebea646f49683880ec053b7fb21640248ee33f"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-qemu.s390x.qcow2.gz",
-                "sha256": "8732cae583dfe86c67bd0d58f35a723b48025bdba512c6d05a53f72ffdaba9ac",
-                "uncompressed-sha256": "d8c86d075e4b043f5c892af40889b8da04b6edc21e532514dfc1841ff070f252"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-qemu.s390x.qcow2.gz",
+                "sha256": "f633de6ff3f2da4839537bd7d4ae56291a262781c81126614ff1dfcaadfba65f",
+                "uncompressed-sha256": "3f5eafc2f417c1b33130a8c92c045eefb7c0baaf9465d278e72a14779bedd932"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/s390x/scos-9.0.20250222-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "22c01287627869563db5abd0098b3a85f3cb5628c4812b6da4359b1b7857dda1",
-                "uncompressed-sha256": "17dad4aea0bcbf99cae65c5ed95525a7dd27d9ebd4a7735f9f5e40b695893810"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/s390x/scos-9.0.20250411-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "217127c6bbf67e19e6b59fe6ff573eef87e77a3060c8250738447f0aa260fcee",
+                "uncompressed-sha256": "72c2b0d322b2c9f90cd1e8893e262e9a18f1ae1853503c09bb6600c8a6e50b5f"
               }
             }
           }
@@ -318,156 +318,156 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-aws.x86_64.vmdk.gz",
-                "sha256": "eb0a64c2f876c431291097a873899b94e508ed9dcb435b1ab0b3ad1baead3c66",
-                "uncompressed-sha256": "2125087b0d3f25f9660f6820283da3e55e89c21c081d044f02d71833c6c494f2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-aws.x86_64.vmdk.gz",
+                "sha256": "6bb8cc38c3421e82fca23055f155ab3dbf6cbfc46dc3a8afc1603da05304b4ba",
+                "uncompressed-sha256": "0d9f1ada3df62e7c4cce354f0b9e94b132655c63357c05355416232c4d6dfb10"
               }
             }
           }
         },
         "azure": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-azure.x86_64.vhd.gz",
-                "sha256": "b21c34227744b531b592efb3573395d37ac29c24ceb68b4e54a6f6fe04d9c228",
-                "uncompressed-sha256": "66b10b9e08751aa42a2a91503108c99fcdfedd66b249b8bd39bb9e9b9b4b87d6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-azure.x86_64.vhd.gz",
+                "sha256": "55a510f70c855aee8e3e9d20a1702d0e5a893ae6767108b8cf789265c44b67de",
+                "uncompressed-sha256": "75933e9a3543e777f8a3d8ef23c686860a75dcb40e130dce0786a48ed6dfd424"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-azurestack.x86_64.vhd.gz",
-                "sha256": "927e9098d531be3d629083c1e32ede262770ef2942274f917a517c553567c86c",
-                "uncompressed-sha256": "5340ce1aa187785315dcfc8afb75b58304d93c2ae1ee10bbf3a0470e7720ee24"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-azurestack.x86_64.vhd.gz",
+                "sha256": "e79788b87a1b16afaab6f1e59932a3160827df869d9901a2f38b2fc80809b79b",
+                "uncompressed-sha256": "5e9c4b34ff6ddd0872ec499569c32e9add13718cb22f20135e52edb3a0c4494a"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-gcp.x86_64.tar.gz",
-                "sha256": "439de908f51f7c73bccda9abed6d81454b2ea826ec2b237364ee266af1d33f29"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-gcp.x86_64.tar.gz",
+                "sha256": "3e1ecfebcac056e72bcea00e7f27d8dec9bd42a76799143d549e6645fce12610"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "16aeffae341a32d7028f626127838a371a1146c466a8330e4de73fb77c66eb03",
-                "uncompressed-sha256": "75c5da86f2214ae50bbcaf16e4a1fb97d9b3d4047b6d03efe118b382942bbd18"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "a2b8d125aabf5cdf5ced1c000da685d5fcd60838b4c7a611bcea9cc50be9ecc9",
+                "uncompressed-sha256": "330780227eeb10e17854ee69a88a67c96c5413386a1eaaf52163c2a0e4fd3926"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-kubevirt.x86_64.ociarchive",
-                "sha256": "f30642facb46b9d197f0b120f68583ed8b2da132b3b1c6da3cd21ae340533909"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-kubevirt.x86_64.ociarchive",
+                "sha256": "8689695123a9f7c23bb17a874bca5ef1ccc7ff44710ee3ee205ff27fb2514a6c"
               }
             }
           }
         },
         "metal": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-metal4k.x86_64.raw.gz",
-                "sha256": "49dd7fac46f8c38f84b80111240539b01fe4693be82874075b4f47fd737a1827",
-                "uncompressed-sha256": "d6d2c3be523f5f49fb31a82e2d46beaed273ba38c7e7f7a7cbe57beb19b3df0a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-metal4k.x86_64.raw.gz",
+                "sha256": "c7ae0cbbc29d429ef1b004c29e342cee7f33deab4a3a9ae786cf4b829369932b",
+                "uncompressed-sha256": "f5ed2e02014f1930c2e4703175ec2c7466a70a503c88ac1dfdda3d1b6c6e38a0"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-live-iso.x86_64.iso",
-                "sha256": "099367ca95dde80025ccabdd6e94333ebe99778be65daa817e9011fe7308d72f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-live-iso.x86_64.iso",
+                "sha256": "7b2df46f1b32f091f28bd01834f40461d363859b5a1045ce344dd087f2130b00"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-live-kernel.x86_64",
-                "sha256": "b3f336b45f6cb914f90db85691dc4dc74b48f8bf0cab8d7f7d756c761db1d3b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-live-kernel.x86_64",
+                "sha256": "5758da2fc443a3fd47b24417ec0d2c90f33c99229d1982d1098cfdffefda0969"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-live-initramfs.x86_64.img",
-                "sha256": "70679c25659b45139df77bd14f0705a156c54136fed556611a8bdf2e3defeb1c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-live-initramfs.x86_64.img",
+                "sha256": "c2322a836ca66c00a477e36fb9542ad199eecde265ed896bd8888c7cd125d628"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-live-rootfs.x86_64.img",
-                "sha256": "ce15fad46ec252408582679d329b273a52358bc52af4f0104cdceea7b93718f6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-live-rootfs.x86_64.img",
+                "sha256": "e73c6840050474191b75aee08ff960e926f3b9244451f483e04e590739717282"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-metal.x86_64.raw.gz",
-                "sha256": "211e073b4a4fe1e8c129b111a8352156442d8dcd39c64e523107d61a6b4ccad8",
-                "uncompressed-sha256": "a9a1c3df234cf0e1d80f225baa732e8f39ae694fe3c74053f71d4f681d496eea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-metal.x86_64.raw.gz",
+                "sha256": "e96e3bb2dd4550c1d3ed8b53ae64f3b8d19a88ea6f6ca43bfa026f49e5b5ea03",
+                "uncompressed-sha256": "0ddbb2d37e861c543b49fe1469b51777a7d0ee656125b1000de2e80b4f8156ab"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-nutanix.x86_64.qcow2",
-                "sha256": "c0cb6eb315c4a892ab1324c292232491aff1d8e20625e0af5a740a222a30ba75"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-nutanix.x86_64.qcow2",
+                "sha256": "d5b8a8bef6d5921edffe3b0b57e8ce9115ed039340a07a5ebedc4b6f5b5c1b0d"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-openstack.x86_64.qcow2.gz",
-                "sha256": "662f5b98988b45b9807b7820a6fcc6cf70eb383ae4b51342b5a3fd7e484dc561",
-                "uncompressed-sha256": "452a2b08b05b6cf2a338bcb2a6b40fd062cfc033713e13057cdc70e5a87e6e7d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-openstack.x86_64.qcow2.gz",
+                "sha256": "293dee25f1835edf042998212f163567660f973ff941c7ab30a9d41cfe9ec4a8",
+                "uncompressed-sha256": "23607593afd7fe134bce64c75cbcb84b0a27462b75531d05e93c702998c51488"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-qemu.x86_64.qcow2.gz",
-                "sha256": "8dd26cfe53746c49aaeb726f41e20578e0be916fbb7ef2a1b4629c9390d7462e",
-                "uncompressed-sha256": "1e0840eb8999f2a5781f583afea1d06dc3a6bc194010aad8106ca839143fb0d9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-qemu.x86_64.qcow2.gz",
+                "sha256": "46dd3b4846ab4b5f8a81a8dc93065e88df3e8162d4e5596fede9a273f02dd128",
+                "uncompressed-sha256": "e1a48cd14566e2d0fa603365bf12e3cb1c2bf72d2dbdba4e8391c642e325b36a"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250222-0/x86_64/scos-9.0.20250222-0-vmware.x86_64.ova",
-                "sha256": "2eee96e1fab42c84678b3f343483fe9fc0ea91efb662ef0baa25ea35e1417f67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/c9s/builds/9.0.20250411-0/x86_64/scos-9.0.20250411-0-vmware.x86_64.ova",
+                "sha256": "74291cc57d0e66da659d2f7702c86ff9071c93391c15901ad0f349e5583cb32a"
               }
             }
           }
@@ -477,33 +477,32 @@
         "aws": {
           "regions": {
             "us-east-1": {
-              "release": "9.0.20250222-0",
-              "image": "ami-0f38745809fe2198d"
+              "release": "9.0.20250411-0",
+              "image": "ami-0786ab8ca9729ad89"
             },
             "us-gov-west-1": {
-              "release": "9.0.20250222-0",
-              "image": "ami-0fa8a4be3083d5757"
+              "release": "9.0.20250411-0",
+              "image": "ami-05ced6038d32aa4f3"
             }
           }
         },
         "gcp": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "project": "rhcos-cloud",
-          "name": "scos-9-0-20250222-0-gcp-x86-64"
+          "name": "scos-9-0-20250411-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.0.20250222-0",
+          "release": "9.0.20250411-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:66202254072a96c7acdb3706982fa3143c5400e272b2afbc20999684b8a86609"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fc7592badceb52b040f0fd683203236017bc411fa4934c8757d6e7982bf5fe78"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.0.20250222-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/scos-9.0.20250222-0-azure.x86_64.vhd"
+          "release": "9.0.20250411-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/scos-9.0.20250411-0-azure.x86_64.vhd"
         }
       }
     }
   }
 }
-


### PR DESCRIPTION
Update to a newer bootimage before we release OKD for 4.19. This change was generated using:

```
plume cosa2stream --target data/data/coreos/scos.json                \
    --distro rhcos --no-signatures --name c9s                        \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=9.0.20250411-0                                     \
    aarch64=9.0.20250411-0                                     \
    s390x=9.0.20250411-0                                       \
    ppc64le=9.0.20250411-0
```