### PR TITLE
OCPBUGS-61373: Fix agent shellcheck issues

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-extract-tui.sh
+++ b/data/data/agent/files/usr/local/bin/agent-extract-tui.sh
@@ -3,17 +3,18 @@
 set -xeuo pipefail
 
 /usr/local/bin/get-container-images.sh
+# shellcheck disable=SC1091
 source /usr/local/share/assisted-service/agent-images.env
 
 echo "Extracting agent-tui and libnmstate from agent-installer-utils image $AGENT_INSTALLER_UTILS_IMAGE"
 
-container_id=$(podman create $AGENT_INSTALLER_UTILS_IMAGE)
-mnt=$(podman mount $container_id)
+container_id=$(podman create "$AGENT_INSTALLER_UTILS_IMAGE")
+mnt=$(podman mount "$container_id")
 
-cp ${mnt}/usr/bin/agent-tui /usr/local/bin
-cp ${mnt}/usr/lib64/libnmstate.so.* /usr/local/lib
+cp "${mnt}/usr/bin/agent-tui" /usr/local/bin
+cp "${mnt}/usr/lib64/libnmstate.so.*" /usr/local/lib
 
-podman unmount $container_id
-podman rm $container_id
+podman unmount "$container_id"
+podman rm "$container_id"
 
 restorecon -FRv /usr/local/bin

--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -54,7 +54,7 @@ check_host_config() {
 check_ui() {
     local ui_issue="90_ui-availability"
     if systemctl is-active --quiet "agent-start-ui"; then
-       echo "\\e{green}Please go to \\e{lightgreen}$AIUI_URL\\e{reset}\\e{green} in your browser to continue the installation\\e{reset}" | set_issue "${ui_issue}"
+       printf "\\e{green}Please go to \\e{lightgreen}%s\\e{reset}\\e{green} in your browser to continue the installation\\e{reset}" "${AIUI_URL}" | set_issue "${ui_issue}"
     else
        clear_issue "${ui_issue}"        
     fi


### PR DESCRIPTION
Disable shellcheck on agent-image.env The file is generated at runtime after get-container-images.sh is executed.

Added missing double quotes and switch echo to printf in install-status.sh