### PR TITLE
MULTIARCH-5817: Upgrade az version in upi-installer image to fix 'az sig image-version create' issue

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -21,7 +21,7 @@ RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.17:cli as cli
 FROM quay.io/ocp-splat/govc:v0.30.7 as govc
-FROM quay.io/ocp-splat/pwsh:v7.3.12 as pwsh
+FROM quay.io/ocp-splat/pwsh:latest as pwsh
 FROM quay.io/multi-arch/yq:3.3.0 as yq3
 FROM quay.io/multi-arch/yq:4.30.5 as yq4
 


### PR DESCRIPTION
we encountered an issue in the Prow CI `ipi-install-heterogeneous` step when running `az sig image-version create`(see the below error message). It is related to issue [#30942](https://github.com/Azure/azure-cli/issues/30942) in the Azure CLI, and the fix is included starting in version v2.72.0. the current version in `upi-installer` image(introduced by `quay.io/ocp-splat/pwsh:v7.3.12`) is v2.61.0. 

Joseph Callen has rebuilt the image with the latest Azure CLI version and pushed it to `quay.io/ocp-splat/pwsh:latest`, Therefore, we need to update the Dockerfile accordingly.

```
ERROR: (InvalidParameter) Parameter 'galleryImageVersion.properties.storageProfile.osDiskImage.source.id' is not allowed.
Code: InvalidParameter
```