### PR TITLE
OCPBUGS-55817: add Lsv4 and Lasv4 series as tested

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -57,9 +57,11 @@
 * `standardHCSFamily`
 * `standardHXFamily`
 * `standardLASv3Family`
+* `standardLasv4Family`
 * `standardLSFamily`
 * `standardLSv2Family`
 * `standardLSv3Family`
+* `standardLsv4Family`
 * `standardMDSHighMemoryv3Family`
 * `standardMDSMediumMemoryv2Family`
 * `standardMDSMediumMemoryv3Family`


### PR DESCRIPTION
Lsv4 and Lasv4 series are already tested by QE on 4.19, and they are preview in Azure now.
But based on Mak's comment https://issues.redhat.com/browse/CORS-3772?focusedId=27122387&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27122387, they will be GA in Azure by mid-May which is before 4.19 release on June.