### PR TITLE
OCPBUGS-58216: allow to deploy single nodes with UPI

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -985,10 +985,10 @@ func IsFencingCredentialsFile(filepath string) (bool, error) {
 // a platform.
 func supportedSingleNodePlatform(bootstrapInPlace bool, platformName string) bool {
 	switch platformName {
-	case awstypes.Name, gcptypes.Name, azuretypes.Name, powervstypes.Name:
+	case awstypes.Name, gcptypes.Name, azuretypes.Name, powervstypes.Name, nonetypes.Name:
 		// Single node OpenShift installations supported without `bootstrapInPlace`
 		return true
-	case nonetypes.Name, externaltypes.Name:
+	case externaltypes.Name:
 		// Single node OpenShift installations supported with `bootstrapInPlace`
 		return bootstrapInPlace
 	default:


### PR DESCRIPTION
This PR allows back deployment of single node openshift using UPI with platform None and without bootstrap in place, since it has worked fine for ever and is used at least internally