### PR TITLE
SPLAT-2294: Azure - add mpool datadisks

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -244,6 +244,87 @@ spec:
                         - storageAccountName
                         - type
                         type: object
+                      dataDisks:
+                        description: DataDisk specifies the parameters that are used
+                          to add one or more data disks to the machine.
+                        items:
+                          description: DataDisk specifies the parameters that are
+                            used to add one or more data disks to the machine.
+                          properties:
+                            cachingType:
+                              description: CachingType specifies the caching requirements.
+                              enum:
+                              - None
+                              - ReadOnly
+                              - ReadWrite
+                              type: string
+                            diskSizeGB:
+                              description: DiskSizeGB is the size in GB to assign
+                                to the data disk.
+                              format: int32
+                              type: integer
+                            lun:
+                              description: |-
+                                Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM.
+                                The value must be between 0 and 63.
+                              format: int32
+                              type: integer
+                            managedDisk:
+                              description: ManagedDisk specifies the Managed Disk
+                                parameters for the data disk.
+                              properties:
+                                diskEncryptionSet:
+                                  description: DiskEncryptionSet specifies the customer-managed
+                                    disk encryption set resource id for the managed
+                                    disk.
+                                  properties:
+                                    id:
+                                      description: ID defines resourceID for diskEncryptionSet
+                                        resource. It must be in the same subscription
+                                      type: string
+                                  type: object
+                                securityProfile:
+                                  description: SecurityProfile specifies the security
+                                    profile for the managed disk.
+                                  properties:
+                                    diskEncryptionSet:
+                                      description: |-
+                                        DiskEncryptionSet specifies the customer-managed disk encryption set resource id for the
+                                        managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and
+                                        VMGuest blob.
+                                      properties:
+                                        id:
+                                          description: ID defines resourceID for diskEncryptionSet
+                                            resource. It must be in the same subscription
+                                          type: string
+                                      type: object
+                                    securityEncryptionType:
+                                      description: |-
+                                        SecurityEncryptionType specifies the encryption type of the managed disk.
+                                        It is set to DiskWithVMGuestState to encrypt the managed disk along with the VMGuestState
+                                        blob, and to VMGuestStateOnly to encrypt the VMGuestState blob only.
+                                        When set to VMGuestStateOnly, VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        When set to DiskWithVMGuestState, EncryptionAtHost should be disabled, SecureBoot and
+                                        VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        It can be set only for Confidential VMs.
+                                      enum:
+                                      - VMGuestStateOnly
+                                      - DiskWithVMGuestState
+                                      type: string
+                                  type: object
+                                storageAccountType:
+                                  type: string
+                              type: object
+                            nameSuffix:
+                              description: |-
+                                NameSuffix is the suffix to be appended to the machine name to generate the disk name.
+                                Each disk name will be in format <machineName>_<nameSuffix>.
+                              type: string
+                          required:
+                          - diskSizeGB
+                          - nameSuffix
+                          type: object
+                        type: array
                       encryptionAtHost:
                         description: EncryptionAtHost enables encryption at the VM
                           host.
@@ -1564,6 +1645,88 @@ spec:
                           - storageAccountName
                           - type
                           type: object
+                        dataDisks:
+                          description: DataDisk specifies the parameters that are
+                            used to add one or more data disks to the machine.
+                          items:
+                            description: DataDisk specifies the parameters that are
+                              used to add one or more data disks to the machine.
+                            properties:
+                              cachingType:
+                                description: CachingType specifies the caching requirements.
+                                enum:
+                                - None
+                                - ReadOnly
+                                - ReadWrite
+                                type: string
+                              diskSizeGB:
+                                description: DiskSizeGB is the size in GB to assign
+                                  to the data disk.
+                                format: int32
+                                type: integer
+                              lun:
+                                description: |-
+                                  Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM.
+                                  The value must be between 0 and 63.
+                                format: int32
+                                type: integer
+                              managedDisk:
+                                description: ManagedDisk specifies the Managed Disk
+                                  parameters for the data disk.
+                                properties:
+                                  diskEncryptionSet:
+                                    description: DiskEncryptionSet specifies the customer-managed
+                                      disk encryption set resource id for the managed
+                                      disk.
+                                    properties:
+                                      id:
+                                        description: ID defines resourceID for diskEncryptionSet
+                                          resource. It must be in the same subscription
+                                        type: string
+                                    type: object
+                                  securityProfile:
+                                    description: SecurityProfile specifies the security
+                                      profile for the managed disk.
+                                    properties:
+                                      diskEncryptionSet:
+                                        description: |-
+                                          DiskEncryptionSet specifies the customer-managed disk encryption set resource id for the
+                                          managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and
+                                          VMGuest blob.
+                                        properties:
+                                          id:
+                                            description: ID defines resourceID for
+                                              diskEncryptionSet resource. It must
+                                              be in the same subscription
+                                            type: string
+                                        type: object
+                                      securityEncryptionType:
+                                        description: |-
+                                          SecurityEncryptionType specifies the encryption type of the managed disk.
+                                          It is set to DiskWithVMGuestState to encrypt the managed disk along with the VMGuestState
+                                          blob, and to VMGuestStateOnly to encrypt the VMGuestState blob only.
+                                          When set to VMGuestStateOnly, VirtualizedTrustedPlatformModule should be set to Enabled.
+                                          When set to DiskWithVMGuestState, EncryptionAtHost should be disabled, SecureBoot and
+                                          VirtualizedTrustedPlatformModule should be set to Enabled.
+                                          It can be set only for Confidential VMs.
+                                        enum:
+                                        - VMGuestStateOnly
+                                        - DiskWithVMGuestState
+                                        type: string
+                                    type: object
+                                  storageAccountType:
+                                    type: string
+                                type: object
+                              nameSuffix:
+                                description: |-
+                                  NameSuffix is the suffix to be appended to the machine name to generate the disk name.
+                                  Each disk name will be in format <machineName>_<nameSuffix>.
+                                type: string
+                            required:
+                            - diskSizeGB
+                            - nameSuffix
+                            type: object
+                          type: array
                         encryptionAtHost:
                           description: EncryptionAtHost enables encryption at the
                             VM host.
@@ -2823,6 +2986,87 @@ spec:
                         - storageAccountName
                         - type
                         type: object
+                      dataDisks:
+                        description: DataDisk specifies the parameters that are used
+                          to add one or more data disks to the machine.
+                        items:
+                          description: DataDisk specifies the parameters that are
+                            used to add one or more data disks to the machine.
+                          properties:
+                            cachingType:
+                              description: CachingType specifies the caching requirements.
+                              enum:
+                              - None
+                              - ReadOnly
+                              - ReadWrite
+                              type: string
+                            diskSizeGB:
+                              description: DiskSizeGB is the size in GB to assign
+                                to the data disk.
+                              format: int32
+                              type: integer
+                            lun:
+                              description: |-
+                                Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM.
+                                The value must be between 0 and 63.
+                              format: int32
+                              type: integer
+                            managedDisk:
+                              description: ManagedDisk specifies the Managed Disk
+                                parameters for the data disk.
+                              properties:
+                                diskEncryptionSet:
+                                  description: DiskEncryptionSet specifies the customer-managed
+                                    disk encryption set resource id for the managed
+                                    disk.
+                                  properties:
+                                    id:
+                                      description: ID defines resourceID for diskEncryptionSet
+                                        resource. It must be in the same subscription
+                                      type: string
+                                  type: object
+                                securityProfile:
+                                  description: SecurityProfile specifies the security
+                                    profile for the managed disk.
+                                  properties:
+                                    diskEncryptionSet:
+                                      description: |-
+                                        DiskEncryptionSet specifies the customer-managed disk encryption set resource id for the
+                                        managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and
+                                        VMGuest blob.
+                                      properties:
+                                        id:
+                                          description: ID defines resourceID for diskEncryptionSet
+                                            resource. It must be in the same subscription
+                                          type: string
+                                      type: object
+                                    securityEncryptionType:
+                                      description: |-
+                                        SecurityEncryptionType specifies the encryption type of the managed disk.
+                                        It is set to DiskWithVMGuestState to encrypt the managed disk along with the VMGuestState
+                                        blob, and to VMGuestStateOnly to encrypt the VMGuestState blob only.
+                                        When set to VMGuestStateOnly, VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        When set to DiskWithVMGuestState, EncryptionAtHost should be disabled, SecureBoot and
+                                        VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        It can be set only for Confidential VMs.
+                                      enum:
+                                      - VMGuestStateOnly
+                                      - DiskWithVMGuestState
+                                      type: string
+                                  type: object
+                                storageAccountType:
+                                  type: string
+                              type: object
+                            nameSuffix:
+                              description: |-
+                                NameSuffix is the suffix to be appended to the machine name to generate the disk name.
+                                Each disk name will be in format <machineName>_<nameSuffix>.
+                              type: string
+                          required:
+                          - diskSizeGB
+                          - nameSuffix
+                          type: object
+                        type: array
                       encryptionAtHost:
                         description: EncryptionAtHost enables encryption at the VM
                           host.
@@ -4550,6 +4794,87 @@ spec:
                         - storageAccountName
                         - type
                         type: object
+                      dataDisks:
+                        description: DataDisk specifies the parameters that are used
+                          to add one or more data disks to the machine.
+                        items:
+                          description: DataDisk specifies the parameters that are
+                            used to add one or more data disks to the machine.
+                          properties:
+                            cachingType:
+                              description: CachingType specifies the caching requirements.
+                              enum:
+                              - None
+                              - ReadOnly
+                              - ReadWrite
+                              type: string
+                            diskSizeGB:
+                              description: DiskSizeGB is the size in GB to assign
+                                to the data disk.
+                              format: int32
+                              type: integer
+                            lun:
+                              description: |-
+                                Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM.
+                                The value must be between 0 and 63.
+                              format: int32
+                              type: integer
+                            managedDisk:
+                              description: ManagedDisk specifies the Managed Disk
+                                parameters for the data disk.
+                              properties:
+                                diskEncryptionSet:
+                                  description: DiskEncryptionSet specifies the customer-managed
+                                    disk encryption set resource id for the managed
+                                    disk.
+                                  properties:
+                                    id:
+                                      description: ID defines resourceID for diskEncryptionSet
+                                        resource. It must be in the same subscription
+                                      type: string
+                                  type: object
+                                securityProfile:
+                                  description: SecurityProfile specifies the security
+                                    profile for the managed disk.
+                                  properties:
+                                    diskEncryptionSet:
+                                      description: |-
+                                        DiskEncryptionSet specifies the customer-managed disk encryption set resource id for the
+                                        managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and
+                                        VMGuest blob.
+                                      properties:
+                                        id:
+                                          description: ID defines resourceID for diskEncryptionSet
+                                            resource. It must be in the same subscription
+                                          type: string
+                                      type: object
+                                    securityEncryptionType:
+                                      description: |-
+                                        SecurityEncryptionType specifies the encryption type of the managed disk.
+                                        It is set to DiskWithVMGuestState to encrypt the managed disk along with the VMGuestState
+                                        blob, and to VMGuestStateOnly to encrypt the VMGuestState blob only.
+                                        When set to VMGuestStateOnly, VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        When set to DiskWithVMGuestState, EncryptionAtHost should be disabled, SecureBoot and
+                                        VirtualizedTrustedPlatformModule should be set to Enabled.
+                                        It can be set only for Confidential VMs.
+                                      enum:
+                                      - VMGuestStateOnly
+                                      - DiskWithVMGuestState
+                                      type: string
+                                  type: object
+                                storageAccountType:
+                                  type: string
+                              type: object
+                            nameSuffix:
+                              description: |-
+                                NameSuffix is the suffix to be appended to the machine name to generate the disk name.
+                                Each disk name will be in format <machineName>_<nameSuffix>.
+                              type: string
+                          required:
+                          - diskSizeGB
+                          - nameSuffix
+                          type: object
+                        type: array
                       encryptionAtHost:
                         description: EncryptionAtHost enables encryption at the VM
                           host.

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -223,6 +223,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 				Identity:               mpool.Identity.Type,
 				UserAssignedIdentities: userAssignedIdentities,
 				Diagnostics:            controlPlaneDiag,
+				DataDisks:              mpool.DataDisks,
 			},
 		}
 

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -79,6 +79,10 @@ type MachinePool struct {
 	// +kubebuilder:default=UserAssigned
 	// +optional
 	Identity *VMIdentity `json:"identity,omitempty"`
+
+	// DataDisk specifies the parameters that are used to add one or more data disks to the machine.
+	// +optional
+	DataDisks []capz.DataDisk `json:"dataDisks,omitempty"`
 }
 
 // SecuritySettings define the security type and the UEFI settings of the virtual machine.
@@ -230,6 +234,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.Identity != nil {
 		a.Identity = required.Identity
+	}
+
+	if required.DataDisks != nil {
+		a.DataDisks = required.DataDisks
 	}
 }
 

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -67,7 +67,7 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 		}
 	}
 	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, "", p, fldPath.Child("defaultMachinePlatform"))...)
+		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, "", p, nil, fldPath.Child("defaultMachinePlatform"))...)
 	}
 	if p.VirtualNetwork != "" {
 		if p.ComputeSubnet == "" {

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -98,7 +98,7 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	}
 	if p.Azure != nil {
 		validate(azure.Name, p.Azure, func(f *field.Path) field.ErrorList {
-			return azurevalidation.ValidateMachinePool(p.Azure, pool.Name, platform.Azure, f)
+			return azurevalidation.ValidateMachinePool(p.Azure, pool.Name, platform.Azure, pool, f)
 		})
 	}
 	if p.GCP != nil {


### PR DESCRIPTION
This PR adds to the machinepool a new field datadisks to allow a user to add additional disks at installation time.

### Changes

- Adds capz DataDisks slice to the machine pool
- Convert capz datadisk to mapi datadisk
- Adds new feature gate for azure multi disk
- Adds validation for datadisks
- Adds machine pool testing


### Additional PRs
- https://github.com/openshift/installer/pull/9706/files
- https://github.com/openshift/api/pull/2289
- https://github.com/openshift/enhancements/pull/1779
