### PR TITLE
pkg/destroy/aws: match IAM users on cluster prefix

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -60,6 +60,7 @@ type ClusterUninstaller struct {
 	ClusterID      string
 	ClusterDomain  string
 	HostedZoneRole string
+	ClusterName    string
 
 	// Session is the AWS session to be used for deletion.  If nil, a
 	// new session will be created based on the usual credential
@@ -90,6 +91,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		ClusterDomain:  metadata.AWS.ClusterDomain,
 		Session:        session,
 		HostedZoneRole: metadata.AWS.HostedZoneRole,
+		ClusterName:    metadata.ClusterName,
 	}, nil
 }
 
@@ -163,9 +165,10 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 		Logger:  o.Logger,
 	}
 	iamUserSearch := &IamUserSearch{
-		client:  iamClient,
-		filters: o.Filters,
-		logger:  o.Logger,
+		client:      iamClient,
+		filters:     o.Filters,
+		logger:      o.Logger,
+		clusterName: o.ClusterName,
 	}
 
 	// Get the initial resources to delete, so that they can be returned if the context is canceled while terminating


### PR DESCRIPTION
AWS destroy code iterates through every single IAM user to check whether it has a tag showing it is owned by the cluster. That iteration consists of a list call and then an additional get user for each user to inspect the tags.

By convention, IAM users names are created prefixed with the cluster name (or infra id, which itself is prefixed with cluster name). **[NOTE: this still needs to be confirmed]**  We can avoid making the API call to get user by checking the prefix before making the call. This is helpful, because we are hitting rate limiting and this is a very slow part of destroy.

The downside for this approach is that if any users are created without the prefix, they will be leaked. This should be testable.

In the future, it would be ideal if we could create all users in a path, which would allow us to list based on the path.

Currently AWS tests are failing because it is taking almost an hour to iterate through all the users, see [for example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_installer/9666/pull-ci-openshift-installer-main-e2e-aws-ovn/1912591802397888512/artifacts/e2e-aws-ovn/ipi-deprovision-deprovision/artifacts/.openshift_install.log):

```
time="2025-04-16T22:37:43Z" level=debug msg="search for IAM users"
time="2025-04-16T22:37:43Z" level=debug msg="iterating over a page of 100 IAM users"
[... repeats a lot...]
time="2025-04-16T23:25:04Z" level=debug msg="iterating over a page of 58 IAM users"
time="2025-04-16T23:25:26Z" level=debug msg="search for IAM instance profiles"
```

Let's see if this helps and speeds up the destroy/cuts down on API calls.