### PR TITLE
OCPBUGS-62124: Update the RHCOS 4.20 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,106 +1,106 @@
 {
   "stream": "rhcos-4.20",
   "metadata": {
-    "last-modified": "2025-08-27T14:08:04Z",
-    "generator": "plume cosa2stream 661d6d6"
+    "last-modified": "2025-10-06T21:41:42Z",
+    "generator": "plume cosa2stream 4f2e2b8"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-aws.aarch64.vmdk.gz",
-                "sha256": "ca263b28bd933823090d18ffa2d2994623a8952e87d94b493d26e4d1ca64472a",
-                "uncompressed-sha256": "5f8a33f8e007f7385bc83e7867c5f1a6abe077cddbe5862c3cfb4f3a30a4cd1f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-aws.aarch64.vmdk.gz",
+                "sha256": "224398f6e21886799ce076709391f5d26e95433dd916c42c39ce7d2c668f9689",
+                "uncompressed-sha256": "960c09b7b9ff2c6c37a9b8a0782ea3663970d0730f3258d1c965ef84cc5338a1"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-azure.aarch64.vhd.gz",
-                "sha256": "32ab8d08702dae0e69d122533700d3ca733ee8f28c92ede9037551cf7d4f862b",
-                "uncompressed-sha256": "3a8aa5c2de71abe8f00fd0528970e86e01ca6563a7c7bd117ea922c174418728"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-azure.aarch64.vhd.gz",
+                "sha256": "f418ecdce5b043412bc18a774dd638509bd7e6cc560f5102840c1576fc5b712e",
+                "uncompressed-sha256": "e59568919f023ac0689cd32f576f216004753c72d52d1e3a9669df8821531b47"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-gcp.aarch64.tar.gz",
-                "sha256": "8b42df0a218afe764eaf455015fbd8802a47fe3cdd270ef4312e37ac629d4f7d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-gcp.aarch64.tar.gz",
+                "sha256": "755e7efca2566090395b6575f2eeed8254f8acf29c5fa8118202153121d08e1e"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-metal4k.aarch64.raw.gz",
-                "sha256": "dcb86216f330c7fac933b7224ed6eac4e54307e33535adfe15d9c5df34ad382d",
-                "uncompressed-sha256": "57e42cca43b5ec571b4cc84f4fc9fe9f521fde1cbf3397c30f7aae689fc5a022"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-metal4k.aarch64.raw.gz",
+                "sha256": "ebf0891ef25774af3266b69fc862bcd0fe9694833f2f7ff5a643a76e1bd982c6",
+                "uncompressed-sha256": "6ce9cb6716c3a99a0ef57af2a88acd7db79f2b6cecdb59cd1f5a18df5ad7d8b9"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-live-iso.aarch64.iso",
-                "sha256": "a126c52866c1698a507bd8a438a8a40a23c84527747dc5c42adcc20ab39a699d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-live-iso.aarch64.iso",
+                "sha256": "9c57126ec60ffe59e057e3740ad622c0d4dc4b4c3b3bc80f17127b2244d40798"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-live-kernel.aarch64",
-                "sha256": "289a4dba916101af17014607d6abbe085a22671cda174c3c1c5425e6afc0c618"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-live-kernel.aarch64",
+                "sha256": "a26e383caf8d7f74e5dcdd107268f4c0056a86f1c9b67d34bb510046470a84ab"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-live-initramfs.aarch64.img",
-                "sha256": "cbd05c2b58ce8c4203855c8db8eac8feb568b97e37fe3016b3c2fdbd4c112e61"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-live-initramfs.aarch64.img",
+                "sha256": "da27ecb827d09f665c606049b16e28ef0322cfa0c5097fa5e8c152cce23a3ff4"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-live-rootfs.aarch64.img",
-                "sha256": "83c632d2733c23041e49060b23db5e45276174cbf61119c12e955fabac7e42dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-live-rootfs.aarch64.img",
+                "sha256": "fa01242046bab0284a018a183dc0fd1f053793859ea6340d5548cdcd8b4f2422"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-metal.aarch64.raw.gz",
-                "sha256": "bb14e2acdd23b3f9c248cefe6a976460bf366d25cd1fd049f726d9d11b27ca1e",
-                "uncompressed-sha256": "1dc0b5557d136929027a2ecbfd9af78f00ce1b0c5d6f26213c04ef7355ba5e3a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-metal.aarch64.raw.gz",
+                "sha256": "caf67995df4fe9c4c335c96496ca6584375dd0a9eac2cde871e5d6916e27d80f",
+                "uncompressed-sha256": "803b38d0fe08e126e1a5a16321fb6954420248c31103e0d956d5e6c468869aa0"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-openstack.aarch64.qcow2.gz",
-                "sha256": "9ccab27ff934e8973296b892fe6ae06988001abff5fff45e3f48f58624fbb2d7",
-                "uncompressed-sha256": "ea0712d8de53f699f33825d725dcafb1ee6d83d596477891bb1aa95fc3648a77"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-openstack.aarch64.qcow2.gz",
+                "sha256": "552646bdc17e4d41e196b2a4242efa1ac53e1fee447b62f27decf11e63f2b36a",
+                "uncompressed-sha256": "76d1b5ddf67b44c2f1399b6dbe318c1695c55947be566ad78120e3fcd122200b"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/aarch64/rhcos-9.6.20250826-1-qemu.aarch64.qcow2.gz",
-                "sha256": "6a4aa4224baf65416e7570ae5a52df19e158ecfe8d2b91b135063b1ca665c2b1",
-                "uncompressed-sha256": "116bab7278aae27b614a3c0f1647cd6fa4c199c4abfb4a219a8a1650b6b81531"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/aarch64/rhcos-9.6.20250930-0-qemu.aarch64.qcow2.gz",
+                "sha256": "d8aa3bddc19bf00a105b54cf8861e2e1330cda65f49975ea24264f8bcc7433ef",
+                "uncompressed-sha256": "30d5c53e9c023ae50da0e564d39d9b0f395d702cca82c7e66bee0153fef48b12"
               }
             }
           }
@@ -110,233 +110,233 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0148286cf26e84d1d"
+              "release": "9.6.20250930-0",
+              "image": "ami-05509424c61c77ac0"
             },
             "ap-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-020178428baa4d29d"
+              "release": "9.6.20250930-0",
+              "image": "ami-08515fc989b682a8f"
             },
             "ap-east-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0dc346212bfae9a5a"
+              "release": "9.6.20250930-0",
+              "image": "ami-01410d0d3f19b4cd7"
             },
             "ap-northeast-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-04cd61839a245df4e"
+              "release": "9.6.20250930-0",
+              "image": "ami-029169fb172167f4e"
             },
             "ap-northeast-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-09f756251f513af27"
+              "release": "9.6.20250930-0",
+              "image": "ami-0eb6143473407ddd4"
             },
             "ap-northeast-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0d2f277e312013de9"
+              "release": "9.6.20250930-0",
+              "image": "ami-059d54f14c4774ffb"
             },
             "ap-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0bc01c2ad16fef268"
+              "release": "9.6.20250930-0",
+              "image": "ami-048d4b79998e9045c"
             },
             "ap-south-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0961ddf05f99aa1ac"
+              "release": "9.6.20250930-0",
+              "image": "ami-0ad1d278f6300df76"
             },
             "ap-southeast-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-086c5fdb20edc12c7"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b0533dc4e0c9e9a0"
             },
             "ap-southeast-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0cd7e64385588d5af"
+              "release": "9.6.20250930-0",
+              "image": "ami-01ed02fd92bd656e4"
             },
             "ap-southeast-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-09a4ec979ba4d8804"
+              "release": "9.6.20250930-0",
+              "image": "ami-0f3b43f56dab0401b"
             },
             "ap-southeast-4": {
-              "release": "9.6.20250826-1",
-              "image": "ami-030445ba8507a3ec6"
+              "release": "9.6.20250930-0",
+              "image": "ami-00915a39f07a89a53"
             },
             "ap-southeast-5": {
-              "release": "9.6.20250826-1",
-              "image": "ami-013bd53f7db86068d"
+              "release": "9.6.20250930-0",
+              "image": "ami-0518c2a379eaef800"
             },
             "ap-southeast-7": {
-              "release": "9.6.20250826-1",
-              "image": "ami-026b8f665827ffda4"
+              "release": "9.6.20250930-0",
+              "image": "ami-0c3393dd70931ee99"
             },
             "ca-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0dd67b8ff235b962c"
+              "release": "9.6.20250930-0",
+              "image": "ami-08482f2c81d7ba118"
             },
             "ca-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-09469dfe86edf2a39"
+              "release": "9.6.20250930-0",
+              "image": "ami-07a7003221b405bfd"
             },
             "eu-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-00bd76511738f7c79"
+              "release": "9.6.20250930-0",
+              "image": "ami-0f36654a6cb470391"
             },
             "eu-central-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0e72cf40ed8ca51f3"
+              "release": "9.6.20250930-0",
+              "image": "ami-0f09bd1806006b251"
             },
             "eu-north-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-06ce6706d18914e38"
+              "release": "9.6.20250930-0",
+              "image": "ami-0cb52702acbb9b906"
             },
             "eu-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0d3c5dedab43b8daa"
+              "release": "9.6.20250930-0",
+              "image": "ami-08956e05248ee0e53"
             },
             "eu-south-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-06c0dd7efd3688e89"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b15e97b9ab3eeed1"
             },
             "eu-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0ba6941055f037421"
+              "release": "9.6.20250930-0",
+              "image": "ami-0144524d854fd1b27"
             },
             "eu-west-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0934f6e7344143299"
+              "release": "9.6.20250930-0",
+              "image": "ami-0e7f94e89b1219eda"
             },
             "eu-west-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0faeee552170fef71"
+              "release": "9.6.20250930-0",
+              "image": "ami-0ef375e39c4bfcc25"
             },
             "il-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0f6dbbdd757912184"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b67c10a2021de139"
             },
             "me-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0f9afa7909fa8890b"
+              "release": "9.6.20250930-0",
+              "image": "ami-0bac29b774661aab2"
             },
             "me-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0f7e06ef6b630d78c"
+              "release": "9.6.20250930-0",
+              "image": "ami-052d8ea42e052a431"
             },
             "mx-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-08956a7d43f06c11a"
+              "release": "9.6.20250930-0",
+              "image": "ami-0457c6741f244b673"
             },
             "sa-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0774d29f6ed96935b"
+              "release": "9.6.20250930-0",
+              "image": "ami-097d3f28b0ad4c4ed"
             },
             "us-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-05834415546b16278"
+              "release": "9.6.20250930-0",
+              "image": "ami-0ad073521cb71d7b8"
             },
             "us-east-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0c59bfd7b7a7cc3e7"
+              "release": "9.6.20250930-0",
+              "image": "ami-093eaa59547934c85"
             },
             "us-gov-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-04c3ea90e1fec5a29"
+              "release": "9.6.20250930-0",
+              "image": "ami-0a51523356864bf86"
             },
             "us-gov-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-05fce4dea56fdf75f"
+              "release": "9.6.20250930-0",
+              "image": "ami-05371c9074d54be36"
             },
             "us-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0104db843a42a4455"
+              "release": "9.6.20250930-0",
+              "image": "ami-0d498b481bdee58a6"
             },
             "us-west-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0b745e03468dc48d2"
+              "release": "9.6.20250930-0",
+              "image": "ami-0957f974622d9c01e"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20250826-1-gcp-aarch64"
+          "name": "rhcos-9-6-20250930-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20250826-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250826-1-azure.aarch64.vhd"
+          "release": "9.6.20250930-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250930-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-metal4k.ppc64le.raw.gz",
-                "sha256": "318ad170ee2437f606db3997aa3d14531b10e8580ef4943f6faa0f90312a8986",
-                "uncompressed-sha256": "def8102a4e2da2db2fe84d57bea6532891f415e7d24180c4cc8be3b1c4b2f218"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-metal4k.ppc64le.raw.gz",
+                "sha256": "68fbae20b499fef9a0aef900d1b9cbf44c58b0e1238338f89dbf015ff46d604d",
+                "uncompressed-sha256": "a3e3c70237c433759f47d0f7e61a3bfed7c56176b925a905767c3babf5ce8542"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-live-iso.ppc64le.iso",
-                "sha256": "115191f3794bdc5a43df695540a097f19cc479b7be129750f5d5d875b95a4886"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-live-iso.ppc64le.iso",
+                "sha256": "2b79cc555b00c53c264e3ceaba6781b2983bb67d79a3e3c32f7dcd5150c94f93"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-live-kernel.ppc64le",
-                "sha256": "654eebfbb67f59c3dc86234c82202f04ff01530580c96adb7297de1a1342f5f2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-live-kernel.ppc64le",
+                "sha256": "8a02322f2da4048e24b010ce4764743978291e689604167104a85bccc46cd026"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-live-initramfs.ppc64le.img",
-                "sha256": "9662203268702c42085b0cd8b8f8b266b96d9af061a8263620e419ee30d78c87"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-live-initramfs.ppc64le.img",
+                "sha256": "f9b3a3993d7bc677f571ca764efa084fcb043c5930a15140572861cd0042dbb8"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-live-rootfs.ppc64le.img",
-                "sha256": "280cdfcd038300d703bc5162405e5728db51b279696bda8afcc09ef4bd778221"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-live-rootfs.ppc64le.img",
+                "sha256": "ab316712659c7e5dd2f7d3eb0c5713f9b91ab753d0b5e56d6c9f6e4461d2b12b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-metal.ppc64le.raw.gz",
-                "sha256": "32ebf9eb42014fc964b23546ec9306f648238541409e01f28fe43f92d261969f",
-                "uncompressed-sha256": "9aad6e67e3efbe44d67b422470192140c1d7ac81d55228958099a2cd75f2fbe6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-metal.ppc64le.raw.gz",
+                "sha256": "689cca4c330583b46b908fa3f3ff4b9696049368205302c7f7991dcd3a012a4d",
+                "uncompressed-sha256": "94c9be88d7189f7dc1c099456385c7f5f3878eb3056533b21a09f94bfa4994f5"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-openstack.ppc64le.qcow2.gz",
-                "sha256": "bcb3789f51d2f8c011e344640d5a7e2bb4f257ec6cdd4f8cd17d0c78cc216ef3",
-                "uncompressed-sha256": "97416bfbdf9685dcf759da2fac58e10b2be04a4af84370b19f08001461cdeee1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "5d07aa139cc92370e6b84384f0c8093eede428b723fa8f7477417f3e065828c0",
+                "uncompressed-sha256": "bdfee3c802ee222b4d508b856725bdd2035a9460be85ce75a50f2a24be158f08"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-powervs.ppc64le.ova.gz",
-                "sha256": "2795c34db7c570bd640bc9d05fa9530b99de4947e317d4512fff7dff37e14866",
-                "uncompressed-sha256": "e283acd2716156823bf289b758e06df3116d3e33c7bb5fdb11c3ed8930bed9fe"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-powervs.ppc64le.ova.gz",
+                "sha256": "111b52567de5c08e69c05d3e803dad64c54eca7f05e012ed0a2f041d644b88b0",
+                "uncompressed-sha256": "e55eed2e927f28356d0ce7000e76186decb4dde37971b547e0a11eb2500c385c"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/ppc64le/rhcos-9.6.20250826-1-qemu.ppc64le.qcow2.gz",
-                "sha256": "9fb01fe3924d29f86d2dbb8887d65784235a7c21157e03863e8f0fe5303ec88c",
-                "uncompressed-sha256": "b9a078f3e0b6562297ef566de0d1fbd3c2d625ba8355bb2ce24f5cf57089c898"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/ppc64le/rhcos-9.6.20250930-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "923495f69a6daf626dbccaacac24c94d4914b69d3a851680ca6e60c14ffcfd0c",
+                "uncompressed-sha256": "eaff50055c4a1bcabe29568b0fe026704644aebd9bf9283ece09898d14cf42e3"
               }
             }
           }
@@ -346,64 +346,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.6.20250826-1",
-              "object": "rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20250930-0",
+              "object": "rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20250826-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20250930-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -412,99 +412,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-ibmcloud.s390x.qcow2.gz",
-                "sha256": "df745c4173585cd8c29543959e413deba536aeecbef847e04a097a7ce33aa981",
-                "uncompressed-sha256": "797aa109b67c0c0d2632de5450abff2f49462076f526ea5b1dd0a3b870cccfed"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "ed9d9533f7029b207eee91a7927153311b8c440f575c4d7ce77e5b477a8165dc",
+                "uncompressed-sha256": "d91db3cd92f3d1509f6ee77a8c0b2cc3341c0c80b90c3acb40089f1eeba869c0"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-kubevirt.s390x.ociarchive",
-                "sha256": "606c25f3d7f38e70f22ff9b331f9987104659b7c33e91172db5341a3c529b0ea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-kubevirt.s390x.ociarchive",
+                "sha256": "34bb2284a5d5c150b9606b1af70313c56f6aab3757b3c3c89961912e83cd6600"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-metal4k.s390x.raw.gz",
-                "sha256": "af40bcb095ee15d4816fb04377c8fbebafea7fb7a482ccb129b38b858d608922",
-                "uncompressed-sha256": "ba1f4b7af0351b2b0b91e10f39b34168ee988d3f842119a6f3609e4f468eff96"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-metal4k.s390x.raw.gz",
+                "sha256": "6f1cefbddd93099df07ad0826e60c4a0fdf56e02257c990b8f1023ba494f452e",
+                "uncompressed-sha256": "8ec784314c8c40825e33b2f7e5c8f6f610c60c911d89183b4f67381b769bc51c"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-live-iso.s390x.iso",
-                "sha256": "5354d5cee2651d75aa08805294da8b96c2bd436e519466c1a3c28ebc460896ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-live-iso.s390x.iso",
+                "sha256": "2d93d9b2a889dd972f1b0ac8782925c0ca58309b407802cf72ae95b6012ca6c0"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-live-kernel.s390x",
-                "sha256": "bd661f1647eb5e9c58d9b37824538559973bea1fbf48faddaa5fc012ef28a228"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-live-kernel.s390x",
+                "sha256": "57b8592277658ee191d52c6bd7a0cb4c532fb6745ada1fcafa0472e652afbc78"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-live-initramfs.s390x.img",
-                "sha256": "f8055f4ba6fc46beea6d8d287ed44899e4beecfb16162826560314702b1a19b5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-live-initramfs.s390x.img",
+                "sha256": "8c690e13f9a8d688ce03e8ccc84fe9827ab80252d2aa56ae626ed76468b1492a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-live-rootfs.s390x.img",
-                "sha256": "72c2a5cbf4a03fffc4a65843937f4b5150477202a0c7dc6bbf368f35ff828f48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-live-rootfs.s390x.img",
+                "sha256": "598ba9cf3d17ff02aa57b0a7a7cc703da4046bcacabadb8278de3f7dbec95738"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-metal.s390x.raw.gz",
-                "sha256": "b921eaeca347348369a72f4d521c0d55c91894724600462651ef8bc0620d3d1c",
-                "uncompressed-sha256": "4797107338a45c7c47e2d7a74e9551cbb28ae36d6829551cc537580197f2b903"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-metal.s390x.raw.gz",
+                "sha256": "8296d78b91ae34e0b917fb83dcd5eb0a5b90a5c066d4ef1d1c57150b5eb4e24a",
+                "uncompressed-sha256": "0b0545a2bea8a8305ad9a2dd611e591e834d5e81904680144f7979258ff54fcb"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-openstack.s390x.qcow2.gz",
-                "sha256": "ad5acf89a9441aaf2d44b84531668bce89935ba296621794066aaf14a19600ca",
-                "uncompressed-sha256": "d20275ad0e5a015ea0ec29dcdf79074558b0f6b9554c2baa5ae3e79ea5f4197d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-openstack.s390x.qcow2.gz",
+                "sha256": "0ce533590aed617f817a240f3acf6cfbcc86edef973e0b36f06fa212952ae11b",
+                "uncompressed-sha256": "4d59ba3f16c1993e3d3948653ca58e4755f4a715b2bc2b7c0b2de9956673d2df"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-qemu.s390x.qcow2.gz",
-                "sha256": "034b86debec11cfc323fb424046ad2a52e1de981d6928a136d02b04d933525f4",
-                "uncompressed-sha256": "6644daf3b09aceabdafd240766b2634ad53793ba007dc3cd28dc99961942b09f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-qemu.s390x.qcow2.gz",
+                "sha256": "b03e90f15a81110524deee28c368dc766808cba19ebb2d2b7df7403b3fccf485",
+                "uncompressed-sha256": "3869ce1f41c0e9ce6356f2879a98a8dda7c5bc0dba648f04a33519e80f20577d"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/s390x/rhcos-9.6.20250826-1-qemu-secex.s390x.qcow2.gz",
-                "sha256": "4488af5a89e3b47a21da423d6f1740b386f9730558f89536c43a3c8ade37cf66",
-                "uncompressed-sha256": "e77fbaf38fbf46142da99f8a9257e4b116e27798279d0a790eb223c85731868c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/s390x/rhcos-9.6.20250930-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "f51237cd4ac98ee31ea4a53238b370fefd57cb4afc816207634bb40cafbbad57",
+                "uncompressed-sha256": "0ae647f9f2773459e468630533679715cdf1a3adc50076be83f1b7a09fa04851"
               }
             }
           }
@@ -512,165 +512,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2f873d1b2bce2165db000d72b55484e4302e289b3e4c1b00630f862003df1a7b"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:157a2fa197b9f6097c6c63e3472cddfe5d459381bbcbcb4c74d19d4c24728bb7"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-aws.x86_64.vmdk.gz",
-                "sha256": "1f71c04b9ad008fa0863c260c1ed6efc2f6d845750cdcdf36f9808f287af2abb",
-                "uncompressed-sha256": "aa63a81d28844be3a12b1e8ef434765b554cb12bd1da8139fb3808b94fa6b556"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-aws.x86_64.vmdk.gz",
+                "sha256": "68318336abec9ac36372ac635d42d6e07e99447897f5ace3410a8a9543cf7ddf",
+                "uncompressed-sha256": "635476442f237e5608c24d86c8a336e7019d73515fba6409cb775893b480ed0a"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-azure.x86_64.vhd.gz",
-                "sha256": "83b88a67e74301aff535ce5e16336b63512ae470fef135c1be84bb48e88c4dc9",
-                "uncompressed-sha256": "0e6538a90f2dc0444356593df6586ef1ffcc01c2bfd0897e93542b19ebd1d94b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-azure.x86_64.vhd.gz",
+                "sha256": "b9159f7056ccddc808d317d08f31d16003adbac42bebb7e6bdc504dadab2302a",
+                "uncompressed-sha256": "4bb9ad4a4af9324be688979cc2ea7517922cd2a789653c71c5c992ef5ac2cb02"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-azurestack.x86_64.vhd.gz",
-                "sha256": "db6d4021172312d65220b724d17a555b7fc35e01a478d94d69baa56e47c7c190",
-                "uncompressed-sha256": "6d93b0eb1614a11ff428906a6cd4e5fe2cb3d1a1b25a11416ab25eaff82111d6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-azurestack.x86_64.vhd.gz",
+                "sha256": "4bf0732c59282c4c4b53bfa2bdc2b50af9c01bf40d22e6fab5962d300229a773",
+                "uncompressed-sha256": "1a662add2a96f18e0cc0f00f4db0671e5ff8c0210ab263adb494327bd1d6afee"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-gcp.x86_64.tar.gz",
-                "sha256": "35107b2a1275fdb34c4044d87af5871b56c235aed9f7114f80f562916febe3ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-gcp.x86_64.tar.gz",
+                "sha256": "9958b4163646c09af24bd7b5e95125ea6c01ae6c788cc03ef4575a00d0d00337"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "d6578a50627098b7010b5622c2c672a67a6cf9068e398a4d1e90a5f8ef667135",
-                "uncompressed-sha256": "c9927cfdfdf3b3ab4efbc055522746726fe0e7b7ae4d39c1ebf3f3f4eb303497"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "6bd5561053e5fc96b090522bc9f179a8fcc942aee47dfbb9d781238493eced4a",
+                "uncompressed-sha256": "498f2049e5fa0a58d63bf8fb315be0944e81b100a334097995a21d03cf8ad114"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-kubevirt.x86_64.ociarchive",
-                "sha256": "e3fc4889b3fac2e0d21b9dd86819f81a7dc808c1c6d4d05606be50c8d425d793"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-kubevirt.x86_64.ociarchive",
+                "sha256": "a36c4e4afb312fd680c5173723892af7f44fed90afe08d75b93710a5ac917b39"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-metal4k.x86_64.raw.gz",
-                "sha256": "bf515cccc749dd7729fce24f0513057ecfb58d055eace8f02fb8217fb0605f60",
-                "uncompressed-sha256": "4c728a634bf4e7de2a168cb1ab7c42d8f439eb2d03dee50c6cdf0dc8be5fb561"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-metal4k.x86_64.raw.gz",
+                "sha256": "721ab6445570ad6eb7c41fdd6f598c37d15d6f73587bf315d7c189f6467ca1ef",
+                "uncompressed-sha256": "ad98fb96e3d3b0b07e58d76e5ab7e1409bf72c2d9e026cba7dbc19879c8eb6be"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-live-iso.x86_64.iso",
-                "sha256": "7a47d0c7a9bf5edb143d52809e793af2d74731567b95d91c6225171a1c49b5ab"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-live-iso.x86_64.iso",
+                "sha256": "048c86b30c82e7541c1cf3a7c01cfdb29f40f85eb75a12bbdbf966a4fab27d58"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-live-kernel.x86_64",
-                "sha256": "9777ef0c25ddf4886f3024bbebf6344e3aa32e719325b16db61e285fb1718143"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-live-kernel.x86_64",
+                "sha256": "a1b30ec8d10ed2cbb256ad81224f48343a9fc6b16c35d13b3a34530f822695a4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-live-initramfs.x86_64.img",
-                "sha256": "90e6dc95b2d96b77382d08dfcac9cd35a02756801cc89e8ff4f75dd5c06ab5bf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-live-initramfs.x86_64.img",
+                "sha256": "514c2741c168654eab7c1f0db58e9aa641dc42b60137b50c0cf13bd4d231c1ce"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-live-rootfs.x86_64.img",
-                "sha256": "4d2e74921d95d4132b12d1088693a1b93b556a7846f93c4a6d6af32cecd10d2c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-live-rootfs.x86_64.img",
+                "sha256": "a81488922656436dfb7231745bb2d0c8a5b265496adcc8b8cf166998d894c0f8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-metal.x86_64.raw.gz",
-                "sha256": "4d2356d0941d4cbdaecd6e6ef3981c4be0d007c08b5387efc345fcdcc7abc045",
-                "uncompressed-sha256": "192fa481448da6a8465fedea0e55fa5c2eadaed21d6aa208c6d3c0406e5d9ebd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-metal.x86_64.raw.gz",
+                "sha256": "67f66c185c6c3d9b3b6b6727c951f36106612e45eb3a50edbd31556f401d5ea1",
+                "uncompressed-sha256": "35f8df0e3dacf30f413274d47dd61637405e9d5627172029f670baa223bd8c0c"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-nutanix.x86_64.qcow2",
-                "sha256": "d560bced2bcbe316eab02ba8afa26e9822ad6fcb71546156b4d87517d23e7671"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-nutanix.x86_64.qcow2",
+                "sha256": "7ecc049676a1611a0e4c3fe114f670099eb16466bfcab75f36686fe6b5a9a87f"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-openstack.x86_64.qcow2.gz",
-                "sha256": "75f4f0dfe1b8d4c1d9e540cb29a9cc2c06763edbdd7f810b68ffaa5199776f3c",
-                "uncompressed-sha256": "11a664edee8543b9beb73f188acf65861ec55cb894b05c701b00a52ca4997be2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-openstack.x86_64.qcow2.gz",
+                "sha256": "283e37008468cc84adf00b3765b393e4756a83c95d89abe8910da60f134a8b61",
+                "uncompressed-sha256": "7e76fc8adf5d94e057dca7e8620b9838d64e38c56fba9512a330ff0002b0aa9f"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-qemu.x86_64.qcow2.gz",
-                "sha256": "3e093d26fb167d3bb43544dae9678d3ce0121b649868207239e2bb07d6127632",
-                "uncompressed-sha256": "4a37be1a6a1e7e1267e7459c69fc1419166e59ffc75ca6af9deb958841ed1eb5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-qemu.x86_64.qcow2.gz",
+                "sha256": "712d756e3f638d06e7cc22e4567cda7a6ed576e2ab83847f38a77ec18c0a2a6a",
+                "uncompressed-sha256": "b103e147ff857fb210f862df1aac19a08bab9917195f284be5ee097d00914cde"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250826-1/x86_64/rhcos-9.6.20250826-1-vmware.x86_64.ova",
-                "sha256": "ca6b88671a166c4254e673ce596ce3e22bd309c9584d7d8b300c431a7cd9726b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20250930-0/x86_64/rhcos-9.6.20250930-0-vmware.x86_64.ova",
+                "sha256": "ff7b11b0e0b29b711312583acbfdbbcbc012da8414fdee30e96eeac6ab1ccffb"
               }
             }
           }
@@ -680,162 +680,298 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-03ec26381f6a347be"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b4bdb06cf2626e83"
             },
             "ap-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-04332931a972c8398"
+              "release": "9.6.20250930-0",
+              "image": "ami-0d4a0494d37418191"
             },
             "ap-east-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0ac916d2813a7b18a"
+              "release": "9.6.20250930-0",
+              "image": "ami-04b1b56d879c4df71"
             },
             "ap-northeast-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0a3254abafd41cbda"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b01d4b9760b075ef"
             },
             "ap-northeast-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-001d35f0b7a38999e"
+              "release": "9.6.20250930-0",
+              "image": "ami-0ab1c7adeef873005"
             },
             "ap-northeast-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-012a97b7293096c47"
+              "release": "9.6.20250930-0",
+              "image": "ami-016cfacfb7ffdcb34"
             },
             "ap-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-021b5ab76f755886f"
+              "release": "9.6.20250930-0",
+              "image": "ami-0c73311f90b80d6e1"
             },
             "ap-south-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-038f598890a52f3c9"
+              "release": "9.6.20250930-0",
+              "image": "ami-0d04d9893c06e6c3b"
             },
             "ap-southeast-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0d191a1bffd735ebe"
+              "release": "9.6.20250930-0",
+              "image": "ami-01337d4693a06cafc"
             },
             "ap-southeast-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-007439e088223214a"
+              "release": "9.6.20250930-0",
+              "image": "ami-0744a459bfea364f9"
             },
             "ap-southeast-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0e024a0bbbdf621da"
+              "release": "9.6.20250930-0",
+              "image": "ami-0e52cd005d8cabc8d"
             },
             "ap-southeast-4": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0929268b6d28ba1e9"
+              "release": "9.6.20250930-0",
+              "image": "ami-0fc004161632b961e"
             },
             "ap-southeast-5": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0a9461ac20d4691fe"
+              "release": "9.6.20250930-0",
+              "image": "ami-00f8d4c96510b3079"
             },
             "ap-southeast-7": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0ae438f9ab8af4459"
+              "release": "9.6.20250930-0",
+              "image": "ami-0241f41169480524d"
             },
             "ca-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-07079826624ddc0d3"
+              "release": "9.6.20250930-0",
+              "image": "ami-0c398d1965cecf904"
             },
             "ca-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0e0a89efe9e4aebd8"
+              "release": "9.6.20250930-0",
+              "image": "ami-0fea766cd701fa582"
             },
             "eu-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0b9392304b25a1be6"
+              "release": "9.6.20250930-0",
+              "image": "ami-09b21a6f89136fdb7"
             },
             "eu-central-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-004899c1b1392a416"
+              "release": "9.6.20250930-0",
+              "image": "ami-03f992141e265de18"
             },
             "eu-north-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-04db8de6d2660d477"
+              "release": "9.6.20250930-0",
+              "image": "ami-0bd30cad442bb391e"
             },
             "eu-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-03f6525889efe953b"
+              "release": "9.6.20250930-0",
+              "image": "ami-03601927dfcf7048e"
             },
             "eu-south-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0214e803d8564e890"
+              "release": "9.6.20250930-0",
+              "image": "ami-0a13d869a4df8dfdb"
             },
             "eu-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-04ca111133e8458c6"
+              "release": "9.6.20250930-0",
+              "image": "ami-00971115e39e09734"
             },
             "eu-west-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-089d8892ef8f88156"
+              "release": "9.6.20250930-0",
+              "image": "ami-0afda496a232f1d58"
             },
             "eu-west-3": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0cebb38e071808759"
+              "release": "9.6.20250930-0",
+              "image": "ami-0353445cd8bbd5375"
             },
             "il-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-08ff4ee35db1e8b29"
+              "release": "9.6.20250930-0",
+              "image": "ami-09a7021eb017e8dc3"
             },
             "me-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0467b2b1a131cb070"
+              "release": "9.6.20250930-0",
+              "image": "ami-035b16cbfd9c055e2"
             },
             "me-south-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-09fe6bcfb3cab07a7"
+              "release": "9.6.20250930-0",
+              "image": "ami-0ef901760b77e5860"
             },
             "mx-central-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0a7e97cb28cbb8354"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b51bda16ae0b9723"
             },
             "sa-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0ff7e5fea2302529b"
+              "release": "9.6.20250930-0",
+              "image": "ami-0e0a5219604c3169c"
             },
             "us-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-09d23adad19cdb25c"
+              "release": "9.6.20250930-0",
+              "image": "ami-06531370ad0040c6d"
             },
             "us-east-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-082a55a580d5538ed"
+              "release": "9.6.20250930-0",
+              "image": "ami-0a7944881e9ad47aa"
             },
             "us-gov-east-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-06eb65026809257f2"
+              "release": "9.6.20250930-0",
+              "image": "ami-0684e690fc7462f1b"
             },
             "us-gov-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-02d89c98e7cb51709"
+              "release": "9.6.20250930-0",
+              "image": "ami-07942dcc66e912f79"
             },
             "us-west-1": {
-              "release": "9.6.20250826-1",
-              "image": "ami-0788e768db7ced74d"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b9c000a1f614e9ba"
             },
             "us-west-2": {
-              "release": "9.6.20250826-1",
-              "image": "ami-000b42519a25cacc5"
+              "release": "9.6.20250930-0",
+              "image": "ami-0b70cf659907842a7"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20250826-1-gcp-x86-64"
+          "name": "rhcos-9-6-20250930-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.6.20250826-1",
+          "release": "9.6.20250930-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b5f1d661d37679437223c735b86beb238f5cc1e2f06352ed67fb2610339278a7"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0eb082e8133260d625a22121089ca7b6d891b1d691deb0d31576220704c1657f"
         }
       },
       "rhel-coreos-extensions": {
+        "aws-winli": {
+          "regions": {
+            "af-south-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0086a4cd83cef7a39"
+            },
+            "ap-east-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-04937b922c92bcc8c"
+            },
+            "ap-east-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-08475086521bf1987"
+            },
+            "ap-northeast-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0fe77e4fd470f2bf4"
+            },
+            "ap-northeast-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-040b49b6207ab3477"
+            },
+            "ap-northeast-3": {
+              "release": "9.6.20250930-0",
+              "image": "ami-016c90e518a28bb70"
+            },
+            "ap-south-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-065f1cae1a824e05f"
+            },
+            "ap-south-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0258800740f05c40a"
+            },
+            "ap-southeast-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-07266160c79311e56"
+            },
+            "ap-southeast-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-079b7d30419274997"
+            },
+            "ap-southeast-3": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0c91c66d3368fb111"
+            },
+            "ap-southeast-4": {
+              "release": "9.6.20250930-0",
+              "image": "ami-045e8211135c2c1d0"
+            },
+            "ap-southeast-5": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0fdf0bf94c96921ad"
+            },
+            "ap-southeast-7": {
+              "release": "9.6.20250930-0",
+              "image": "ami-009563c1e8fbae556"
+            },
+            "ca-central-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0673ea7b0c897fbd1"
+            },
+            "ca-west-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0b88038ab1ebaaae0"
+            },
+            "eu-central-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0afbb2b4a1553eb1d"
+            },
+            "eu-central-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0a9b748c838b2e5de"
+            },
+            "eu-north-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0426f7fddadf5f01a"
+            },
+            "eu-south-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0bc43023cf6292aed"
+            },
+            "eu-south-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-014e507126d3bb9c7"
+            },
+            "eu-west-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-010897335f5a1dc50"
+            },
+            "eu-west-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0a8c13efc075f7c6d"
+            },
+            "eu-west-3": {
+              "release": "9.6.20250930-0",
+              "image": "ami-019a6fddda41a451b"
+            },
+            "il-central-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0d9d831fec18ef935"
+            },
+            "me-central-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0d4119865f85332d7"
+            },
+            "me-south-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0fa757a26d1f5e8de"
+            },
+            "mx-central-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-02445e5558e493266"
+            },
+            "sa-east-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-08f3c5dee24bcdfb2"
+            },
+            "us-east-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0048635d244b1b7a4"
+            },
+            "us-east-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-010107dcd8fb5d1bb"
+            },
+            "us-west-1": {
+              "release": "9.6.20250930-0",
+              "image": "ami-02dcd60555ff8d098"
+            },
+            "us-west-2": {
+              "release": "9.6.20250930-0",
+              "image": "ami-0cbc2e9452a78670c"
+            }
+          }
+        },
         "azure-disk": {
-          "release": "9.6.20250826-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250826-1-azure.x86_64.vhd"
+          "release": "9.6.20250930-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20250930-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
The changes done here will update the RHCOS 4.20 bootimage metadata and address the following issues:

COS-3042: GA ROSA-HCP support Windows LI for CNV

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json \
    --distro rhcos --no-signatures --name rhel-9.6 \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=9.6.20250930-0     \
    aarch64=9.6.20250930-0    \
    s390x=9.6.20250930-0      \
    ppc64le=9.6.20250930-0
```