### PR TITLE
OCPBUGS-56451: Provide a way to configure a fallback policy for imageDigestSources

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4335,6 +4335,14 @@ spec:
                   description: Source is the repository that users refer to, e.g.
                     in image pull specifications.
                   type: string
+                sourcePolicy:
+                  description: |-
+                    SourcePolicy defines the fallback policy when there is a failure pulling an
+                    image from the mirrors.
+                  enum:
+                  - NeverContactSource
+                  - AllowContactingSource
+                  type: string
               required:
               - source
               type: object

--- a/pkg/asset/ignition/bootstrap/registries.go
+++ b/pkg/asset/ignition/bootstrap/registries.go
@@ -39,7 +39,7 @@ func MergedMirrorSets(sources []types.ImageDigestSource) []types.ImageDigestSour
 func ContentSourceToDigestMirror(sources []types.ImageContentSource) []types.ImageDigestSource {
 	digestSources := []types.ImageDigestSource{}
 	for _, s := range sources {
-		digestSources = append(digestSources, types.ImageDigestSource(s))
+		digestSources = append(digestSources, types.ImageDigestSource{Source: s.Source, Mirrors: s.Mirrors})
 	}
 	return digestSources
 }

--- a/pkg/asset/manifests/imagedigestmirrorset.go
+++ b/pkg/asset/manifests/imagedigestmirrorset.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -90,8 +91,8 @@ func ConvertImageDigestMirrorSet(imageDigestSources []types.ImageDigestSource) *
 		for mi, mirror := range imageDigestSource.Mirrors {
 			mirrors[mi] = apicfgv1.ImageMirror(mirror)
 		}
-
-		imageDigestMirrorSet.Spec.ImageDigestMirrors[idsi] = apicfgv1.ImageDigestMirrors{Source: imageDigestSource.Source, Mirrors: mirrors}
+		logrus.Debugf("SourcePolicy is %q for Source: %s", imageDigestSource.SourcePolicy, imageDigestSource.Source)
+		imageDigestMirrorSet.Spec.ImageDigestMirrors[idsi] = apicfgv1.ImageDigestMirrors{Source: imageDigestSource.Source, Mirrors: mirrors, MirrorSourcePolicy: imageDigestSource.SourcePolicy}
 	}
 
 	return imageDigestMirrorSet

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -517,6 +517,11 @@ type ImageDigestSource struct {
 	// Mirrors is one or more repositories that may also contain the same images.
 	// +optional
 	Mirrors []string `json:"mirrors,omitempty"`
+
+	// SourcePolicy defines the fallback policy when there is a failure pulling an
+	// image from the mirrors.
+	// +optional
+	SourcePolicy configv1.MirrorSourcePolicy `json:"sourcePolicy"`
 }
 
 // CredentialsMode is the mode by which CredentialsRequests will be satisfied.

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1222,8 +1222,25 @@ func validateImageDigestSources(groups []types.ImageDigestSource, fldPath *field
 				continue
 			}
 		}
+		if group.SourcePolicy != "" {
+			if len(group.Mirrors) == 0 {
+				allErrs = append(allErrs, field.Invalid(groupf.Child("sourcePolicy"), group.SourcePolicy, "sourcePolicy cannot be configured without a mirror"))
+			}
+			if err := validateImageMirrorSourcePolicy(group.SourcePolicy); err != nil {
+				allErrs = append(allErrs, field.Invalid(groupf.Child("sourcePolicy"), group.SourcePolicy, err.Error()))
+			}
+		}
 	}
 	return allErrs
+}
+
+func validateImageMirrorSourcePolicy(sourcePolicy configv1.MirrorSourcePolicy) error {
+	switch sourcePolicy {
+	case configv1.NeverContactSource, configv1.AllowContactingSource:
+		return nil
+	default:
+		return fmt.Errorf("supported values are %q and %q", configv1.NeverContactSource, configv1.AllowContactingSource)
+	}
 }
 
 func validateNamedRepository(r string) error {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1488,6 +1488,43 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 		},
 		{
+			name: "valid release image source ImageDigstSource with valid mirror and sourcePolicy",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.ImageDigestSources = []types.ImageDigestSource{{
+					Source:       "quay.io/ocp/release-x.y",
+					Mirrors:      []string{"mirror.example.com:5000"},
+					SourcePolicy: "NeverContactSource",
+				}}
+				return c
+			}(),
+		},
+		{
+			name: "valid release image source ImageDigstSource with no mirror and valid sourcePolicy",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.ImageDigestSources = []types.ImageDigestSource{{
+					Source:       "quay.io/ocp/release-x.y",
+					SourcePolicy: "NeverContactSource",
+				}}
+				return c
+			}(),
+			expectedError: `^imageDigestSources\[0\]\.sourcePolicy: Invalid value: "NeverContactSource": sourcePolicy cannot be configured without a mirror$`,
+		},
+		{
+			name: "valid release image source ImageDigstSource with invalid sourcePolicy",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.ImageDigestSources = []types.ImageDigestSource{{
+					Source:       "quay.io/ocp/release-x.y",
+					Mirrors:      []string{"mirror.example.com:5000"},
+					SourcePolicy: "InvalidPolicy",
+				}}
+				return c
+			}(),
+			expectedError: `^imageDigestSources\[0\]\.sourcePolicy: Invalid value: "InvalidPolicy": supported values are "NeverContactSource" and "AllowContactingSource"$`,
+		},
+		{
 			name: "error out ImageContentSources and ImageDigestSources and are set at the same time",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
1. Add an install-config option to specify `sourcePolicy` that captures user's intention regarding the fallback policy when there is an error getting images from the mirror
2. Update the ImageDigestcwMirrorSet manifest with this policy. API changes were not required because this value was already present in the API.
3. Update logic to translate from deprecated `imageContentSources` to `imageDigestSources` with the new `sourcePolicy` in place.
4. Updated install-config validation and tests for this new field.