### PR TITLE
no-jira: handle baremetal platform in CAPI manifests

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -39,6 +39,7 @@ import (
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	azuredefaults "github.com/openshift/installer/pkg/types/azure/defaults"
+	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
@@ -498,7 +499,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		if err != nil {
 			return fmt.Errorf("failed to generate IBM Cloud VPC machine manifests: %w", err)
 		}
-	case externaltypes.Name, nonetypes.Name:
+	case externaltypes.Name, nonetypes.Name, baremetaltypes.Name:
 		return nil
 	default:
 		return fmt.Errorf("unrecognized platform: %q", ic.Platform.Name())

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/installer/pkg/clusterapi"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	externaltypes "github.com/openshift/installer/pkg/types/external"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
@@ -145,7 +146,7 @@ func (c *Cluster) Generate(_ context.Context, dependencies asset.Parents) error 
 		if err != nil {
 			return fmt.Errorf("failed to generate IBM Cloud VPC manifests: %w", err)
 		}
-	case externaltypes.Name, nonetypes.Name:
+	case externaltypes.Name, nonetypes.Name, baremetal.Name:
 		return nil
 	default:
 		return fmt.Errorf("unsupported platform %q", platform)


### PR DESCRIPTION
Baremetal IPI does not use any CAPI manifests so, handle the platform.