### PR TITLE
OCPBUGS-57732: Catch gcp destroy cases where the operation is nil

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -416,7 +416,11 @@ func (o *ClusterUninstaller) handleOperation(ctx context.Context, op *compute.Op
 		identifier = []string{item.typeName, item.zone, item.name}
 	}
 
-	if err != nil && !isNoOp(err) {
+	if err != nil {
+		if isNoOp(err) {
+			o.Logger.Debugf("No operation found for %s %s", resourceType, item.name)
+			return nil
+		}
 		o.resetRequestID(identifier...)
 		return fmt.Errorf("failed to delete %s %s: %w", resourceType, item.name, err)
 	}


### PR DESCRIPTION
pkg/destroy/gcp/gcp.go:
** In the case where no error exists but the operation is nil when passed into gcp.go:handleOperation the destroy process would cause a system panic. Now create an error in this case so that the destroy process will continue and retry if there are more pending items.