### PR TITLE
CORS-4078: allow toggling AWS client logging

### DIFF
--- a/pkg/asset/installconfig/aws/endpoints.go
+++ b/pkg/asset/installconfig/aws/endpoints.go
@@ -68,8 +68,6 @@ type ServiceEndpointResolver struct {
 	// indexed by service ID.
 	endpoints       map[string]typesaws.ServiceEndpoint
 	endpointOptions EndpointOptions
-
-	logger logrus.FieldLogger
 }
 
 // NewServiceEndpointResolver returns a new ServiceEndpointResolver.
@@ -81,7 +79,6 @@ func NewServiceEndpointResolver(opts EndpointOptions) *ServiceEndpointResolver {
 	return &ServiceEndpointResolver{
 		endpoints:       endpointMap,
 		endpointOptions: opts,
-		logger:          logrus.StandardLogger(),
 	}
 }
 
@@ -98,11 +95,9 @@ func (s *EC2EndpointResolver) ResolveEndpoint(ctx context.Context, params ec2.En
 	// If custom endpoint not found, return default endpoint for the service.
 	endpoint, ok := s.endpoints[ec2.ServiceID]
 	if !ok {
-		s.logger.Debug("Custom EC2 endpoint not found, using default endpoint")
 		return ec2.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 	}
 
-	s.logger.Debugf("Custom EC2 endpoint found, using custom endpoint: %s", endpoint.URL)
 	params.Endpoint = aws.String(endpoint.URL)
 	params.Region = aws.String(s.endpointOptions.Region)
 	return ec2.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
@@ -121,11 +116,9 @@ func (s *IAMEndpointResolver) ResolveEndpoint(ctx context.Context, params iam.En
 	// If custom endpoint not found, return default endpoint for the service.
 	endpoint, ok := s.endpoints[iam.ServiceID]
 	if !ok {
-		s.logger.Debug("Custom IAM endpoint not found, using default endpoint")
 		return iam.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 	}
 
-	s.logger.Debugf("Custom IAM endpoint found, using custom endpoint: %s", endpoint.URL)
 	params.Endpoint = aws.String(endpoint.URL)
 	params.Region = aws.String(s.endpointOptions.Region)
 	return iam.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
@@ -144,11 +137,9 @@ func (s *STSEndpointResolver) ResolveEndpoint(ctx context.Context, params sts.En
 	// If custom endpoint not found, return default endpoint for the service
 	endpoint, ok := s.endpoints[sts.ServiceID]
 	if !ok {
-		s.logger.Debug("Custom STS endpoint not found, using default endpoint")
 		return sts.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 	}
 
-	s.logger.Debugf("Custom STS endpoint found, using custom endpoint: %s", endpoint.URL)
 	params.Endpoint = aws.String(endpoint.URL)
 	params.Region = aws.String(s.endpointOptions.Region)
 	return sts.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
@@ -167,11 +158,9 @@ func (s *Route53EndpointResolver) ResolveEndpoint(ctx context.Context, params ro
 	// If custom endpoint not found, return default endpoint for the service.
 	endpoint, ok := s.endpoints[route53.ServiceID]
 	if !ok {
-		s.logger.Debug("Custom Route53 endpoint not found, using default endpoint")
 		return route53.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 	}
 
-	s.logger.Debugf("Custom Route53 endpoint found, using custom endpoint: %s", endpoint.URL)
 	params.Endpoint = aws.String(endpoint.URL)
 	params.Region = aws.String(s.endpointOptions.Region)
 	return route53.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
@@ -190,11 +179,9 @@ func (s *ServiceQuotasEndpointResolver) ResolveEndpoint(ctx context.Context, par
 	// If custom endpoint not found, return default endpoint for the service.
 	endpoint, ok := s.endpoints[servicequotas.ServiceID]
 	if !ok {
-		s.logger.Debug("Custom Service Quotas endpoint not found, using default endpoint")
 		return servicequotas.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 	}
 
-	s.logger.Debugf("Custom Service Quotas endpoint found, using custom endpoint: %s", endpoint.URL)
 	params.Endpoint = aws.String(endpoint.URL)
 	params.Region = aws.String(s.endpointOptions.Region)
 	return servicequotas.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)

--- a/pkg/asset/installconfig/aws/sessionv2.go
+++ b/pkg/asset/installconfig/aws/sessionv2.go
@@ -46,7 +46,7 @@ type ConfigOptions []func(*config.LoadOptions) error
 
 // getDefaultConfigOptions returns the default settings for config.LoadOptions.
 func getDefaultConfigOptions() ConfigOptions {
-	return ConfigOptions{
+	opts := ConfigOptions{
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(so *retry.StandardOptions) {
 				so.MaxAttempts = RetryMaxAttempts
@@ -68,6 +68,14 @@ func getDefaultConfigOptions() ConfigOptions {
 			awsmiddleware.AddUserAgentKeyValue(OpenShiftInstallerUserAgent, version.Raw),
 		}),
 	}
+
+	// Enable logging the HTTP request sent to the AWS service
+	// including headers and body (if applicable).
+	if _, ok := os.LookupEnv("OPENSHIFT_INSTALL_AWS_ENABLE_SDK_LOG"); ok {
+		opts = append(opts, config.WithClientLogMode(aws.LogRequestWithBody|aws.LogResponseWithBody))
+	}
+
+	return opts
 }
 
 // GetConfig returns an AWS config by checking credentials


### PR DESCRIPTION
Debug logging within endpoint resolvers is useful to inspect whether the custom endpoints are correctly used. However, the setup prints a log line for every single API call. This pollutes the install logs, especially in CI environments.

Thus, the changes allows toggling the API call logs via environment varialble: `OPENSHIFT_INSTALL_AWS_ENABLE_SDK_LOG`. The logs will now include API request with body and response with body.

For example:

```bash
OPENSHIFT_INSTALL_AWS_ENABLE_SDK_LOG=true ./openshift-install create manifests --dir=.
```

```bash
INFO Credentials loaded from the AWS config using "SharedConfigCredentials: /home/user/.aws/credentials" provider 
SDK 2025/09/29 14:32:02 DEBUG Request
POST / HTTP/1.1
Host: ec2.us-east-1.amazonaws.com
User-Agent: aws-sdk-go-v2/1.39.0 ua/2.1 os/linux lang/go#1.24.6 md/GOOS#linux md/GOARCH#amd64 api/ec2#1.159.0 OpenShift-4.x-Installer/unreleased-master-12239-gfd9c351ca05e694283c62370aa2e40434607167f
Content-Length: 57
Amz-Sdk-Request: attempt=1; max=25


Action=DescribeRegions&AllRegions=true&Version=2016-11-15
SDK 2025/09/29 14:32:02 DEBUG Response
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cache-Control: no-cache, no-store
Content-Type: text/xml;charset=UTF-8
Date: Mon, 29 Sep 2025 21:32:02 GMT
Server: AmazonEC2

...something XML body...
```

**Note**: Some content in above example output is trimmed. That being said, there might be some sensitive information so copy logs with caution.