### PR TITLE
OCPBUGS-56465: pkg/infrastructure/azure: Bubble ssh rule deltion error up to caller

### DIFF
--- a/pkg/infrastructure/azure/network.go
+++ b/pkg/infrastructure/azure/network.go
@@ -399,11 +399,11 @@ func deleteSecurityGroupRule(ctx context.Context, in *securityGroupInput) error 
 	securityRulesClient := in.networkClientFactory.NewSecurityRulesClient()
 	securityRulesPoller, err := securityRulesClient.BeginDelete(ctx, in.resourceGroupName, in.securityGroupName, in.securityRuleName, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete security rule: %w", err)
+		return err
 	}
 	_, err = securityRulesPoller.PollUntilDone(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete security rule: %w", err)
+		return err
 	}
 	return nil
 }
@@ -446,11 +446,11 @@ func deleteInboundNatRule(ctx context.Context, in *inboundNatRuleInput) error {
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to delete inbound nat rule: %w", err)
+		return err
 	}
 	_, err = inboundNatRulesPoller.PollUntilDone(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete inbound nat rule: %w", err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Bubbling up the error to see exactly where the deletion is failing. 

https://issues.redhat.com/browse/OCPBUGS-56465