### PR TITLE
OCPBUGS-57527: Add descriptions back to the aws survey

### DIFF
--- a/pkg/asset/installconfig/aws/platform.go
+++ b/pkg/asset/installconfig/aws/platform.go
@@ -25,8 +25,10 @@ func Platform() (*aws.Platform, error) {
 	for _, region := range regions {
 		if longName, ok := aws.RegionLookupMap[region]; ok {
 			longRegions = append(longRegions, fmt.Sprintf("%s (%s)", region, longName))
-			shortRegions = append(shortRegions, region)
+		} else {
+			longRegions = append(longRegions, region)
 		}
+		shortRegions = append(shortRegions, region)
 	}
 
 	var regionTransform survey.Transformer = func(ans interface{}) interface{} {

--- a/pkg/asset/installconfig/aws/platform.go
+++ b/pkg/asset/installconfig/aws/platform.go
@@ -3,8 +3,10 @@ package aws
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/types/aws"
@@ -17,6 +19,24 @@ func Platform() (*aws.Platform, error) {
 	regions, err := knownPublicRegions(architecture)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AWS public regions: %w", err)
+	}
+	longRegions := make([]string, 0, len(aws.RegionLookupMap))
+	shortRegions := make([]string, 0, len(aws.RegionLookupMap))
+	for _, region := range regions {
+		if longName, ok := aws.RegionLookupMap[region]; ok {
+			longRegions = append(longRegions, fmt.Sprintf("%s (%s)", region, longName))
+			shortRegions = append(shortRegions, region)
+		}
+	}
+
+	var regionTransform survey.Transformer = func(ans interface{}) interface{} {
+		switch v := ans.(type) {
+		case core.OptionAnswer:
+			return core.OptionAnswer{Value: strings.SplitN(v.Value, " ", 2)[0], Index: v.Index}
+		case string:
+			return strings.SplitN(v, " ", 2)[0]
+		}
+		return ""
 	}
 
 	defaultRegion := "us-east-1"
@@ -42,7 +62,8 @@ func Platform() (*aws.Platform, error) {
 		}
 	}
 
-	sort.Strings(regions)
+	sort.Strings(longRegions)
+	sort.Strings(shortRegions)
 
 	var region string
 	err = survey.Ask([]*survey.Question{
@@ -50,9 +71,18 @@ func Platform() (*aws.Platform, error) {
 			Prompt: &survey.Select{
 				Message: "Region",
 				Help:    "The AWS region to be used for installation.",
-				Default: defaultRegion,
-				Options: regions,
+				Default: fmt.Sprintf("%s (%s)", defaultRegion, aws.RegionLookupMap[defaultRegion]),
+				Options: longRegions,
 			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				choice := regionTransform(ans).(core.OptionAnswer).Value
+				i := sort.SearchStrings(shortRegions, choice)
+				if i == len(shortRegions) || shortRegions[i] != choice {
+					return fmt.Errorf("invalid region %q", choice)
+				}
+				return nil
+			}),
+			Transform: regionTransform,
 		},
 	}, &region)
 	if err != nil {

--- a/pkg/types/aws/regions.go
+++ b/pkg/types/aws/regions.go
@@ -1,0 +1,43 @@
+package aws
+
+var (
+	// RegionLookupMap is a static map containing the known AWS regions and the
+	// descriptive location information including the Continent and City/Area.
+	RegionLookupMap = map[string]string{
+		"af-south-1":     "Africa (Cape Town)",
+		"ap-east-1":      "Asia Pacific (Hong Kong)",
+		"ap-south-2":     "Asia Pacific (Hyderabad)",
+		"ap-southeast-3": "Asia Pacific (Jakarta)",
+		"ap-southeast-5": "Asia Pacific (Malaysia)",
+		"ap-southeast-4": "Asia Pacific (Melbourne)",
+		"ap-south-1":     "Asia Pacific (Mumbai)",
+		"ap-northeast-3": "Asia Pacific (Osaka)",
+		"ap-northeast-2": "Asia Pacific (Seoul)",
+		"ap-southeast-1": "Asia Pacific (Singapore)",
+		"ap-southeast-2": "Asia Pacific (Sydney)",
+		"ap-east-2":      "Asia Pacific (Taipei)",
+		"ap-southeast-7": "Asia Pacific (Thailand)",
+		"ap-northeast-1": "Asia Pacific (Tokyo)",
+		"us-gov-east-1":  "AWS GovCloud (US-East)",
+		"us-gov-west-1":  "AWS GovCloud (US-West)",
+		"ca-central-1":   "Canada (Central)",
+		"ca-west-1":      "Canada West (Calgary)",
+		"eu-central-1":   "Europe (Frankfurt)",
+		"eu-west-1":      "Europe (Ireland)",
+		"eu-west-2":      "Europe (London)",
+		"eu-south-1":     "Europe (Milan)",
+		"eu-west-3":      "Europe (Paris)",
+		"eu-south-2":     "Europe (Spain)",
+		"eu-north-1":     "Europe (Stockholm)",
+		"eu-central-2":   "Europe (Zurich)",
+		"il-central-1":   "Israel (Tel Aviv)",
+		"mx-central-1":   "Mexico (Central)",
+		"me-south-1":     "Middle East (Bahrain)",
+		"me-central-1":   "Middle East (UAE)",
+		"sa-east-1":      "South America (São Paulo)",
+		"us-east-1":      "US East (N. Virginia)",
+		"us-east-2":      "US East (Ohio)",
+		"us-west-1":      "US West (N. California)",
+		"us-west-2":      "US West (Oregon)",
+	}
+)


### PR DESCRIPTION
pkg/types/aws/regions.go: Create a map of the region to the descriptive name
pkg/asset/installconfig/aws/platform.go: Add the description information to the survey.