### PR TITLE
OCPBUGS-59430: Fail install config validation when base domain is invalid

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -257,7 +258,10 @@ func (c *Client) GetDNSZone(ctx context.Context, project, baseDomain string, isP
 	}
 	if res == nil {
 		if isPublic {
-			return nil, errors.New("no matching public DNS Zone found")
+			return nil, &googleapi.Error{
+				Code:    http.StatusNotFound,
+				Message: "no matching public DNS Zone found",
+			}
 		}
 		// A Private DNS Zone may be created (if the correct permissions exist)
 		return nil, nil


### PR DESCRIPTION
installconfig/gcp:

** Add a check during Validate() for the base domain of the public zone. 
** Validation tests updated.