### PR TITLE
OCPBUGS-56008: don't expect identity on ASH

### DIFF
--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -62,7 +62,7 @@ func GetClusterProfileName() features.ClusterProfileName {
 // identity should be created by the installer, based on the
 // install config values.
 func (c *InstallConfig) CreateAzureIdentity() bool {
-	if c.Azure == nil {
+	if c.Azure == nil || c.Azure.CloudName == azure.StackCloud {
 		return false
 	}
 


### PR DESCRIPTION
On AzureStack, we don't expect a user-assigned
identity to be assigned to nodes. This updates the create identity helper function to reflect that.