### PR TITLE
OCPBUGS-59104: Set kernel dual-stack arg for all platforms

### DIFF
--- a/pkg/asset/machines/arbiter.go
+++ b/pkg/asset/machines/arbiter.go
@@ -31,8 +31,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
-	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
-	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 	ibmcloudapi "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis"
 	ibmcloudprovider "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1"
 )
@@ -202,8 +200,7 @@ func (m *Arbiter) Generate(ctx context.Context, dependencies asset.Parents) erro
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 	// The cluster-network-operator handles the validation of this field.
 	// Reference: https://github.com/openshift/cluster-network-operator/blob/fc3e0e25b4cfa43e14122bdcdd6d7f2585017d75/pkg/network/cluster_config.go#L45-L52
-	if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 &&
-		(ic.Platform.Name() == openstacktypes.Name || ic.Platform.Name() == vspheretypes.Name) {
+	if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 {
 		// Only configure kernel args for dual-stack clusters.
 		ignIPv6, err := machineconfig.ForDualStackAddresses("arbiter")
 		if err != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -606,8 +606,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 	// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 	// The cluster-network-operator handles the validation of this field.
 	// Reference: https://github.com/openshift/cluster-network-operator/blob/fc3e0e25b4cfa43e14122bdcdd6d7f2585017d75/pkg/network/cluster_config.go#L45-L52
-	if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 &&
-		(ic.Platform.Name() == openstacktypes.Name || ic.Platform.Name() == vspheretypes.Name) {
+	if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 {
 		// Only configure kernel args for dual-stack clusters.
 		ignIPv6, err := machineconfig.ForDualStackAddresses("master")
 		if err != nil {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -399,8 +399,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 		// The maximum number of networks supported on ServiceNetwork is two, one IPv4 and one IPv6 network.
 		// The cluster-network-operator handles the validation of this field.
 		// Reference: https://github.com/openshift/cluster-network-operator/blob/fc3e0e25b4cfa43e14122bdcdd6d7f2585017d75/pkg/network/cluster_config.go#L45-L52
-		if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 &&
-			(ic.Platform.Name() == openstacktypes.Name || ic.Platform.Name() == vspheretypes.Name) {
+		if ic.Networking != nil && len(ic.Networking.ServiceNetwork) == 2 {
 			// Only configure kernel args for dual-stack clusters.
 			ignIPv6, err := machineconfig.ForDualStackAddresses("worker")
 			if err != nil {


### PR DESCRIPTION
In order to properly work in a dual-stack environment nodes of the cluster need to have `ip=dhcp,dhcp6` kernel argument. Without this, they are prone to a race condition which exposes itself when DHCP is significantly faster than DHCPv6. When such a scenario happens, the node registers itself with kubeapi using only its IPv4 address. As a consequence its `InternalIP` list contains only single address. As a consequence, pods running on this node are only getting IPv4 address as Pod IP.

The logic to handle this was till now only enabled for OpenStack and vSphere platforms. For Metal this is separately handled in the build-ironic-env in bootstrap. The problem arises with users of `platform: none`. They often run on Metal or vSphere but use no platform integration. Currently they cannot reliably use dual-stack functionality.

With this PR we are removing the platform check from the responsible code. It means that any platform that tries to deploy a dual-stack cluster will get `ip=dhcp,dhcp6` kernel param.

Fixes: OCPBUGS-59104