### PR TITLE
OCPBUGS-65893: CORS-4055: configure AWS SDK v2 clients with common config

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/aws.go
+++ b/pkg/infrastructure/aws/clusterapi/aws.go
@@ -232,19 +232,10 @@ func (*Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput) 
 func getVPCFromSubnets(ctx context.Context, ic *installconfig.InstallConfig, subnetIDs []string) (string, error) {
 	var vpcID string
 
-	cfg, err := configv2.LoadDefaultConfig(ctx, configv2.WithRegion(ic.Config.AWS.Region))
+	client, err := ic.AWS.EC2Client(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to load AWS config: %w", err)
+		return "", err
 	}
-
-	client := ec2.NewFromConfig(cfg, func(options *ec2.Options) {
-		options.Region = ic.Config.AWS.Region
-		for _, endpoint := range ic.Config.AWS.ServiceEndpoints {
-			if strings.EqualFold(endpoint.Name, "ec2") {
-				options.BaseEndpoint = aws.String(endpoint.URL)
-			}
-		}
-	})
 
 	paginator := ec2.NewDescribeSubnetsPaginator(client, &ec2.DescribeSubnetsInput{SubnetIds: subnetIDs})
 	for paginator.HasMorePages() {

--- a/pkg/infrastructure/aws/clusterapi/iam.go
+++ b/pkg/infrastructure/aws/clusterapi/iam.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	configv2 "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -18,6 +17,7 @@ import (
 	iamv1 "sigs.k8s.io/cluster-api-provider-aws/v2/iam/api/v1beta1"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 )
 
 const (
@@ -97,21 +97,15 @@ var (
 // createIAMRoles creates the roles used by control-plane and compute nodes.
 func createIAMRoles(ctx context.Context, infraID string, ic *installconfig.InstallConfig) error {
 	logrus.Infoln("Reconciling IAM roles for control-plane and compute nodes")
-	// Create the IAM Role with the aws sdk.
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM.CreateRole
-	cfg, err := configv2.LoadDefaultConfig(ctx, configv2.WithRegion(ic.Config.Platform.AWS.Region))
-	if err != nil {
-		return fmt.Errorf("failed to load AWS config: %w", err)
-	}
 
-	client := iam.NewFromConfig(cfg, func(options *iam.Options) {
-		options.Region = ic.Config.Platform.AWS.Region
-		for _, endpoint := range ic.Config.AWS.ServiceEndpoints {
-			if strings.EqualFold(endpoint.Name, "iam") {
-				options.BaseEndpoint = aws.String(endpoint.URL)
-			}
-		}
+	platformAWS := ic.Config.Platform.AWS
+	client, err := awsconfig.NewIAMClient(ctx, awsconfig.EndpointOptions{
+		Region:    platformAWS.Region,
+		Endpoints: platformAWS.ServiceEndpoints,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create iam client: %w", err)
+	}
 
 	// Create the IAM Roles for master and workers.
 	tags := []iamtypes.Tag{


### PR DESCRIPTION
## Description

The SDK v2 introduces a new built-in client rate limiter [[0]](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html), whose default settings break the install process when under heavy stress. For example, we have seen rate limit issues when runnning in CI with high number of AWS resources, especially IAM.

Thus, we explicitly disable the rate limiter in the common client config, defined in `pkg/asset/installconfig/aws/sessionv2.go`. Any v2 client will need to use this config.

## Background

While attempting to migrate the destroy code, we have run into rate limiting issues previously where IAM API calls are rate limited. We reverted that.

However, there are other IAM calls within the install path to getOrCreate IAM roles and instance profile. Thus, we need to make sure the IAM v2 client disables the rate limiter. Otherwise, we will run into the error such as:

```
time="2025-11-13T08:21:44Z" level=error msg="failed to fetch Cluster: failed to generate asset \"Cluster\": failed to create cluster: failed during pre-provisioning: failed to create IAM roles: failed to create IAM master role: failed to get master role: operation error IAM: GetRole, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: 910e3801-5fc1-45d7-91cc-092bb8e3e4b1, api error Throttling: Rate exceeded"}
```