### PR TITLE
feat: Add metadata to the baremetal hosts from install-config.yaml

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -90,10 +90,7 @@ func createBaremetalHost(host *baremetal.Host, bmc baremetalhost.BMCDetails) bar
 			APIVersion: baremetalhost.GroupVersion.String(),
 			Kind:       "BareMetalHost",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      host.Name,
-			Namespace: "openshift-machine-api",
-		},
+		ObjectMeta: host.ObjectMeta,
 		Spec: baremetalhost.BareMetalHostSpec{
 			Online:          true,
 			BMC:             bmc,
@@ -103,6 +100,8 @@ func createBaremetalHost(host *baremetal.Host, bmc baremetalhost.BMCDetails) bar
 			RootDeviceHints: host.RootDeviceHints.MakeCRDHints(),
 		},
 	}
+	newHost.ObjectMeta.Name = host.Name
+	newHost.ObjectMeta.Namespace = "openshift-machine-api"
 
 	return newHost
 }
@@ -164,9 +163,10 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 				Method: "install_coreos",
 			}
 
-			newHost.ObjectMeta.Labels = map[string]string{
-				"installer.openshift.io/role": "control-plane",
+			if newHost.ObjectMeta.Labels == nil {
+				newHost.ObjectMeta.Labels = map[string]string{}
 			}
+			newHost.ObjectMeta.Labels["installer.openshift.io/role"] = "control-plane"
 
 			// Link the new host to the currently available machine
 			machine := machines[numMasters]
@@ -183,9 +183,10 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 			numMasters++
 		} else {
 			// Pause workers until the real control plane is up.
-			newHost.ObjectMeta.Annotations = map[string]string{
-				"baremetalhost.metal3.io/paused": "",
+			if newHost.ObjectMeta.Annotations == nil {
+				newHost.ObjectMeta.Annotations = map[string]string{}
 			}
+			newHost.ObjectMeta.Annotations["baremetalhost.metal3.io/paused"] = ""
 		}
 
 		settings.Hosts = append(settings.Hosts, newHost)

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -447,6 +447,15 @@ routes:
 					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy(),
 				).build(),
 		},
+		{
+			Scenario: "host-with-custom-metadata",
+			Machines: machines(machine("machine-0")),
+			Config:   configHosts(hostType("master-0").bmc("usr0", "pwd0").annotation("custom.openshift.io/example", "test-value")),
+
+			ExpectedSetting: settings().
+				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
+				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").annotation("custom.openshift.io/example", "test-value").customDeploy()).build(),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -566,6 +575,15 @@ func (htb *hostTypeBuilder) bmc(user, password string) *hostTypeBuilder {
 
 func (htb *hostTypeBuilder) networkConfig(config string) *hostTypeBuilder {
 	yaml.Unmarshal([]byte(config), &htb.NetworkConfig)
+	return htb
+}
+
+func (htb *hostTypeBuilder) annotation(key, value string) *hostTypeBuilder {
+	if htb.ObjectMeta.Annotations == nil {
+		htb.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	htb.ObjectMeta.Annotations[key] = value
 	return htb
 }
 

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -2,6 +2,7 @@ package baremetal
 
 import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -44,6 +45,7 @@ type Host struct {
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
 	BootMode        BootMode         `json:"bootMode,omitempty"`
 	NetworkConfig   *apiextv1.JSON   `json:"networkConfig,omitempty"`
+	ObjectMeta      v1.ObjectMeta    `json:"metadata,omitempty"`
 }
 
 // IsMaster checks if the current host is a master


### PR DESCRIPTION
Users may wish to add additional customer labels and annotations to help with inventory and control purposes.

Fixes #9826