### PR TITLE
CORS-3682: log falsy conditions when CAPI infra/machine provisioning failed

### DIFF
--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -13,6 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
@@ -101,7 +103,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		rootCA,
 	)
 
-	var clusterIDs []string
+	var capiClusters []*clusterv1.Cluster
 
 	// Collect cluster and non-machine-related infra manifests
 	// to be applied during the initial stage.
@@ -109,7 +111,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	for _, m := range capiManifestsAsset.RuntimeFiles() {
 		// Check for cluster definition so that we can collect the names.
 		if cluster, ok := m.Object.(*clusterv1.Cluster); ok {
-			clusterIDs = append(clusterIDs, cluster.GetName())
+			capiClusters = append(capiClusters, cluster)
 		}
 
 		infraManifests = append(infraManifests, m.Object)
@@ -188,10 +190,10 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	logrus.Info("Done creating infra manifests")
 
 	// Pass cluster kubeconfig and store it in; this is usually the role of a bootstrap provider.
-	for _, capiClusterID := range clusterIDs {
-		logrus.Infof("Creating kubeconfig entry for capi cluster %v", capiClusterID)
+	for _, capiCluster := range capiClusters {
+		logrus.Infof("Creating kubeconfig entry for capi cluster %v", capiCluster.GetName())
 		key := client.ObjectKey{
-			Name:      capiClusterID,
+			Name:      capiCluster.GetName(),
 			Namespace: capiutils.Namespace,
 		}
 		cluster := &clusterv1.Cluster{}
@@ -217,43 +219,41 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 	untilTime := time.Now().Add(networkTimeout)
 	timezone, _ := untilTime.Zone()
 	logrus.Infof("Waiting up to %v (until %v %s) for network infrastructure to become ready...", networkTimeout, untilTime.Format(time.Kitchen), timezone)
-	var cluster *clusterv1.Cluster
 	{
 		if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, networkTimeout, true,
 			func(ctx context.Context) (bool, error) {
-				c := &clusterv1.Cluster{}
-				var clusters []*clusterv1.Cluster
-				for _, curClusterID := range clusterIDs {
+				for _, capiCluster := range capiClusters {
 					if err := cl.Get(ctx, client.ObjectKey{
-						Name:      curClusterID,
+						Name:      capiCluster.GetName(),
 						Namespace: capiutils.Namespace,
-					}, c); err != nil {
+					}, capiCluster); err != nil {
 						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
 					}
-					clusters = append(clusters, c)
 				}
-
-				for _, curCluster := range clusters {
-					if !curCluster.Status.InfrastructureReady {
+				for _, capiCluster := range capiClusters {
+					if !capiCluster.Status.InfrastructureReady {
 						return false, nil
 					}
 				}
-
-				cluster = clusters[0]
 				return true, nil
 			}); err != nil {
+			// Attempt to find and report falsy conditions in infra cluster if any.
+			if len(capiClusters) > 0 {
+				warnIfFalsyInfraConditions(ctx, capiClusters[0].Spec.InfrastructureRef, cl)
+			}
 			if wait.Interrupted(err) {
-				return fileList, fmt.Errorf("infrastructure was not ready within %v: %w", networkTimeout, err)
+				return fileList, fmt.Errorf("infrastructure was not ready within %v", networkTimeout)
 			}
 			return fileList, fmt.Errorf("infrastructure is not ready: %w", err)
 		}
-		if cluster == nil {
+
+		if len(capiClusters) == 0 {
 			return fileList, fmt.Errorf("error occurred during load balancer ready check")
 		}
-		if cluster.Spec.ControlPlaneEndpoint.Host == "" {
+		if capiClusters[0].Spec.ControlPlaneEndpoint.Host == "" {
 			return fileList, fmt.Errorf("control plane endpoint is not set")
 		}
 	}
@@ -316,7 +316,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 
 	// Create the machine manifests.
 	timer.StartTimer(machineStage)
-	machineNames := []string{}
+	capiMachines := []*clusterv1.Machine{}
 
 	for _, m := range machineManifests {
 		m.SetNamespace(capiutils.Namespace)
@@ -326,7 +326,7 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		i.appliedManifests = append(i.appliedManifests, m)
 
 		if machine, ok := m.(*clusterv1.Machine); ok {
-			machineNames = append(machineNames, machine.Name)
+			capiMachines = append(capiMachines, machine)
 		}
 		logrus.Infof("Created manifest %+T, namespace=%s name=%s", m, m.GetNamespace(), m.GetName())
 	}
@@ -341,14 +341,13 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 		untilTime := time.Now().Add(provisionTimeout)
 		timezone, _ := untilTime.Zone()
 		reqBootstrapPubIP := installConfig.Config.Publish == types.ExternalPublishingStrategy && i.impl.PublicGatherEndpoint() == ExternalIP
-		logrus.Infof("Waiting up to %v (until %v %s) for machines %v to provision...", provisionTimeout, untilTime.Format(time.Kitchen), timezone, machineNames)
+		logrus.Infof("Waiting up to %v (until %v %s) for machines %v to provision...", provisionTimeout, untilTime.Format(time.Kitchen), timezone, capiMachines)
 		if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, provisionTimeout, true,
 			func(ctx context.Context) (bool, error) {
 				allReady := true
-				for _, machineName := range machineNames {
-					machine := &clusterv1.Machine{}
+				for _, machine := range capiMachines {
 					if err := cl.Get(ctx, client.ObjectKey{
-						Name:      machineName,
+						Name:      machine.Name,
 						Namespace: capiutils.Namespace,
 					}, machine); err != nil {
 						if apierrors.IsNotFound(err) {
@@ -357,7 +356,8 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 						}
 						return false, err
 					}
-					reqPubIP := reqBootstrapPubIP && machineName == capiutils.GenerateBoostrapMachineName(clusterID.InfraID)
+
+					reqPubIP := reqBootstrapPubIP && machine.Name == capiutils.GenerateBoostrapMachineName(clusterID.InfraID)
 					ready, err := checkMachineReady(machine, reqPubIP)
 					if err != nil {
 						return false, fmt.Errorf("failed waiting for machines: %w", err)
@@ -370,8 +370,14 @@ func (i *InfraProvider) Provision(ctx context.Context, dir string, parents asset
 				}
 				return allReady, nil
 			}); err != nil {
+			// Attempt to find and report falsy conditions in infra machines if any.
+			for _, machine := range capiMachines {
+				if machine != nil {
+					warnIfFalsyInfraConditions(ctx, &machine.Spec.InfrastructureRef, cl)
+				}
+			}
 			if wait.Interrupted(err) {
-				return fileList, fmt.Errorf("%s within %v: %w", asset.ControlPlaneCreationError, provisionTimeout, err)
+				return fileList, fmt.Errorf("%s within %v", asset.ControlPlaneCreationError, provisionTimeout)
 			}
 			return fileList, fmt.Errorf("%s: machines are not ready: %w", asset.ControlPlaneCreationError, err)
 		}
@@ -659,4 +665,67 @@ func hasRequiredIP(machine *clusterv1.Machine, requirePublicIP bool) bool {
 	}
 	logrus.Debugf("Still waiting for machine %s to get required IPs", machine.Name)
 	return false
+}
+
+// gatherInfraConditions gather conditions from CAPI infra cluster or machine
+// in a provider-agnostic way from the "status.condition" field, which should be present in all providers.
+// https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster#infracluster-conditions
+// https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine#inframachine-conditions
+func gatherInfraConditions(ctx context.Context, objRef *corev1.ObjectReference, cl client.Client) (clusterv1.Conditions, error) {
+	unstructuredObj := &unstructured.Unstructured{}
+	unstructuredObj.SetGroupVersionKind(objRef.GroupVersionKind())
+
+	if err := cl.Get(ctx, client.ObjectKey{
+		Namespace: objRef.Namespace,
+		Name:      objRef.Name,
+	}, unstructuredObj); err != nil {
+		return nil, err
+	}
+
+	// Field .status.conditions should be implemented by all providers
+	// and has type clusterv1.Conditions
+	infraObj := &struct {
+		Status struct {
+			Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+		} `json:"status,omitempty"`
+	}{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), infraObj); err != nil {
+		return nil, err
+	}
+
+	return infraObj.Status.Conditions, nil
+}
+
+// warnIfFalsyInfraConditions logs warning messages for any conditions that are not "True"
+// in the infra cluster or machine status.
+func warnIfFalsyInfraConditions(ctx context.Context, objRef *corev1.ObjectReference, cl client.Client) {
+	apiVersion, kind := objRef.GroupVersionKind().ToAPIVersionAndKind()
+	objInfo := fmt.Sprintf("apiVersion=%s, kind=%s, namespace=%s, name=%s", apiVersion, kind, objRef.Namespace, objRef.Name)
+
+	logrus.Debugf("Gathering conditions for %s", objInfo)
+	conditions, err := gatherInfraConditions(ctx, objRef, cl)
+	if err != nil {
+		logrus.Warnf("Failed to gather conditions: %s", err.Error())
+		return
+	}
+
+	logrus.Debugf("Checking conditions for %s", objInfo)
+	if len(conditions) > 0 {
+		var falsyConditions clusterv1.Conditions
+		for _, condition := range conditions {
+			if condition.Status != corev1.ConditionTrue {
+				falsyConditions = append(falsyConditions, condition)
+			}
+		}
+
+		if len(falsyConditions) == 0 {
+			logrus.Debugf("All conditions are satisfied")
+		}
+		for _, condition := range falsyConditions {
+			logrus.Warnf("Condition %s has status: %q, reason: %q, message: %q", condition.Type, condition.Status, condition.Reason, condition.Message)
+		}
+	} else {
+		logrus.Debugf("No conditions found")
+	}
+	logrus.Debugf("Done checking conditions for %s", objInfo)
 }


### PR DESCRIPTION
## Description

The installer collects status from CAPI provider cluster and machines to report any falsy conditions. Every provider must implement the CAPI conditions [[0]](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster#infracluster-conditions) [[1]](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine#inframachine-conditions)its infra cluster and machine.

**Note:** CAPI cluster and machine currently use CAPI-defined Conditions type, which will be deprecated/removed in favor of k8s metav1.Conditions type [[2]](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md).

## Sample failure log

To force fail the installation, I did:
-  `openshift-install create manifests`
- Manually added bad/invalid values in infra CAPI infra manifests.
- `openshift-install create cluster --log-level=debug`

#### Invalid VPC CIDR
```
DEBUG Gathering conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSCluster, namespace=openshift-cluster-api-guests, name=thvo-dev-82fnr 
DEBUG Checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSCluster, namespace=openshift-cluster-api-guests, name=thvo-dev-82fnr 
WARNING Condition Ready has status: "False", reason: "SubnetsReconciliationFailed", message: "1 of 8 completed" 
WARNING Condition SubnetsReady has status: "False", reason: "SubnetsReconciliationFailed", message: "failed to create subnet: InvalidSubnet.Range: The CIDR '10.0.0.0/19' is invalid.\n\tstatus code: 400, request id: eaa15e49-a90d-4d73-9c27-1a2d0a513771" 
DEBUG Done checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSCluster, namespace=openshift-cluster-api-guests, name=thvo-dev-82fnr 
DEBUG Collecting applied cluster api manifests...  
ERROR failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: infrastructure was not ready within 15m0s 
```

#### Invalid instance type, invalid instance profile, and invalid subnet ID

```
DEBUG Gathering conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-bootstrap 
DEBUG Checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-bootstrap 
DEBUG All conditions are satisfied                 
DEBUG Done checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-bootstrap 
DEBUG Gathering conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-0 
DEBUG Checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-0 
WARNING Condition Ready has status: "False", reason: "InstanceProvisionFailed", message: "0 of 3 completed" 
WARNING Condition InstanceReady has status: "False", reason: "InstanceProvisionFailed", message: "failed to create AWSMachine instance: failed to describe instance types for instance type \"m6ii.xlarge\": InvalidInstanceType: The following supplied instance types do not exist: [m6ii.xlarge]\n\tstatus code: 400, request id: 36b2872b-d414-41a4-b202-4336e8659737" 
DEBUG Done checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-0 
DEBUG Gathering conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-1 
DEBUG Checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-1 
WARNING Condition Ready has status: "False", reason: "InstanceProvisionFailed", message: "0 of 3 completed" 
WARNING Condition InstanceReady has status: "False", reason: "InstanceProvisionFailed", message: "failed to create AWSMachine instance: failed to run instance: InvalidParameterValue: Value (thvo-dev-8nfz6-master-profiles) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name\n\tstatus code: 400, request id: 41402f13-7ada-418a-9c8a-42b8ce31ab68" 
DEBUG Done checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-1 
DEBUG Gathering conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-2 
DEBUG Checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-2 
WARNING Condition Ready has status: "False", reason: "InstanceProvisionFailed", message: "0 of 3 completed" 
WARNING Condition InstanceReady has status: "False", reason: "InstanceProvisionFailed", message: "failed to create AWSMachine instance: failed to run machine \"thvo-dev-8nfz6-master-2\", no subnets available matching criteria [\"{\\n  Name: \\\"state\\\",\\n  Values: [\\\"pending\\\",\\\"available\\\"]\\n}\" \"{\\n  Name: \\\"tag:Name\\\",\\n  Values: [\\\"thvo-dev-8nfz6-subnet-private-us-east-1cc\\\"]\\n}\"]" 
DEBUG Done checking conditions for apiVersion=infrastructure.cluster.x-k8s.io/v1beta2, kind=AWSMachine, namespace=openshift-cluster-api-guests, name=thvo-dev-8nfz6-master-2 
DEBUG Collecting applied cluster api manifests...  
...
ERROR failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to provision control-plane machines within 15m0s 
```