### PR TITLE
OCPBUGS-65748: vSphere upi - change to infra id for folders

### DIFF
--- a/upi/vsphere/powercli/upi-functions.ps1
+++ b/upi/vsphere/powercli/upi-functions.ps1
@@ -315,7 +315,7 @@ function New-OpenshiftVMs {
             $tag = Get-Tag -Server $node.server -Category $tagCategory -Name "$($metadata.infraID)" -ErrorAction continue 2>$null
 
             # Get correct template / folder
-            $folder = Get-Folder -Server $node.server -Name $clustername -Location $node.datacenter
+            $folder = Get-Folder -Server $node.server -Name $metadata.infraID -Location $node.datacenter
             $template = Get-VM -Server $node.server -Name $vm_template -Location $($node.datacenter)
 
             # Clone the virtual machine from the imported template

--- a/upi/vsphere/powercli/upi.ps1
+++ b/upi/vsphere/powercli/upi.ps1
@@ -177,13 +177,13 @@ foreach ($fd in $fds)
 
     # If the folder already exists
     Write-Output "Checking for folder in failure domain $($fd.datacenter)/$($fd.cluster)"
-    $folder = Get-Folder -Server $viserver -Name $clustername -Location $fd.datacenter -ErrorAction continue 2>$null
+    $folder = Get-Folder -Server $viserver -Name $metadata.infraID -Location $fd.datacenter -ErrorAction continue 2>$null
 
     # Otherwise create the folder within the datacenter as defined in the upi-variables
     if (-Not $?) {
         Write-Output "Creating folder $($clustername) in datacenter $($fd.datacenter) of vCenter $($fd.server)"
-        (get-view (Get-Datacenter -Server $viserver -Name $fd.datacenter).ExtensionData.vmfolder).CreateFolder($clustername)
-        $folder = Get-Folder -Server $viserver -Name $clustername -Location $fd.datacenter
+        (get-view (Get-Datacenter -Server $viserver -Name $fd.datacenter).ExtensionData.vmfolder).CreateFolder($metadata.infraID)
+        $folder = Get-Folder -Server $viserver -Name $metadata.infraID -Location $fd.datacenter
         New-TagAssignment -Server $viserver -Entity $folder -Tag $tag > $null
     }
 
@@ -257,7 +257,7 @@ $tagCategory = Get-TagCategory -Server $fds[0].server -Name "openshift-$($metada
 $tag = Get-Tag -Server $fds[0].server -Category $tagCategory -Name "$($metadata.infraID)" -ErrorAction continue 2>$null
 $rp = Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Server $fds[0].server -Name $($fds[0].cluster))
 $datastoreInfo = Get-Datastore -Name $fds[0].datastore -Server $fds[0].server -Location $fds[0].datacenter
-$folder = Get-Folder -Server $fds[0].server -Name $clustername -Location $fds[0].datacenter
+$folder = Get-Folder -Server $fds[0].server -Name $metadata.infraID -Location $fds[0].datacenter
 $template = Get-VM -Server $fds[0].server -Name $vm_template -Location $fds[0].datacenter
 
 # Create LB for Cluster


### PR DESCRIPTION
This commit changes from using the cluster name
for folder creation naming to infraid.

We think that the reuse of build cluster namespaces might be contributing to ci failures