### PR TITLE
OCPBUGS-57348: consider custom AMI for edge compute machine pool

### DIFF
--- a/pkg/asset/manifests/mco.go
+++ b/pkg/asset/manifests/mco.go
@@ -52,8 +52,11 @@ func awsBootImages(ic *types.InstallConfig) (cpImg bool, wImg bool) {
 		cpImg = true
 	}
 
-	if w := ic.Compute; len(w) > 0 && w[0].Platform.AWS != nil && w[0].Platform.AWS.AMIID != "" {
-		wImg = true
+	// On AWS, we need to check both compute and edge compute machine pool.
+	for _, computeMP := range ic.Compute {
+		if awsPlatform := computeMP.Platform.AWS; awsPlatform != nil && awsPlatform.AMIID != "" {
+			wImg = true
+		}
 	}
 	return
 }

--- a/pkg/asset/manifests/mco_test.go
+++ b/pkg/asset/manifests/mco_test.go
@@ -41,6 +41,11 @@ func TestGenerateMCO(t *testing.T) {
 			expectedMCO:   mcoBuild.build(mcoBuild.withComputeBootImageMgmtDisabled()),
 		},
 		{
+			name:          "aws with a custom edge compute image disables mco management",
+			installConfig: icBuild.build(icBuild.withAWSEdgeComputeAMI()),
+			expectedMCO:   mcoBuild.build(mcoBuild.withComputeBootImageMgmtDisabled()),
+		},
+		{
 			name:          "gcp with a custom compute image disables mco management",
 			installConfig: icBuild.build(icBuild.withGCPComputeAMI()),
 			expectedMCO:   mcoBuild.build(mcoBuild.withComputeBootImageMgmtDisabled()),
@@ -116,6 +121,27 @@ func (b icBuildNamespace) withAWSComputeAMI() icOption {
 		b.forAWS()(ic)
 		ic.Compute = []types.MachinePool{
 			{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{
+						AMIID: "ami-xxxxxxxxxxxxx",
+					},
+				},
+			},
+		}
+	}
+}
+
+func (b icBuildNamespace) withAWSEdgeComputeAMI() icOption {
+	return func(ic *types.InstallConfig) {
+		b.forAWS()(ic)
+		ic.Compute = []types.MachinePool{
+			{
+				Platform: types.MachinePoolPlatform{
+					AWS: &aws.MachinePool{},
+				},
+			},
+			{
+				Name: "edge",
 				Platform: types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{
 						AMIID: "ami-xxxxxxxxxxxxx",


### PR DESCRIPTION
If custom boot images are specified, the installer generates an MCO manifest to disable MCO boot image management (https://github.com/openshift/installer/pull/9783).

On AWS, previously edge compute machine pool was not considered for custom AMI. This commit ensures custom AMI is considered in all compute machine pools.