### PR TITLE
OCPBUGS-56079: apply fixes for yaml-lint errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,7 +43,7 @@ linters-settings:
   gosec:
     excludes:
       # Potential integer overflow when converting between integer types
-      - G115
+    - G115
   errcheck:
     # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
     # Such cases aren't reported by default.
@@ -157,14 +157,14 @@ issues:
     - goconst
     path: _test\.go
   exclude-dirs:
-    - ^bin
-    - ^cluster-api
-    - ^data/data
-    - ^docs
-    - ^hack
-    - ^images
-    - ^scripts
-    - ^terraform
-    - ^upi
-    - ^pkg/asset/manifests/azure/stack/v1beta1 # local copy of capi azurestack provider fork api
+  - ^bin
+  - ^cluster-api
+  - ^data/data
+  - ^docs
+  - ^hack
+  - ^images
+  - ^scripts
+  - ^terraform
+  - ^upi
+  - ^pkg/asset/manifests/azure/stack/v1beta1 # local copy of capi azurestack provider fork api
   uniq-by-line: false

--- a/scripts/openstack/manifest-tests/lb-unmanaged/install-config.yaml
+++ b/scripts/openstack/manifest-tests/lb-unmanaged/install-config.yaml
@@ -31,7 +31,7 @@ platform:
     loadBalancer:
       type: UserManaged
     apiVIPs:
-      - 10.0.128.10
+    - 10.0.128.10
     ingressVIPs:
-      - 10.0.128.20
+    - 10.0.128.20
 pullSecret: ${PULL_SECRET}


### PR DESCRIPTION
Notes: there are other yaml-lint warnings but they've been there for a long time. This commit only focuses on the errors introduced during 4.19 cycle.