### PR TITLE
OCPBUGS-63305: Make SimulatePrincipalPolicy optional

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -173,7 +173,6 @@ var permissions = map[PermissionGroup][]string{
 		"iam:ListRoles",
 		"iam:ListUsers",
 		"iam:PassRole",
-		"iam:SimulatePrincipalPolicy",
 		"iam:TagInstanceProfile",
 		"iam:TagRole",
 
@@ -375,7 +374,6 @@ var permissions = map[PermissionGroup][]string{
 	PermissionPassthroughCreds: {
 		// so we can query whether we have the below list of creds
 		"iam:GetUser",
-		"iam:SimulatePrincipalPolicy",
 
 		// openshift-ingress
 		"elasticloadbalancing:DescribeLoadBalancers",


### PR DESCRIPTION
Removing SimulatePrincipalPolicy as a required permission for Mint and Passthrough modes. Instead it will be required when a credential mode is not set.