### PR TITLE
CORS-3960: Remove Terraform from Dockerfiles

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,7 +1,6 @@
 # This Dockerfile builds an image containing Mac and Linux/AMD64 versions of
 # the installer layered on top of the cluster-native Linux installer image.
 
-FROM registry.ci.openshift.org/ocp/4.19:installer-terraform-providers AS providers
 # We copy from the -artifacts images because they are statically linked
 FROM registry.ci.openshift.org/ocp/4.19:installer-kube-apiserver-artifacts AS kas-artifacts
 FROM registry.ci.openshift.org/ocp/4.19:installer-etcd-artifacts AS etcd-artifacts
@@ -13,7 +12,6 @@ ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_amd64 terraform/bin/darwin_amd64
 COPY --from=kas-artifacts /usr/share/openshift/darwin/amd64 cluster-api/bin/darwin_amd64
 COPY --from=etcd-artifacts /usr/share/openshift/darwin/amd64 cluster-api/bin/darwin_amd64
 RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
@@ -23,7 +21,6 @@ ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/darwin_arm64 terraform/bin/darwin_arm64
 COPY --from=kas-artifacts /usr/share/openshift/darwin/arm64 cluster-api/bin/darwin_arm64
 COPY --from=etcd-artifacts /usr/share/openshift/darwin/arm64 cluster-api/bin/darwin_arm64
 RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
@@ -33,7 +30,6 @@ ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_amd64 terraform/bin/linux_amd64
 COPY --from=kas-artifacts /usr/share/openshift/linux/amd64 cluster-api/bin/linux_amd64
 COPY --from=etcd-artifacts /usr/share/openshift/linux/amd64 cluster-api/bin/linux_amd64
 RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
@@ -44,7 +40,6 @@ ARG TAGS=""
 ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/linux_arm64 terraform/bin/linux_arm64
 COPY --from=kas-artifacts /usr/share/openshift/linux/arm64 cluster-api/bin/linux_arm64
 COPY --from=etcd-artifacts /usr/share/openshift/linux/arm64 cluster-api/bin/linux_arm64
 RUN GOOS=linux GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,7 +1,6 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.ci.openshift.org/ocp/4.19:installer-terraform-providers AS providers
 # We copy from the -artifacts images because they are statically linked
 FROM registry.ci.openshift.org/ocp/4.19:installer-kube-apiserver-artifacts AS kas-artifacts
 FROM registry.ci.openshift.org/ocp/4.19:installer-etcd-artifacts AS etcd-artifacts
@@ -13,7 +12,6 @@ ARG TAGS=""
 ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
 COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
 RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -2,7 +2,6 @@
 # It builds an image containing binaries like jq, terraform, awscli, oc, etc. to allow bringing up UPI infrastructure.
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
-FROM registry.ci.openshift.org/ocp/4.17:installer-terraform-providers as providers
 # We copy from the -artifacts images because they are statically linked
 FROM registry.ci.openshift.org/ocp/4.17:installer-kube-apiserver-artifacts AS kas-artifacts
 FROM registry.ci.openshift.org/ocp/4.17:installer-etcd-artifacts AS etcd-artifacts
@@ -14,7 +13,6 @@ ARG TAGS=""
 ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
 COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
 RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,6 +1,6 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.ci.openshift.org/ocp/4.17:installer-terraform-providers as providers
+
 # We copy from the -artifacts images because they are statically linked
 FROM registry.ci.openshift.org/ocp/4.17:installer-kube-apiserver-artifacts AS kas-artifacts
 FROM registry.ci.openshift.org/ocp/4.17:installer-etcd-artifacts AS etcd-artifacts
@@ -12,7 +12,6 @@ ARG TAGS=""
 ARG SKIP_ENVTEST="y"
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-COPY --from=providers /go/src/github.com/openshift/installer/terraform/bin/ terraform/bin/
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/
 COPY --from=etcd-artifacts /usr/share/openshift/ cluster-api/bin/
 RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \


### PR DESCRIPTION
Removes all dependencies for the Terraform providers image from the Dockerfiles. We want to do this separately from removing all the build artifacts, so that the image can stop being built by ART without breaking anything, then remove the build artifacts.