### PR TITLE
CORS-4126: add descriptions for ap-southeast-6

### DIFF
--- a/pkg/types/aws/regions.go
+++ b/pkg/types/aws/regions.go
@@ -15,6 +15,7 @@ var (
 		"ap-northeast-2": "Asia Pacific (Seoul)",
 		"ap-southeast-1": "Asia Pacific (Singapore)",
 		"ap-southeast-2": "Asia Pacific (Sydney)",
+		"ap-southeast-6": "Asia Pacific (New Zealand)",
 		"ap-east-2":      "Asia Pacific (Taipei)",
 		"ap-southeast-7": "Asia Pacific (Thailand)",
 		"ap-northeast-1": "Asia Pacific (Tokyo)",


### PR DESCRIPTION
The upgrade to AWS SDK v2 removes the ability to look up the region description; thus, we are keeping the lookup map in the installer code. This updates the lookup map to support new region `ap-southeast-6`.

**Reference**

https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html

|Code| 	Name| 	AZs| 	Geography| 	Opt-in status|
|--|--|--|--|--|
|ap-southeast-6| 	Asia Pacific (New Zealand)| 	3| 	New Zealand| 	Required|