### PR TITLE
OCPBUGS-55683: Pre-create password files for agent installer OVE

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -121,7 +121,7 @@ var (
 		name: "Agent create certificates",
 		command: &cobra.Command{
 			Use:    "certificates",
-			Short:  "Generates the tls certificates that can be used to create kubeconfig",
+			Short:  "Generates the tls certificates that can be used to create kubeconfig, along with kubeadmin-password",
 			Args:   cobra.ExactArgs(0),
 			Hidden: true,
 		},
@@ -130,6 +130,7 @@ var (
 			&tls.KubeAPIServerLocalhostSignerCertKey{},
 			&tls.KubeAPIServerServiceNetworkSignerCertKey{},
 			&tls.AdminKubeConfigSignerCertKey{},
+			&image.AgentPassword{},
 		},
 	}
 

--- a/pkg/asset/agent/image/agentpassword.go
+++ b/pkg/asset/agent/image/agentpassword.go
@@ -1,0 +1,61 @@
+package image
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/password"
+)
+
+// AgentPassword is an asset that generates the kubadmin-password and hash and stores it to the tls directory.
+type AgentPassword struct {
+	FileList []*asset.File
+}
+
+var _ asset.WritableAsset = (*AgentPassword)(nil)
+
+// Dependencies returns the assets on which the AgentPassword asset depends.
+func (a *AgentPassword) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&password.KubeadminPassword{},
+	}
+}
+
+// Generate generates the password file (and hash) and stores it in the tls directory.
+func (a *AgentPassword) Generate(ctx context.Context, dependencies asset.Parents) error {
+	pwd := &password.KubeadminPassword{}
+	dependencies.Get(pwd)
+
+	agentKubeadminPasswordPath := filepath.Join("tls", "kubeadmin-password")
+	agentKubeadminPasswordHashPath := filepath.Join("tls", "kubeadmin-password.hash")
+
+	a.FileList = []*asset.File{
+		{
+			Filename: agentKubeadminPasswordPath,
+			Data:     []byte(pwd.Password),
+		},
+		{
+			Filename: agentKubeadminPasswordHashPath,
+			Data:     pwd.PasswordHash,
+		},
+	}
+
+	return nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *AgentPassword) Name() string {
+	return "Agent Installer ISO"
+}
+
+// Load returns the password from disk.
+func (a *AgentPassword) Load(f asset.FileFetcher) (bool, error) {
+	// This is implemented because it is required by WritableAsset
+	return false, nil
+}
+
+// Files returns the asset's files.
+func (a *AgentPassword) Files() []*asset.File {
+	return a.FileList
+}

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -216,7 +216,7 @@ networkConfig:
 `,
 
 			expectedFound: false,
-			expectedError: "networkConfig: Invalid value: invalid: config\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: unknown field `invalid`",
+			expectedError: "unknown field `invalid`",
 		},
 		{
 			name: "empty networkConfig",

--- a/pkg/asset/password/password.go
+++ b/pkg/asset/password/password.go
@@ -102,7 +102,7 @@ func (a *KubeadminPassword) Files() []*asset.File {
 	return []*asset.File{}
 }
 
-// Load loads a predefined hash only, if one is supplied
+// Load loads a predefined hash and/or password, if they are supplied.
 func (a *KubeadminPassword) Load(f asset.FileFetcher) (found bool, err error) {
 	hashFilePath := filepath.Join("tls", "kubeadmin-password.hash")
 	hashFile, err := f.FetchByName(hashFilePath)
@@ -114,10 +114,19 @@ func (a *KubeadminPassword) Load(f asset.FileFetcher) (found bool, err error) {
 	}
 
 	a.PasswordHash = hashFile.Data
+
+	// Also load the kubeadmin-password from the tls dir if it exists,
+	passwordFilePath := filepath.Join("tls", "kubeadmin-password")
+	passwordFile, err := f.FetchByName(passwordFilePath)
+	if err == nil {
+		a.Password = string(passwordFile.Data)
+	}
+
 	// Assisted-service expects to always see a password file, so generate an
-	// empty one
+	// empty one if there is no password file.
 	a.File = &asset.File{
 		Filename: kubeadminPasswordPath,
+		Data:     []byte(a.Password),
 	}
 	return true, nil
 }


### PR DESCRIPTION
For the agent-based installer OVE UI, the password files should also be created at boot via the 'agent create certificates' command. The kubeadmin-password and hash will be stored in the tls dir so that assisted-service does not regenerate them each time the call to GenerateInstallConfig is invoked.