### PR TITLE
OCPBUGS-62791: Correct color formatting for AI UI

### DIFF
--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -54,7 +54,7 @@ check_host_config() {
 check_ui() {
     local ui_issue="90_ui-availability"
     if systemctl is-active --quiet "agent-start-ui"; then
-       printf "\\e{green}Please go to \\e{lightgreen}%s\\e{reset}\\e{green} in your browser to continue the installation\\e{reset}" "${AIUI_URL}" | set_issue "${ui_issue}"
+       printf '\\e{green}Please go to \\e{lightgreen}%s\\e{reset}\\e{green} in your browser to continue the installation\\e{reset}' "${AIUI_URL}" | set_issue "${ui_issue}"
     else
        clear_issue "${ui_issue}"        
     fi


### PR DESCRIPTION
This PR fixes an issue where Assisted UI URL information was displaying literal color placeholders such as
green} and lightgreen} instead of showing colored text.