### PR TITLE
OCPBUGS-54502: ensure ctrplane nodes can access bootstrap MCS

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -185,11 +185,11 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 				},
 				IngressRules: []capa.IngressRule{
 					{
-						Description: "Machine Config Server internal traffic from cluster",
-						Protocol:    capa.SecurityGroupProtocolTCP,
-						FromPort:    22623,
-						ToPort:      22623,
-						CidrBlocks:  []string{capiutils.CIDRFromInstallConfig(ic).String()},
+						Description:              "Machine Config Server internal traffic from cluster",
+						Protocol:                 capa.SecurityGroupProtocolTCP,
+						FromPort:                 22623,
+						ToPort:                   22623,
+						SourceSecurityGroupRoles: []capa.SecurityGroupRole{"node", "controlplane"},
 					},
 				},
 			},


### PR DESCRIPTION
When using BYO subnets, users might define subnets in aws.vpc.subnets and define the machineCIDRs in the installconfig from those subnets.

Previously, an SG is attached to api lb that only allows ingress to tcp/22623 (MCS) from the only the first machineCIDR, which blocks master nodes from reaching MCS on bootstrap node.

This commit adjusts the source for the SG to allow ingress from control plane nodes via SG reference instead of relying on the machineCIDR field.