### PR TITLE
no-jira: IBI nmstate unit test fix

### DIFF
--- a/pkg/asset/imagebased/configimage/imagebased_config_test.go
+++ b/pkg/asset/imagebased/configimage/imagebased_config_test.go
@@ -95,7 +95,7 @@ networkConfig:
       state: invalid`,
 
 			expectedFound: false,
-			expectedError: "networkConfig: Invalid value: interfaces:\n- name: eth0\n  state: invalid\n  type: ethernet\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: interfaces: unknown variant `invalid`",
+			expectedError: "interfaces: unknown variant `invalid`",
 		},
 		{
 			name: "invalid-additional-ntp-sources",

--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -216,7 +216,7 @@ networkConfig:
 `,
 
 			expectedFound: false,
-			expectedError: "networkConfig: Invalid value: invalid: config\n: failed to execute 'nmstatectl gc', error: InvalidArgument: Invalid YAML string: unknown field `invalid`",
+			expectedError: "unknown field `invalid`",
 		},
 		{
 			name: "empty networkConfig",


### PR DESCRIPTION
It appears that nmstatectl version 2.44 has additional error output which causes the unit test string compare to fail. Use a string subset to ensure the error is captured.