### PR TITLE
OCPBUGS-60758: Add coreos-update-ca-trust.service as dependency

### DIFF
--- a/data/data/agent/systemd/units/agent-interactive-console-serial@.service
+++ b/data/data/agent/systemd/units/agent-interactive-console-serial@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Get interactive user configuration at boot on %I
-After=dev-fb0.device dev-%i.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service
+After=dev-fb0.device dev-%i.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service coreos-update-ca-trust.service
 Before=serial-getty@%i.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
 Wants=agent-extract-tui.service
 ConditionPathExists=/usr/local/bin/agent-tui

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Get interactive user configuration at boot
-After=dev-fb0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service
+After=dev-fb0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service coreos-update-ca-trust.service
 Before=getty@tty1.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
 Wants=agent-extract-tui.service
 ConditionPathExists=/usr/local/bin/agent-tui


### PR DESCRIPTION
Currently there isn't an ordering dependency between agent-interactive-console.service and
coreos-update-ca-trust.service.

When an external mirror registry is configured, the registry's certificate is included in the add node ISO at
/etc/pki/ca-trust/source/anchors/domain.crt.

When the node ISO is booted, agent-tui checks connectivity to the release image by performing a "podman pull". In this case the mirror registry is queried.

If the certificate has not be properly added to the system's trust files by update-ca-trust, then agent-tui shows a "failed to verify certificate: x509: certificate signed by unknown authority" error.

This patches adds After=coreos-update-ca-trust.service as an ordering dependency in agent-interactive-console.service.