### PR TITLE
wip: test faster capz probe responsiveness

### DIFF
--- a/cluster-api/providers/azure/vendor/sigs.k8s.io/cluster-api-provider-azure/azure/services/loadbalancers/spec.go
+++ b/cluster-api/providers/azure/vendor/sigs.k8s.io/cluster-api-provider-azure/azure/services/loadbalancers/spec.go
@@ -263,8 +263,8 @@ func getProbes(lbSpec LBSpec) []*armnetwork.Probe {
 					Protocol:          ptr.To(armnetwork.ProbeProtocolHTTPS),
 					Port:              ptr.To[int32](lbSpec.APIServerPort),
 					RequestPath:       ptr.To(httpsProbeRequestPath),
-					IntervalInSeconds: ptr.To[int32](15),
-					NumberOfProbes:    ptr.To[int32](4),
+					IntervalInSeconds: ptr.To[int32](5),
+					NumberOfProbes:    ptr.To[int32](2),
 				},
 			},
 		}


### PR DESCRIPTION
https://github.com/openshift/installer/blob/release-4.15/data/data/azure/vnet/internal-lb.tf#L125-L133


https://github.com/openshift/machine-config-operator/blob/5a97a9a29a99e93f15b55242fefb7b41da4a4a82/cmd/apiserver-watcher/run.go#L88-L101