### PR TITLE
OCPBUGS-58352: Increase timeout on gcp wait for operation

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/operation.go
+++ b/pkg/infrastructure/gcp/clusterapi/operation.go
@@ -3,7 +3,6 @@ package clusterapi
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"google.golang.org/api/compute/v1"
 )
@@ -11,9 +10,6 @@ import (
 // WaitForOperationGlobal will attempt to wait for a operation to complete where the operational
 // resource is globally scoped.
 func WaitForOperationGlobal(ctx context.Context, projectID string, operation *compute.Operation) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
-	defer cancel()
-
 	service, err := NewComputeService()
 	if err != nil {
 		return err
@@ -21,7 +17,7 @@ func WaitForOperationGlobal(ctx context.Context, projectID string, operation *co
 
 	g := compute.NewGlobalOperationsService(service)
 	if _, err := g.Wait(projectID, operation.Name).Context(ctx).Do(); err != nil {
-		return fmt.Errorf("failed to wait for regional operation: %w", err)
+		return fmt.Errorf("failed to wait for global operation: %w", err)
 	}
 
 	return nil
@@ -30,9 +26,6 @@ func WaitForOperationGlobal(ctx context.Context, projectID string, operation *co
 // WaitForOperationRegional will attempt to wait for a operation to complete where the operational
 // resource is regionally scoped.
 func WaitForOperationRegional(ctx context.Context, projectID, region string, operation *compute.Operation) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
-	defer cancel()
-
 	service, err := NewComputeService()
 	if err != nil {
 		return err


### PR DESCRIPTION
** The child context was set at 1 minute. This should be long enough to determine if an operation has completed. However, the HIVE team noticed a timeout. Increasing the timeout to 2 minutes for the wait for operation.