### PR TITLE
OCPBUGS-60071: Remove VPC-based resource discovery in AWS destroy

### DIFF
--- a/pkg/destroy/aws/elbhelpers.go
+++ b/pkg/destroy/aws/elbhelpers.go
@@ -19,7 +19,7 @@ func deleteElasticLoadBalancing(ctx context.Context, session *session.Session, a
 	if err != nil {
 		return err
 	}
-	logger = logger.WithField("id", id)
+	logger = logger.WithField("id", id).WithField("resourceType", resourceType)
 
 	switch resourceType {
 	case "loadbalancer":


### PR DESCRIPTION
Discovering resources for deletion based on VPC association can lead to outages and catastrophic failure if a cluster is incorrectly installed into a VPC owned by another cluster. This scenario should not happen and is a misconfiguration, but in practice it has happened.

Furthermore, it is unnecessary to discover resources by VPC association because all relevant resources can be correctly identified by tags.

Discovering resources by vpc was added in several commits:
https://github.com/openshift/installer/commit/37a7f49c7746ba786dd552ab723c4613674da7d5
https://github.com/openshift/installer/commit/55630a304333f82d3b8c35329fc4c1d1dc170d08
https://github.com/openshift/installer/commit/03dd133959f9f59bf40ba237aeb5ac25d3d92b5e

Those commmits mention that in Terraform there was a delay between resource creation and tagging. That problem has subsequently been remedied and tags are always applied at resource creation time, so we will not hit this problem again.