### PR TITLE
CORS-4066: Remove the function to check if multiarch is enabled/allowed

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -619,19 +619,6 @@ func (c *InstallConfig) EnabledFeatureGates() featuregates.FeatureGate {
 	return fg
 }
 
-// MultiArchFeatureGateEnabled checks whether feature gate enabling multi-arch clusters is enabled.
-func MultiArchFeatureGateEnabled(platform string, fgs featuregates.FeatureGate) bool {
-	switch platform {
-	case aws.Name:
-		return true
-	case gcp.Name:
-		// The MultiArchInstallGCP feature gate is enabled by default
-		return true
-	default:
-		return false
-	}
-}
-
 // PublicAPI indicates whether the API load balancer should be public
 // by inspecting the cluster and operator publishing strategies.
 func (c *InstallConfig) PublicAPI() bool {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2993,7 +2993,7 @@ func TestValidateTNF(t *testing.T) {
 			// Build default wrapping installConfig
 			var err error
 			if tc.checkCompute {
-				err = validateCompute(&tc.config.Platform, tc.config.ControlPlane, tc.config.Compute, field.NewPath("compute"), false).ToAggregate()
+				err = validateCompute(&tc.config.Platform, tc.config.ControlPlane, tc.config.Compute, field.NewPath("compute")).ToAggregate()
 			} else {
 				err = validateFencingCredentials(tc.config).ToAggregate()
 			}


### PR DESCRIPTION
** The function was a switch that returns true if the platform is gcp or aws. This can be a simple check in the function that uses this value.