### PR TITLE
OCPBUGS-55499: Misleading error when confidentialCompute: Enabled

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -123,14 +123,15 @@ func validateInstanceAndConfidentialCompute(fldPath *field.Path, instanceType st
 	}
 
 	machineType, _, _ := strings.Cut(instanceType, "-")
+	machineSupportMatrixSelector := confidentialCompute
 	if confidentialCompute == gcp.ConfidentialComputePolicy(gcp.EnabledFeature) {
-		confidentialCompute = gcp.ConfidentialComputePolicySEV
+		machineSupportMatrixSelector = gcp.ConfidentialComputePolicySEV
 	}
-	supportedMachineTypes, ok := gcp.ConfidentialComputePolicyToSupportedInstanceType[confidentialCompute]
+	supportedMachineTypes, ok := gcp.ConfidentialComputePolicyToSupportedInstanceType[machineSupportMatrixSelector]
 	if !ok {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("confidentialCompute"), confidentialCompute, fmt.Sprintf("Unknown confidential computing technology %s", confidentialCompute)))
 	} else if !slices.Contains(supportedMachineTypes, machineType) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), instanceType, fmt.Sprintf("Machine type do not support %s. Machine types supporting %s: %s", confidentialCompute, confidentialCompute, strings.Join(supportedMachineTypes, ", "))))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), instanceType, fmt.Sprintf("Machine type does not support a Confidential Compute value of %s. Machine types supporting %s: %s", confidentialCompute, confidentialCompute, strings.Join(supportedMachineTypes, ", "))))
 	}
 
 	return allErrs

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1129,6 +1129,26 @@ func TestValidateInstanceType(t *testing.T) {
 			expectedErrMsg:      `^\[instance.onHostMaintenance: Invalid value: "Migrate": onHostMaintenace must be set to Terminate when confidentialCompute is IntelTrustedDomainExtensions\]`,
 		},
 		{
+			name:                "Enabled confidential compute with unsupported machine type",
+			zones:               []string{"a"},
+			instanceType:        "c3-standard-4",
+			diskType:            "pd-ssd",
+			onHostMaintenance:   "Terminate",
+			confidentialCompute: "Enabled",
+			expectedError:       true,
+			expectedErrMsg:      `^\[instance.type: Invalid value: "c3-standard-4": Machine type does not support a Confidential Compute value of Enabled. Machine types supporting Enabled: c2d, n2d, c3d\]`,
+		},
+		{
+			name:                "Enabled confidential compute with supported machine type",
+			zones:               []string{"a"},
+			instanceType:        "c3d-standard-4",
+			diskType:            "pd-ssd",
+			onHostMaintenance:   "Terminate",
+			confidentialCompute: "Enabled",
+			expectedError:       false,
+			expectedErrMsg:      "",
+		},
+		{
 			name:                "AMDEncryptedVirtualization confidential compute with unsupported machine type",
 			zones:               []string{"a"},
 			instanceType:        "c3-standard-4",
@@ -1136,7 +1156,7 @@ func TestValidateInstanceType(t *testing.T) {
 			onHostMaintenance:   "Terminate",
 			confidentialCompute: "AMDEncryptedVirtualization",
 			expectedError:       true,
-			expectedErrMsg:      `^\[instance.type: Invalid value: "c3-standard-4": Machine type do not support AMDEncryptedVirtualization. Machine types supporting AMDEncryptedVirtualization: c2d, n2d, c3d\]`,
+			expectedErrMsg:      `^\[instance.type: Invalid value: "c3-standard-4": Machine type does not support a Confidential Compute value of AMDEncryptedVirtualization. Machine types supporting AMDEncryptedVirtualization: c2d, n2d, c3d\]`,
 		},
 		{
 			name:                "AMDEncryptedVirtualization confidential compute with supported machine type",
@@ -1156,7 +1176,7 @@ func TestValidateInstanceType(t *testing.T) {
 			onHostMaintenance:   "Terminate",
 			confidentialCompute: "AMDEncryptedVirtualizationNestedPaging",
 			expectedError:       true,
-			expectedErrMsg:      `^\[instance.type: Invalid value: "c2d-standard-4": Machine type do not support AMDEncryptedVirtualizationNestedPaging. Machine types supporting AMDEncryptedVirtualizationNestedPaging: n2d\]`,
+			expectedErrMsg:      `^\[instance.type: Invalid value: "c2d-standard-4": Machine type does not support a Confidential Compute value of AMDEncryptedVirtualizationNestedPaging. Machine types supporting AMDEncryptedVirtualizationNestedPaging: n2d\]`,
 		},
 		{
 			name:                "AMDEncryptedVirtualizationNestedPaging confidential compute with supported machine type",
@@ -1176,7 +1196,7 @@ func TestValidateInstanceType(t *testing.T) {
 			onHostMaintenance:   "Terminate",
 			confidentialCompute: "IntelTrustedDomainExtensions",
 			expectedError:       true,
-			expectedErrMsg:      `^\[instance.type: Invalid value: "n2d-standard-4": Machine type do not support IntelTrustedDomainExtensions. Machine types supporting IntelTrustedDomainExtensions: c3\]`,
+			expectedErrMsg:      `^\[instance.type: Invalid value: "n2d-standard-4": Machine type does not support a Confidential Compute value of IntelTrustedDomainExtensions. Machine types supporting IntelTrustedDomainExtensions: c3\]`,
 		},
 		{
 			name:                "IntelTrustedDomainExtensions confidential compute with supported machine type",


### PR DESCRIPTION
Fixes the misleading error when `Enabled` and an unsupported machine type were configured:

    "Machine type do not support AMDEncryptedVirtualization...."

It also corrects the s/do/does/ typo.