### PR TITLE
OCPBUGS-65659: Add StandardFXmdsv2Family to azure tested instance type list

### DIFF
--- a/docs/user/azure/tested_instance_types_x86_64.md
+++ b/docs/user/azure/tested_instance_types_x86_64.md
@@ -47,6 +47,7 @@
 * `standardESv3Family`
 * `standardESv4Family`
 * `standardESv5Family`
+* `StandardFXmdsv2Family`
 * `standardFXMDVSFamily`
 * `standardFSFamily`
 * `standardFSv2Family`


### PR DESCRIPTION
QE verified StandardFXmdsv2Family instance type on 4.19+, adding it into Azure tested instance type list