### PR TITLE
OCPBUGS-61373: Fix shellcheck issues in bootstrap

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/build-metal3-env.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/build-metal3-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -10,7 +10,7 @@ function lookup_url() {
     unset IPS
     unset IP
     IPS=$(dig "${2}" +short)
-    if [[ ! -z "${IPS}" ]] ; then
+    if [[ -n "${IPS}" ]] ; then
         echo "Successfully resolved ${1} ${2}"
         return 0
     else

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -6,7 +6,7 @@
 # Get target architecture
 arch=$(uname -m)
 
-if test "x${1}" = 'x--id'
+if test "${1}" = '--id'
 then
 	GATHER_ID="${2}"
 	shift 2

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -3,7 +3,7 @@
 # Get target architecture
 arch=$(uname -m)
 
-if test "x${1}" = 'x--id'
+if test "${1}" = '--id'
 then
 	GATHER_ID="${2}"
 	shift 2


### PR DESCRIPTION
This patch addresses these shellcheck errors:
```
./data/data/bootstrap/baremetal/files/usr/local/bin/build-metal3-env.sh:3:10: warning: In POSIX sh, set option pipefail is undefined. [SC3040]
./data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh:13:11: note: Use -n instead of ! -z. [SC2236]
./data/data/bootstrap/files/usr/local/bin/installer-gather.sh:9:9: note: Avoid x-prefix in comparisons as it no longer serves a purpose. [SC2268]
./data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh:6:9: note: Avoid x-prefix in comparisons as it no longer serves a purpose. [SC2268]
```
Seen in https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_release/67587/rehearse-67587-pull-ci-openshift-installer-main-shellcheck/1964017457890856960/build-log.txt