### PR TITLE
OCPBUGS-57000: Revert "CORS-3883: Remove user-assigned identity from ARM template"

### DIFF
--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -58,6 +58,7 @@
     "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
@@ -119,6 +120,12 @@
       "type" : "Microsoft.Compute/virtualMachines",
       "name" : "[variables('vmName')]",
       "location" : "[variables('location')]",
+      "identity" : {
+        "type" : "userAssigned",
+        "userAssignedIdentities" : {
+          "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
+        }
+      },
       "dependsOn" : [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -80,6 +80,7 @@
     "masterLoadBalancerName" : "[parameters('baseName')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
     "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
@@ -131,6 +132,12 @@
       },
       "name" : "[variables('vmNames')[copyIndex()]]",
       "location" : "[variables('location')]",
+      "identity" : {
+        "type" : "userAssigned",
+        "userAssignedIdentities" : {
+          "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
+        }
+      },
       "dependsOn" : [
         "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"
       ],

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -65,6 +65,7 @@
     "nodeSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('nodeSubnetName'))]",
     "infraLoadBalancerName" : "[parameters('baseName')]",
     "sshKeyPath" : "/home/capi/.ssh/authorized_keys",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
     "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
@@ -116,6 +117,12 @@
               "location" : "[variables('location')]",
               "tags" : {
                 "kubernetes.io-cluster-ffranzupi": "owned"
+              },
+              "identity" : {
+                "type" : "userAssigned",
+                "userAssignedIdentities" : {
+                  "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" : {}
+                }
               },
               "dependsOn" : [
                 "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"


### PR DESCRIPTION
Reverts openshift/installer#9625

Based on https://github.com/openshift/installer/pull/9718, installer default behavior is changed back to create user-assigned identity to avoid pulling image from ACR failed.

https://github.com/openshift/installer/pull/9625 removed the user-assigned identity configuration from Azure ARM template, so the issue also happens on UPI cluster.

The Azure ARM template in UPI installation doc is synced from installer repo automatically, #9625 needs to be reverted until installer default behavior changes to use "None" identity type, so that doc has correct ARM template content. 