### PR TITLE
OCPBUGS-61514: Add check for gcp firewall deletion permission

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -262,7 +262,7 @@ func (p Provider) DestroyBootstrap(ctx context.Context, in clusterapi.BootstrapD
 	if in.Metadata.GCP.NetworkProjectID != "" {
 		projectID = in.Metadata.GCP.NetworkProjectID
 
-		createFwRules, err := hasFirewallPermission(ctx, projectID, in.Metadata.GCP.ServiceEndpoints)
+		createFwRules, err := hasFirewallPermission(ctx, projectID, []string{gcpDeleteFirewallPermission}, in.Metadata.GCP.ServiceEndpoints)
 		if err != nil {
 			return fmt.Errorf("failed to remove bootstrap firewall rules: %w", err)
 		}


### PR DESCRIPTION
** If the user did not have the firewall create permission it was possible for the user to skip the creation of gcp firewall rules and their creation is left to the user. When the user does have the firewall create permission but is missing the delete permission it was possible for the bootstrap firewall rules to be skipped leaking resources. Typically these permissions should be paired together, but if a user accidentally left the destroy out we were failing to check for this permission. Now the permission is checked to ensure that any resource created by the installer is also destroyed.