### PR TITLE
OCPBUGS-65512: Removing resources on destroy by other filters

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -127,33 +127,14 @@ func (o *ClusterUninstaller) discoverCloudControllerLoadBalancerResources(ctx co
 	}
 	o.insertPendingItems(regionalAddressResource, found)
 
-	// Discover associated firewall rules: loadBalancerName
-	found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken", loadBalancerFilterFunc)
-	if err != nil {
-		return err
-	}
-	o.insertPendingItems(firewallResourceName, found)
-
-	// Discover associated firewall rules: loadBalancerName-hc
-	found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken", o.createLoadBalancerFilterFunc(fmt.Sprintf("%s-hc", loadBalancerName)))
-	if err != nil {
-		return err
-	}
-	o.insertPendingItems(firewallResourceName, found)
-
-	// Discover associated firewall rules: k8s-fw-loadBalancerName
-	found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken",
-		o.createLoadBalancerFilterFunc(fmt.Sprintf("k8s-fw-%s", loadBalancerName)),
-	)
-	if err != nil {
-		return err
-	}
-	o.insertPendingItems(firewallResourceName, found)
-
-	// Discover associated firewall rules: k8s-loadBalancerName-http-hc
-	found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken",
-		o.createLoadBalancerFilterFunc(fmt.Sprintf("k8s-%s-http-hc", loadBalancerName)),
-	)
+	// Discover associated firewall rules:
+	// 1. loadBalancerName
+	// 2. loadBalancerName-hc
+	// 3. k8s-fw-loadBalancerName
+	// 4. k8s-loadBalancerName-http-hc
+	// 5. k8s-%s-node-hc
+	// 6. k8s-%s-node-http-hc
+	found, err = o.listFirewallsWithFilter(ctx, "items(name,targetTags),nextPageToken", o.firewallFilterFunc)
 	if err != nil {
 		return err
 	}
@@ -271,23 +252,6 @@ func (o *ClusterUninstaller) discoverCloudControllerResources(ctx context.Contex
 			return err
 		}
 		o.insertPendingItems(httpHealthCheckResourceName, found)
-
-		// Discover Cloud Controller firewall rules: k8s-cloudControllerUID-node-hc, k8s-cloudControllerUID-node-http-hc
-		found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken",
-			o.createLoadBalancerFilterFunc(fmt.Sprintf("k8s-%s-node-hc", o.cloudControllerUID)),
-		)
-		if err != nil {
-			return err
-		}
-		o.insertPendingItems(firewallResourceName, found)
-
-		found, err = o.listFirewallsWithFilter(ctx, "items(name),nextPageToken",
-			o.createLoadBalancerFilterFunc(fmt.Sprintf("k8s-%s-node-http-hc", o.cloudControllerUID)),
-		)
-		if err != nil {
-			return err
-		}
-		o.insertPendingItems(firewallResourceName, found)
 	}
 
 	return aggregateError(errs, 0)


### PR DESCRIPTION
** Firewall rules seem to be an issue on destroy with load balancers. The load balancers may have resource names created with a name such as a9123-xxxxx-xxxx. These resources are only discovered once, and it is possible when a failure occurs that the destroy process will skip finding these resources later. Now the firewall rules will be found using the name OR target tags. When the name does not appear to be part of the cluster (including the cluster id), then the target tags should be searched to determine if they are part of the cluster. This should handle the load balancer resources too.