### PR TITLE
CORS-4278: Hardening the GCP destroy code to attempt to delete dependent resources

### DIFF
--- a/pkg/destroy/gcp/backendservice.go
+++ b/pkg/destroy/gcp/backendservice.go
@@ -15,6 +15,25 @@ const (
 	regionBackendServiceResource = "regionbackendservice"
 )
 
+func (o *ClusterUninstaller) deleteBackendServiceByName(ctx context.Context, resourceName, location string) error {
+	typeName := globalBackendServiceResource
+	if location != string(global) {
+		typeName = regionBackendServiceResource
+	}
+	items, err := o.listBackendServicesWithFilter(ctx, typeName, "items(name),nextPageToken", func(item *compute.BackendService) bool {
+		return item.Name == resourceName
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list backend services by name : %w", err)
+	}
+	for _, item := range items {
+		if err := o.deleteBackendService(ctx, item); err != nil {
+			return fmt.Errorf("failed to delete backend service by name: %w", err)
+		}
+	}
+	return nil
+}
+
 func (o *ClusterUninstaller) listBackendServices(ctx context.Context, typeName string) ([]cloudResource, error) {
 	return o.listBackendServicesWithFilter(ctx, typeName, "items(name),nextPageToken",
 		func(item *compute.BackendService) bool {

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -14,6 +15,19 @@ import (
 const (
 	firewallResourceName = "firewall"
 )
+
+func (o *ClusterUninstaller) deleteFirewallByName(ctx context.Context, resourceName string) error {
+	items, err := o.listFirewallsWithFilter(ctx, "items(name),nextPageToken", func(item string) bool { return strings.Contains(item, resourceName) })
+	if err != nil {
+		return fmt.Errorf("failed to list firewall by name: %w", err)
+	}
+	for _, item := range items {
+		if err := o.deleteFirewall(ctx, item); err != nil {
+			return fmt.Errorf("failed to delete firewall by name: %w", err)
+		}
+	}
+	return nil
+}
 
 func (o *ClusterUninstaller) listFirewalls(ctx context.Context) ([]cloudResource, error) {
 	// The firewall rules that the destroyer is searching for here include a

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
@@ -13,6 +14,19 @@ import (
 const (
 	routerResourceName = "router"
 )
+
+func (o *ClusterUninstaller) deleteRouterByName(ctx context.Context, resourceName string) error {
+	items, err := o.listRoutersWithFilter(ctx, "items(name),nextPageToken", func(item string) bool { return item == resourceName })
+	if err != nil {
+		return fmt.Errorf("failed to list router by name: %w", err)
+	}
+	for _, item := range items {
+		if err := o.deleteRouter(ctx, item); err != nil {
+			return fmt.Errorf("failed to delete router by name: %w", err)
+		}
+	}
+	return nil
+}
 
 func (o *ClusterUninstaller) listRouters(ctx context.Context) ([]cloudResource, error) {
 	return o.listRoutersWithFilter(ctx, "items(name),nextPageToken", o.isClusterResource)

--- a/pkg/destroy/gcp/subnetwork.go
+++ b/pkg/destroy/gcp/subnetwork.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
@@ -13,6 +14,19 @@ import (
 const (
 	subnetworkResourceName = "subnetwork"
 )
+
+func (o *ClusterUninstaller) deleteSubnetworkByName(ctx context.Context, resourceName string) error {
+	items, err := o.listSubnetworksWithFilter(ctx, "items(name),nextPageToken", func(item string) bool { return item == resourceName })
+	if err != nil {
+		return fmt.Errorf("failed to list subnetworks by name: %w", err)
+	}
+	for _, item := range items {
+		if err := o.deleteSubnetwork(ctx, item); err != nil {
+			return fmt.Errorf("failed to delete subnetwork by name: %w", err)
+		}
+	}
+	return nil
+}
 
 func (o *ClusterUninstaller) listSubnetworks(ctx context.Context) ([]cloudResource, error) {
 	return o.listSubnetworksWithFilter(ctx, "items(name,network),nextPageToken", o.isClusterResource)

--- a/pkg/destroy/gcp/targetTCPProxies.go
+++ b/pkg/destroy/gcp/targetTCPProxies.go
@@ -14,6 +14,21 @@ const (
 	globalTargetTCPProxyResource = "targettcpproxy"
 )
 
+func (o *ClusterUninstaller) deleteTargetTCPProxyByName(ctx context.Context, resourceName string) error {
+	items, err := o.listTargetTCPProxiesWithFilter(ctx, globalTargetTCPProxyResource, "items(name),nextPageToken", func(item string) bool {
+		return item == resourceName
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list target TCP Proxy by name: %w", err)
+	}
+	for _, item := range items {
+		if err := o.deleteTargetTCPProxy(ctx, item); err != nil {
+			return fmt.Errorf("failed to delete target TCP Proxy by name: %w", err)
+		}
+	}
+	return nil
+}
+
 func (o *ClusterUninstaller) listTargetTCPProxies(ctx context.Context, typeName string) ([]cloudResource, error) {
 	return o.listTargetTCPProxiesWithFilter(ctx, typeName, "items(name),nextPageToken", o.isClusterResource)
 }


### PR DESCRIPTION
The destroy process sporadically runs into ResourceInUseByAnotherResource error, but sometimes the dependent resource is not found by the cluster uninstaller. Now these resources will be removed when the error is found.