### PR TITLE
CORS-4058: use tags from ListUserTags response

### DIFF
--- a/pkg/destroy/aws/iamhelpers.go
+++ b/pkg/destroy/aws/iamhelpers.go
@@ -130,7 +130,7 @@ func (search *IamUserSearch) arns(ctx context.Context) ([]string, error) {
 				}
 			} else {
 				tags := make(map[string]string, len(response.Tags))
-				for _, tag := range user.Tags {
+				for _, tag := range response.Tags {
 					tags[*tag.Key] = *tag.Value
 				}
 				if tagMatch(search.filters, tags) {


### PR DESCRIPTION
The ListUsers API call does not return tags for the IAM users in the response. There is a separate call ListUserTags to fetch its tag for checking in the installer code.

This means the all IAM users, in the perspective of the installer, has no tags. Thus, the installer will "skip" deleting those. As a consequence, the installer discovers those IAM users but never deletes them...