### PR TITLE
OCPBUGS-63711: Remove pending items on gcp no-op

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -448,11 +448,12 @@ func (o *ClusterUninstaller) handleOperation(ctx context.Context, op *compute.Op
 	}
 
 	if err != nil {
+		o.resetRequestID(identifier...)
 		if isNoOp(err) {
 			o.Logger.Debugf("No operation found for %s %s", resourceType, item.name)
+			o.deletePendingItems(item.typeName, []cloudResource{item})
 			return nil
 		}
-		o.resetRequestID(identifier...)
 		return fmt.Errorf("failed to delete %s %s: %w", resourceType, item.name, err)
 	}
 


### PR DESCRIPTION
The GCP Destroy process should remove pending items when a no-op error has occurred. Currently the process is to warn the user, but the items should be removed from the list of pending items to be deleted otherwise it will hold up the deprovision process indefinitely.