### PR TITLE
WIP: CORS-4265: Pass Firewall Rules Management Value to Cloud Provider

### DIFF
--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -31,10 +31,12 @@ type global struct {
 	// ContainerAPIEndpoint is the container API endpoint to use. If this is blank,
 	// then the default endpoint is used.
 	ContainerAPIEndpoint string `gcfg:"container-api-endpoint"`
+
+	FirewallManagement string `gcfg:"firewall-rules-management"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, apiEndpoint, containerAPIEndpoint string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, apiEndpoint, containerAPIEndpoint, firewallManagement string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -58,6 +60,8 @@ func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, apiEndpoi
 			// Used for api endpoint overrides in the cloud provider.
 			APIEndpoint:          apiEndpoint,
 			ContainerAPIEndpoint: containerAPIEndpoint,
+
+			FirewallManagement: firewallManagement,
 		},
 	}
 
@@ -82,5 +86,6 @@ subnetwork-name = {{.Global.SubnetworkName}}
 {{- if ne .Global.NetworkProjectID "" }}{{"\n"}}network-project-id = {{.Global.NetworkProjectID}}{{ end }}
 {{- if ne .Global.APIEndpoint "" }}{{"\n"}}api-endpoint = {{.Global.APIEndpoint}}{{ end }}
 {{- if ne .Global.ContainerAPIEndpoint "" }}{{"\n"}}container-api-endpoint = {{.Global.ContainerAPIEndpoint}}{{ end }}
+{{- if ne .Global.FirewallManagement "" }}{{"\n"}}firewall-rules-management = {{.Global.FirewallManagement}}{{ end }}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -17,9 +17,10 @@ node-tags       = uid-worker
 node-instance-prefix = uid
 external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
+firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "", "")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "", "", "Enabled")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }
@@ -36,9 +37,10 @@ node-instance-prefix = uid
 external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
 network-project-id = test-network-project-id
+firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id", "", "")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id", "", "", "Enabled")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }
@@ -56,9 +58,10 @@ external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
 api-endpoint = compute-testendpoint.p.googleapis.com
 container-api-endpoint = container-testendpoint.p.googleapis.com
+firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "compute-testendpoint.p.googleapis.com", "container-testendpoint.p.googleapis.com")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", "compute-testendpoint.p.googleapis.com", "container-testendpoint.p.googleapis.com", "Enabled")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
Set Enabled vs Disabled when the firewall rules should be managed by the cloud provider. Enabled in this case will indicate that the user has the permissions to manage firewall rules.