### PR TITLE
OCPBUGS-55672: Remove MultiArchInstallGCP featuregate

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -625,7 +625,8 @@ func MultiArchFeatureGateEnabled(platform string, fgs featuregates.FeatureGate) 
 	case aws.Name:
 		return fgs.Enabled(features.FeatureGateMultiArchInstallAWS)
 	case gcp.Name:
-		return fgs.Enabled(features.FeatureGateMultiArchInstallGCP)
+		// The MultiArchInstallGCP feature gate is enabled by default
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
** The MultiArchInstallGCP feature gate has been enabled by default. This change removes the check for the feature gate during gcp installs, and the feature gate is treated as enabled by default.