### PR TITLE
OCPBUGS-54413: Make swift containers removal not fatal for UPI.

### DIFF
--- a/upi/openstack/down-containers.yaml
+++ b/upi/openstack/down-containers.yaml
@@ -14,8 +14,9 @@
     ansible.builtin.command:
       cmd: "openstack container list --prefix {{ os_infra_id }} -f value -c Name"
     register: container_list
+    ignore_errors: true
 
   - name: 'Delete the containers associated with the cluster'
     ansible.builtin.command:
       cmd: "openstack container delete -r {{ container_list.stdout }}"
-    when: container_list.stdout|length > 0
+    when: container_list.rc == 0 and container_list.stdout|length > 0


### PR DESCRIPTION
When there is OpenStack deployment, which doesn't have swift services, or there are no containers used at all, listing them will fail the playbook and leave exit code other than 0, which may interrupt CI.

With this commit, errors from listing containers will be ignored, which will cover both cases.