### PR TITLE
CORS-4162: Remove GCPClusterHostedDNSInstall featuregate

### DIFF
--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -5,7 +5,6 @@ import (
 
 	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/featuregates"
 )
 
@@ -14,11 +13,6 @@ import (
 func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
 	g := c.GCP
 	return []featuregates.GatedInstallConfigFeature{
-		{
-			FeatureGateName: features.FeatureGateGCPClusterHostedDNSInstall,
-			Condition:       g.UserProvisionedDNS == dns.UserProvisionedDNSEnabled,
-			Field:           field.NewPath("platform", "gcp", "userProvisionedDNS"),
-		},
 		{
 			FeatureGateName: features.FeatureGateGCPCustomAPIEndpointsInstall,
 			Condition:       len(g.ServiceEndpoints) > 0,

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -20,16 +20,6 @@ func TestFeatureGates(t *testing.T) {
 		expected      string
 	}{
 		{
-			name: "GCP UserProvisionedDNS is not allowed without Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.GCP = validGCPPlatform()
-				c.GCP.UserProvisionedDNS = dns.UserProvisionedDNSEnabled
-				return c
-			}(),
-			expected: `^platform.gcp.userProvisionedDNS: Forbidden: this field is protected by the GCPClusterHostedDNSInstall feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
-		{
 			name: "GCP Custom API Endpoints is not allowed without Feature Gates",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
Remove check for this featuregate since the feature has been promoted to GA. 
openshift/api version update is going to be part of a larger effort to update several packages.