### PR TITLE
OCPBUGS-60162: reject byo vpc/subnets with CAPI owned cluster tag

### DIFF
--- a/pkg/asset/installconfig/aws/tags.go
+++ b/pkg/asset/installconfig/aws/tags.go
@@ -12,6 +12,10 @@ const (
 	// to differentiate multiple logically independent clusters running in the same AZ.
 	TagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
 
+	// TagNameAWSProviderClusterPrefix is the tag prefix added by CAPI/CAPA to differentiate
+	// cluster-api-provider-aws owned components.
+	TagNameAWSProviderClusterPrefix = "sigs.k8s.io/cluster-api-provider-aws/cluster/"
+
 	// TagValueOwned is the tag value to indicate that a resource is considered owned
 	// and managed by the cluster.
 	TagValueOwned = "owned"
@@ -55,7 +59,7 @@ func (t Tags) HasTagKeyPrefix(prefix string) bool {
 }
 
 // HasClusterOwnedTag returns true if there is a cluster owned tag.
-// That is  kubernetes.io/cluster/<cluster-id>: owned.
+// That is "kubernetes.io/cluster/<cluster-id>: owned".
 func (t Tags) HasClusterOwnedTag() bool {
 	clusterIDs := t.GetOwnedClusterIDs()
 	return len(clusterIDs) > 0
@@ -68,6 +72,27 @@ func (t Tags) GetOwnedClusterIDs() []string {
 	for _, key := range keys {
 		if value := t[key]; value == TagValueOwned {
 			if clusterID := strings.TrimPrefix(key, TagNameKubernetesClusterPrefix); clusterID != "" {
+				clusterIDs = append(clusterIDs, clusterID)
+			}
+		}
+	}
+	return clusterIDs
+}
+
+// HasClusterAPIOwnedTag returns true if there is a CAPI/CAPA cluster owned tag.
+// That is "sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-id>: owned".
+func (t Tags) HasClusterAPIOwnedTag() bool {
+	clusterIDs := t.GetOwnedCAPIClusterIDs()
+	return len(clusterIDs) > 0
+}
+
+// GetOwnedCAPIClusterIDs returns the cluster IDs from tag "sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-id>: owned" if any.
+func (t Tags) GetOwnedCAPIClusterIDs() []string {
+	clusterIDs := make([]string, 0)
+	keys := t.GetTagKeysWithPrefix(TagNameAWSProviderClusterPrefix)
+	for _, key := range keys {
+		if value := t[key]; value == TagValueOwned {
+			if clusterID := strings.TrimPrefix(key, TagNameAWSProviderClusterPrefix); clusterID != "" {
 				clusterIDs = append(clusterIDs, clusterID)
 			}
 		}

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -721,7 +721,9 @@ func validateUntaggedSubnets(ctx context.Context, fldPath *field.Path, meta *Met
 }
 
 // validateSharedVPC ensures the BYO VPC can be shared to install the new cluster.
-// That is the VPC must not have have tag: kubernetes.io/cluster/<another-cluster-id>: owned.
+// That is the VPC must not have have tags:
+// - "kubernetes.io/cluster/<another-cluster-id>: owned"
+// - "sigs.k8s.io/cluster-api-provider-aws/cluster/<another-cluster-id>: owned".
 func validateSharedVPC(ctx context.Context, meta *Metadata, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -730,8 +732,15 @@ func validateSharedVPC(ctx context.Context, meta *Metadata, fldPath *field.Path)
 		return append(allErrs, field.Invalid(fldPath, meta.ProvidedSubnets, err.Error()))
 	}
 
-	if vpc.Tags.HasClusterOwnedTag() {
-		clusterIDs := vpc.Tags.GetOwnedClusterIDs()
+	var clusterIDs []string
+	switch {
+	case vpc.Tags.HasClusterOwnedTag():
+		clusterIDs = vpc.Tags.GetOwnedClusterIDs()
+	case vpc.Tags.HasClusterAPIOwnedTag():
+		clusterIDs = vpc.Tags.GetOwnedCAPIClusterIDs()
+	}
+
+	if len(clusterIDs) > 0 {
 		allErrs = append(allErrs, field.Forbidden(fldPath,
 			fmt.Sprintf("VPC of subnets is owned by other clusters %v and cannot be used for new installations, another VPC must be created separately", clusterIDs)))
 	}
@@ -740,7 +749,9 @@ func validateSharedVPC(ctx context.Context, meta *Metadata, fldPath *field.Path)
 }
 
 // validateSharedSubnets ensures the BYO subnets can be shared to install the new cluster.
-// That is the subnets must not have have tag: kubernetes.io/cluster/<another-cluster-id>: owned.
+// That is the subnets must not have have tags:
+// - "kubernetes.io/cluster/<another-cluster-id>: owned"
+// - "sigs.k8s.io/cluster-api-provider-aws/cluster/<another-cluster-id>: owned".
 func validateSharedSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -750,8 +761,15 @@ func validateSharedSubnets(ctx context.Context, meta *Metadata, fldPath *field.P
 	}
 
 	for id, subnet := range mergeSubnets(subnets.Private, subnets.Public, subnets.Edge) {
-		if subnet.Tags.HasClusterOwnedTag() {
-			clusterIDs := subnet.Tags.GetOwnedClusterIDs()
+		var clusterIDs []string
+		switch {
+		case subnet.Tags.HasClusterOwnedTag():
+			clusterIDs = subnet.Tags.GetOwnedClusterIDs()
+		case subnet.Tags.HasClusterAPIOwnedTag():
+			clusterIDs = subnet.Tags.GetOwnedCAPIClusterIDs()
+		}
+
+		if len(clusterIDs) > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("subnet %s is owned by other clusters %v and cannot be used for new installations, another subnet must be created separately", id, clusterIDs)))
 		}
 	}

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -1173,6 +1173,22 @@ func TestValidate(t *testing.T) {
 			expectErr: `^\Qplatform.aws.vpc.subnets: Forbidden: VPC of subnets is owned by other clusters [another-cluster] and cannot be used for new installations, another VPC must be created separately\E$`,
 		},
 		{
+			name: "invalid byo subnets, vpc has CAPI cluster-owned tags",
+			installConfig: icBuild.build(
+				icBuild.withBaseBYO(),
+			),
+			availRegions: validAvailRegions(),
+			subnets: SubnetGroups{
+				Private: validSubnets("private"),
+				Public:  validSubnets("public"),
+				VpcID:   validVPCID,
+			},
+			vpcTags: Tags{
+				"sigs.k8s.io/cluster-api-provider-aws/cluster/another-cluster": "owned",
+			},
+			expectErr: `^\Qplatform.aws.vpc.subnets: Forbidden: VPC of subnets is owned by other clusters [another-cluster] and cannot be used for new installations, another VPC must be created separately\E$`,
+		},
+		{
 			name: "invalid byo subnets, subnets have cluster-owned tags",
 			installConfig: icBuild.build(
 				icBuild.withBaseBYO(),
@@ -1186,7 +1202,7 @@ func TestValidate(t *testing.T) {
 			subnets: SubnetGroups{
 				Private: validSubnets("private"),
 				Public: mergeSubnets(validSubnets("public"), Subnets{
-					"subnet-valid-public-a1": {
+					"subnet-valid-public-d": {
 						ID:     "subnet-valid-public-d",
 						Zone:   &Zone{Name: "d"},
 						CIDR:   "10.0.6.0/24",
@@ -1198,7 +1214,35 @@ func TestValidate(t *testing.T) {
 				}),
 				VpcID: validVPCID,
 			},
-			expectErr: `^\Qplatform.aws.vpc.subnets: Forbidden: subnet subnet-valid-public-a1 is owned by other clusters [another-cluster] and cannot be used for new installations, another subnet must be created separately\E$`,
+			expectErr: `^\Qplatform.aws.vpc.subnets: Forbidden: subnet subnet-valid-public-d is owned by other clusters [another-cluster] and cannot be used for new installations, another subnet must be created separately\E$`,
+		},
+		{
+			name: "invalid byo subnets, subnets have CAPI cluster-owned tags",
+			installConfig: icBuild.build(
+				icBuild.withBaseBYO(),
+				icBuild.withVPCSubnets([]aws.Subnet{
+					{
+						ID: "subnet-valid-public-d",
+					},
+				}, false),
+			),
+			availRegions: validAvailRegions(),
+			subnets: SubnetGroups{
+				Private: validSubnets("private"),
+				Public: mergeSubnets(validSubnets("public"), Subnets{
+					"subnet-valid-public-d": {
+						ID:     "subnet-valid-public-d",
+						Zone:   &Zone{Name: "d"},
+						CIDR:   "10.0.6.0/24",
+						Public: true,
+						Tags: Tags{
+							"sigs.k8s.io/cluster-api-provider-aws/cluster/another-cluster": "owned",
+						},
+					},
+				}),
+				VpcID: validVPCID,
+			},
+			expectErr: `^\Qplatform.aws.vpc.subnets: Forbidden: subnet subnet-valid-public-d is owned by other clusters [another-cluster] and cannot be used for new installations, another subnet must be created separately\E$`,
 		},
 	}
 


### PR DESCRIPTION
This adds an additional check for CAPI owned cluster tag sigs.k8s.io/cluster-api-provider-aws/cluster/<id>:owned.

Since the destroy code is also searching for this tag to clean up cluster resources[1], it is reasonable to safe-guard against this case.

**References** (`metadata.json`)

https://github.com/openshift/installer/blob/d0aabcc2a97cc8d383d6dd957169ca6713be94af/pkg/asset/cluster/aws/aws.go#L30-L32

**Notes**

It seems unlikely that a vpc/subnet has a tag `sigs.k8s.io/cluster-api-provider-aws/cluster/<id>:owned` but doesn't have the corresponding `kubernetes.io/cluster/<id>:owned` tag... :thought_balloon: 

But "unlikely" does not mean it won't happen and the destroy code is also searching that CAPA tag. So, I thought we could just add this additional check.

The tag search order is:
1. `kubernetes.io/cluster/<id>:owned`
2. `sigs.k8s.io/cluster-api-provider-aws/cluster/<id>:owned` if none is found in 1.