### PR TITLE
MON-4357: Bump API version to include Monitoring capability

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1461,6 +1461,7 @@ spec:
                   - Ingress
                   - CloudControllerManager
                   - OperatorLifecycleManagerV1
+                  - Monitoring
                   type: string
                 type: array
               baselineCapabilitySet:

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0
 	github.com/nutanix-cloud-native/prism-go-client v0.5.0
 	github.com/onsi/gomega v1.36.3
-	github.com/openshift/api v0.0.0-20250806102053-6a7223edb2fc
+	github.com/openshift/api v0.0.0-X-Y
 	github.com/openshift/assisted-image-service v0.0.0-20240607085136-02df2e56dde6
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/client v0.0.0


### PR DESCRIPTION
Bump API version to include "Monitoring" capability in Installer so it doesn't get rejected.

Blocked by: https://github.com/openshift/api/pull/2468/files