### PR TITLE
OCPBUGS-56006: [release-4.19] CORS-3634, CORS-3771, CORS-3772: Azure doc: add support for Lsv4, Lasv4, Dxv6, NDs and NV series

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -13,14 +13,18 @@
 * `standardDDCSv3Family`
 * `standardDDSv4Family`
 * `standardDDSv5Family`
+* `StandardDdsv6Family`
 * `standardDLDSv5Family`
+* `StandardDldsv6Family`
 * `standardDLSv5Family`
+* `StandardDlsv6Family`
 * `standardDSFamily`
 * `standardDSv2Family`
 * `standardDSv2PromoFamily`
 * `standardDSv3Family`
 * `standardDSv4Family`
 * `standardDSv5Family`
+* `StandardDsv6Family`
 * `standardEADSv5Family`
 * `standardEASv4Family`
 * `standardEASv5Family`
@@ -74,5 +78,7 @@
 * `StandardNGADSV620v1Family`
 * `standardNPSFamily`
 * `StandardNVADSA10v5Family`
+* `StandardNVadsV710v5Family`
+* `Standard NDASv4_A100 Family`
 * `standardNVSv3Family`
 * `standardXEISv4Family`

--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -57,9 +57,11 @@
 * `standardHCSFamily`
 * `standardHXFamily`
 * `standardLASv3Family`
+* `standardLasv4Family`
 * `standardLSFamily`
 * `standardLSv2Family`
 * `standardLSv3Family`
+* `standardLsv4Family`
 * `standardMDSHighMemoryv3Family`
 * `standardMDSMediumMemoryv2Family`
 * `standardMDSMediumMemoryv3Family`


### PR DESCRIPTION
Manual backport the change for https://github.com/openshift/installer/pull/9696 and https://github.com/openshift/installer/pull/9696 