### PR TITLE
CORS-3992: skip dns zone validation with custom DNS

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -393,7 +393,7 @@ func validatePreexistingServiceAccount(client API, ic *types.InstallConfig) fiel
 // checked for any public zone that can be used.
 func ValidatePreExistingPublicDNS(client API, ic *types.InstallConfig) field.ErrorList {
 	// If this is an internal cluster, this check is not necessary
-	if ic.Publish == types.InternalPublishingStrategy {
+	if ic.Publish == types.InternalPublishingStrategy || ic.GCP.UserProvisionedDNS == dnstypes.UserProvisionedDNSEnabled {
 		return nil
 	}
 	allErrs := field.ErrorList{}

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig/gcp/mock"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	customDNS "github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
@@ -116,6 +117,7 @@ var (
 	validateXpnSA            = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.GCP.ServiceAccount = validXpnSA }
 	invalidateXpnSA          = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.GCP.ServiceAccount = invalidXpnSA }
 	invalidateBaseDomain     = func(ic *types.InstallConfig) { ic.BaseDomain = invalidBaseDomain }
+	enableCustomDNS          = func(ic *types.InstallConfig) { ic.GCP.UserProvisionedDNS = customDNS.UserProvisionedDNSEnabled }
 
 	validServiceEndpoint = func(ic *types.InstallConfig) {
 		ic.Publish = types.InternalPublishingStrategy
@@ -484,6 +486,12 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 			records:        []*dns.ResourceRecordSet{},
 			expectedError:  true,
 			expectedErrMsg: `baseDomain: Not found: "invalid.installer.domain."`,
+		},
+		{
+			name:          "Custom DNS does not require existing base domain",
+			edits:         editFunctions{enableCustomDNS, invalidateBaseDomain},
+			records:       []*dns.ResourceRecordSet{},
+			expectedError: false,
 		},
 	}
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
1c9589a21f816b317628b85412acf3fdda3893f6 added validation to require an existing DNS zone matching the base domain before installation. In custom DNS scenarios, it is valid to create the zone after install, so we should relax the validation in those cases.