### PR TITLE
OCPBUGS-62260: GCP Resources were not discovered on destroy

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -25,8 +25,7 @@ func (o *ClusterUninstaller) createLoadBalancerFilterFunc(loadBalancerName strin
 // https://github.com/openshift/kubernetes/blob/1e5983903742f64bca36a464582178c940353e9a/pkg/cloudprovider/providers/gce/gce_clusterid.go#L210-L238
 func (o *ClusterUninstaller) listCloudControllerInstanceGroups(ctx context.Context) ([]cloudResource, error) {
 	return o.listInstanceGroupsWithFilter(ctx, "items/*/instanceGroups(name,selfLink,zone),nextPageToken", func(itemName string) bool {
-		// TODO: Why does this have an extra - ??
-		return itemName == fmt.Sprintf("k8s-ig--%s", o.cloudControllerUID)
+		return itemName == fmt.Sprintf("k8s-ig-%s", o.cloudControllerUID)
 	})
 }
 


### PR DESCRIPTION
** The Instance Groups were being searched for with criteria where the name included a double dash (k8s-ig--%s). This second dash meant that similar named resources were not being discovered, and this caused destroy processes to hang with resource dependencies. This was also causing resources to be leaked.