### PR TITLE
OCPBUGS-44840: Mount the user-ca-bundle into ICC

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/image-customization.container
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/image-customization.container
@@ -16,6 +16,7 @@ Volume=ironic.volume:/shared:z
 Volume=/etc/containers:/tmp/containers:z
 Volume=${AUTH_DIR}:/auth:z,ro
 Volume=/opt/openshift:/opt/openshift:z,ro
+Volume=/etc/pki/ca-trust/source/anchors/ca.crt:/tmp/ca.crt:z,ro
 Environment="DEPLOY_ISO=/shared/html/images/ironic-python-agent.iso"
 Environment="DEPLOY_INITRD=/shared/html/images/ironic-python-agent.initramfs"
 Environment="IRONIC_BASE_URL=${IRONIC_BASE_URL}"
@@ -25,6 +26,7 @@ Environment="IP_OPTIONS=${EXTERNAL_IP_OPTIONS}"
 Environment="REGISTRIES_CONF_PATH=/tmp/containers/registries.conf"
 Environment="KUBECONFIG=/opt/openshift/auth/kubeconfig-loopback"
 Environment="ADDITIONAL_NTP_SERVERS=${ADDITIONAL_NTP_SERVERS}"
+Environment="CA_BUNDLE=/tmp/ca.crt"
 
 [Service]
 EnvironmentFile=/etc/ironic.env


### PR DESCRIPTION
The ICC will then add it to the custom image in order to pull down the IPA image.

(cherry picked from commit 3a496ec73b9947459b103861ca3f8a1f2ee130e5)