### PR TITLE
no-jira: add support for g2-standard* GCP instances

### DIFF
--- a/pkg/asset/quota/gcp/gcp.go
+++ b/pkg/asset/quota/gcp/gcp.go
@@ -214,7 +214,7 @@ func guessMachineCPUCount(machineType string) int64 {
 		}
 	case 3:
 		switch split[0] {
-		case "c2", "m1", "m2", "n1", "n2", "n2d", "e2":
+		case "c2", "m1", "m2", "n1", "n2", "n2d", "e2", "g2":
 			if c, err := strconv.ParseInt(split[2], 10, 0); err == nil {
 				return c
 			}

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -43,6 +43,7 @@ var (
 		"c4":  {HyperDiskBalanced},
 		"c4a": {HyperDiskBalanced},
 		"e2":  {PDStandard, PDSSD, PDBalanced},
+		"g2":  {PDStandard, PDSSD, PDBalanced},
 		"m1":  {PDSSD, PDBalanced, HyperDiskBalanced},
 		"n1":  {PDStandard, PDSSD, PDBalanced},
 		"n2":  {PDStandard, PDSSD, PDBalanced},


### PR DESCRIPTION
Currently, it is not possible to create a GCP OpenShift cluster with g2-standard instances as master nodes.

Without this change, an install-config with:

```
controlPlane:
  architecture: amd64
  hyperthreading: Enabled
  name: master
  platform:
    gcp:
      type: g2-standard-8
      onHostMaintenance: Terminate
```

always reliably fails at `ERROR failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: controlPlane.platform.gcp.type: Not found: "g2"`.