### PR TITLE
OCPBUGS-56008: Remove unnecessary validation

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -147,7 +147,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	}); err != nil {
 		errMsg := "error creating user-assigned identity: please ensure your user credentials " +
 			"have the User Access Admin Role or if you are not utilizing an Azure Container Registry " +
-			"you can set installconfig.platform.azure.defaultMachinePlatform.identity: None to skip " +
+			"you can set installconfig.platform.azure.defaultMachinePlatform.identity.type: None to skip " +
 			"the creation of the identity: creation failed with: %w"
 		return fmt.Errorf(errMsg, err)
 	}

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -250,10 +250,6 @@ func validateIdentity(poolName string, p *azure.MachinePool, fldPath *field.Path
 	}
 
 	var errs field.ErrorList
-	if poolName == "worker" && id.Type != capz.VMIdentityUserAssigned {
-		return append(errs, field.Invalid(fldPath.Child("type"), id.Type, "only user-assigned identities are supported for compute nodes"))
-	}
-
 	if id.Type == "" {
 		return append(errs, field.Required(fldPath.Child("type"), "type must be specified if using identity"))
 	}


### PR DESCRIPTION
Removes unnecessary validation that prevents setting the None identity type on compute nodes.