### PR TITLE
AGENT-1205: Update agent-installer-ui tar path

### DIFF
--- a/data/data/agent/systemd/units/agent-extract-tui.service
+++ b/data/data/agent/systemd/units/agent-extract-tui.service
@@ -10,7 +10,7 @@ Type=oneshot
 # Temporarily load assisted-install-ui here. It was previously in agent-extract-tui.service in the
 # agent-install-utils repo but that service is being removed. 
 # TODO: Remove after assisted-install-ui is productized.
-ExecStartPre=/bin/bash -c "podman tag $(podman load -q -i /run/media/iso/images/assisted-install-ui/assisted-install-ui.tar | awk '{print $NF}') localhost/agent-installer-ui:latest"
+ExecStartPre=/bin/bash -c "podman tag $(podman load -q -i /run/media/iso/images/agent-installer-ui/agent-installer-ui.tar | awk '{print $NF}') localhost/agent-installer-ui:latest"
 ExecStart=/usr/local/bin/agent-extract-tui.sh
 TimeoutStartSec=0
 


### PR DESCRIPTION
The tar file path was changed in https://github.com/openshift/agent-installer-utils/pull/132 when the image was switched to agent-installer-ui.

The path to the tar file in agent-extract-tui.service now needs to be updated.