### PR TITLE
CORS-4062: Migrate endpoints in pkg/types/aws/platform.go to sdk v2

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -499,8 +499,13 @@ func RequiredPermissionGroups(ic *types.InstallConfig) []PermissionGroup {
 		permissionGroups = append(permissionGroups, PermissionKMSEncryptionKeys)
 	}
 
+	isSecretRegion, err := IsSecretRegion(ic.AWS.Region)
+	if err != nil {
+		logrus.Warnf("Unable to determine if AWS region is secret: %v", err)
+		return permissionGroups
+	}
 	// Add delete permissions for non-C2S installs.
-	if !aws.IsSecretRegion(ic.AWS.Region) {
+	if !isSecretRegion {
 		permissionGroups = append(permissionGroups, PermissionDeleteBase)
 		if usingExistingVPC {
 			permissionGroups = append(permissionGroups, PermissionDeleteSharedNetworking)

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -14,6 +14,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	awsic "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	ibmcloudmachines "github.com/openshift/installer/pkg/asset/machines/ibmcloud"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
@@ -101,7 +102,11 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 	case awstypes.Name:
 		// Store the additional trust bundle in the ca-bundle.pem key if the cluster is being installed on a C2S region.
 		trustBundle := installConfig.Config.AdditionalTrustBundle
-		if trustBundle != "" && awstypes.IsSecretRegion(installConfig.Config.AWS.Region) {
+		isSecretRegion, err := awsic.IsSecretRegion(installConfig.Config.AWS.Region)
+		if err != nil {
+			return fmt.Errorf("failed to determine if AWS region is secret: %w", err)
+		}
+		if trustBundle != "" && isSecretRegion {
 			cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
 		}
 

--- a/pkg/asset/tls/cloudprovidercabundle.go
+++ b/pkg/asset/tls/cloudprovidercabundle.go
@@ -2,9 +2,11 @@ package tls
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	awsic "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
@@ -35,7 +37,12 @@ func (a *CloudProviderCABundle) Generate(_ context.Context, deps asset.Parents) 
 	if ic.Config.Platform.Name() != awstypes.Name {
 		return nil
 	}
-	if !awstypes.IsSecretRegion(ic.Config.Platform.AWS.Region) {
+
+	isSecretRegion, err := awsic.IsSecretRegion(ic.Config.Platform.AWS.Region)
+	if err != nil {
+		return fmt.Errorf("failed to determine if AWS region is secret: %w", err)
+	}
+	if !isSecretRegion {
 		return nil
 	}
 

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/dns"
 )
@@ -231,19 +229,6 @@ const (
 	// load balancer that serves the Kubernetes API server.
 	ControlPlaneInternalLBSubnetRole SubnetRoleType = "ControlPlaneInternalLB"
 )
-
-// IsSecretRegion returns true if the region is part of either the ISO or ISOB partitions.
-func IsSecretRegion(region string) bool {
-	partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
-	if !ok {
-		return false
-	}
-	switch partition.ID() {
-	case endpoints.AwsIsoPartitionID, endpoints.AwsIsoBPartitionID:
-		return true
-	}
-	return false
-}
 
 // IsPublicOnlySubnetsEnabled returns whether the public-only subnets feature has been enabled via env var.
 func IsPublicOnlySubnetsEnabled() bool {


### PR DESCRIPTION
pkg/types/aws:

** Remove the endpoints package from aws sdk v1.
** Remove the function to check for secret regions

pkg/asset/installconfig/aws:

** Add a function to check for secret regions.
** The function was moved here (and changed) because the types package should not make api calls. As we migrated to aws sdk v2 the partitions are no longer publicly available BUT we can access them through endpoints. To get the partition we go through the ec2 api (make a proxy call) and get the endpoint from that call then the endpoint will provide us with the partition.