### PR TITLE
OCPBUGS-60583: Unblock cluster installation when dependent systemd unit fails

### DIFF
--- a/data/data/agent/files/usr/local/bin/wait-for-service-active.sh
+++ b/data/data/agent/files/usr/local/bin/wait-for-service-active.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+systemd_service="$1"
+
+echo "Waiting for $systemd_service to be ready"
+
+until systemctl is-active --quiet $systemd_service; do
+    printf '.'
+    sleep 5
+done

--- a/data/data/agent/systemd/units/apply-host-config.service
+++ b/data/data/agent/systemd/units/apply-host-config.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Service that applies host-specific configuration
-Wants=network-online.target
-Requires=agent-register-infraenv.service
+Wants=network-online.target agent-register-infraenv.service
 PartOf=assisted-service-pod.service
 After=network-online.target agent-register-infraenv.service
 ConditionPathExists=/etc/assisted/node0
@@ -15,6 +14,7 @@ EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
+ExecStartPre=/usr/local/bin/wait-for-service-active.sh agent-register-infraenv.service
 ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=passthrough --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID --env WORKFLOW_TYPE --env USER_AUTH_TOKEN $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id

--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Service that starts cluster installation
-Wants=network-online.target
-Requires=apply-host-config.service
+Wants=network-online.target apply-host-config.service
 Conflicts=agent-add-node.service
 PartOf=assisted-service-pod.service
 After=network-online.target apply-host-config.service
@@ -12,6 +11,7 @@ ConditionPathExists=!/etc/assisted/add-nodes.env
 EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
 EnvironmentFile=/usr/local/share/start-cluster/start-cluster.env
 EnvironmentFile=/etc/assisted/rendezvous-host.env
+ExecStartPre=/usr/local/bin/wait-for-service-active.sh apply-host-config.service
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
 ExecStart=/usr/local/bin/start-cluster-installation.sh
 


### PR DESCRIPTION
## Background
When the network is unstable, the dependent systemd unit required by the installation service(apply-host-config and start-cluster-installation) may fail to start. If this happens, these two services will not run, causing the cluster installation process to be blocked.

## What has been changed
- Improved the dependency configuration and failure handling between the dependent systemd unit and the installation service.
- Ensured that temporary failures in the dependent unit do not permanently block the installation flow.

## How to test
1. Simulate an unstable network environment (such as by introducing packet loss or toggling the network interface).
2. Start the cluster installation process.
3. Confirm that even if the dependent systemd unit fails initially, the installation service is eventually executed and the installation is not blocked.


Please let me know if further documentation or tests are needed.