### PR TITLE
no-jira: OWNERS: add splat team as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - installer-team
+  - splat-team
   - sdodson
   - zaneb
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,11 @@ aliases:
     - rwsu
     - sadasu
     - tthvo
+  splat-team:
+    - jcpowermac
+    - mtulio
+    - rvanderp3
+    - vr4manta
   libvirt-approvers:
     - praveenkumar
     - cfergeau


### PR DESCRIPTION
SPLAT team should be approvers in the installer repo, as well as CI.