### PR TITLE
CORS-4057: migrate EC2 quota checking code AWS SDK v2

### DIFF
--- a/pkg/asset/quota/aws/instancetypes.go
+++ b/pkg/asset/quota/aws/instancetypes.go
@@ -2,12 +2,14 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/pkg/errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	typesaws "github.com/openshift/installer/pkg/types/aws"
 )
 
 // InstanceTypeInfo describes the instance type
@@ -18,39 +20,39 @@ type InstanceTypeInfo struct {
 
 // InstanceTypes returns information of the all the instance types available for a region.
 // It returns a map of instance type name to it's information.
-func InstanceTypes(ctx context.Context, sess *session.Session, region string) (map[string]InstanceTypeInfo, error) {
+func InstanceTypes(ctx context.Context, region string, serviceEndpoints []typesaws.ServiceEndpoint) (map[string]InstanceTypeInfo, error) {
 	ret := map[string]InstanceTypeInfo{}
 
-	client := ec2.New(sess, aws.NewConfig().WithRegion(region))
-	if err := client.DescribeInstanceTypesPagesWithContext(ctx,
-		&ec2.DescribeInstanceTypesInput{},
-		func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
-			for _, info := range page.InstanceTypes {
-				ti := InstanceTypeInfo{Name: aws.StringValue(info.InstanceType)}
-				if info.VCpuInfo == nil {
-					continue
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return ret, fmt.Errorf("failed to create AWS config: %w", err)
+	}
+
+	client := ec2.NewFromConfig(cfg,
+		func(o *ec2.Options) {
+			for _, endpoint := range serviceEndpoints {
+				if strings.EqualFold(endpoint.Name, ec2.ServiceID) {
+					o.BaseEndpoint = aws.String(endpoint.URL)
 				}
-				ti.vCPU = aws.Int64Value(info.VCpuInfo.DefaultVCpus)
-				ret[ti.Name] = ti
 			}
-			return !lastPage
-		}); err != nil {
-		return nil, err
+		},
+	)
+
+	paginator := ec2.NewDescribeInstanceTypesPaginator(client, &ec2.DescribeInstanceTypesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return ret, fmt.Errorf("failed to get ec2 instance types: %w", err)
+		}
+		for _, info := range page.InstanceTypes {
+			ti := InstanceTypeInfo{Name: string(info.InstanceType)}
+			if info.VCpuInfo == nil {
+				continue
+			}
+			ti.vCPU = int64(aws.ToInt32(info.VCpuInfo.DefaultVCpus))
+			ret[ti.Name] = ti
+		}
 	}
 
 	return ret, nil
-}
-
-// IsUnauthorizedOperation checks if the error is un authorized due to permission failure or lack of service availability.
-func IsUnauthorizedOperation(err error) bool {
-	if err == nil {
-		return false
-	}
-	var awsErr awserr.Error
-	if errors.As(err, &awsErr) {
-		// see reference:
-		// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors
-		return awsErr.Code() == "UnauthorizedOperation" || awsErr.Code() == "AuthFailure" || awsErr.Code() == "Blocked"
-	}
-	return false
 }

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -90,7 +90,7 @@ func (a *PlatformQuotaCheck) Generate(ctx context.Context, dependencies asset.Pa
 		if err != nil {
 			return errors.Wrapf(err, "failed to load Quota for services: %s", strings.Join(services, ", "))
 		}
-		instanceTypes, err := aws.InstanceTypes(ctx, session, ic.AWS.Region)
+		instanceTypes, err := aws.InstanceTypes(ctx, ic.AWS.Region, ic.AWS.Services)
 		if quotaaws.IsUnauthorized(err) {
 			logrus.Warnf("Missing permissions to fetch instance types and therefore will skip checking Quotas: %v, make sure you have `ec2:DescribeInstanceTypes` permission available to the user.", err)
 			return nil


### PR DESCRIPTION
Part of CORS-3819, this focuses on the quote checking code for EC2 instance types.

**Note**: This only upgrades code for fetching instance types during quota check. Full quote code upgrades to v2 is being tracked in [CORS-4061](https://issues.redhat.com/browse/CORS-4061).

**Questions**: User-provided service endpoints were never considered here. Is this intentional?