### PR TITLE
OCPBUGS-41879: vSphere - if regions are the same cannot dup zones

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -157,7 +157,16 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path, isLegacyUp
 	allErrs := field.ErrorList{}
 	topologyFld := fldPath.Child("topology")
 	var associatedVCenter *vsphere.VCenter
+
+	zoneNames := make(map[string]string)
+
 	for index, failureDomain := range p.FailureDomains {
+		if regionName, ok := zoneNames[failureDomain.Zone]; !ok {
+			zoneNames[failureDomain.Zone] = failureDomain.Region
+		} else if regionName == failureDomain.Region {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("zone"), failureDomain.Zone, fmt.Sprintf("cannot be used more than once for the failure domain region %q", failureDomain.Region)))
+		}
+
 		if failureDomain.ZoneType == "" && failureDomain.RegionType == "" {
 			logrus.Debug("using the defaults regionType is Datacenter and zoneType is ComputeCluster")
 		}

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -389,6 +389,15 @@ func TestValidatePlatform(t *testing.T) {
 			platform: validPlatform(),
 		},
 		{
+			name: "Multi-zone platform duplicated zone names",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains[1].Zone = "test-east-1a"
+				return p
+			}(),
+			expectedError: `^test-path.failureDomains.zone: Invalid value: "test-east-1a": cannot be used more than once for the failure domain region "test-east"`,
+		},
+		{
 			name: "Multi-zone platform missing failureDomains",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()


### PR DESCRIPTION
If the vsphere failure domain region names are the same across multiples the zones cannot be duplicated.
This commit adds this validation and unit tests.