### PR TITLE
CORS-4178: handle deleting AWS egress-only internet gateway

### DIFF
--- a/pkg/destroy/aws/ec2helpers.go
+++ b/pkg/destroy/aws/ec2helpers.go
@@ -163,6 +163,8 @@ func (o *ClusterUninstaller) deleteEC2(ctx context.Context, session *session.Ses
 		return deleteEC2VPCPeeringConnection(ctx, o.EC2Client, id, logger)
 	case "vpc-endpoint-service":
 		return deleteEC2VPCEndpointService(ctx, o.EC2Client, id, logger)
+	case "egress-only-internet-gateway":
+		return deleteEgressOnlyInternetGateway(ctx, o.EC2Client, id, logger)
 	default:
 		return errors.Errorf("unrecognized EC2 resource type %s", resourceType)
 	}
@@ -912,6 +914,21 @@ func deleteEC2VPCEndpointService(ctx context.Context, client *ec2v2.Client, id s
 		}
 		return errors.Wrapf(err, "cannot delete VPC Endpoint Service %s", id)
 	}
+	logger.Info("Deleted")
+	return nil
+}
+
+func deleteEgressOnlyInternetGateway(ctx context.Context, client *ec2v2.Client, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteEgressOnlyInternetGateway(ctx, &ec2v2.DeleteEgressOnlyInternetGatewayInput{
+		EgressOnlyInternetGatewayId: aws.String(id),
+	})
+	if err != nil {
+		if HandleErrorCode(err) == "InvalidEgressOnlyInternetGatewayId.NotFound" {
+			return nil
+		}
+		return err
+	}
+
 	logger.Info("Deleted")
 	return nil
 }


### PR DESCRIPTION
The egress-only internet gateway, created for and owned by the IPv6-enabled cluster, should be deleted in the destroy code.

This is a new resource that we need to have additional logic to handle deleting. Currently, the installer destroy code hangs and fails to delete the owned VPC with a warning below:

```
DEBUG unrecognized EC2 resource type egress-only-internet-gateway  arn=arn:aws:ec2:us-east-1:REDACTED:egress-only-internet-gateway/REDACTED

```