### PR TITLE
OCPBUGS-61111: Allow user to BYO private zone without specifying name

### DIFF
--- a/pkg/asset/cluster/tfvars/tfvars.go
+++ b/pkg/asset/cluster/tfvars/tfvars.go
@@ -517,10 +517,11 @@ func (t *TerraformVariables) Generate(ctx context.Context, parents asset.Parents
 			}
 
 			// Set the private zone
-			privateZoneName, _, err = manifests.GetGCPPrivateZoneName(ctx, client, installConfig, clusterID.InfraID)
+			params, err := manifests.GetGCPPrivateZoneInfo(ctx, client, installConfig, clusterID.InfraID)
 			if err != nil {
 				return fmt.Errorf("failed to find gcp private dns zone: %w", err)
 			}
+			privateZoneName = params.Name
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -238,7 +238,7 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 		}
 
 		// Create the public (optional) and private dns records
-		if err := createDNSRecords(ctx, in.InstallConfig, in.InfraID, apiIPAddress, apiIntIPAddress); err != nil {
+		if err := createDNSRecords(ctx, client, in.InstallConfig, in.InfraID, apiIPAddress, apiIntIPAddress); err != nil {
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}
 	}

--- a/pkg/types/gcp/dns.go
+++ b/pkg/types/gcp/dns.go
@@ -17,4 +17,9 @@ type DNSZoneParams struct {
 	// BaseDomain is the base domain of the DNS zone.
 	// Note that either `Name` or `BaseDomain` must be provided.
 	BaseDomain string
+
+	// InstallerCreated is true when the DNS zone should be created
+	// by the OpenShift Installer (and will be owned by the
+	// OpenShift Installer).
+	InstallerCreated bool
 }


### PR DESCRIPTION
pkg/asset/manifests/dns.go:
** Find private DNS zone for XPN installs even when the user did not specify one. If there is an existing private DNS zone then the user can bring that for XPN installs. This fixes a regression that forced users to enter the name or use the default name for private zones.