### PR TITLE
OCPBUGS-60545: Azure: change LB and pubic IP skus to Standard

### DIFF
--- a/upi/azurestack/03_infra.json
+++ b/upi/azurestack/03_infra.json
@@ -21,9 +21,12 @@
     "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
     "masterLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('masterLoadBalancerName'))]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-cluster')]",
+    "outboundPulicIpAddressName" : "[concat(parameters('baseName'), '-outbound-pip')]",
+    "outboundPulicIpAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('outboundPulicIpAddressName'))]",
+    "outboundBackendPoolName" : "[concat(parameters('baseName'), '-outbound')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal')]",
     "internalLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('internalLoadBalancerName'))]",
-    "skuName": "Basic"
+    "skuName": "Standard"
   },
   "resources" : [
     {
@@ -56,6 +59,21 @@
     },
     {
       "apiVersion" : "2017-10-01",
+      "type" : "Microsoft.Network/publicIPAddresses",
+      "name" : "[variables('outboundPulicIpAddressName')]",
+      "location" : "[variables('location')]",
+      "sku": {
+        "name": "[variables('skuName')]"
+      },
+      "properties" : {
+        "publicIPAllocationMethod" : "Static",
+        "dnsSettings" : {
+          "domainNameLabel" : "[variables('outboundPulicIpAddressName')]"
+        }
+      }
+    },
+    {
+      "apiVersion" : "2018-06-01",
       "type" : "Microsoft.Network/loadBalancers",
       "name" : "[variables('masterLoadBalancerName')]",
       "location" : "[variables('location')]",
@@ -74,11 +92,22 @@
                 "id" : "[variables('masterPublicIpAddressID')]"
               }
             }
+          },
+          {
+            "name" : "outbound-frontendEnd",
+            "properties" : {
+              "publicIPAddress" : {
+                "id" : "[variables('outboundPulicIpAddressID')]"
+              }
+            }
           }
         ],
         "backendAddressPools" : [
           {
             "name" : "[variables('masterLoadBalancerName')]"
+          },
+          {
+            "name" : "[variables('outboundBackendPoolName')]"
           }
         ],
         "loadBalancingRules" : [
@@ -99,6 +128,24 @@
               "probe" : {
                 "id" : "[concat(variables('masterLoadBalancerID'), '/probes/api-public-probe')]"
               }
+            }
+          }
+        ],
+        "outboundRules": [
+          {
+            "name": "OutboundNATAllProtocols",
+            "properties": {
+              "backendAddressPool": {
+                "id": "[concat(variables('masterLoadBalancerID'), '/backendAddressPools/', variables('outboundBackendPoolName'))]"
+              },
+              "enableTcpReset": false,
+              "frontendIPConfigurations": [
+                {
+                  "id": "[concat(variables('masterLoadBalancerID'), '/frontendIPConfigurations/outbound-frontendEnd')]"
+                }
+              ],
+              "idleTimeoutInMinutes": 4,
+              "protocol": "All"
             }
           }
         ],

--- a/upi/azurestack/04_bootstrap.json
+++ b/upi/azurestack/04_bootstrap.json
@@ -56,7 +56,7 @@
       "name" : "[variables('sshPublicIpAddressName')]",
       "location" : "[variables('location')]",
       "sku": {
-        "name": "Basic"
+        "name": "Standard"
       },
       "properties" : {
         "publicIPAllocationMethod" : "Static",

--- a/upi/azurestack/05_masters.json
+++ b/upi/azurestack/05_masters.json
@@ -48,6 +48,7 @@
     "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-cluster')]",
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal')]",
+    "outboundBackendPoolName" : "[concat(parameters('baseName'), '-outbound')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "clusterNsgName" : "[concat(parameters('baseName'), '-nsg')]",
     "imageName" : "[parameters('baseName')]",
@@ -97,6 +98,9 @@
               "loadBalancerBackendAddressPools" : [
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
+                },
+                {
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('outboundBackendPoolName'))]"
                 },
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/', variables('internalLoadBalancerName'))]"

--- a/upi/azurestack/06_workers.json
+++ b/upi/azurestack/06_workers.json
@@ -47,7 +47,8 @@
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
     "nodeSubnetName" : "[concat(parameters('baseName'), '-worker-subnet')]",
     "nodeSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('nodeSubnetName'))]",
-    "infraLoadBalancerName" : "[parameters('baseName')]",
+    "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
+    "outboundBackendPoolName" : "[concat(parameters('baseName'), '-outbound')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "imageName" : "[parameters('baseName')]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-cluster')]",
@@ -93,7 +94,12 @@
               "privateIPAllocationMethod" : "Dynamic",
               "subnet" : {
                 "id" : "[variables('nodeSubnetRef')]"
-              }
+              },
+              "loadBalancerBackendAddressPools" : [
+                {
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('outboundBackendPoolName'))]"
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
4.19 UPI installation on Azure Stack Hub failed when waiting for cluster completed, ingress operator was degraded, see below error reported from ingress operator:
```
2025-08-18T07:31:57.379Z        ERROR   operator.ingress_controller     controller/controller.go:118    got retryable error; requeueing {"after": "1m0s", "error": "IngressController is degraded: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: PUT https://management.mtcazs.wwtatc.com/subscriptions/d751283a-64fa-401b-92a1-58f1750ac0a7/resourceGroups/jima419-xwlcj-rg/providers/Microsoft.Network/loadBalancers/jima419-xwlcj\n--------------------------------------------------------------------------------\nRESPONSE 400: 400 Bad Request\nERROR CODE: EnableTcpResetOnlyAllowedForStandardSkuLoadBalancer\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"EnableTcpResetOnlyAllowedForStandardSkuLoadBalancer\",\n    \"message\": \"Enable Tcp reset is only allowed for standard SKU load balancer. Load balancer /subscriptions/d751283a-64fa-401b-92a1-58f1750ac0a7/resourceGroups/jima419-xwlcj-rg/providers/Microsoft.Network/loadBalancers/jima419-xwlcj is not standard SKU.\",\n    \"details\": []\n  }\n}\n--------------------------------------------------------------------------------\n\nThe cloud-controller-manager logs may contain more details.), CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing. Last 1 error messages:\nerror sending canary HTTP request: DNS error: Get \"https://canary-openshift-ingress-canary.apps.jima419.installer-2.redhat.wwtatc.com/\": dial tcp: lookup canary-openshift-ingress-canary.apps.jima419.installer-2.redhat.wwtatc.com on 172.30.0.10:53: no such host (x15 over 14m0s))"}
```
The public IP skus of router rules in public LB is changed to `Standard` while public LB skus created by installer is still `Basic`, this causes the failure.

On 4.20, the situation gets worse, both public LB and internal LB were deleted when running 03_master.json template to provision master nodes.

Checked on 4.19+ CAPI-based IPI installation on ASH, all skus for load balancer and public IP are changed to Standard, so update azure stack hub UPI arm template to modify those skus.

After updating skus from "Basic" to "Standard", installation still failed because node could not access internet.
So do the similar things as IPI, create outbound rules in public LB to provide outbound access.

The changes have already been verified through QE jenkins jobs ([flexy-templates#2343](https://gitlab.cee.redhat.com/aosqe/flexy-templates/-/merge_requests/2343)). UPI installation on both 4.19 and 4.20 get successful.