### PR TITLE
CORS-4064: Add support for multi zonal NAT gateways

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4847,13 +4847,13 @@ spec:
                     type: string
                   outboundType:
                     default: Loadbalancer
-                    description: |-
-                      OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
-                      "NatGateway" is only available in TechPreview.
+                    description: OutboundType is a strategy for how egress from cluster
+                      is achieved. When not specified default is "Loadbalancer".
                     enum:
                     - ""
                     - Loadbalancer
                     - NatGateway
+                    - NATGatewaySingleZone
                     - UserDefinedRouting
                     type: string
                   region:

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -332,9 +332,8 @@ platform configuration.
 
     outboundType <string>
       Default: "Loadbalancer"
-      Valid Values: "","Loadbalancer","NatGateway","UserDefinedRouting"
+      Valid Values: "","Loadbalancer","NatGateway","NATGatewaySingleZone","UserDefinedRouting"
       OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
-"NatGateway" is only available in TechPreview.
 
     region <string> -required-
       Region specifies the Azure region where the cluster will be created.

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -9,7 +9,7 @@ import (
 var aro bool
 
 // OutboundType is a strategy for how egress from cluster is achieved.
-// +kubebuilder:validation:Enum="";Loadbalancer;NatGateway;UserDefinedRouting
+// +kubebuilder:validation:Enum="";Loadbalancer;NatGateway;NATGatewaySingleZone;UserDefinedRouting
 type OutboundType string
 
 const (
@@ -18,8 +18,13 @@ const (
 	LoadbalancerOutboundType OutboundType = "Loadbalancer"
 
 	// NatGatewayOutboundType uses NAT gateway for egress from the cluster
+	// Only valid for 4.14-4.16 tech preview.
 	// see https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-gateway-resource
 	NatGatewayOutboundType OutboundType = "NatGateway"
+
+	// NATGatewaySingleZoneOutboundType uses a single (non-zone-resilient) NAT Gateway for compute node outbound access.
+	// see https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-gateway-resource
+	NATGatewaySingleZoneOutboundType OutboundType = "NATGatewaySingleZone"
 
 	// UserDefinedRoutingOutboundType uses user defined routing for egress from the cluster.
 	// see https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview
@@ -76,7 +81,6 @@ type Platform struct {
 	CloudName CloudEnvironment `json:"cloudName,omitempty"`
 
 	// OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
-	// "NatGateway" is only available in TechPreview.
 	//
 	// +kubebuilder:default=Loadbalancer
 	// +optional

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -26,6 +26,9 @@ const (
 	// see https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-gateway-resource
 	NATGatewaySingleZoneOutboundType OutboundType = "NATGatewaySingleZone"
 
+	// NATGatewayMultiZoneOutboundType uses NAT gateways in multiple zones in the compute node subnets for outbound access.
+	NatGatewayMultiZoneOutboundType OutboundType = "MultiZoneNatGateway"
+
 	// UserDefinedRoutingOutboundType uses user defined routing for egress from the cluster.
 	// see https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview
 	UserDefinedRoutingOutboundType OutboundType = "UserDefinedRouting"
@@ -86,6 +89,11 @@ type Platform struct {
 	// +optional
 	OutboundType OutboundType `json:"outboundType"`
 
+	// NatGatewaySpec allows the user to specify the subnets and the nat gateway configuration for each subnet.
+	// Since only one nat gateway is allowed per subnet, users can create multiple subnets and create nat gateway
+	// for each subnet for zone resilience.
+	NatGatewaySpec []NatGatewaySpec `json:"natGatewaySpec"`
+
 	// ResourceGroupName is the name of an already existing resource group where the cluster should be installed.
 	// This resource group should only be used for this specific cluster and the cluster components will assume
 	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
@@ -104,6 +112,19 @@ type Platform struct {
 
 	// CustomerManagedKey has the keys needed to encrypt the storage account.
 	CustomerManagedKey *CustomerManagedKey `json:"customerManagedKey,omitempty"`
+}
+
+type NatGatewaySpec struct {
+	// Name of the nat gateway to be created.
+	Name string `json:"name"`
+	// PublicIPName specifies any public IP to be assigned to the nat gateway
+	// +optional
+	PublicIPName string `json:"publicIPName"`
+	// IPDNSName specifies the dns name for the public IP specified.
+	// +optional
+	IPDNSName string `json:"IPDNSName"`
+	// Subnet specifies the name of the subnet to be created.
+	Subnet string `json:"subnet"`
 }
 
 // KeyVault defines an Azure Key Vault.

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -8,7 +8,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
@@ -98,13 +97,10 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	if p.OutboundType == azure.UserDefinedRoutingOutboundType && p.VirtualNetwork == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is only allowed when installing to pre-existing network", azure.UserDefinedRoutingOutboundType)))
 	}
-	if p.OutboundType == azure.NatGatewayOutboundType {
-		if ic.FeatureSet != configv1.TechPreviewNoUpgrade {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "not supported in this feature set"))
-		}
+	if p.OutboundType == azure.NATGatewaySingleZoneOutboundType || p.OutboundType == azure.NatGatewayOutboundType {
 		if p.VirtualNetwork != "" {
 			// For now, BYO network and NAT gateways are not compatible
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is not allowed when installing to pre-existing network", azure.NatGatewayOutboundType)))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, fmt.Sprintf("%s is not allowed when installing to pre-existing network", p.OutboundType)))
 		}
 	}
 
@@ -242,9 +238,10 @@ func findDuplicateTagKeys(tagSet map[string]string) error {
 
 var (
 	validOutboundTypes = map[azure.OutboundType]struct{}{
-		azure.LoadbalancerOutboundType:       {},
-		azure.NatGatewayOutboundType:         {},
-		azure.UserDefinedRoutingOutboundType: {},
+		azure.LoadbalancerOutboundType:         {},
+		azure.NatGatewayOutboundType:           {},
+		azure.NATGatewaySingleZoneOutboundType: {},
+		azure.UserDefinedRoutingOutboundType:   {},
 	}
 
 	validOutboundTypeValues = func() []string {
@@ -262,10 +259,7 @@ func validateAzureStack(p *azure.Platform, fldPath *field.Path) field.ErrorList 
 	if p.ARMEndpoint == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("armEndpoint"), "ARM endpoint must be set when installing on Azure Stack"))
 	}
-	switch p.OutboundType {
-	case azure.UserDefinedRoutingOutboundType:
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "Azure Stack does not support user-defined routing"))
-	case azure.NatGatewayOutboundType:
+	if p.OutboundType != azure.LoadbalancerOutboundType {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "Azure Stack does not support NAT routing currently"))
 	}
 	return allErrs

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -134,7 +134,7 @@ func TestValidatePlatform(t *testing.T) {
 				p.OutboundType = "random-egress"
 				return p
 			}(),
-			expected: `^test-path\.outboundType: Unsupported value: "random-egress": supported values: "Loadbalancer", "NatGateway", "UserDefinedRouting"$`,
+			expected: `^test-path\.outboundType: Unsupported value: "random-egress": supported values: "Loadbalancer", "NATGatewaySingleZone", "NatGateway", "UserDefinedRouting"$`,
 		},
 		{
 			name: "invalid user defined type",
@@ -144,15 +144,6 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			expected: `^test-path\.outboundType: Invalid value: "UserDefinedRouting": UserDefinedRouting is only allowed when installing to pre-existing network$`,
-		},
-		{
-			name: "invalid nat gateway",
-			platform: func() *azure.Platform {
-				p := validPlatform()
-				p.OutboundType = azure.NatGatewayOutboundType
-				return p
-			}(),
-			expected: `^test-path\.outboundType: Invalid value: "NatGateway": not supported in this feature set$`,
 		},
 		{
 			name: "missing key vault name",


### PR DESCRIPTION
Adding support to install multiple NAT gateways per subnet.
The zone in which they will be installed is not customizable
due to needing an upstream PR to fix CAPZ.