### PR TITLE
OCPBUGS-59678: PowerVS Support VPC and TG ids

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -7102,15 +7102,15 @@ spec:
                       instance during cluster creation.
                     type: string
                   tgName:
-                    description: TGName is the name of a pre-created TransitGateway
+                    description: tgName is the name or id of a pre-created TransitGateway
                       inside IBM Cloud.
                     type: string
                   userID:
                     description: UserID is the login for the user's IBM Cloud account.
                     type: string
                   vpcName:
-                    description: VPCName is the name of a pre-created VPC inside IBM
-                      Cloud.
+                    description: vpcName is the name or id of a pre-created VPC inside
+                      IBM Cloud.
                     type: string
                   vpcRegion:
                     description: |-

--- a/pkg/asset/cluster/powervs/powervs.go
+++ b/pkg/asset/cluster/powervs/powervs.go
@@ -38,6 +38,7 @@ func Metadata(config *types.InstallConfig, meta *icpowervs.Metadata) (*powervs.M
 		Zone:                 config.Platform.PowerVS.Zone,
 		ServiceInstanceGUID:  config.Platform.PowerVS.ServiceInstanceGUID,
 		ServiceEndpoints:     overrides,
-		TransitGatewayName:   config.Platform.PowerVS.TGName,
+		TransitGateway:       config.Platform.PowerVS.TransitGateway,
+		VPC:                  config.Platform.PowerVS.VPC,
 	}, nil
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -355,6 +355,21 @@ func (mr *MockAPIMockRecorder) GetTGConnectionVPC(ctx, gatewayID, vpcSubnetID an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTGConnectionVPC", reflect.TypeOf((*MockAPI)(nil).GetTGConnectionVPC), ctx, gatewayID, vpcSubnetID)
 }
 
+// GetVPCByID mocks base method.
+func (m *MockAPI) GetVPCByID(ctx context.Context, vpcID, region string) (*vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCByID", ctx, vpcID, region)
+	ret0, _ := ret[0].(*vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCByID indicates an expected call of GetVPCByID.
+func (mr *MockAPIMockRecorder) GetVPCByID(ctx, vpcID, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCByID", reflect.TypeOf((*MockAPI)(nil).GetVPCByID), ctx, vpcID, region)
+}
+
 // GetVPCByName mocks base method.
 func (m *MockAPI) GetVPCByName(ctx context.Context, vpcName string) (*vpcv1.VPC, error) {
 	m.ctrl.T.Helper()
@@ -489,17 +504,31 @@ func (mr *MockAPIMockRecorder) SetVPCServiceURLForRegion(ctx, region any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVPCServiceURLForRegion", reflect.TypeOf((*MockAPI)(nil).SetVPCServiceURLForRegion), ctx, region)
 }
 
-// TransitGatewayID mocks base method.
-func (m *MockAPI) TransitGatewayID(ctx context.Context, name string) (string, error) {
+// TransitGatewayIDValid mocks base method.
+func (m *MockAPI) TransitGatewayIDValid(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransitGatewayID", ctx, name)
+	ret := m.ctrl.Call(m, "TransitGatewayIDValid", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TransitGatewayIDValid indicates an expected call of TransitGatewayIDValid.
+func (mr *MockAPIMockRecorder) TransitGatewayIDValid(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitGatewayIDValid", reflect.TypeOf((*MockAPI)(nil).TransitGatewayIDValid), ctx, id)
+}
+
+// TransitGatewayNameToID mocks base method.
+func (m *MockAPI) TransitGatewayNameToID(ctx context.Context, name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransitGatewayNameToID", ctx, name)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// TransitGatewayID indicates an expected call of TransitGatewayID.
-func (mr *MockAPIMockRecorder) TransitGatewayID(ctx, name any) *gomock.Call {
+// TransitGatewayNameToID indicates an expected call of TransitGatewayNameToID.
+func (mr *MockAPIMockRecorder) TransitGatewayNameToID(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitGatewayID", reflect.TypeOf((*MockAPI)(nil).TransitGatewayID), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitGatewayNameToID", reflect.TypeOf((*MockAPI)(nil).TransitGatewayNameToID), ctx, name)
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsmetadata_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsmetadata_generated.go
@@ -40,36 +40,6 @@ func (m *MockMetadataAPI) EXPECT() *MockMetadataAPIMockRecorder {
 	return m.recorder
 }
 
-// APIKey mocks base method.
-func (m *MockMetadataAPI) APIKey(ctx context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIKey", ctx)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// APIKey indicates an expected call of APIKey.
-func (mr *MockMetadataAPIMockRecorder) APIKey(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIKey", reflect.TypeOf((*MockMetadataAPI)(nil).APIKey), ctx)
-}
-
-// AccountID mocks base method.
-func (m *MockMetadataAPI) AccountID(ctx context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AccountID", ctx)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AccountID indicates an expected call of AccountID.
-func (mr *MockMetadataAPIMockRecorder) AccountID(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountID", reflect.TypeOf((*MockMetadataAPI)(nil).AccountID), ctx)
-}
-
 // CISInstanceCRN mocks base method.
 func (m *MockMetadataAPI) CISInstanceCRN(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -67,7 +67,7 @@ var (
 	validVPCID             = "valid-id"
 	anotherValidVPCID      = "another-valid-id"
 	validVPC               = "valid-vpc"
-	setValidVPCName        = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPCName = validVPC }
+	setValidVPCName        = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPC = validVPC }
 	anotherValidVPC        = "another-valid-vpc"
 	invalidVPC             = "bogus-vpc"
 	validVPCs              = []vpcv1.VPC{
@@ -320,7 +320,7 @@ func TestValidateCustomVPCSettings(t *testing.T) {
 			name: "invalid VPC name supplied, without VPC region, not found near PowerVS region",
 			edits: editFunctions{
 				func(ic *types.InstallConfig) {
-					ic.Platform.PowerVS.VPCName = invalidVPC
+					ic.Platform.PowerVS.VPC = invalidVPC
 				},
 			},
 			errorMsg: fmt.Sprintf(`VPC.vpcName: Not found: "%s"`, invalidVPC),

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -3,7 +3,9 @@ package powervs
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/types"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
@@ -24,13 +27,17 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		network            string
 		dhcpSubnet         string
 		service            capibm.IBMPowerVSResourceReference
-		vpcName            string
+		vpcNameOrID        string
+		vpcStruct          *vpcv1.VPC
 		vpcRegion          string
-		transitGatewayName string
 		cosName            string
 		cosRegion          string
 		imageName          string
 		bucketName         string
+		transitGatewayName string
+		client             *powervsconfig.Client
+		vpcResourceRef     *capibm.VPCResourceReference
+		transitGateway     *capibm.TransitGateway
 		err                error
 		powerVSCluster     *capibm.IBMPowerVSCluster
 		powerVSImage       *capibm.IBMPowerVSImage
@@ -40,8 +47,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		logrus.Debugf("GenerateClusterAssets: installConfig = %+v, clusterID = %v, bucket = %v, object = %v", installConfig, *clusterID, bucket, object)
 		logrus.Debugf("GenerateClusterAssets: ic.ObjectMeta = %+v", installConfig.Config.ObjectMeta.Name)
 		logrus.Debugf("GenerateClusterAssets: installConfig.Config.PowerVS = %+v", *installConfig.Config.PowerVS)
-		logrus.Debugf("GenerateClusterAssets: vpcName = %v", vpcName)
+		logrus.Debugf("GenerateClusterAssets: installConfig.Config.Platform.PowerVS.VPC = %v", installConfig.Config.Platform.PowerVS.VPC)
+		logrus.Debugf("GenerateClusterAssets: vpcNameOrID = %v", vpcNameOrID)
 		logrus.Debugf("GenerateClusterAssets: vpcRegion = %v", vpcRegion)
+		logrus.Debugf("GenerateClusterAssets: installConfig.Config.Platform.PowerVS.TransitGateway = %v", installConfig.Config.Platform.PowerVS.TransitGateway)
 		logrus.Debugf("GenerateClusterAssets: transitGatewayName = %v", transitGatewayName)
 		logrus.Debugf("GenerateClusterAssets: cosName = %v", cosName)
 		logrus.Debugf("GenerateClusterAssets: cosRegion = %v", cosRegion)
@@ -73,10 +82,13 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		}
 	}
 
-	vpcName = installConfig.Config.Platform.PowerVS.VPCName
-	if vpcName == "" {
-		vpcName = fmt.Sprintf("vpc-%s", clusterID.InfraID)
+	client, err = powervsconfig.NewClient()
+	if err != nil {
+		return nil, err
 	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	defer cancel()
 
 	vpcRegion = installConfig.Config.Platform.PowerVS.VPCRegion
 	if vpcRegion == "" {
@@ -85,9 +97,65 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		}
 	}
 
-	transitGatewayName = installConfig.Config.Platform.PowerVS.TGName
-	if transitGatewayName == "" {
-		transitGatewayName = fmt.Sprintf("%s-tg", clusterID.InfraID)
+	// The VPC specified can be either:
+	// 1) blank - CAPI will create one for us.
+	// 2) an id of an existing VPC.
+	// 3) a name of an existing VPC.
+	vpcNameOrID = installConfig.Config.Platform.PowerVS.VPC
+	if vpcStruct, err = client.GetVPCByID(ctx, vpcNameOrID, vpcRegion); err == nil {
+		// #2
+		logrus.Debugf("GenerateClusterAssets: PowerVS.VPC ID is valid")
+
+		vpcResourceRef = &capibm.VPCResourceReference{
+			ID:     &installConfig.Config.Platform.PowerVS.VPC,
+			Region: &vpcRegion,
+		}
+	} else if vpcStruct, err = client.GetVPCByName(ctx, vpcNameOrID); err == nil {
+		// #3
+		logrus.Debugf("GenerateClusterAssets: PowerVS.VPC Name is valid")
+
+		vpcResourceRef = &capibm.VPCResourceReference{
+			Name:   &vpcNameOrID,
+			Region: &vpcRegion,
+		}
+	} else {
+		if vpcNameOrID == "" {
+			// #1
+			logrus.Debugf("GenerateClusterAssets: PowerVS.VPC is empty")
+
+			vpcNameOrID = fmt.Sprintf("vpc-%s", clusterID.InfraID)
+			vpcStruct = nil
+
+			vpcResourceRef = &capibm.VPCResourceReference{
+				Name:   &vpcNameOrID,
+				Region: &vpcRegion,
+			}
+		} else {
+			return nil, fmt.Errorf("generateClusterAssets could not handle vpc")
+		}
+	}
+
+	// The Transit Gateway can be either:
+	// 1) blank - CAPI will create one for us.
+	// 2) an id of an existing TG.
+	// 3) a name of an existing TG.
+	transitGatewayName = installConfig.Config.Platform.PowerVS.TransitGateway
+	if err = client.TransitGatewayIDValid(ctx, transitGatewayName); err == nil {
+		logrus.Debugf("GenerateClusterAssets: TG ID is valid")
+
+		transitGateway = &capibm.TransitGateway{
+			ID: &installConfig.Config.Platform.PowerVS.TransitGateway,
+		}
+	} else {
+		if transitGatewayName == "" {
+			logrus.Debugf("GenerateClusterAssets: PowerVS.TransitGateway is empty")
+
+			transitGatewayName = fmt.Sprintf("%s-tg", clusterID.InfraID)
+		}
+
+		transitGateway = &capibm.TransitGateway{
+			Name: &transitGatewayName,
+		}
 	}
 
 	cosName = fmt.Sprintf("%s-cos", clusterID.InfraID)
@@ -124,13 +192,8 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			ResourceGroup: &capibm.IBMPowerVSResourceReference{
 				Name: &installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
 			},
-			VPC: &capibm.VPCResourceReference{
-				Name:   &vpcName,
-				Region: &vpcRegion,
-			},
-			TransitGateway: &capibm.TransitGateway{
-				Name: &transitGatewayName,
-			},
+			VPC:            vpcResourceRef,
+			TransitGateway: transitGateway,
 			LoadBalancers: []capibm.VPCLoadBalancerSpec{
 				{
 					Name:   fmt.Sprintf("%s-loadbalancer", clusterID.InfraID),
@@ -173,13 +236,13 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	// Use a custom resolver if using an Internal publishing strategy
 	if installConfig.Config.Publish == types.InternalPublishingStrategy {
 		var dnsServerIP string
-		err := installConfig.PowerVS.EnsureVPCNameIsSpecifiedForInternal(installConfig.Config.PowerVS.VPCName)
+		err := installConfig.PowerVS.EnsureVPCNameIsSpecifiedForInternal(installConfig.Config.PowerVS.VPC)
 		if err != nil {
 			return nil, err
 		}
-		dnsServerIP, err = installConfig.PowerVS.GetDNSServerIP(context.TODO(), installConfig.Config.PowerVS.VPCName)
+		dnsServerIP, err = installConfig.PowerVS.GetDNSServerIP(ctx, installConfig.Config.PowerVS.VPC)
 		if err != nil {
-			return nil, fmt.Errorf("unable to find a DNS server for specified VPC: %s %w", installConfig.Config.PowerVS.VPCName, err)
+			return nil, fmt.Errorf("unable to find a DNS server for specified VPC: %s %w", installConfig.Config.PowerVS.VPC, err)
 		}
 
 		powerVSCluster.Spec.DHCPServer.DNSServer = &dnsServerIP
@@ -188,17 +251,16 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	}
 
 	// If a VPC was specified, pass all subnets in it to cluster API
-	if installConfig.Config.Platform.PowerVS.VPCName != "" {
-		logrus.Debugf("GenerateClusterAssets: VPCName = %s", installConfig.Config.Platform.PowerVS.VPCName)
+	if vpcStruct != nil {
 		if installConfig.Config.Publish == types.InternalPublishingStrategy {
-			err = installConfig.PowerVS.EnsureVPCIsPermittedNetwork(context.TODO(), installConfig.Config.PowerVS.VPCName)
+			err = installConfig.PowerVS.EnsureVPCIsPermittedNetwork(ctx, vpcStruct)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("error ensuring VPC is permitted: %s %w", installConfig.Config.PowerVS.VPCName, err)
+			return nil, fmt.Errorf("error ensuring VPC is permitted: %s %w", *vpcStruct.Name, err)
 		}
-		subnets, err := installConfig.PowerVS.GetVPCSubnets(context.TODO(), vpcName)
+		subnets, err := installConfig.PowerVS.GetVPCSubnets(ctx, vpcStruct)
 		if err != nil {
-			return nil, fmt.Errorf("error getting subnets in specified VPC: %s %w", installConfig.Config.PowerVS.VPCName, err)
+			return nil, fmt.Errorf("error getting subnets in specified VPC: %s %w", *vpcStruct.Name, err)
 		}
 		for _, subnet := range subnets {
 			powerVSCluster.Spec.VPCSubnets = append(powerVSCluster.Spec.VPCSubnets,

--- a/pkg/destroy/powervs/cloud-transit-gateways.go
+++ b/pkg/destroy/powervs/cloud-transit-gateways.go
@@ -699,7 +699,7 @@ func (o *ClusterUninstaller) destroyTransitGateways() error {
 	)
 
 	// Old style: delete all TGs matching by name
-	if o.TransitGatewayName == "" {
+	if o.TransitGateway == "" {
 		return o.innerDestroyTransitGateways()
 	}
 

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -69,19 +69,19 @@ type User struct {
 
 // ClusterUninstaller holds the various options for the cluster we want to delete.
 type ClusterUninstaller struct {
-	APIKey             string
-	BaseDomain         string
-	CISInstanceCRN     string
-	ClusterName        string
-	DNSInstanceCRN     string
-	DNSZone            string
-	InfraID            string
-	Logger             logrus.FieldLogger
-	Region             string
-	ServiceGUID        string
-	VPCRegion          string
-	Zone               string
-	TransitGatewayName string
+	APIKey         string
+	BaseDomain     string
+	CISInstanceCRN string
+	ClusterName    string
+	DNSInstanceCRN string
+	DNSZone        string
+	InfraID        string
+	Logger         logrus.FieldLogger
+	Region         string
+	ServiceGUID    string
+	VPCRegion      string
+	Zone           string
+	TransitGateway string
 
 	managementSvc      *resourcemanagerv2.ResourceManagerV2
 	controllerSvc      *resourcecontrollerv2.ResourceControllerV2
@@ -141,7 +141,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.VPCRegion = %v", metadata.ClusterPlatformMetadata.PowerVS.VPCRegion)
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.Zone = %v", metadata.ClusterPlatformMetadata.PowerVS.Zone)
 	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID = %v", metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID)
-	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName = %v", metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName)
+	logger.Debugf("powervs.New: metadata.ClusterPlatformMetadata.PowerVS.TransitGateway = %v", metadata.ClusterPlatformMetadata.PowerVS.TransitGateway)
 
 	// Handle an optional setting in install-config.yaml
 	if metadata.ClusterPlatformMetadata.PowerVS.VPCRegion == "" {
@@ -170,7 +170,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		pendingItemTracker: newPendingItemTracker(),
 		resourceGroupID:    metadata.ClusterPlatformMetadata.PowerVS.PowerVSResourceGroup,
 		ServiceGUID:        metadata.ClusterPlatformMetadata.PowerVS.ServiceInstanceGUID,
-		TransitGatewayName: metadata.ClusterPlatformMetadata.PowerVS.TransitGatewayName,
+		TransitGateway:     metadata.ClusterPlatformMetadata.PowerVS.TransitGateway,
 		searchByTag:        false, // @TODO Enable in the future
 		siPreconfigured:    siPreconfigured,
 	}, nil

--- a/pkg/types/powervs/metadata.go
+++ b/pkg/types/powervs/metadata.go
@@ -13,5 +13,6 @@ type Metadata struct {
 	Zone                 string                            `json:"zone"`
 	ServiceInstanceGUID  string                            `json:"serviceInstanceGUID"`
 	ServiceEndpoints     []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
-	TransitGatewayName   string                            `json:"transitGatewayName"`
+	TransitGateway       string                            `json:"transitGatewayName"`
+	VPC                  string                            `json:"vpcName"`
 }

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -27,10 +27,10 @@ type Platform struct {
 	// UserID is the login for the user's IBM Cloud account.
 	UserID string `json:"userID"`
 
-	// VPCName is the name of a pre-created VPC inside IBM Cloud.
+	// vpcName is the name or id of a pre-created VPC inside IBM Cloud.
 	//
 	// +optional
-	VPCName string `json:"vpcName,omitempty"`
+	VPC string `json:"vpcName,omitempty"`
 
 	// VPCSubnets specifies existing subnets (by ID) where cluster
 	// resources will be created.  Leave unset to have the installer
@@ -48,23 +48,26 @@ type Platform struct {
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on Power VS for machine pools which do not define their own
 	// platform configuration.
+	//
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 
 	// ServiceInstanceGUID is the GUID of the Power IAAS instance created from the IBM Cloud Catalog
 	// before the cluster is completed.  Leave unset to allow the installer to create a service
 	// instance during cluster creation.
+	//
 	// +optional
 	ServiceInstanceGUID string `json:"serviceInstanceGUID,omitempty"`
 
 	// ServiceEndpoints is a list which contains custom endpoints to override default
 	// service endpoints of IBM Cloud Services.
 	// There must only be one ServiceEndpoint for a service (no duplicates).
+	//
 	// +optional
 	ServiceEndpoints []configv1.PowerVSServiceEndpoint `json:"serviceEndpoints,omitempty"`
 
-	// TGName is the name of a pre-created TransitGateway inside IBM Cloud.
+	// tgName is the name or id of a pre-created TransitGateway inside IBM Cloud.
 	//
 	// +optional
-	TGName string `json:"tgName,omitempty"`
+	TransitGateway string `json:"tgName,omitempty"`
 }

--- a/pkg/types/powervs/validation/machinepool_test.go
+++ b/pkg/types/powervs/validation/machinepool_test.go
@@ -142,7 +142,7 @@ func TestValidateMachinePool(t *testing.T) {
 			pool: &powervs.MachinePool{
 				SysType: "p922",
 			},
-			expected: `^test-path\.sysType: Invalid value: "p922": unknown system type specified$`,
+			expected: `^test-path\.sysType: Invalid value: "p922": unknown system type specified.*$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Currently you can only specify a name for an existing Transit Gateway or Virtual Private Cloud.  This can lead to issues since names are not guaranteed to be unique.  So allow a UUID instead of a name.