### PR TITLE
OCPBUGS-51299: Set default project and location for KMS key manifest

### DIFF
--- a/pkg/asset/manifests/clustercsidriver.go
+++ b/pkg/asset/manifests/clustercsidriver.go
@@ -98,11 +98,22 @@ func (csi *ClusterCSIDriverConfig) Generate(_ context.Context, dependencies asse
 			return nil
 		}
 		kmsKey := platform.OSDisk.EncryptionKey.KMSKey
+
+		projectID := kmsKey.ProjectID
+		if projectID == "" {
+			projectID = installConfig.Config.GCP.ProjectID
+		}
+
+		location := kmsKey.Location
+		if location == "" {
+			location = installConfig.Config.GCP.Region
+		}
+
 		configData, err := gcp.ClusterCSIDriverConfig{
 			Name:      kmsKey.Name,
 			KeyRing:   kmsKey.KeyRing,
-			ProjectID: kmsKey.ProjectID,
-			Location:  kmsKey.Location,
+			ProjectID: projectID,
+			Location:  location,
 		}.YAML()
 		if err != nil {
 			return errors.Wrap(err, "could not create CSI cluster driver config")


### PR DESCRIPTION
pkg/asset/manifests/clustercsidriver.go:

** When the default GCP Platform KMS Key info does not include the location and/or Porject ID, default to using the values set in the installconfig under the GCP platform.