### PR TITLE
no-jira: azure: add tested instance types for CORS-3634 and CORS-3771

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -12,14 +12,18 @@
 * `standardDDCSv3Family`
 * `standardDDSv4Family`
 * `standardDDSv5Family`
+* `StandardDdsv6Family`
 * `standardDLDSv5Family`
+* `StandardDldsv6Family`
 * `standardDLSv5Family`
+* `StandardDlsv6Family`
 * `standardDSFamily`
 * `standardDSv2Family`
 * `standardDSv2PromoFamily`
 * `standardDSv3Family`
 * `standardDSv4Family`
 * `standardDSv5Family`
+* `StandardDsv6Family`
 * `standardEADSv5Family`
 * `standardEASv4Family`
 * `standardEASv5Family`
@@ -66,5 +70,7 @@
 * `standardNDSv2Family`
 * `standardNPSFamily`
 * `StandardNVADSA10v5Family`
+* `StandardNVadsV710v5Family`
+* `Standard NDASv4_A100 Family`
 * `standardNVSv3Family`
 * `standardXEISv4Family`


### PR DESCRIPTION
Add following instance types which are tested.

- [CORS-3634](https://issues.redhat.com/browse/CORS-3634) List Azure's NDs-series and NV-series as tested instance type
    - StandardNVadsV710v5Family
    - Standard NDASv4_A100 Family

- [CORS-3771](https://issues.redhat.com/browse/CORS-3771) Azure - Add support for Dxv6 machine series
    - StandardDsv6Family
    - StandardDdsv6Family
    - StandardDlsv6Family
    - StandardDldsv6Family 