### PR TITLE
OCPBUGS-62363: Set agent-extract-tui start timeout

### DIFF
--- a/data/data/agent/systemd/units/agent-extract-tui.service
+++ b/data/data/agent/systemd/units/agent-extract-tui.service
@@ -12,7 +12,7 @@ Type=oneshot
 # TODO: Remove after assisted-install-ui is productized.
 ExecStartPre=/bin/bash -c "podman tag $(podman load -q -i /run/media/iso/images/agent-installer-ui/agent-installer-ui.tar | awk '{print $NF}') localhost/agent-installer-ui:latest"
 ExecStart=/usr/local/bin/agent-extract-tui.sh
-TimeoutStartSec=0
+TimeoutStartSec=300s
 
 [Install]
 WantedBy=getty@tty1.service


### PR DESCRIPTION
Not timeout is currently set. If there is an underlying issue like an incorrectly configured registry.conf, the service runs continously.

Ssh and login waits for agent-extract-tui to complete and are blocked, leaving the host inaccessible.