### PR TITLE
OCPBUGS-60288: check ipv6 dns during bootkube

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -10,7 +10,8 @@ function lookup_url() {
     unset IPS
     unset IP
     IPS=$(dig "${2}" +short)
-    if [[ ! -z "${IPS}" ]] ; then
+    V6IPS=$(dig "${2}" AAAA +short)
+    if [[ ! -z "${IPS}" ]] || [[ ! -z "${V6IPS}" ]]; then
         echo "Successfully resolved ${1} ${2}"
         return 0
     else


### PR DESCRIPTION
The dig command only returns results for A records by default. For single-stack ipv6, we need to also check for AAAA records so ~~as not to block bootkube~~ so we don't send false negative warnings that we can't resolve DNS when we actually can.

Should cut down on this warning in bootkube: 

```
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Check if API URL is resolvable during bootstrap
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Checking if api.ck07.rh.ser.tn of type API_URL is resolvable
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Starting stage resolve-api-url
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Unable to resolve API_URL api.ck07.rh.ser.tn
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Check if API-Int URL is resolvable during bootstrap
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Checking if api-int.ck07.rh.ser.tn of type API_INT_URL is resolvable
Aug 10 19:18:51 localhost.localdomain bootkube.sh[13821]: Starting stage resolve-api-int-url
Aug 10 19:18:52 localhost.localdomain bootkube.sh[13821]: Unable to resolve API_INT_URL api-int.ck07.rh.ser.tn
```