### PR TITLE
OCPBUGS-56262: Added better logging for vSphere destroy

### DIFF
--- a/pkg/destroy/vsphere/client.go
+++ b/pkg/destroy/vsphere/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/find"
@@ -40,21 +41,24 @@ type API interface {
 	DeleteHostZoneObjects(ctx context.Context, infraID string) error
 	DeleteCnsVolumes(ctx context.Context, volume cnstypes.CnsVolume) error
 	GetCnsVolumes(ctx context.Context, infraID string) ([]cnstypes.CnsVolume, error)
+	GetVCenterName() string
 }
 
 // Client makes calls to the Azure API.
 type Client struct {
+	vcenter    string
 	client     *vim25.Client
 	restClient *rest.Client
 	cnsClient  *cns.Client
 	cleanup    vsphere.ClientLogout
+	logger     logrus.FieldLogger
 }
 
 const defaultTimeout = time.Minute * 5
 
 // NewClient initializes a client.
 // Logout() must be called when you are done with the client.
-func NewClient(vCenter, username, password string) (*Client, error) {
+func NewClient(vCenter, username, password string, logger logrus.FieldLogger) (*Client, error) {
 	vim25Client, restClient, cleanup, err := vsphere.CreateVSphereClients(
 		context.TODO(),
 		vCenter,
@@ -70,10 +74,12 @@ func NewClient(vCenter, username, password string) (*Client, error) {
 	}
 
 	return &Client{
+		vcenter:    vCenter,
 		client:     vim25Client,
 		restClient: restClient,
 		cleanup:    cleanup,
 		cnsClient:  cnsClient,
+		logger:     logger,
 	}, nil
 }
 
@@ -92,8 +98,11 @@ func (c *Client) getAttachedObjectsOnTag(ctx context.Context, tag, objType strin
 
 	tagManager := tags.NewManager(c.restClient)
 	attached, err := tagManager.GetAttachedObjectsOnTags(ctx, []string{tag})
-	if err != nil && !isNotFound(err) {
-		return nil, err
+	if err != nil {
+		c.logger.Debugf("Got error when attempting to get attached objects on tags: %s", err)
+		if !isNotFound(err) {
+			return nil, err
+		}
 	}
 
 	// Separate the objects attached to the tag based on type
@@ -116,7 +125,8 @@ func (c *Client) getVirtualMachineManagedObjects(ctx context.Context, moRef []ty
 	var virtualMachineMoList []mo.VirtualMachine
 	if len(moRef) > 0 {
 		pc := property.DefaultCollector(c.client)
-		err := pc.Retrieve(ctx, moRef, []string{"name"}, &virtualMachineMoList)
+		// Passing nil in for property list so that we get all properties.
+		err := pc.Retrieve(ctx, moRef, nil, &virtualMachineMoList)
 		if err != nil {
 			return nil, err
 		}
@@ -139,6 +149,11 @@ func (c *Client) getFolderManagedObjects(ctx context.Context, moRef []types.Mana
 	return folderMoList, nil
 }
 
+// GetVCenterName returns the name of the vcenter being queried.
+func (c *Client) GetVCenterName() string {
+	return c.vcenter
+}
+
 // ListFolders returns all ManagedObjects of type "Folder".
 func (c *Client) ListFolders(ctx context.Context, tagID string) ([]mo.Folder, error) {
 	folderList, err := c.getAttachedObjectsOnTag(ctx, tagID, "Folder")
@@ -152,6 +167,7 @@ func (c *Client) ListFolders(ctx context.Context, tagID string) ([]mo.Folder, er
 // ListVirtualMachines returns ManagedObjects of type "VirtualMachine".
 func (c *Client) ListVirtualMachines(ctx context.Context, tagID string) ([]mo.VirtualMachine, error) {
 	virtualMachineList, err := c.getAttachedObjectsOnTag(ctx, tagID, "VirtualMachine")
+	c.logger.WithField("vCenter", c.GetVCenterName()).WithField("Count", len(virtualMachineList)).Debug("List VirtualMachine")
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +183,7 @@ func isPoweredOff(vmMO mo.VirtualMachine) bool {
 func (c *Client) StopVirtualMachine(ctx context.Context, vmMO mo.VirtualMachine) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*30)
 	defer cancel()
-
+	// The following isPoweredOff() is an extra check to make sure still powered off.  We might be able to remove this.
 	if !isPoweredOff(vmMO) {
 		vm := object.NewVirtualMachine(c.client, vmMO.Reference())
 		task, err := vm.PowerOff(ctx)
@@ -361,6 +377,7 @@ func (c *Client) DeleteHostZoneObjects(ctx context.Context, infraID string) erro
 				if err := task.Wait(ctx); err != nil {
 					return err
 				}
+				c.logger.WithField("VmHostRule", infraID).WithField("vCenter", c.GetVCenterName())
 			}
 		}
 	}

--- a/pkg/destroy/vsphere/mock/vsphereclient_generated.go
+++ b/pkg/destroy/vsphere/mock/vsphereclient_generated.go
@@ -155,6 +155,20 @@ func (mr *MockAPIMockRecorder) GetCnsVolumes(ctx, infraID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCnsVolumes", reflect.TypeOf((*MockAPI)(nil).GetCnsVolumes), ctx, infraID)
 }
 
+// GetVCenterName mocks base method.
+func (m *MockAPI) GetVCenterName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVCenterName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVCenterName indicates an expected call of GetVCenterName.
+func (mr *MockAPIMockRecorder) GetVCenterName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVCenterName", reflect.TypeOf((*MockAPI)(nil).GetVCenterName))
+}
+
 // ListFolders mocks base method.
 func (m *MockAPI) ListFolders(ctx context.Context, tagID string) ([]mo.Folder, error) {
 	m.ctrl.T.Helper()

--- a/pkg/destroy/vsphere/vsphere_test.go
+++ b/pkg/destroy/vsphere/vsphere_test.go
@@ -189,6 +189,11 @@ func TestVsphereDeleteFolder(t *testing.T) {
 		DeleteFolder(gomock.Any(), gomock.Any()).
 		Return(errors.New("some vsphere error deleting Folder")).
 		AnyTimes()
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -316,6 +321,11 @@ func TestVsphereStopVirtualMachines(t *testing.T) {
 		EXPECT().
 		StopVirtualMachine(gomock.Any(), gomock.Any()).
 		Times(0)
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -412,6 +422,11 @@ func TestVsphereDeleteVirtualMachines(t *testing.T) {
 		EXPECT().
 		StopVirtualMachine(gomock.Any(), gomock.Any()).
 		Times(0)
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -464,6 +479,11 @@ func TestDeleteStoragePolicy(t *testing.T) {
 		DeleteStoragePolicy(gomock.Any(), gomock.Any()).
 		Return(nil).
 		AnyTimes()
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -514,6 +534,11 @@ func TestDeleteTag(t *testing.T) {
 		DeleteTag(gomock.Any(), gomock.Any()).
 		Return(nil).
 		AnyTimes()
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -566,6 +591,11 @@ func TestDeleteTagCategory(t *testing.T) {
 		DeleteTagCategory(gomock.Any(), gomock.Any()).
 		Return(nil).
 		AnyTimes()
+	vsphereClient.
+		EXPECT().
+		GetVCenterName().
+		Return("").
+		AnyTimes() // We should be logging vCenter name
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
[OCPBUGS-56262](https://issues.redhat.com/browse/OCPBUGS-56262)

### Changes
- Enhanced logging to log creating client for each vCenter
- Enhanced logging to include vCenter name for each vCenter specific cleanup activity
- Enhanced logging to show when attempts start for each process
- Added log warning if no VMs are found during stop or destroy for virtual machines
- Fixed issue where the properties for VM were not including power state causing an issue where destroy would loop.