### PR TITLE
OCPBUGS-64839: Azure UPI ARM template: use storageAccountId

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -68,7 +68,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-10-01",
+              "apiVersion": "2022-03-03",
               "type": "versions",
               "name": "[variables('imageRelease')]",
               "location": "[variables('location')]",
@@ -88,7 +88,7 @@
                 "storageProfile": {
                   "osDiskImage": {
                     "source": {
-                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
                       "uri": "[parameters('vhdBlobURL')]"
                     }
                   }


### PR DESCRIPTION
The fix in https://issues.redhat.com//browse/OCPBUGS-62653 also needs to be applied in Azure UPI ARM template for UPI installation.

```
If you use blobs as source to create ACG Image versions:

    If you're using the old property ‘[properties.storageProfile.[osDiskImage/dataDiskImages].source.Id,‘](https://learn.microsoft.com/rest/api/compute/gallery-image-versions/create-or-update?view=rest-compute-2023-10-02&%253Btabs=HTTP&tabs=HTTP#gallerydiskimagesource) you should move to the property ’[properties.storageProfile.osDiskImage.source.storageAccountId’](https://learn.microsoft.com/rest/api/compute/gallery-image-versions/create-or-update?view=rest-compute-2023-10-02&%3Btabs=HTTP&tabs=HTTP#gallerydiskimagesource). This property requires minimum api-version 2022-03-03.
```