### PR TITLE
SPLAT-2465: Changed LB VM creation to not be hard coded and use from variables.ps1

### DIFF
--- a/upi/vsphere/powercli/upi.ps1
+++ b/upi/vsphere/powercli/upi.ps1
@@ -263,7 +263,7 @@ $template = Get-VM -Server $fds[0].server -Name $vm_template -Location $fds[0].d
 # Create LB for Cluster
 $ignition = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((New-LoadBalancerIgnition $sshKey)))
 $network = New-VMNetworkConfig -Server $fds[0].server -Hostname "$($metadata.infraID)-lb" -IPAddress $lb_ip_address -Netmask $netmask -Gateway $gateway -DNS $dns -Network $failure_domains[0].network
-$vm = New-OpenShiftVM -IgnitionData $ignition -Name "$($metadata.infraID)-lb" -Template $template -Server $fds[0].server -ResourcePool $rp -Datastore $datastoreInfo -Location $folder -Tag $tag -Networking $network -Network $($fds[0].network) -SecureBoot $secureboot -StoragePolicy $storagepolicy -MemoryMB 8192 -NumCpu 4 -CoresPerSocket 4
+$vm = New-OpenShiftVM -IgnitionData $ignition -Name "$($metadata.infraID)-lb" -Template $template -Server $fds[0].server -ResourcePool $rp -Datastore $datastoreInfo -Location $folder -Tag $tag -Networking $network -Network $($fds[0].network) -SecureBoot $secureboot -StoragePolicy $storagepolicy -MemoryMB $lb_memory -NumCpu $lb_num_cpus -CoresPerSocket $lb_cores_per_socket
 $vm | Start-VM
 
 # Take the $virtualmachines defined in upi-variables and convert to a powershell object


### PR DESCRIPTION
[SPLAT-2465](https://issues.redhat.com//browse/SPLAT-2465)

###  Changes
- Changed the creation of the LB VM to get cpu / memory / coresPerSocket from variables.ps1 instead of being hard coded.