### PR TITLE
CORS-3998: Remove base domain from metadata

### DIFF
--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -27,7 +27,6 @@ func Metadata(config *types.InstallConfig) *azure.Metadata {
 		Region:                      config.Platform.Azure.Region,
 		ResourceGroupName:           config.Azure.ResourceGroupName,
 		BaseDomainResourceGroupName: config.Azure.BaseDomainResourceGroupName,
-		BaseDomainName:              config.BaseDomain,
 	}
 }
 

--- a/pkg/types/azure/metadata.go
+++ b/pkg/types/azure/metadata.go
@@ -7,7 +7,6 @@ type Metadata struct {
 	Region                      string           `json:"region"`
 	ResourceGroupName           string           `json:"resourceGroupName"`
 	BaseDomainResourceGroupName string           `json:"baseDomainResourceGroupName"`
-	BaseDomainName              string           `json:"baseDomainName"`
 }
 
 // Keys used to save Metadata information as tags.


### PR DESCRIPTION
Since HIVE finds it real hard to add extra field to the metadata, adding this base domain causes things to crash at their end. Removing the base domain field from the metadata.

The base domain field was added to the metadata for the sole purpose of checking the public dns zone for any stray records of a cluster. This only happens if the user deletes the resource group of the cluster instead of running destroy cluster through the installer.

Ascertaining the public record is going to be a real tough task without passing the value through the metadata and hence, choosing the bug with the lower probability.

This reverts commit 9f392fac9551d6baaddfaee006eab705b15412d8.