### PR TITLE
OCPBUGS-54240: Update timeout for GCP WaitFor operation

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/operation.go
+++ b/pkg/infrastructure/gcp/clusterapi/operation.go
@@ -11,7 +11,7 @@ import (
 // WaitForOperationGlobal will attempt to wait for a operation to complete where the operational
 // resource is globally scoped.
 func WaitForOperationGlobal(ctx context.Context, projectID string, operation *compute.Operation) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
 	service, err := NewComputeService()


### PR DESCRIPTION
** This applies to 4.16 only. The LB Code was migrated to CAPG for all other versions. 
** Increase the context timeout for WaitFor operations from 1 minute to 2 minutes. This was necessary for the Load Balancer (Backend Service) Patch() to have enough time to complete and verify the operation.