### PR TITLE
MGMT-21586: Add an option in image-based installation to specify architecture

### DIFF
--- a/pkg/asset/imagebased/image/imagebased_config_test.go
+++ b/pkg/asset/imagebased/image/imagebased_config_test.go
@@ -457,6 +457,54 @@ extraPartitionStart: ""
 			expectedFound: false,
 			expectedError: "invalid Image-based Installation ISO Config: ExtraPartitionStart: Required value: partition start sector cannot be empty",
 		},
+		{
+			name: "valid-architecture-amd64",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+architecture: amd64
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
+		{
+			name: "valid-architecture-arm64",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+architecture: arm64
+`,
+
+			expectedFound: true,
+			expectedError: "",
+		},
+		{
+			name: "invalid-architecture-random-string",
+			data: `
+apiVersion: v1beta1
+metadata:
+  name: image-based-installation-config
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}"
+seedVersion: 4.16.0
+seedImage: quay.io/openshift-kni/seed-image:4.16.0
+installationDisk: /dev/vda
+architecture: "invalid"
+`,
+
+			expectedFound: false,
+			expectedError: "invalid Image-based Installation ISO Config: architecture: Invalid value: \"invalid\": architecture must be one of [amd64 arm64]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -540,6 +588,11 @@ func (icb *ImageBasedInstallationConfigBuilder) imageDigestSources(ids []types.I
 
 func (icb *ImageBasedInstallationConfigBuilder) ignitionConfigOverride(ignitionConfigOverride string) *ImageBasedInstallationConfigBuilder {
 	icb.InstallationConfig.IgnitionConfigOverride = ignitionConfigOverride
+	return icb
+}
+
+func (icb *ImageBasedInstallationConfigBuilder) architecture(architecture string) *ImageBasedInstallationConfigBuilder {
+	icb.InstallationConfig.Architecture = architecture
 	return icb
 }
 

--- a/pkg/types/imagebased/imagebased_config_types.go
+++ b/pkg/types/imagebased/imagebased_config_types.go
@@ -62,6 +62,11 @@ type InstallationConfig struct {
 	// +optional
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
+	// Architecture is the instruction set architecture for the machines
+	// that will be installed. Defaults to amd64.
+	// +optional
+	Architecture string `json:"architecture,omitempty"`
+
 	// ExtraPartitionLabel label of extra partition used for /var/lib/containers.
 	// Default is var-lib-containers
 	// +optional


### PR DESCRIPTION
Recently LCA operator added support for ARM-based clusters, and we want to extend that support to image-based installations.
This PR adds the option for users to choose the architecture they want and specify arm64 as it's value.