### PR TITLE
no-jira: Fix verify capi manifests script

### DIFF
--- a/data/data/cluster-api/core-components.yaml
+++ b/data/data/cluster-api/core-components.yaml
@@ -4422,6 +4422,15 @@ spec:
                     description: The name of the ClusterClass object to create the
                       topology.
                     type: string
+                  classNamespace:
+                    description: |-
+                      classNamespace is the namespace of the ClusterClass object to create the topology.
+                      If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
+                      Value must follow the DNS1123Subdomain syntax.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   controlPlane:
                     description: controlPlane describes the cluster control plane.
                     properties:
@@ -8034,7 +8043,7 @@ spec:
                   behavior:
                     description: |-
                       behavior defines the drain behavior.
-                      Can be either "Drain" or "Skip".
+                      Can be either "Drain", "Skip", or "WaitCompleted".
                       "Drain" means that the Pods to which this MachineDrainRule applies will be drained.
                       If behavior is set to "Drain" the order in which Pods are drained can be configured
                       with the order field. When draining Pods of a Node the Pods will be grouped by order
@@ -8042,9 +8051,12 @@ spec:
                       wait until all Pods of a group are terminated / removed from the Node before starting
                       with the next group.
                       "Skip" means that the Pods to which this MachineDrainRule applies will be skipped during drain.
+                      "WaitCompleted" means that the pods to which this MachineDrainRule applies will never be evicted
+                      and we wait for them to be completed, it is enforced that pods marked with this behavior always have Order=0.
                     enum:
                     - Drain
                     - Skip
+                    - WaitCompleted
                     type: string
                   order:
                     description: |-

--- a/data/data/cluster-api/nutanix-infrastructure-components.yaml
+++ b/data/data/cluster-api/nutanix-infrastructure-components.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     cluster.x-k8s.io/provider: infrastructure-nutanix
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -153,6 +153,7 @@ spec:
                       type: array
                   required:
                   - cluster
+                  - controlPlane
                   - name
                   - subnets
                   type: object
@@ -323,7 +324,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     cluster.x-k8s.io/provider: infrastructure-nutanix
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -467,6 +468,7 @@ spec:
                               type: array
                           required:
                           - cluster
+                          - controlPlane
                           - name
                           - subnets
                           type: object
@@ -562,7 +564,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     cluster.x-k8s.io/provider: infrastructure-nutanix
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -656,7 +658,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -923,7 +924,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -969,7 +969,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     cluster.x-k8s.io/provider: infrastructure-nutanix
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -1083,7 +1083,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -1337,6 +1336,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - delete
   - get
@@ -1351,16 +1351,6 @@ rules:
   - get
   - list
   - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - delete
-  - get
-  - list
-  - update
   - watch
 - apiGroups:
   - bootstrap.cluster.x-k8s.io
@@ -1385,15 +1375,7 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
-  - clusters
   - clusters/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machines
   - machines/status
   verbs:
@@ -1404,31 +1386,6 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - nutanixclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - nutanixclusters/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - nutanixclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - nutanixmachines
   verbs:
   - create
@@ -1441,12 +1398,14 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - nutanixclusters/finalizers
   - nutanixmachines/finalizers
   verbs:
   - update
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - nutanixclusters/status
   - nutanixmachines/status
   verbs:
   - get
@@ -1679,7 +1638,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:v1.5.3
+        image: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/hack/verify-capi-manifests.sh
+++ b/hack/verify-capi-manifests.sh
@@ -27,8 +27,12 @@ generate_capi_manifest() {
 		clone_path="$(mktemp -d)"
 		git clone "${repo_origin}" "${clone_path}"
 		pushd "${clone_path}"
+		git fetch "${repo_origin}" "${revision}"
 		git checkout "${revision}"
 		case "${provider}" in
+		azurestack)
+		    # skip this for now--until unforked
+			;;
 		vsphere)
 			make release-manifests-all
 			;;
@@ -57,6 +61,16 @@ if [ "$IS_CONTAINER" != "" ]; then
 	if ! command -v jq; then
 		curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/bin/jq
 		chmod u+x /usr/bin/jq
+	fi
+
+
+	# Install `controller-gen` & `kustomize`, which are needed by nutanix, if not present
+	if ! command -v controller-gen; then
+		go install sigs.k8s.io/controller-tools/cmd/controller-gen
+	fi
+
+	if ! command -v kustomize; then
+		go install sigs.k8s.io/kustomize/kustomize/v5@latest
 	fi
 
 	# Silence git hints and advices


### PR DESCRIPTION
The verify-capi-manifests script was failing on nutanix, which referenced an individual commit--not a release. Fixed that by adding `git fetch` and scripting some dependency management. 

Also included fixup of mismatched CRDs.