### PR TITLE
clusterapi: use default envtest timeouts

### DIFF
--- a/pkg/clusterapi/localcontrolplane.go
+++ b/pkg/clusterapi/localcontrolplane.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	capnv1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/sirupsen/logrus"
@@ -91,8 +90,6 @@ func (c *localControlPlane) Run(ctx context.Context) error {
 		Scheme:                   Scheme,
 		AttachControlPlaneOutput: true,
 		BinaryAssetsDirectory:    c.BinDir,
-		ControlPlaneStartTimeout: 10 * time.Second,
-		ControlPlaneStopTimeout:  10 * time.Second,
 		ControlPlane: envtest.ControlPlane{
 			Etcd: &envtest.Etcd{
 				DataDir: c.EtcdDataDir,


### PR DESCRIPTION
We're seeing the local control plane fail to start on systems with resource restrictions (say a laptop in "quiet" mode). This commit removes the hardcoded 10 second envtest timeouts to use the default 20 second timeouts. By using the defaults, it also allows the timeouts to be tuned with the environment variables:
KUBEBUILDER_CONTROLPLANE_START_TIMEOUT
KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT

TODO: needs a bug