### PR TITLE
OCPBUGS-65661: continue to update 02_storage.json using new property storageAccountId

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -118,7 +118,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-10-01",
+              "apiVersion": "2022-03-03",
               "type": "versions",
               "name": "[variables('imageRelease')]",
               "location": "[variables('location')]",
@@ -138,7 +138,7 @@
                 "storageProfile": {
                   "osDiskImage": {
                     "source": {
-                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
                       "uri": "[parameters('vhdBlobURL')]"
                     }
                   }


### PR DESCRIPTION
In the previous PR https://github.com/openshift/installer/pull/10065, the update is not enough, and missed one old property to be updated.
PR installer#10065 has been backported to 4.19 (but 4.19 PR is not merged yet), so this PR only need to be backported to 4.20, then will do manual backport to 4.19.