### PR TITLE
OCPBUGS-37943: FIPS based ISO Boot support for s390x arch

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -168,6 +168,15 @@ func (a *AgentImage) appendKargs(kargs string) error {
 		return nil
 	}
 
+	if a.cpuArch == "s390x" {
+		err := isoeditor.EmbedKargsIntoBootImage(a.isoPath, a.tmpPath, kargs)
+		if err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
+
 	fileInfo, err := isoeditor.NewKargsReader(a.isoPath, kargs)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

This PR introduces enhancements to the `agentimage.go` file, particularly focusing on appending kargs into the boot image itself where ignition is already embedded using the staging ISO boot image files. This is necessary for architecture like s390x where ignition and kargs lies in the same boot image (cdboot.img) unlike x86 where we have different boot files for booth.

It includes a decision making in the `appendKargs` function based on the CPU Architecture to call a newly added function `EmbedKargsIntoBootImage` in the isoeditor package of assisted-image-service for embedding kernel arguments into boot images where ignition content is also present

This decision making skips to call `NewKargsReader` function `in-case of s390x` architecture where the kargs details fetching and updating them into boot images are specific to x86, which is not relevant for s390x

Initially this PR is added to make decision for `cpu arch: s390x` only but this can be extended for other architectures which falls under same category of not being dependant on `COREOS_KARGS_EMBED_AREA` string to calculate kargs offsets and embed kargs & ignition into different boot files

## Links 

This PR related with the code changes that are done in assisted-image-service. Check out this PR for the same : https://github.com/openshift/assisted-image-service/pull/472 