### PR TITLE
OCPBUGS-55722: azure stack: switch cloud provider to standard lb

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -59,7 +59,6 @@ func (params CloudProviderConfig) JSON() (string, error) {
 
 	if params.CloudName == azure.StackCloud {
 		config.authConfig.ResourceManagerEndpoint = params.ResourceManagerEndpoint
-		config.LoadBalancerSku = "basic"
 		config.UseInstanceMetadata = false
 	}
 


### PR DESCRIPTION
Azure Stack is now using standard LBs (rather than basic): https://learn.microsoft.com/en-us/azure-stack/user/standard-load-balancer-considerations?view=azs-2501 Update the cloud provider config to expect a standard LB and avoid

```
level=error msg=--------------------------------------------------------------------------------
level=error msg=RESPONSE 400: 400 Bad Request
level=error msg=ERROR CODE: PublicIPAndLBSkuDoNotMatch
level=error msg=--------------------------------------------------------------------------------
level=error msg={
level=error msg=  "error": {
level=error msg=    "code": "PublicIPAndLBSkuDoNotMatch",
level=error msg=    "message": "Standard sku load balancer /subscriptions/de7e09c3-b59a-4c7d-9c77-439c11b92879/resourceGroups/ci-op-xsi7s39l-4055a/providers/Microsoft.Network/loadBalancers/ci-op-xsi7s39l-4055a-q5m6z cannot reference Basic sku publicIP /subscriptions/de7e09c3-b59a-4c7d-9c77-439c11b92879/resourceGroups/ci-op-xsi7s39l-4055a/providers/Microsoft.Network/publicIPAddresses/ci-op-xsi7s39l-4055a-q5m6z-a7a05bf34d81542a98fee7a9367aafe7.",
level=error msg=    "details": []
level=error msg=  }
level=error msg=}
level=error msg=-------------------------------------------------------------------------------- 
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_installer/9683/pull-ci-openshift-installer-main-e2e-azurestack/1917442841194270720

I just uncovered this in CI (because ingress was blocked on another bug), I will create an appropriate bug soon