### PR TITLE
OCPBUGS-60240: baremetal: always set external v6 URL on dualstack

### DIFF
--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -99,12 +99,14 @@ func externalURLs(apiVIPs []string, protocol string) (externalURLv4 string, exte
 		if protocol == "https" {
 			port = "6183"
 		}
-		externalURL := fmt.Sprintf("%s://%s/", protocol, net.JoinHostPort(apiVIPs[1], port))
-		if utilsnet.IsIPv6String(apiVIPs[1]) {
-			externalURLv6 = externalURL
-		}
-		if utilsnet.IsIPv4String(apiVIPs[1]) {
-			externalURLv4 = externalURL
+		for _, apiVIP := range apiVIPs {
+			externalURL := fmt.Sprintf("%s://%s/", protocol, net.JoinHostPort(apiVIP, port))
+			if utilsnet.IsIPv6String(apiVIP) {
+				externalURLv6 = externalURL
+			}
+			if utilsnet.IsIPv4String(apiVIP) {
+				externalURLv4 = externalURL
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, we did not set this parameter on v6-primary stacks, wrongly
assuming that the Ironic container would pick up the right stack.
It wouldn't. Presenting with both IP addresses, the networking logic in
the container picks up the first one, which is usually IPv4.
This breaks virtual media on BMC's that cannot access IPv4 addresses.
