### PR TITLE
OCPEDGE-1749: [TNF] Updated bare-metal init sequence to detach control-plane nodes in Two Node OpenShift.

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1600,11 +1600,8 @@ func validateFencingCredentials(installConfig *types.InstallConfig) (errors fiel
 func validateFencingForPlatform(config *types.InstallConfig, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 	switch {
-	case config.None != nil, config.External != nil:
-	case config.BareMetal != nil:
-		if len(config.Platform.BareMetal.Hosts) > 0 {
-			errs = append(errs, field.Forbidden(fldPath, "fencing is mutually exclusive with hosts, please remove either of them"))
-		}
+	case config.None != nil, config.External != nil, config.BareMetal != nil:
+		// Allowed platforms
 	default:
 		errs = append(errs, field.Forbidden(fldPath, fmt.Sprintf("fencing is only supported on baremetal, external or none platforms, instead %s platform was found", config.Platform.Name())))
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2814,6 +2814,7 @@ func TestValidateTNF(t *testing.T) {
 		},
 		{
 			config: installConfig().
+				PlatformBMWithHosts().
 				MachinePoolCP(machinePool().
 					Credential(c1(), c2())).
 				CpReplicas(2).
@@ -2831,6 +2832,7 @@ func TestValidateTNF(t *testing.T) {
 		},
 		{
 			config: installConfig().
+				PlatformBMWithHosts().
 				MachinePoolArbiter(machinePool()).
 				MachinePoolCP(machinePool().Credential(c1(), c2())).
 				ArbiterReplicas(1).
@@ -2840,6 +2842,7 @@ func TestValidateTNF(t *testing.T) {
 		},
 		{
 			config: installConfig().
+				PlatformBMWithHosts().
 				MachinePoolArbiter(machinePool()).
 				MachinePoolCP(machinePool().Credential(c1(), c2(), c3())).
 				ArbiterReplicas(1).
@@ -2920,8 +2923,8 @@ func TestValidateTNF(t *testing.T) {
 					Credential(c1(), c2())).
 				CpReplicas(2).
 				build(),
-			name:     "fencing_hosts_mutually_exclusive",
-			expected: "controlPlane.fencing: Forbidden: fencing is mutually exclusive with hosts, please remove either of them",
+			name:     "tnf_supported_platforms",
+			expected: "",
 		},
 		{
 			config: installConfig().
@@ -2930,7 +2933,7 @@ func TestValidateTNF(t *testing.T) {
 					Credential(c1(), c2())).
 				CpReplicas(2).
 				build(),
-			name:     "supported_platforms",
+			name:     "tnf_unsupported_platform",
 			expected: "controlPlane.fencing: Forbidden: fencing is only supported on baremetal, external or none platforms, instead aws platform was found",
 		},
 	}
@@ -3060,10 +3063,8 @@ type installConfigBuilder struct {
 }
 
 func installConfig() *installConfigBuilder {
-	bmPlatform := validBareMetalPlatform()
-	bmPlatform.Hosts = nil
 	return &installConfigBuilder{
-		InstallConfig: types.InstallConfig{Platform: types.Platform{BareMetal: bmPlatform}},
+		InstallConfig: types.InstallConfig{},
 	}
 }
 


### PR DESCRIPTION
Two Node OpenShift (TNF) is DevPreview in 4.19. In order to ensure that ironic doesn't try to manage the power state of the nodes, we add a check for the DualReplica topology after the control-plane nodes are provisioned during bootstrapping and detach them from ironic. In a future release, when fencing is enabled, it will be important to enforce that this remains an invariant for the DualReplica control-plane topology. There is currently nothing preventing the annotation that detaches these nodes from being removed.

See https://redhat-internal.slack.com/archives/CFP6ST0A3/p1744635159894649
