### PR TITLE
upkeep: update fencing unit tests

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -222,7 +222,7 @@ func (a *OptionalInstallConfig) validateControlPlaneConfiguration(installConfig 
 		if *installConfig.ControlPlane.Replicas < 1 || *installConfig.ControlPlane.Replicas > 5 || (installConfig.Arbiter == nil && *installConfig.ControlPlane.Replicas == 2) {
 			fieldPath = field.NewPath("controlPlane", "replicas")
 			supportedControlPlaneRange := []string{"3", "1", "4", "5"}
-			if installConfig.EnabledFeatureGates().Enabled(features.FeatureGateHighlyAvailableArbiter) {
+			if installConfig.EnabledFeatureGates().Enabled(features.FeatureGateHighlyAvailableArbiter) || installConfig.EnabledFeatureGates().Enabled(features.FeatureGateDualReplica) {
 				supportedControlPlaneRange = append(supportedControlPlaneRange, "2")
 			}
 			allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Replicas, supportedControlPlaneRange))

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -882,6 +882,9 @@ controlPlane:
   name: master
   platform: {}
   replicas: 2
+featureSet: CustomNoUpgrade
+featureGates:
+- DualReplica=true
 platform:
   external:
     platformName: oci
@@ -889,7 +892,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [controlPlane.fencing.credentials: Forbidden: there should be exactly two fencing credentials to support the two node cluster, instead 0 credentials were found, controlPlane.replicas: Unsupported value: 2: supported values: \"3\", \"1\", \"4\", \"5\"]",
+			expectedError: "invalid install-config configuration: [controlPlane.fencing.credentials: Forbidden: there should be exactly two fencing credentials to support the two node cluster, instead 0 credentials were found, controlPlane.replicas: Unsupported value: 2: supported values: \"3\", \"1\", \"4\", \"5\", \"2\"]",
 		},
 		{
 			name: "invalid platform for SNO cluster",

--- a/pkg/asset/imagebased/configimage/installconfig_test.go
+++ b/pkg/asset/imagebased/configimage/installconfig_test.go
@@ -101,7 +101,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [controlPlane.fencing.credentials: Forbidden: there should be exactly two fencing credentials to support the two node cluster, instead 0 credentials were found, ControlPlane.Replicas: Required value: Only Single Node OpenShift (SNO) is supported, total number of ControlPlane.Replicas must be 1. Found 2]",
+			expectedError: "invalid install-config configuration: ControlPlane.Replicas: Required value: Only Single Node OpenShift (SNO) is supported, total number of ControlPlane.Replicas must be 1. Found 2",
 		},
 		{
 			name: "invalid number of MachineNetworks",

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -761,7 +761,9 @@ func validateControlPlane(installConfig *types.InstallConfig, fldPath *field.Pat
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("replicas"), pool.Replicas, "number of control plane replicas must be positive"))
 	}
 	allErrs = append(allErrs, ValidateMachinePool(platform, pool, fldPath)...)
-	allErrs = append(allErrs, validateFencingCredentials(installConfig)...)
+	if installConfig.EnabledFeatureGates().Enabled(features.FeatureGateDualReplica) {
+		allErrs = append(allErrs, validateFencingCredentials(installConfig)...)
+	}
 	return allErrs
 }
 


### PR DESCRIPTION
wrapped fencing validation in featuregate check
updated supported control plane count to also include DualReplica feature gate check updated image based validation error to only check for SNO

Note that for image based validation, when DualReplica hits GA this will need to be updated to include fencing credentials to correctly check for control plane count or what ever makes the most sense.

ex. installConfig

```yaml
controlPlane:
  architecture: amd64
  hyperthreading: Enabled
  name: master
  platform: {}
  replicas: 2
  fencing:
    credentials:
      - hostName: "host1"
        username: "root"
        password: "password"
        address:  "ipmi://192.168.111.1"
      - hostName: "host2"
        username: "root"
        password: "password"
        address:  "ipmi://192.168.111.2"
```