### PR TITLE
OCPBUGS-17667: Validate vCenter datacenters in failure domain topology

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -228,6 +228,8 @@ func validateFailureDomains(p *vsphere.Platform, platformFldPath *field.Path, fl
 
 		if len(failureDomain.Topology.Datacenter) == 0 {
 			allErrs = append(allErrs, field.Required(topologyFld.Child("datacenter"), "must specify a datacenter"))
+		} else if associatedVCenter != nil && len(associatedVCenter.Datacenters) > 0 && !slices.Contains(associatedVCenter.Datacenters, failureDomain.Topology.Datacenter) {
+			allErrs = append(allErrs, field.Invalid(topologyFld.Child("datacenter"), failureDomain.Topology.Datacenter, fmt.Sprintf("datacenter must be defined in vCenter %s datacenters list", failureDomain.Server)))
 		}
 		if len(failureDomain.Topology.Datastore) == 0 {
 			allErrs = append(allErrs, field.Required(topologyFld.Child("datastore"), "must specify a datastore"))

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -461,6 +461,19 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.failureDomains\.server: Invalid value: "bad-vcenter": server does not exist in vcenters`,
 		},
 		{
+			name: "Multi-zone platform datacenter not in vCenter datacenters list",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains[0].Topology.Datacenter = "non-existent-datacenter"
+				p.FailureDomains[0].Topology.Datastore = "/non-existent-datacenter/datastore/test-datastore"
+				p.FailureDomains[0].Topology.ComputeCluster = "/non-existent-datacenter/host/test-cluster"
+				p.FailureDomains[0].Topology.ResourcePool = "/non-existent-datacenter/host/test-cluster/Resources/test-resourcepool"
+				p.FailureDomains[0].Topology.Folder = "/non-existent-datacenter/vm/test-folder"
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomains\.topology\.datacenter: Invalid value: "non-existent-datacenter": datacenter must be defined in vCenter test-vcenter datacenters list$`,
+		},
+		{
 			name: "Multi-zone platform failure domain topology cluster relative path",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()


### PR DESCRIPTION
Add validation to ensure failureDomain.Topology.Datacenter is listed in the associated vCenter.Datacenters array. Previously, users could specify a datacenter that wasn't in the vCenter's datacenters list, which would only fail at runtime during installation.

This change provides early validation with a clear error message indicating which vCenter's datacenters list is missing the entry.

Assisted by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)