### PR TITLE
OCPBUGS-63386: Increase agent-installer pre-network-manager timeout

### DIFF
--- a/data/data/agent/systemd/units/pre-network-manager-config.service
+++ b/data/data/agent/systemd/units/pre-network-manager-config.service
@@ -6,7 +6,7 @@ DefaultDependencies=no
 [Service]
 User=root
 ExecStart=/usr/local/bin/pre-network-manager-config.sh
-TimeoutSec=60
+TimeoutSec=300
 Type=oneshot
 PrivateTmp=true
 RemainAfterExit=no


### PR DESCRIPTION
We have a report that a baremetal installation with VLAN interfaces can require longer than the current setting for the timeout of the pre-network-manager-config service. Increasing it to 300 seconds.