### PR TITLE
WIP OCPBUGS-61473: PowerVC: Upload ignition to Swift

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6917,6 +6917,11 @@ spec:
                       in your OpenShift cluster.
                       Deprecated: the machine manifest should be used to specify that trunk should be used.
                     type: string
+                  uploadIgnitionSwift:
+                    description: |-
+                      UploadIgnitionSwift will upload the bootstrap's ignition file to the Swift object storage
+                      rather than the Glance image storage.
+                    type: boolean
                 required:
                 - cloud
                 type: object

--- a/pkg/infrastructure/openstack/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/openstack/clusterapi/clusterapi.go
@@ -140,7 +140,7 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		installConfig    = in.InstallConfig
 	)
 
-	ignShim, err := preprovision.UploadIgnitionAndBuildShim(ctx, installConfig.Config.Platform.OpenStack.Cloud, infraID, installConfig.Config.Proxy, bootstrapIgnData)
+	ignShim, err := preprovision.UploadIgnitionAndBuildShim(ctx, installConfig.Config.Platform.OpenStack.Cloud, infraID, installConfig.Config.Proxy, bootstrapIgnData, installConfig.Config.Platform.OpenStack.UploadIgnitionSwift)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload and build ignition shim: %w", err)
 	}

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -129,4 +129,9 @@ type Platform struct {
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
 	// +optional
 	LoadBalancer *configv1.OpenStackPlatformLoadBalancer `json:"loadBalancer,omitempty"`
+
+	// UploadIgnitionSwift will upload the bootstrap's ignition file to the Swift object storage
+	// rather than the Glance image storage.
+	// +optional
+	UploadIgnitionSwift bool `json:"uploadIgnitionSwift,omitempty"`
 }


### PR DESCRIPTION
Provide an install-config.yaml option to upload the bootstrap node's ignition file to Swift object storage instead of Glance image storage.