### PR TITLE
OCPBUGS-62297: Set default for PrivateDNSZone Project ID

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -85,13 +85,19 @@ type ClusterUninstaller struct {
 
 // New returns a GCP destroyer from ClusterMetadata.
 func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
+	privateZoneProjectID := metadata.ClusterPlatformMetadata.GCP.PrivateZoneProjectID
+	if privateZoneProjectID == "" {
+		// During upgrades, the PrivateZoneProjectID may not exist, default to ProjectID.
+		privateZoneProjectID = metadata.ClusterPlatformMetadata.GCP.ProjectID
+	}
+
 	return &ClusterUninstaller{
 		Logger:               logger,
 		Region:               metadata.ClusterPlatformMetadata.GCP.Region,
 		ProjectID:            metadata.ClusterPlatformMetadata.GCP.ProjectID,
 		NetworkProjectID:     metadata.ClusterPlatformMetadata.GCP.NetworkProjectID,
 		PrivateZoneDomain:    metadata.ClusterPlatformMetadata.GCP.PrivateZoneDomain,
-		PrivateZoneProjectID: metadata.ClusterPlatformMetadata.GCP.PrivateZoneProjectID,
+		PrivateZoneProjectID: privateZoneProjectID,
 		ClusterID:            metadata.InfraID,
 		cloudControllerUID:   gcptypes.CloudControllerUID(metadata.InfraID),
 		requestIDTracker:     newRequestIDTracker(),


### PR DESCRIPTION
Picks #9967 

** On upgrades, the PrivateZonePRojectID in the metadata will be left empty. This caused the deletion of Private DNS Zones to fail during an install from 4.19 that was upgrade to 4.20. In 4.20+ the field is expected and would contain the correct default value, but this field was unknown to 4.19. The field is now filled with the ProjectID when one does not exist.