### PR TITLE
OCPBUGS-61901: Update explain for Publish

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -7837,11 +7837,13 @@ spec:
             default: External
             description: |-
               Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+              A "Mixed" strategy only applies to the "azure" platform, and requires "operatorPublishingStrategy" to be configured.
               When no strategy is specified, the strategy is "External".
             enum:
             - ""
             - External
             - Internal
+            - Mixed
             type: string
           pullSecret:
             description: PullSecret is the secret to use when pulling images.

--- a/pkg/explain/fields_lookup_test.go
+++ b/pkg/explain/fields_lookup_test.go
@@ -20,6 +20,7 @@ func Test_lookup(t *testing.T) {
 	}, {
 		path: []string{"publish"},
 		desc: `Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+A "Mixed" strategy only applies to the "azure" platform, and requires "operatorPublishingStrategy" to be configured.
 When no strategy is specified, the strategy is "External".`,
 	}, {
 		path: []string{"publish", "unknown"},

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -143,8 +143,9 @@ If unset, the cluster will not be configured to use a proxy.
 
     publish <string>
       Default: "External"
-      Valid Values: "","External","Internal"
+      Valid Values: "","External","Internal","Mixed"
       Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+A "Mixed" strategy only applies to the "azure" platform, and requires "operatorPublishingStrategy" to be configured.
 When no strategy is specified, the strategy is "External".
 
     pullSecret <string> -required-
@@ -414,8 +415,9 @@ VERSION:  v1
 
 RESOURCE: <string>
   Default: "External"
-  Valid Values: "","External","Internal"
+  Valid Values: "","External","Internal","Mixed"
   Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+A "Mixed" strategy only applies to the "azure" platform, and requires "operatorPublishingStrategy" to be configured.
 When no strategy is specified, the strategy is "External".
 		`,
 	}, {

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -63,7 +63,7 @@ var (
 )
 
 // PublishingStrategy is a strategy for how various endpoints for the cluster are exposed.
-// +kubebuilder:validation:Enum="";External;Internal
+// +kubebuilder:validation:Enum="";External;Internal;Mixed
 type PublishingStrategy string
 
 const (
@@ -157,6 +157,7 @@ type InstallConfig struct {
 	ImageDigestSources []ImageDigestSource `json:"imageDigestSources,omitempty"`
 
 	// Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+	// A "Mixed" strategy only applies to the "azure" platform, and requires "operatorPublishingStrategy" to be configured.
 	// When no strategy is specified, the strategy is "External".
 	//
 	// +kubebuilder:default=External


### PR DESCRIPTION
Update the publish strategy to include "Mixed" (it was left out of the kube enum). 
Update the explain commands to ensure the Mixed info is present.