### PR TITLE
OCPBUGS-55671: AWS Mutliarch feature gate is enabled by default

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -623,7 +623,7 @@ func (c *InstallConfig) EnabledFeatureGates() featuregates.FeatureGate {
 func MultiArchFeatureGateEnabled(platform string, fgs featuregates.FeatureGate) bool {
 	switch platform {
 	case aws.Name:
-		return fgs.Enabled(features.FeatureGateMultiArchInstallAWS)
+		return true
 	case gcp.Name:
 		return fgs.Enabled(features.FeatureGateMultiArchInstallGCP)
 	default:


### PR DESCRIPTION
** Remove the check to determine if the aws multi arch feature gate is enabled. It is enabled by default so we will always return true when the platform is AWS.