### PR TITLE
NO-JIRA: OWNERS: add platform team leads as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - zaneb
   - dtantsur
   - stephenfin
+  - andfasano
 reviewers:
   - installer-team
 component: Installer


### PR DESCRIPTION
Extend approval powers to platform team leads.

/cc @dtantsur @stephenfin 