### PR TITLE
MGMT-20738: Add a file to the ignitions that specifies the cluster's control plane topology

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -16,6 +16,7 @@ import (
 	externalinfra "github.com/openshift/installer/pkg/asset/manifests/external"
 	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	nutanixinfra "github.com/openshift/installer/pkg/asset/manifests/nutanix"
+	"github.com/openshift/installer/pkg/asset/manifests/topologies"
 	vsphereinfra "github.com/openshift/installer/pkg/asset/manifests/vsphere"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -92,11 +93,11 @@ func (i *Infrastructure) Generate(ctx context.Context, dependencies asset.Parent
 		},
 	}
 
-	controlPlaneTopology, infrastructureTopology := determineTopologies(installConfig.Config)
+	controlPlaneTopology, infrastructureTopology := topologies.DetermineTopologies(installConfig.Config)
 
 	config.Status.InfrastructureTopology = infrastructureTopology
 	config.Status.ControlPlaneTopology = controlPlaneTopology
-	config.Status.CPUPartitioning = determineCPUPartitioning(installConfig.Config)
+	config.Status.CPUPartitioning = topologies.DetermineCPUPartitioning(installConfig.Config)
 
 	switch installConfig.Config.Platform.Name() {
 	case aws.Name:

--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -13,6 +13,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/manifests/topologies"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
@@ -79,7 +80,7 @@ func (ing *Ingress) Generate(_ context.Context, dependencies asset.Parents) erro
 }
 
 func (ing *Ingress) generateClusterConfig(config *types.InstallConfig) ([]byte, error) {
-	controlPlaneTopology, _ := determineTopologies(config)
+	controlPlaneTopology, _ := topologies.DetermineTopologies(config)
 
 	isSingleControlPlaneNode := controlPlaneTopology == configv1.SingleReplicaTopologyMode
 

--- a/pkg/asset/manifests/ingress_test.go
+++ b/pkg/asset/manifests/ingress_test.go
@@ -11,12 +11,13 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/manifests/topologies"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
 // installConfigFromTopologies generates an install config that would yield the
-// given topologies when determineTopologies is called on it
+// given topologies when DetermineTopologies is called on it
 func installConfigFromTopologies(t *testing.T, options []icOption,
 	controlPlaneTopology configv1.TopologyMode, infrastructureTopology configv1.TopologyMode) *types.InstallConfig {
 	installConfig := icBuild.build(options...)
@@ -47,7 +48,7 @@ func installConfigFromTopologies(t *testing.T, options []icOption,
 	}
 
 	// Assert that this function actually works
-	generatedControlPlaneTopology, generatedInfrastructureTopology := determineTopologies(installConfig)
+	generatedControlPlaneTopology, generatedInfrastructureTopology := topologies.DetermineTopologies(installConfig)
 	assert.Equal(t, generatedControlPlaneTopology, controlPlaneTopology)
 	assert.Equal(t, generatedInfrastructureTopology, infrastructureTopology)
 

--- a/pkg/asset/manifests/topologies/topologies.go
+++ b/pkg/asset/manifests/topologies/topologies.go
@@ -1,4 +1,4 @@
-package manifests
+package topologies
 
 import (
 	"k8s.io/utils/ptr"
@@ -7,12 +7,14 @@ import (
 	"github.com/openshift/installer/pkg/types"
 )
 
-// determineTopologies determines the Infrastructure CR's
-// infrastructureTopology and controlPlaneTopology given an install config file
-func determineTopologies(installConfig *types.InstallConfig) (controlPlaneTopology configv1.TopologyMode, infrastructureTopology configv1.TopologyMode) {
+// DetermineTopologies determines the Infrastructure CR's controlPlaneTopology and infrastructureTopology given an install-config file.
+func DetermineTopologies(installConfig *types.InstallConfig) (controlPlaneTopology configv1.TopologyMode, infrastructureTopology configv1.TopologyMode) {
 	controlPlaneTopology = configv1.HighlyAvailableTopologyMode
 
-	controlPlaneReplicas := ptr.Deref(installConfig.ControlPlane.Replicas, 3)
+	var controlPlaneReplicas int64 = 3
+	if installConfig.ControlPlane != nil {
+		controlPlaneReplicas = ptr.Deref(installConfig.ControlPlane.Replicas, 3)
+	}
 	if controlPlaneReplicas == 2 {
 		controlPlaneTopology = configv1.DualReplicaTopologyMode
 
@@ -47,7 +49,8 @@ func determineTopologies(installConfig *types.InstallConfig) (controlPlaneTopolo
 	return controlPlaneTopology, infrastructureTopology
 }
 
-func determineCPUPartitioning(installConfig *types.InstallConfig) configv1.CPUPartitioningMode {
+// DetermineCPUPartitioning determines the Infrastructure CR's CPUPartitioning given an install-config file.
+func DetermineCPUPartitioning(installConfig *types.InstallConfig) configv1.CPUPartitioningMode {
 	switch installConfig.CPUPartitioning {
 	case types.CPUPartitioningAllNodes:
 		return configv1.CPUPartitioningAllNodes

--- a/pkg/asset/manifests/topologies/topologies_test.go
+++ b/pkg/asset/manifests/topologies/topologies_test.go
@@ -1,4 +1,4 @@
-package manifests
+package topologies
 
 import (
 	"testing"
@@ -96,7 +96,7 @@ func Test_DetermineTopologies(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			controlPlane, infra := determineTopologies(tc.installConfig)
+			controlPlane, infra := DetermineTopologies(tc.installConfig)
 			if controlPlane != tc.expectedControlPlane {
 				t.Fatalf("expected control plane topology to be %s but got %s", tc.expectedControlPlane, controlPlane)
 			}
@@ -135,7 +135,7 @@ func Test_DetermineCPUPartitioning(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			mode := determineCPUPartitioning(tc.installConfig)
+			mode := DetermineCPUPartitioning(tc.installConfig)
 			if mode != tc.expectedPartitioningMode {
 				t.Fatalf("expected cpu partitioning mode to be %s but got %s", tc.expectedPartitioningMode, mode)
 			}


### PR DESCRIPTION
This will be used by baremetal-runtimecfg to determine if the cluster is TNF/TNA.

The reason this is needed is because when installing TNF/TNA with assisted-installer, 1 of the control plane nodes acts as the bootstrap which means that during the installation there is only going to be 1 control plane node ready. This causes the keepalived-monitor container (which runs baremetal-runtimecfg) not to generate the keepalived.conf. So we need a temporary workaround during the installation, and we only want that workaround to happen when the cluster is TNF/TNA.