### PR TITLE
OCPBUGS-55772: Add support for Azure TDX confidential VM type

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +24,18 @@ import (
 	aztypes "github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/azure/defaults"
 )
+
+const (
+	// confidentialComputingTypeSNP is the AMD SEV-SNP confidential computing type.
+	confidentialComputingTypeSNP = "SNP"
+	// confidentialComputingTypeTDX is the Intel TDX confidential computing type.
+	confidentialComputingTypeTDX = "TDX"
+)
+
+var supportedConfidentialComputingTypes = []string{
+	confidentialComputingTypeSNP,
+	confidentialComputingTypeTDX,
+}
 
 type resourceRequirements struct {
 	minimumVCpus  int64
@@ -220,18 +233,19 @@ func validateSecurityType(fieldPath *field.Path, securityType aztypes.SecurityTy
 
 	_, hasTrustedLaunchDisabled := capabilities["TrustedLaunchDisabled"]
 	confidentialComputingType, hasConfidentialComputingType := capabilities["ConfidentialComputingType"]
-	isConfidentialComputingTypeSNP := confidentialComputingType == "SNP"
+	hasSupportedConfidentialComputingType := slices.Contains(supportedConfidentialComputingTypes, confidentialComputingType)
 
 	var reason string
 	supportedSecurityType := true
 	switch securityType {
 	case aztypes.SecurityTypesConfidentialVM:
-		supportedSecurityType = hasConfidentialComputingType && isConfidentialComputingTypeSNP
+		supportedSecurityType = hasConfidentialComputingType && hasSupportedConfidentialComputingType
 
 		if !hasConfidentialComputingType {
 			reason = "no support for Confidential Computing"
-		} else if !isConfidentialComputingTypeSNP {
-			reason = "no support for AMD-SEV SNP"
+		} else if !hasSupportedConfidentialComputingType {
+			reason = fmt.Sprintf("no support for required confidential computing type (found: %s, supported: %s)",
+				confidentialComputingType, strings.Join(supportedConfidentialComputingTypes, ", "))
 		}
 	case aztypes.SecurityTypesTrustedLaunch:
 		supportedSecurityType = !(hasTrustedLaunchDisabled || hasConfidentialComputingType)

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -51,6 +51,7 @@ var (
 		"Standard_D8ps_v5":   {"vCPUsAvailable": "8", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "Arm64", "TrustedLaunchDisabled": "True"},
 		"Standard_D4ps_v5":   {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "Arm64", "TrustedLaunchDisabled": "True"},
 		"Standard_DC8ads_v5": {"vCPUsAvailable": "8", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "False", "CpuArchitectureType": "x64", "ConfidentialComputingType": "SNP"},
+		"Standard_DC8eds_v5": {"vCPUsAvailable": "8", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "False", "CpuArchitectureType": "x64", "ConfidentialComputingType": "TDX"},
 		"Standard_DC8s_v3":   {"vCPUsAvailable": "8", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64", "ConfidentialComputingType": "SGX"},
 	}
 
@@ -120,6 +121,14 @@ var (
 
 	validConfidentialVMInstanceTypes = func(ic *types.InstallConfig) {
 		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_DC8ads_v5"
+	}
+
+	validConfidentialVMSNPInstanceTypes = func(ic *types.InstallConfig) {
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_DC8ads_v5"
+	}
+
+	validConfidentialVMTDXInstanceTypes = func(ic *types.InstallConfig) {
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_DC8eds_v5"
 	}
 
 	invalidConfidentialVMInstanceTypes = func(ic *types.InstallConfig) {
@@ -524,8 +533,13 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			errorMsg: `compute\[0\].platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_B4ms`,
 		},
 		{
-			name:     "Supported ConfidentialVM security type",
-			edits:    editFunctions{validConfidentialVMInstanceTypes, securityTypeConfidentialVMControlPlane},
+			name:     "Supported ConfidentialVM security type SNP",
+			edits:    editFunctions{validConfidentialVMSNPInstanceTypes, securityTypeConfidentialVMControlPlane},
+			errorMsg: "",
+		},
+		{
+			name:     "Supported ConfidentialVM security type TDX",
+			edits:    editFunctions{validConfidentialVMTDXInstanceTypes, securityTypeConfidentialVMControlPlane},
 			errorMsg: "",
 		},
 		{


### PR DESCRIPTION
This change adds support for [Azure Intel TDX confidential computing VM sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dcesv6-series?tabs=sizebasic).