### PR TITLE
OCPBUGS-60600: node-joner ignore error if SSH key was not found

### DIFF
--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -320,6 +320,10 @@ func (ci *ClusterInfo) retrieveSSHKey() error {
 			ci.SSHKey = installConfig.SSHKey
 			return nil
 		}
+
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	var ign igntypes.Config


### PR DESCRIPTION
When collecting the data from the target cluster, the ClusterInfo asset shouldn't fail if there wasn't any SSH key configured