### PR TITLE
OCPBUGS-60687: PowerVS: Add lon04 support

### DIFF
--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -62,6 +62,9 @@ var Regions = map[string]Region{
 			"lon06": {
 				SysTypes: []string{"s922", "e980"},
 			},
+			"lon04": {
+				SysTypes: []string{"s922", "e980"},
+			},
 		},
 		VPCZones: []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
 	},


### PR DESCRIPTION
Add the zone lon4 to the PowerVS installer.