### PR TITLE
CORS-4107: Update default release image to 4.21

### DIFF
--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.20"
+	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.21"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
Updating default release image to latest version 4.21.