### PR TITLE
OCPBUGS-56808: Remove configv1.GCPServiceEndpointNameTagManager references

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -89,7 +89,6 @@ var (
 		configv1.GCPServiceEndpointNameIAM,
 		configv1.GCPServiceEndpointNameServiceUsage,
 		configv1.GCPServiceEndpointNameStorage,
-		configv1.GCPServiceEndpointNameTagManager,
 	)
 )
 


### PR DESCRIPTION
The `GCPServiceEndpointNameTagManager` is removed from API, so the reference(s) should be removed from the installer.