### PR TITLE
Refine check for supported SNO platforms

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -177,7 +177,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 	// Check if SNO topology is supported on this platform
 	if pool.Replicas != nil && *pool.Replicas == 1 {
 		bootstrapInPlace := false
-		if ic.BootstrapInPlace != nil {
+		if ic.BootstrapInPlace != nil && ic.BootstrapInPlace.InstallationDisk != "" {
 			bootstrapInPlace = true
 		}
 		if !supportedSingleNodePlatform(bootstrapInPlace, ic.Platform.Name()) {
@@ -905,7 +905,7 @@ func createAssetFiles(objects []interface{}, fileName string) ([]*asset.File, er
 // a platform.
 func supportedSingleNodePlatform(bootstrapInPlace bool, platformName string) bool {
 	switch platformName {
-	case awstypes.Name, gcptypes.Name, azuretypes.Name, powervstypes.Name, nonetypes.Name:
+	case awstypes.Name, gcptypes.Name, azuretypes.Name, powervstypes.Name, nonetypes.Name, ibmcloudtypes.Name:
 		// Single node OpenShift installations supported without `bootstrapInPlace`
 		return true
 	case externaltypes.Name:


### PR DESCRIPTION
Include IBMCloud platforms in the list of supported SNO platforms. Also, add unit test to verify this functionality.

Manual backport of https://github.com/openshift/installer/pull/9836