### PR TITLE
OCPBUGS-55492:  sort zone slices extracted from map of byo subnets

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -125,6 +126,10 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 				for zone := range subnets {
 					mpool.Zones = append(mpool.Zones, zone)
 				}
+				// Since zones are extracted from map keys, order is not guaranteed.
+				// Thus, sort the zones by lexical order to ensure CAPI and MAPI machines
+				// are distributed to zones in the same order.
+				slices.Sort(mpool.Zones)
 			} else {
 				mpool.Zones, err = installConfig.AWS.AvailabilityZones(ctx)
 				if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	baremetalhost "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -196,6 +197,10 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 				for zone := range subnets {
 					mpool.Zones = append(mpool.Zones, zone)
 				}
+				// Since zones are extracted from map keys, order is not guaranteed.
+				// Thus, sort the zones by lexical order to ensure CAPI and MAPI machines
+				// are distributed to zones in the same order.
+				slices.Sort(mpool.Zones)
 			} else {
 				mpool.Zones, err = installConfig.AWS.AvailabilityZones(ctx)
 				if err != nil {


### PR DESCRIPTION
Previously, since zones are extracted from map keys, order is not guaranteed. This can lead to an issue where master CAPI machine manifest is configured with a different subnet ID than MAPI machine manifest as they are handled separately.

Thist PR ensures the zones are sorted by lexical order before processing CAPI/MAP machine manifests so that zones are distributed in the same order.