### PR TITLE
OCPBUGS-58117: Update RHCOS 4.20 bootimage metadata to 9.6.20250701-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,106 +1,106 @@
 {
   "stream": "rhcos-4.20",
   "metadata": {
-    "last-modified": "2025-05-25T02:15:43Z",
-    "generator": "plume cosa2stream 6ec2120"
+    "last-modified": "2025-07-08T21:02:24Z",
+    "generator": "plume cosa2stream 78a253b"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-aws.aarch64.vmdk.gz",
-                "sha256": "89bf6b12bd742bd413847162110afddad5401467608c2bcaae57eba2dfc4ba2e",
-                "uncompressed-sha256": "7311cd6b5acbd71da4ac4f1ad8a8c3e737780d7f24de0ec16c96e7e0d1a1361d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-aws.aarch64.vmdk.gz",
+                "sha256": "8dc078ce7ff484ea865d2617113dcb9607f7324a2c01b4ef8a3d49ea259068c1",
+                "uncompressed-sha256": "50f55ea1f155b6c5e6651fd43580d4017ccfe6b0adeca86078c68932879ad00c"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-azure.aarch64.vhd.gz",
-                "sha256": "362e30ce30d36afaea3472d697ba2f8be3606def3b54dcf6c9c61cb136635261",
-                "uncompressed-sha256": "cb23c68e3d1429ad48a386f1479e37ba1e75fa00cf6f0faa8539a2aebbf00348"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-azure.aarch64.vhd.gz",
+                "sha256": "37f8f4a1108932d2273fd60a71ef69526ad09f5e604032cac383e42a86705489",
+                "uncompressed-sha256": "62234d6cee408957c0948009d2886141c94598a3c6c1771136bd150e2d902018"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-gcp.aarch64.tar.gz",
-                "sha256": "143b31b5e4f4cf8fc52b56bed06eb30a40c55ed8bdb1022462519b3fbf7dbb28"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-gcp.aarch64.tar.gz",
+                "sha256": "204ae8938512ee028f5fee34940fe003dcde53b62426349ff81077fe96ccd66a"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-metal4k.aarch64.raw.gz",
-                "sha256": "c08e43a1afc05f22e37d8d8c608db64fda31cf0f4d26d64f403be9c2de34beed",
-                "uncompressed-sha256": "99267d7a0c7273ed038b6870810d3033d138993cbb95bf800a464ab14c8227b7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-metal4k.aarch64.raw.gz",
+                "sha256": "5b0f79017571e366ec738fdbc4c3787bd8d8082fedd693a9f6e9dfb082e6123f",
+                "uncompressed-sha256": "8a4681ed8abd8c623d5b5f90ef3f744e038ca693bf0061be373bedd98ca796f2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-live-iso.aarch64.iso",
-                "sha256": "32dd6902bee250cd0a8fbefcd74d384a5457a66677ac9384def532b974b91a12"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-live-iso.aarch64.iso",
+                "sha256": "42ec46a078572912ed611e0c2c4d2be03d63fe84aebb69ae6bac993e3d2e4394"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-live-kernel.aarch64",
-                "sha256": "cfb1ce9579e03f1ab39c72fb396795078caa2a42fb48fc5a4b3c67fe09f0cac5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-live-kernel.aarch64",
+                "sha256": "3ac1eca7c85bd0ab4b175347fb8000c98519e241ed7101cfba77f888a616f235"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-live-initramfs.aarch64.img",
-                "sha256": "35b4ca8db6a0be9d03fb4c8859f4515d8ee9b5c6715182a108d53ccc50f667ef"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-live-initramfs.aarch64.img",
+                "sha256": "0e487bc541bdf8e5d95b9a528455773549a4606ef6e69721460538701aedac77"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-live-rootfs.aarch64.img",
-                "sha256": "edb15c50f8baf7fc0390f937b5f6c1d8655e6cbb3ff62111fd0db85b90153eab"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-live-rootfs.aarch64.img",
+                "sha256": "0e38acbb150234ad4d69fed79eabf359c8dc8e42f357e1d04b3599e21622dc6f"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-metal.aarch64.raw.gz",
-                "sha256": "0d7eb3caec1483e434a1c2b7d2f2b41c9227b64b1a93a1dec5af59062976cfc5",
-                "uncompressed-sha256": "27a08dd1c2e86ace3cefdea051707d0d66572c87b1e4679bbcc22dc2cea1f1aa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-metal.aarch64.raw.gz",
+                "sha256": "8c08badf530be6d94a6c6763efdf1bf3e98bdb15c3eeb16c9b46a501e6096b5f",
+                "uncompressed-sha256": "88c4b205f59aa228090f9b19cef99a0452a37e1162de63a059833b9a7c386aca"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-openstack.aarch64.qcow2.gz",
-                "sha256": "3cea89503fc35f2a8464d34ea94fb282d7420b5e7a7c3316e4f6facaeffb730f",
-                "uncompressed-sha256": "06b88f26e9baf43e3d47f03b5c1dda91e19bd46b841f4c570e727f2263c735f5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-openstack.aarch64.qcow2.gz",
+                "sha256": "3c0ea1ea6ec722b2b36d744197f616babf8a46a34062b2e23f46f121fce01e00",
+                "uncompressed-sha256": "a2e17ce68bf31408acd72147cb6e1c73893fad807cff28826c77ee2753072427"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/aarch64/rhcos-9.6.20250523-0-qemu.aarch64.qcow2.gz",
-                "sha256": "0cf33bfd3206e4df660ec79e3f3c53c381d962579f018f8a84a22b8a9177875a",
-                "uncompressed-sha256": "4bdd44a9f91802d0e1f4ec2cd9a4af4f2bb72b2da212f2009ecb34dc728196f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/aarch64/rhcos-9.6.20250701-0-qemu.aarch64.qcow2.gz",
+                "sha256": "e1c667debe5ae7f726de47a57137d9f822fdcd7d687d47e110e16282840ceb77",
+                "uncompressed-sha256": "51cde8e50c52a58c0e0825722e0819b65496cd8b3ea4ebad610a7ad65387dbdb"
               }
             }
           }
@@ -110,229 +110,233 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-009231bfc2490c6f9"
+              "release": "9.6.20250701-0",
+              "image": "ami-0ff561b9a6261fac9"
             },
             "ap-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0a23fad8fb25f5bb7"
+              "release": "9.6.20250701-0",
+              "image": "ami-0afe0c55043adaf0a"
+            },
+            "ap-east-2": {
+              "release": "9.6.20250701-0",
+              "image": "ami-09e3bf4a7e74ce7db"
             },
             "ap-northeast-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0754a269f165f227c"
+              "release": "9.6.20250701-0",
+              "image": "ami-049ef84221f8c41fb"
             },
             "ap-northeast-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0d81f596571ce27d8"
+              "release": "9.6.20250701-0",
+              "image": "ami-08a972c2bc8a15c46"
             },
             "ap-northeast-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-01eb2f8b176229523"
+              "release": "9.6.20250701-0",
+              "image": "ami-033695428741399bd"
             },
             "ap-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0be3b34441044e437"
+              "release": "9.6.20250701-0",
+              "image": "ami-05ac23294a4ae1451"
             },
             "ap-south-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-02a86359661950bb0"
+              "release": "9.6.20250701-0",
+              "image": "ami-0228c2964a198026b"
             },
             "ap-southeast-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0c70d35c9b5b190be"
+              "release": "9.6.20250701-0",
+              "image": "ami-0ba39a0e658a28b9b"
             },
             "ap-southeast-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0310f2acbeca636ed"
+              "release": "9.6.20250701-0",
+              "image": "ami-00c57db622051df7b"
             },
             "ap-southeast-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-04db4055063382442"
+              "release": "9.6.20250701-0",
+              "image": "ami-0aab399b5d22e4302"
             },
             "ap-southeast-4": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e2e40cc31633d7d6"
+              "release": "9.6.20250701-0",
+              "image": "ami-07b9d012be3de4f52"
             },
             "ap-southeast-5": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0cf0c9ee9f324f763"
+              "release": "9.6.20250701-0",
+              "image": "ami-06a69920498a19505"
             },
             "ap-southeast-7": {
-              "release": "9.6.20250523-0",
-              "image": "ami-04cdafcdc85bf9040"
+              "release": "9.6.20250701-0",
+              "image": "ami-08cd8521bbeef13da"
             },
             "ca-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0aee20271a9396925"
+              "release": "9.6.20250701-0",
+              "image": "ami-0ab3d3804935c276d"
             },
             "ca-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-03ca778cd4265aad9"
+              "release": "9.6.20250701-0",
+              "image": "ami-029e68d76a61871b1"
             },
             "eu-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0281dddee0884d9f0"
+              "release": "9.6.20250701-0",
+              "image": "ami-097ddc2cc5a145e29"
             },
             "eu-central-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-00fc4e5e3926530af"
+              "release": "9.6.20250701-0",
+              "image": "ami-056269e07d092d729"
             },
             "eu-north-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0696b5b31d326ccc6"
+              "release": "9.6.20250701-0",
+              "image": "ami-08f4d022a29e9eca7"
             },
             "eu-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-04090792b7bdb9e0f"
+              "release": "9.6.20250701-0",
+              "image": "ami-0c5e7ad0cce0b5b68"
             },
             "eu-south-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0d45a2586055d5daa"
+              "release": "9.6.20250701-0",
+              "image": "ami-0aff54e74e2bf4555"
             },
             "eu-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-02f08479c3613ed0e"
+              "release": "9.6.20250701-0",
+              "image": "ami-054cb427389152da1"
             },
             "eu-west-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0ef2fc25f02a2d475"
+              "release": "9.6.20250701-0",
+              "image": "ami-087742c9801577ca8"
             },
             "eu-west-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0ba5d0a0e5d796da8"
+              "release": "9.6.20250701-0",
+              "image": "ami-0695977d7105dd264"
             },
             "il-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e5b8f3b8e71961e7"
+              "release": "9.6.20250701-0",
+              "image": "ami-0b83bc614ecbb4381"
             },
             "me-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0d13d6a91da2ba547"
+              "release": "9.6.20250701-0",
+              "image": "ami-020f780ada6ae8dad"
             },
             "me-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0183dab9f96845e3f"
+              "release": "9.6.20250701-0",
+              "image": "ami-012fa36dc30f5e43c"
             },
             "mx-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-072535d81a5de8e76"
+              "release": "9.6.20250701-0",
+              "image": "ami-05bcd8360b8e667ba"
             },
             "sa-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0977fa46dff272ba9"
+              "release": "9.6.20250701-0",
+              "image": "ami-025c94ec9eb0e18ff"
             },
             "us-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-083de3282c55be3f7"
+              "release": "9.6.20250701-0",
+              "image": "ami-0ed302ffd26100bbb"
             },
             "us-east-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-02f30107e3441227b"
+              "release": "9.6.20250701-0",
+              "image": "ami-045c4882302e99352"
             },
             "us-gov-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0abaadf7322cfc258"
+              "release": "9.6.20250701-0",
+              "image": "ami-0871eb73b7eba6b71"
             },
             "us-gov-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0ca27128d77d732aa"
+              "release": "9.6.20250701-0",
+              "image": "ami-02e1801c5d670fc58"
             },
             "us-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-05a9426ae7c35740c"
+              "release": "9.6.20250701-0",
+              "image": "ami-03f93a32298fb00fb"
             },
             "us-west-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0cd6ec50e0480b3a3"
+              "release": "9.6.20250701-0",
+              "image": "ami-09c2ab0e2e7411878"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20250523-0-gcp-aarch64"
+          "name": "rhcos-9-6-20250701-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20250523-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250523-0-azure.aarch64.vhd"
+          "release": "9.6.20250701-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250701-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-metal4k.ppc64le.raw.gz",
-                "sha256": "1f1b1dce5d3dd2d138655792f51898370a4d37d32df8d97c79aab48746ce2e64",
-                "uncompressed-sha256": "76d7f6270547dd9d6365bad0a45aa70d8549d5e6f5d236b93dc499c717371010"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-metal4k.ppc64le.raw.gz",
+                "sha256": "86fbda37c6c34ceea59402117748446f792c505b6a740523f9e2bff5750fc0d0",
+                "uncompressed-sha256": "de6516a1084dc25861f80f8fe447573b37aa89ccdeff02669eaf2366ca6bb71d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-live-iso.ppc64le.iso",
-                "sha256": "1877a11ea2e7edbed831a1a79c4cd8b86afa9c6fe16ef452122c971ff92069c9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-live-iso.ppc64le.iso",
+                "sha256": "fd3a9e3ce15d00c0457cd272c522897c5b28c3254b5e8e519d8ee2496cc70835"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-live-kernel.ppc64le",
-                "sha256": "59f7fcdbcf864f10d503360f024564efb8e981711d62b5f18422c768ec0ddacd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-live-kernel.ppc64le",
+                "sha256": "4fcceeac31969357f6df5f79719ddfa20aae4986dff5afbbefae59b1197f0b27"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-live-initramfs.ppc64le.img",
-                "sha256": "df1d3a87a12be33340eb2858f174d47aabf4df98bb7c83309b3552cf059cee7c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-live-initramfs.ppc64le.img",
+                "sha256": "4e0aa7e476b0af2728d7678b73aaa17645afdc2c3841f6be84fe3b8f4887689e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-live-rootfs.ppc64le.img",
-                "sha256": "f56db34ead356ab4af474b739f488d1611f20d4938a682fda7f086b6f8c1a6a3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-live-rootfs.ppc64le.img",
+                "sha256": "1bc8b6db4c2a74043409459990e78f7c1e4790bff8b5cea8a9bce344378aad18"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-metal.ppc64le.raw.gz",
-                "sha256": "7c4306e866a78e3fdd45a9952feff4e6b1e5e97e0c6731ef3eddcf42e5787e9d",
-                "uncompressed-sha256": "9c67529256ebb8cf4b832b630ca0b51414e9cfcb125ab4a3b6939b5cf5a5478e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-metal.ppc64le.raw.gz",
+                "sha256": "fd24fe6c9facf95046958bcb006bc0f6d107ffa110cf4a208819c5c0a75ec7f0",
+                "uncompressed-sha256": "953551bf7b7997bbcc87b0891cf34ef061a596824ad3eaf9cb1890961415098e"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "e22043c5ad7c5381c884f773a796d9b044077f1ba9b325d33f3eb59f0748a109",
-                "uncompressed-sha256": "da18f22ffad37c7327e438411fbb46fc745d8866df4d57dc37c5c3f9dc3ff68b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "2c60f157fcc505bceffc1782936bf344b8a02aabf0a47756c274bebe2f321d96",
+                "uncompressed-sha256": "ea4aa51115310e8424119c1bf821b41b34dda1a552732f745c287195ddd7f064"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-powervs.ppc64le.ova.gz",
-                "sha256": "5d6564ed7487e13af64c0b04a9794fefaa341866e51c4af1e32ec3a5b796f345",
-                "uncompressed-sha256": "f716aeb9019847b8bb70ac69d786b4081ce4aece02855bc8c2cdd8a384ede595"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-powervs.ppc64le.ova.gz",
+                "sha256": "a31796ef2368c15da72d1b83a530223607c31c77d119c9d80edd8f21314d1f2f",
+                "uncompressed-sha256": "0b915ed9bab699fdd8faaf686a337e4195697d2c61f7167504ff1e41f4af5374"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/ppc64le/rhcos-9.6.20250523-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "bd9cd2737e3bc32e9a4ee9b7332c320cb2f3889a6fce044bdc5ab57143ddd6a3",
-                "uncompressed-sha256": "0f2a94a5f825f126373b29f6699419c3e640bc89d3fba2611835e296a0aa6291"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/ppc64le/rhcos-9.6.20250701-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "dd220193b2b5f39bcb6a96214b4d91ab5680fe8e6a9f789c2ec9813ad86cf3c2",
+                "uncompressed-sha256": "539565bd15bbae52a1cbc8e3e71ee1b336fe2c6f68f890b2dbf7ac0a221223b7"
               }
             }
           }
@@ -342,64 +346,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.6.20250523-0",
-              "object": "rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250701-0",
+              "object": "rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20250523-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20250701-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -408,248 +412,265 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "5c4cda4961d5b14122afe22695a2ae507a2c0a8a0628cad760047734e1d6fab0",
-                "uncompressed-sha256": "9f1fd86762484d13f47dec29ccd9a3d684f41fd4243eeb51e36cbdba15461349"
-              }
-            }
-          }
-        },
-        "metal": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "4k.raw.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-metal4k.s390x.raw.gz",
-                "sha256": "0cf3088591fcabf83dea8a76f6a2505912a7c44b3da401dffec52d1a84bbdd6f",
-                "uncompressed-sha256": "cb43894f3e0eb1fd18619106c4ea8fb18fe525399bdf302b6d6dec2dcf2afa08"
-              }
-            },
-            "iso": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-live-iso.s390x.iso",
-                "sha256": "edf60388c90efc3331ec65d4ab3ca16f60bf84ee6949715b5775bd062370db80"
-              }
-            },
-            "pxe": {
-              "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-live-kernel.s390x",
-                "sha256": "24faac3b1e2d4d583e86eab917ab163721611a214f4ad58e7254cb73b1ed9d3e"
-              },
-              "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-live-initramfs.s390x.img",
-                "sha256": "f8a1064b4b066d6781db38d7443b61b4886eadf290ad64cf5f955ab055d52c50"
-              },
-              "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-live-rootfs.s390x.img",
-                "sha256": "3cc55286ceca683d96fac41ac79cc99bff3ca939e887b85beb60f013fabbe58d"
-              }
-            },
-            "raw.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-metal.s390x.raw.gz",
-                "sha256": "53bb0cb0c6d500097d717ef7fe0096cd60721a117950a0158d8f70e887ac0b91",
-                "uncompressed-sha256": "4f5603f3fc8f57e41af4a0188c886417f420591d603166d59112bf2043e289c3"
-              }
-            }
-          }
-        },
-        "openstack": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "qcow2.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-openstack.s390x.qcow2.gz",
-                "sha256": "e3a78643f3e2edd238cf84c0b1d1e0a47e3837aa2112d344c0f9e074d0f50bc3",
-                "uncompressed-sha256": "38e8e08dca8e4e04622215dc707691f66b1e92a8e475378c1c40b959e8bdab76"
-              }
-            }
-          }
-        },
-        "qemu": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "qcow2.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-qemu.s390x.qcow2.gz",
-                "sha256": "06860567e12d89d498c01eaf92245cceec79b5d342647452e001b3478ab14aff",
-                "uncompressed-sha256": "e9ef12edc38766ad37537acc41c90484d468f5e39eb762597c606c634bb152e8"
-              }
-            }
-          }
-        },
-        "qemu-secex": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "qcow2.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/s390x/rhcos-9.6.20250523-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "f9fa72b93aa4b76576b10ae11ae2dfdda4a794c449a18baae788c720a4316657",
-                "uncompressed-sha256": "43cd0ef86100ebdaa471ecaaeba96bf97ab530f02ba7ef24005bdb16401ad6d3"
-              }
-            }
-          }
-        }
-      },
-      "images": {}
-    },
-    "x86_64": {
-      "artifacts": {
-        "aws": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "vmdk.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-aws.x86_64.vmdk.gz",
-                "sha256": "1a6ede3293b176479d060ddbabe7c9ca4d11d1fb16381e6996e9c50a5e6a3eb6",
-                "uncompressed-sha256": "4f3d985f7940f5d6b6ee926850c8c766bb5b64c01c3ab40c8da4a0944b2fcdea"
-              }
-            }
-          }
-        },
-        "azure": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "vhd.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-azure.x86_64.vhd.gz",
-                "sha256": "af68ee9cb4fcc5ff2fae32e52a5e27e0da019c8776da91fadfeb8889c7db840a",
-                "uncompressed-sha256": "1af192e673f488157fbef6e5caa77dc87b508c8c32b1b7d6a62293e8477e8e7f"
-              }
-            }
-          }
-        },
-        "azurestack": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "vhd.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-azurestack.x86_64.vhd.gz",
-                "sha256": "56b9e16ade60f5f819e07df42077b1ee2e4286cc3f65ff52f3e65afdd2e0c47f",
-                "uncompressed-sha256": "64a2a3e8bf9d38bd59f3c6fe6e5fde9037493898b991313615d78fc37100f1b6"
-              }
-            }
-          }
-        },
-        "gcp": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "tar.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-gcp.x86_64.tar.gz",
-                "sha256": "3dce45801f48dba931d4bd25aa17693a7b50e62ce3c0139aeb199af4a7ab4a31"
-              }
-            }
-          }
-        },
-        "ibmcloud": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "qcow2.gz": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "24f2fa494a26f3e15a597daf7840754df3e64261f7b41b4e7b616d52d6ef220c",
-                "uncompressed-sha256": "4ba9adcdcd3e1fa7f79446bfdb07e76539be14e567d32d37f2f4cdb5f6dadc72"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "2d516c82f40faf16ae09f34111eefc285bd80feb6950f65cab96a851d9aea373",
+                "uncompressed-sha256": "50ca92129da44c68da230279193e4c366522d6573ed2768da9bb3dd6e40f02a8"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-kubevirt.x86_64.ociarchive",
-                "sha256": "ca0d2738cca82ede72246992d2d1f9e40c91cb7d3a444d9849beed5742bedc5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-kubevirt.s390x.ociarchive",
+                "sha256": "da27daeea29bd93ca844259156031e9f0d09c7ade0825d6906d6f800e66bfcd5"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-metal4k.x86_64.raw.gz",
-                "sha256": "34db2c7fdc4b535ddb87a4646804214f26444b4edbd15109a37acbf2dffb123c",
-                "uncompressed-sha256": "4ffa12b6a490df2411c01162019b6ad15b2c1d16abee9d93314e773b80634ff6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-metal4k.s390x.raw.gz",
+                "sha256": "0539782d779b9de71b0309a66293a96014d44728b478db5b7f341df0d72f24ad",
+                "uncompressed-sha256": "54a31fb11f6f76a71cb006a22b2d206208a892f68e69399f73b60f3820590c5b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-live-iso.x86_64.iso",
-                "sha256": "6a9cf9df708e014a2b44f372ab870f873cf2db5685f9ef4518f52caa36160c36"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-live-iso.s390x.iso",
+                "sha256": "0fc00c1de9d9e2dd30e8cddf7514b7010b7bb23471ba1b7d12cdab9f41e704ca"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-live-kernel.x86_64",
-                "sha256": "9a23d6d32b797c29579ef82dc711c47d4699ba88fbd89a4cee4aec56e9d3641f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-live-kernel.s390x",
+                "sha256": "ce7776ddab38295e362f190ac5f4fb4cf1a6c03b7a2ff6c101cadaf32f248723"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-live-initramfs.x86_64.img",
-                "sha256": "fedcac8103eb155f0a18b4be73e7b1a812cf562f988338e3d708264c026da993"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-live-initramfs.s390x.img",
+                "sha256": "410544eb2dc18ebf8126d4d8b520ae683dce20e6fcd5f5a425652ddc7c82b4b0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-live-rootfs.x86_64.img",
-                "sha256": "0355f3cc1f3e539836640257f7162a920ce1a45b9a2154a80acd1d8385726659"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-live-rootfs.s390x.img",
+                "sha256": "efcfd3de7e1b7b4769a0ab7c53897fd11110dda1e49d1a5bdd6d91bd55fd6b84"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-metal.x86_64.raw.gz",
-                "sha256": "c5b401c9f152a7a909b29258b2325d294811a4dd244786842381fe5d34315b10",
-                "uncompressed-sha256": "3e883df9e33e828d73593908d1a45393ab80cf72cc4f61fb21bb968722ef706b"
-              }
-            }
-          }
-        },
-        "nutanix": {
-          "release": "9.6.20250523-0",
-          "formats": {
-            "qcow2": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-nutanix.x86_64.qcow2",
-                "sha256": "c3a1d0029cf5c50f0b6d850f95a3a267065569a1e890b6b73e988572dbfdde37"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-metal.s390x.raw.gz",
+                "sha256": "8a7aa5a54c0df61311b508e8a58cff2ec4da77b32f8f83b36c8e353750387c04",
+                "uncompressed-sha256": "4ae7f7f06de1fbff9bd51b0c3347f09b83492cf87d35cc09639c13fd2974266e"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-openstack.x86_64.qcow2.gz",
-                "sha256": "6f8e3d95cadc8334b9d601f2505060d52f1ae06836e3f9ed810ec6d4d0ca0a12",
-                "uncompressed-sha256": "b059c2d08ca5048f555df65c0a9edfb1f0bb4cf399bd67e62860c3211289fbfb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-openstack.s390x.qcow2.gz",
+                "sha256": "2ba3861e60a000cc45d14404af4ac080b5467b2ba0a00c9615ad248bf5f74bf5",
+                "uncompressed-sha256": "4f586a3f2f12a3c2872fc2acdfbd73492da1c972a1ab7dd94ce2b536e5e33648"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-qemu.x86_64.qcow2.gz",
-                "sha256": "60ba3dea0a1c9d7e67a815562cceffeb2eb492d8721958c6c3b527a3af8ca805",
-                "uncompressed-sha256": "36e00fe6d1b6b72664ff7814cf3136429a717e2e62ebf0bf6579fa243a8bab15"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-qemu.s390x.qcow2.gz",
+                "sha256": "3d16470b8905f2611c5b04247aa6d6bf4da1fced5ad9f83c75e0066596b63388",
+                "uncompressed-sha256": "3aca49f68424aed1fac062b61d241f78a4ff6d7423c17044e7c585c7f7e59636"
+              }
+            }
+          }
+        },
+        "qemu-secex": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/s390x/rhcos-9.6.20250701-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "2939f13ea58856e686c13c7ed1c0f72fa31656f46cd83aae2de7b6fcd8e3e512",
+                "uncompressed-sha256": "9b17898c8824521ad18d0f5ebe1fc513b310d81358c98e2b1eebac54075bac10"
+              }
+            }
+          }
+        }
+      },
+      "images": {
+        "kubevirt": {
+          "release": "9.6.20250701-0",
+          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:110d013c07f66a48414e060d542f87cdb25120f803a23a374f30217d0ed31cdb"
+        }
+      }
+    },
+    "x86_64": {
+      "artifacts": {
+        "aws": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "vmdk.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-aws.x86_64.vmdk.gz",
+                "sha256": "720fa69abb1fe5167dd060cc2e080a9853d37894831f486f696b9d578b1e72f7",
+                "uncompressed-sha256": "92fab591febe4f22f99d1c99ce677f29b1aa297af38d49724140ed446eef33c9"
+              }
+            }
+          }
+        },
+        "azure": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "vhd.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-azure.x86_64.vhd.gz",
+                "sha256": "65c11944b83e26113ddae97acc2a938db2ef3f2aebfbb0d6cf8573127cadb1e1",
+                "uncompressed-sha256": "d3c1e13a57297372f01ddc5df356a351ec41613740978a106e4872a8b0fb5886"
+              }
+            }
+          }
+        },
+        "azurestack": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "vhd.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-azurestack.x86_64.vhd.gz",
+                "sha256": "d58b711633baccd902cf5c5002b2ada307aec9935fef01ca54a61b7d377ef17f",
+                "uncompressed-sha256": "9b0b8a2ba6d6e56587f71c05ac5d1001ca6243babb9569b4711ac3c31607da92"
+              }
+            }
+          }
+        },
+        "gcp": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "tar.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-gcp.x86_64.tar.gz",
+                "sha256": "9f9fee6952b3f0bf3e6e53008346a527488a21a8aeb2efcdae3c8ea66d812c3a"
+              }
+            }
+          }
+        },
+        "ibmcloud": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "cba5fa41ef2794e4de07bd5f8245bfd40e099a0977dd2cbaaa053ee54f043042",
+                "uncompressed-sha256": "02e391d1f7b9c812dae05d5b19fae04e0fd2081aa76e399648544f072e6fae1a"
+              }
+            }
+          }
+        },
+        "kubevirt": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "ociarchive": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-kubevirt.x86_64.ociarchive",
+                "sha256": "fe0790b092c9f47f6f76153dd01f5c84250dbfaefdc7bbbfd75d220297d884ab"
+              }
+            }
+          }
+        },
+        "metal": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "4k.raw.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-metal4k.x86_64.raw.gz",
+                "sha256": "049258a51bd38ad8de11db69c800899410e9dfb909643739321efb076289264e",
+                "uncompressed-sha256": "3cf38527713373ff7677354f247ae971da64a1677f873b06a57f815c06a51b6a"
+              }
+            },
+            "iso": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-live-iso.x86_64.iso",
+                "sha256": "5ec9acd8d5cbb9ee5e206f2e4894476afded2903b17d607ae58db393f1e909ba"
+              }
+            },
+            "pxe": {
+              "kernel": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-live-kernel.x86_64",
+                "sha256": "66b846764f41cb8c8da1827c6e3390e3f7524dbd9d69e1f715acf9d1e3d0ea3c"
+              },
+              "initramfs": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-live-initramfs.x86_64.img",
+                "sha256": "1ab6c8584a91658a8a33ab4b9b05fee3936f40ce47f99ea98b7aacbce02587d4"
+              },
+              "rootfs": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-live-rootfs.x86_64.img",
+                "sha256": "37c989b06b7ec850d1f6367ffccc727c11ac732bec41f20682eef278c2bae63b"
+              }
+            },
+            "raw.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-metal.x86_64.raw.gz",
+                "sha256": "9e9a9416e5a157005bca60141d789b2a8f8d1d1cce54d84d3a9add9651894b1e",
+                "uncompressed-sha256": "815b4bfbaa9cfae83c7db7a54a00a7a3927b730489ad6369ba3c841f8853d098"
+              }
+            }
+          }
+        },
+        "nutanix": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "qcow2": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-nutanix.x86_64.qcow2",
+                "sha256": "95e84e797424b6dcc3dd0cdbf5bcfb493f45f25bdf798f853035d9c129ba2b7f"
+              }
+            }
+          }
+        },
+        "openstack": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-openstack.x86_64.qcow2.gz",
+                "sha256": "777193e5e7c8961f98c1aac1fa93df384cde58cd5a6e23782233cd4f6d72809f",
+                "uncompressed-sha256": "19b623031643bad09e0c6ce4aa4ef0e6c1b7e4a87d7e03fe53dbc9da829e6f95"
+              }
+            }
+          }
+        },
+        "qemu": {
+          "release": "9.6.20250701-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-qemu.x86_64.qcow2.gz",
+                "sha256": "da03eb56d53351c395750993712dcc9ba3ed41e521a709b467f064eb440809d2",
+                "uncompressed-sha256": "ab34d2d79ce83751ccfdae73d7e8663c58980c597c16ef7830152fddefcf2f6c"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250523-0/x86_64/rhcos-9.6.20250523-0-vmware.x86_64.ova",
-                "sha256": "1409be2836e555eced548623b1683482cdd4d6ab6310a6cb2bf29fce8dc7f04a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250701-0/x86_64/rhcos-9.6.20250701-0-vmware.x86_64.ova",
+                "sha256": "38a6fb83dbb297c4ebb811b1f04ba86462e51f8ec141373ebfd3780f50be8829"
               }
             }
           }
@@ -659,158 +680,162 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0163621ea085783d8"
+              "release": "9.6.20250701-0",
+              "image": "ami-0d05d8687e94714da"
             },
             "ap-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-033db3b659641feea"
+              "release": "9.6.20250701-0",
+              "image": "ami-0f79de75c0bb9ea50"
+            },
+            "ap-east-2": {
+              "release": "9.6.20250701-0",
+              "image": "ami-0907a17ccca484f8a"
             },
             "ap-northeast-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0baf16f8c6bd53f63"
+              "release": "9.6.20250701-0",
+              "image": "ami-0e62ef7268af3c2ca"
             },
             "ap-northeast-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-01a92be7f419359cc"
+              "release": "9.6.20250701-0",
+              "image": "ami-08587b3c3e9c0b132"
             },
             "ap-northeast-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0f16895f6f50e656e"
+              "release": "9.6.20250701-0",
+              "image": "ami-0e76fbd6c355a48c4"
             },
             "ap-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0272be2f6528576f3"
+              "release": "9.6.20250701-0",
+              "image": "ami-0764fc8a8a3159ee8"
             },
             "ap-south-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0311119df2ebc0bbc"
+              "release": "9.6.20250701-0",
+              "image": "ami-02f64485ccc70a4b0"
             },
             "ap-southeast-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0637678b0ad540477"
+              "release": "9.6.20250701-0",
+              "image": "ami-05a118f475704e651"
             },
             "ap-southeast-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0b67b492c091ac746"
+              "release": "9.6.20250701-0",
+              "image": "ami-0890ea87ff5edfe5d"
             },
             "ap-southeast-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0a9e63bf1df36a936"
+              "release": "9.6.20250701-0",
+              "image": "ami-0c5f9e47b5c3e9c13"
             },
             "ap-southeast-4": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0f153b95673592039"
+              "release": "9.6.20250701-0",
+              "image": "ami-0bbc07f8031693f95"
             },
             "ap-southeast-5": {
-              "release": "9.6.20250523-0",
-              "image": "ami-025944207bb28ae8f"
+              "release": "9.6.20250701-0",
+              "image": "ami-09b876828c9cb81f2"
             },
             "ap-southeast-7": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0b5e29c2ae4aaa66d"
+              "release": "9.6.20250701-0",
+              "image": "ami-06e1f97c47558c2cc"
             },
             "ca-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-03263f0cfdfa8bbdb"
+              "release": "9.6.20250701-0",
+              "image": "ami-024f628f2bf9dadba"
             },
             "ca-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0254620c2dc7dcacc"
+              "release": "9.6.20250701-0",
+              "image": "ami-01e129afb49fdd7ac"
             },
             "eu-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0a0a87862b24395d8"
+              "release": "9.6.20250701-0",
+              "image": "ami-0b31157035ce913d5"
             },
             "eu-central-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-015c8ca32f5d8300a"
+              "release": "9.6.20250701-0",
+              "image": "ami-0f22ba0e5c926e85a"
             },
             "eu-north-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0c4404a6ae5921a1b"
+              "release": "9.6.20250701-0",
+              "image": "ami-045044c91f08f0141"
             },
             "eu-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e0724943dd915bb2"
+              "release": "9.6.20250701-0",
+              "image": "ami-07e7ddbe74370b8d4"
             },
             "eu-south-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e6cac787a21b221d"
+              "release": "9.6.20250701-0",
+              "image": "ami-071273656bbd5ceaf"
             },
             "eu-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0355d4c968e466965"
+              "release": "9.6.20250701-0",
+              "image": "ami-019cdefdbe8ae3f45"
             },
             "eu-west-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e079f8742280b034"
+              "release": "9.6.20250701-0",
+              "image": "ami-04d3462fcff665a38"
             },
             "eu-west-3": {
-              "release": "9.6.20250523-0",
-              "image": "ami-06702aad076acda7b"
+              "release": "9.6.20250701-0",
+              "image": "ami-0df908df0aad1f3b2"
             },
             "il-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0094ac2722d41c18c"
+              "release": "9.6.20250701-0",
+              "image": "ami-0b4093c08d6b1e916"
             },
             "me-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-03680a3dcecfbe79d"
+              "release": "9.6.20250701-0",
+              "image": "ami-063fdc060a1235bfd"
             },
             "me-south-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-04e14a3c4be812ac7"
+              "release": "9.6.20250701-0",
+              "image": "ami-0e0eb82f12439136c"
             },
             "mx-central-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0eac1c8d4154a417f"
+              "release": "9.6.20250701-0",
+              "image": "ami-0c110862155a78151"
             },
             "sa-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-07abd63bb465f89b6"
+              "release": "9.6.20250701-0",
+              "image": "ami-09f65446cd0bf6996"
             },
             "us-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0e8fd9094e487d1ff"
+              "release": "9.6.20250701-0",
+              "image": "ami-000abd48695e852a9"
             },
             "us-east-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0d4a7b7677c0c883f"
+              "release": "9.6.20250701-0",
+              "image": "ami-0e939a03652163c23"
             },
             "us-gov-east-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0b67e7ffd11a17645"
+              "release": "9.6.20250701-0",
+              "image": "ami-0cca0b255eebfac0d"
             },
             "us-gov-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-041e18a76f42c752c"
+              "release": "9.6.20250701-0",
+              "image": "ami-023b6cb1f845e69bf"
             },
             "us-west-1": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0167f257577d883cc"
+              "release": "9.6.20250701-0",
+              "image": "ami-0612e7d07f913d6da"
             },
             "us-west-2": {
-              "release": "9.6.20250523-0",
-              "image": "ami-0b29d41f2ed6b8c94"
+              "release": "9.6.20250701-0",
+              "image": "ami-0db4e8c33879b1a97"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20250523-0-gcp-x86-64"
+          "name": "rhcos-9-6-20250701-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.6.20250523-0",
+          "release": "9.6.20250701-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6b002503ba1c5411fa4be10a4b85632c19f8efe36aa69d734ddf1a1061d86964"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2d3e9ec9efb395a72a54fb95a9ee5dadb84f1aca42e83872475afbce40e81c0a"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20250523-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250523-0-azure.x86_64.vhd"
+          "release": "9.6.20250701-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250701-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
The changes done here will update the RHCOS 4.20 bootimage metadata.

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json                \
    --distro rhcos --no-signatures --name rhel-9.6                    \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=9.6.20250701-0                                     \
    aarch64=9.6.20250701-0                                     \
    s390x=9.6.20250701-0                                       \
    ppc64le=9.6.20250701-0
```