### PR TITLE
OCPBUGS-60197: PowerVS: config variables not honored

### DIFF
--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -417,6 +417,41 @@ func saveSessionStoreToAuthFile(pss *SessionStore) error {
 	return os.WriteFile(authFilePath, jsonVars, 0o600)
 }
 
+// UpdateSessionStoreToAuthFile updates the saved session store structure on the disk.
+func UpdateSessionStoreToAuthFile(update *SessionStore) error {
+	var (
+		original SessionStore
+		err      error
+	)
+
+	if update == nil {
+		return fmt.Errorf("empty session store passed to UpdateSessionStoreToAuthFile")
+	}
+
+	err = getSessionStoreFromAuthFile(&original)
+	if err != nil {
+		return err
+	}
+
+	if update.ID != "" {
+		original.ID = update.ID
+	}
+	if update.APIKey != "" {
+		original.APIKey = update.APIKey
+	}
+	if update.DefaultRegion != "" {
+		original.DefaultRegion = update.DefaultRegion
+	}
+	if update.DefaultZone != "" {
+		original.DefaultZone = update.DefaultZone
+	}
+	if update.PowerVSResourceGroup != "" {
+		original.PowerVSResourceGroup = update.PowerVSResourceGroup
+	}
+
+	return saveSessionStoreToAuthFile(&original)
+}
+
 func getEnv(envs []string) string {
 	for _, k := range envs {
 		if v := os.Getenv(k); v != "" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -192,6 +192,19 @@ func defaultPowerVSMachinePoolPlatform(ic *types.InstallConfig) powervstypes.Mac
 		err      error
 	)
 
+	// Update the saved session storage with the install config since the session
+	// storage is used as the defaults.
+	err = powervsconfig.UpdateSessionStoreToAuthFile(&powervsconfig.SessionStore{
+		ID:                   ic.PowerVS.UserID,
+		DefaultRegion:        ic.PowerVS.Region,
+		DefaultZone:          ic.PowerVS.Zone,
+		PowerVSResourceGroup: ic.PowerVS.PowerVSResourceGroup,
+	})
+	if err != nil {
+		fallback = true
+		logrus.Warnf("could not UpdateSessionStoreToAuthFile in defaultPowerVSMachinePoolPlatform")
+	}
+
 	client, err = powervsconfig.NewClient()
 	if err != nil {
 		fallback = true


### PR DESCRIPTION
If ~/.powervs/config.json is empty except for the APIKey, and a cluster is created with an install-config.yaml, then the installer will prompt for the other empty config variables.  So update those variables with values from the install config to avoid prompting.