### PR TITLE
OCPBUGS-57021: Use less permissive access for /var/lib/etcd for SNO

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/master-update.fcc
+++ b/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/master-update.fcc
@@ -14,6 +14,9 @@ storage:
       path: /etc/kubernetes/static-pod-resources/etcd-member
     - local: etcd-data
       path: /var/lib/etcd
+  directories:
+    - path: /var/lib/etcd/member
+      mode: 0700
   files:
     - path: /etc/kubernetes/bootstrap-secrets/kubeconfig
       contents:


### PR DESCRIPTION
With multi-node installations the settings for /var/lib/etcd are 0700. This should be the same from SNO but the bootstrap-in-place ignition is setting it to 0755.