### PR TITLE
OCPBUGS-65588: Update the RHCOS 4.18 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.18",
   "metadata": {
-    "last-modified": "2025-10-13T19:18:55Z",
-    "generator": "plume cosa2stream 431819c"
+    "last-modified": "2025-11-20T12:15:58Z",
+    "generator": "plume cosa2stream 5d742df"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-aws.aarch64.vmdk.gz",
-                "sha256": "e20251dfd9608bad0b2ff54cad44971fb8229ddc7e537c0ee633bbe5b5216f83",
-                "uncompressed-sha256": "5c08bcf87ec52a7c023c666db4cbe7ded3e289e2ee72c7d4a98282a40c514e52"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-aws.aarch64.vmdk.gz",
+                "sha256": "8f6e175d0c2111ea61541a936dc51bf7e28a19b69ac7486cab9940e931627918",
+                "uncompressed-sha256": "019f89acc86935e105dc91a6fd30e9d536d919b0605086cae81116b08f23515b"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-azure.aarch64.vhd.gz",
-                "sha256": "7b62625d417e279eeef48db0e100d629596c6d03807e84ee96438b827226cd40",
-                "uncompressed-sha256": "3b01d617927bfe90a98992ea5dc4862a7159a9ece212b11c04f9bde6738cd4c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-azure.aarch64.vhd.gz",
+                "sha256": "1d29cf342533460505ddc0653b9128e3540954cf751aa41b9e5145fe857aa940",
+                "uncompressed-sha256": "4c9d16220605ec5db1ecc880568a3be5ca790782d5a225e145e0c24db8d94ec2"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-gcp.aarch64.tar.gz",
-                "sha256": "bb1453b0a7eda8ce14938ce8452141c67cf9ae2e672ecc42e0647a83b150a49e",
-                "uncompressed-sha256": "48dfd6c824a42015362f97b810a859767a7b6f34f88ab6f7d255270d1ffb6dd1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-gcp.aarch64.tar.gz",
+                "sha256": "d0d297e3631e033da97de9dc91915290d0795ceee8024d6aeeb4499152d7ea28",
+                "uncompressed-sha256": "768f4f2dfa1aad2bf05917ee723e639b0117ac512de421d15902b93034778eac"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-metal4k.aarch64.raw.gz",
-                "sha256": "b795893ecb62e902a81c05b80f2ec64dadc5988c6e9ff7695dcc4d1145cf6c54",
-                "uncompressed-sha256": "3a26a697c01ac1b34b94610e455f534af8621951f93a996e4a1d33a23a17b853"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-metal4k.aarch64.raw.gz",
+                "sha256": "3520604348872b9a5fd0c51e34301ae2fefe5039000d49ae884236ef795bdba5",
+                "uncompressed-sha256": "a069453caaa53f10899dc6f18a923e931a1bd47fa2eb620b3a48b12a434b8360"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-live.aarch64.iso",
-                "sha256": "efc4d6cbf08649f00e05a0a8c77694982769d4b31c12be0c5327005d45251e73"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live.aarch64.iso",
+                "sha256": "512a1667ac3b905da45c971b5c5ca4f20c10c291ad122e0e19e6c922ce94896b"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-live-kernel-aarch64",
-                "sha256": "27d1978bb3f9effdda32e99bf02c114cf7173cc4a4733b37aefcd2b79631e27d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-kernel-aarch64",
+                "sha256": "edcad7cc2acb04389a9ba8d8f837dca534008a5d274e5c51d8608e02afb8485b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-live-initramfs.aarch64.img",
-                "sha256": "b0eab5f1fa21c943cd2e5c34971ac8f76b02cea1dc8876a59c1d7b8f14ecf820"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-initramfs.aarch64.img",
+                "sha256": "2214713975d2257efa63095db5bf2352a907e513a1e49a8b3e6fd20ad14f4297"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-live-rootfs.aarch64.img",
-                "sha256": "8ed0e90613836d0aa4f1818a63c4064cfd5cdd350cbdf0f4ac6d22f5e0e7d6a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-rootfs.aarch64.img",
+                "sha256": "5fc51974a7cf1b6be68ec73aefd5d66501e7ada8d53b27ef1ef51b7b2318946d"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-metal.aarch64.raw.gz",
-                "sha256": "12447bcaaa7bd45a7301be1d58eda5764e050219adb0c491cdb46ec7b945f6fe",
-                "uncompressed-sha256": "d7e1fb7f47674cd6a34d8049406a1853b65ddfc77536b176557dec063d1110be"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-metal.aarch64.raw.gz",
+                "sha256": "49bc651e9fd7e7971860608109b8f13bce36b18f6c00ac7573d45325f861be7e",
+                "uncompressed-sha256": "9b6fbf74b2af23fd0fd8244ab842aaec8558f2d7e3e56ff498ab51b07c773279"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-openstack.aarch64.qcow2.gz",
-                "sha256": "16aa55c6c246e62689c9c185d64b2c7c1ee0013b005c9ae3cd5063fd5fabcc59",
-                "uncompressed-sha256": "8c40e63dce16dcecb8c68e267a8b8b687814868722a44101a447f87e6e436c5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-openstack.aarch64.qcow2.gz",
+                "sha256": "e8c2c3d9fdb8a536600b2e30bf5321f2d03f6eca8abc9609681db53f27a36086",
+                "uncompressed-sha256": "cfe9ebca376fa87a0e6d09bb32369d79c43353d1be6ad8091fe37e0d6a0bf6db"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/aarch64/rhcos-418.94.202510081222-0-qemu.aarch64.qcow2.gz",
-                "sha256": "3f9490e309f54e02fc379a135d6a96ae33fa86d59e0347185e9c68b9bcfd099c",
-                "uncompressed-sha256": "01fbb7675a65727ae03cad1a3d2918569f17a27c399b9b20fc55c245cca9adf6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-qemu.aarch64.qcow2.gz",
+                "sha256": "93d690bfb4f043ce2d6c609d0cb29d36947f30c82eb8e260f5ce22cbfb719258",
+                "uncompressed-sha256": "153339efd1652128640d87d3d184127eba93cd7b46f48128e0d3013296873eb5"
               }
             }
           }
@@ -111,237 +111,237 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-05fc4764597e3ae8c"
+              "release": "418.94.202511191518-0",
+              "image": "ami-05457218b93924a1b"
             },
             "ap-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0de76122b97421b2c"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0c00cb6d08c75e584"
             },
             "ap-east-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0fd77b9b31046643e"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0bde509eea8a5a001"
             },
             "ap-northeast-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-05cda4a5ec2d604a1"
+              "release": "418.94.202511191518-0",
+              "image": "ami-09b5ef37857ce7f09"
             },
             "ap-northeast-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0165631f59cf443ab"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0e3d83a57853ab680"
             },
             "ap-northeast-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0851f410f7ef7659c"
+              "release": "418.94.202511191518-0",
+              "image": "ami-085de759aba52d089"
             },
             "ap-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-096e5e46415741451"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0e4ebbcc134fa8e8d"
             },
             "ap-south-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0ad184cf8f5fbcbf6"
+              "release": "418.94.202511191518-0",
+              "image": "ami-01783057e4deaaf36"
             },
             "ap-southeast-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0e4dbe22c19cd909b"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0416c2f0b26f59b09"
             },
             "ap-southeast-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-068f6dc008846dad9"
+              "release": "418.94.202511191518-0",
+              "image": "ami-01bffeaf91cf3497d"
             },
             "ap-southeast-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0355b1c0dead0fa18"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0cc0002570e11f538"
             },
             "ap-southeast-4": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-03d8e2ebf2a0fe816"
+              "release": "418.94.202511191518-0",
+              "image": "ami-09779e41beff513f1"
             },
             "ap-southeast-5": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0f47d377fb5569bb5"
+              "release": "418.94.202511191518-0",
+              "image": "ami-04f8e1a5b2f7d7887"
             },
             "ap-southeast-6": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0a029323215394d2a"
+              "release": "418.94.202511191518-0",
+              "image": "ami-07df9710dc7cec116"
             },
             "ap-southeast-7": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-03b9190815e7f29c8"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0962bbe6781c54e30"
             },
             "ca-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0516191290feaf5c3"
+              "release": "418.94.202511191518-0",
+              "image": "ami-045cc23fb5d28e555"
             },
             "ca-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-02b0af7975e663c73"
+              "release": "418.94.202511191518-0",
+              "image": "ami-041acba9d9a5d19cb"
             },
             "eu-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0338bfad184463ca9"
+              "release": "418.94.202511191518-0",
+              "image": "ami-06139d7ec6134180d"
             },
             "eu-central-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0ef6c833729e86da6"
+              "release": "418.94.202511191518-0",
+              "image": "ami-00ad559fc930398e5"
             },
             "eu-north-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0e449f4b72848d537"
+              "release": "418.94.202511191518-0",
+              "image": "ami-02e805b1b4cfab2e7"
             },
             "eu-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0eec734ab8d03055b"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0770985d740e28d8a"
             },
             "eu-south-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0181411ddbed2d4d8"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0925f45015194a3cd"
             },
             "eu-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0b932961a2b5a46e3"
+              "release": "418.94.202511191518-0",
+              "image": "ami-099fe0e81e4eab17f"
             },
             "eu-west-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-01d0ffa736bdf21a9"
+              "release": "418.94.202511191518-0",
+              "image": "ami-030d19b1fd9364be9"
             },
             "eu-west-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0124b5040cc5aeed2"
+              "release": "418.94.202511191518-0",
+              "image": "ami-00f338e6e710d7c5e"
             },
             "il-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-093d1ce3ce349f03a"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0535fac6e664ce43e"
             },
             "me-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0030284bad4bca311"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0bb1409cb2a27e3af"
             },
             "me-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0325ac72c7d3dc78e"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0a6664f7743cd3e65"
             },
             "mx-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-075dd464f62c15020"
+              "release": "418.94.202511191518-0",
+              "image": "ami-01e941f94a7a1e14b"
             },
             "sa-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-080f8185787db31c7"
+              "release": "418.94.202511191518-0",
+              "image": "ami-076cc67cb438fe315"
             },
             "us-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-03c0100d3d3b83a44"
+              "release": "418.94.202511191518-0",
+              "image": "ami-05aa7e1d4ac758a5f"
             },
             "us-east-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-077d6bf87a659de3a"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0370be55ebca09a9b"
             },
             "us-gov-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0b944a7d3b930c42d"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0a47f24f68cc4c924"
             },
             "us-gov-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0627bbfb339953e63"
+              "release": "418.94.202511191518-0",
+              "image": "ami-004e11fd06d5cc890"
             },
             "us-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-058857b7d3c755405"
+              "release": "418.94.202511191518-0",
+              "image": "ami-02a09bbfa063f461c"
             },
             "us-west-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0f3ea6facb8e4f2f5"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0b76526e37ab59b22"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202510081222-0-gcp-aarch64"
+          "name": "rhcos-418-94-202511191518-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202510081222-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202510081222-0-azure.aarch64.vhd"
+          "release": "418.94.202511191518-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202511191518-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-metal4k.ppc64le.raw.gz",
-                "sha256": "f5c352784dbfb65875890c8e070aac7a0a98641982d5bf278ead281b7668bd9e",
-                "uncompressed-sha256": "5579692261c385a0811d27337247261077d4f035407f5dfd8ec490f18289f1a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-metal4k.ppc64le.raw.gz",
+                "sha256": "327aa7d125ceb1990aa721f52927bd078dbeccb5f6a5b9d7e75a55eebf8feb9a",
+                "uncompressed-sha256": "7915191e56951a31280166e4e2d7c7ed58ec8cb272561c835a59dea6b5f0ea5d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-live.ppc64le.iso",
-                "sha256": "d854f8b9183c861461ee185f07bc42064db391907fef1f9d4b7f4e24973249ea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live.ppc64le.iso",
+                "sha256": "5332f8ef4e26bdfdf539b9e80b1c2fd5d092843c2714defa6bceab6b33f29009"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-live-kernel-ppc64le",
-                "sha256": "7703d8e7d74a4b5ca10bc8df688be05019c0cc06174ae01991be5898bb89b213"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-kernel-ppc64le",
+                "sha256": "33802298e5217e0aef4dcd66310d7340be28b264d506c1368504224efa4500e1"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-live-initramfs.ppc64le.img",
-                "sha256": "98cbff95c8cb404df0baf8dc4fd21c96ba7f46159217367b9cb4e1d9b81fcc61"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-initramfs.ppc64le.img",
+                "sha256": "c25d2b87974c38105b0c94c99ceb5c5ed3eee86520348b44258e60a2b4dffb30"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-live-rootfs.ppc64le.img",
-                "sha256": "21286d16553ccd5e49a6ad4a6bacd4c301dbba589f713655f786e593101f7c1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-rootfs.ppc64le.img",
+                "sha256": "053c46c274180385d279351dacc78ada7a8d55b356d964007068e938d818be61"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-metal.ppc64le.raw.gz",
-                "sha256": "c5d0efaded91a537519ef96249b228b4d23c0887598f503f991be0a34da86d50",
-                "uncompressed-sha256": "03feb203041e05a1307b4082a5e8640cbfeee3fdb1a5e41a046819d8fd91ccec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-metal.ppc64le.raw.gz",
+                "sha256": "e484fbc818d02535e47d9197d64ef67a741a6584118605481b165dc4c67f978b",
+                "uncompressed-sha256": "884545c3c0ab6c400d64e8ea9ba188e5fd980d97b955fa0d93bdbed0fd15cbe0"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "383898998c9ba437a844f94eea48472e42e1d92b3bb7dfcd5a9e0897fb335380",
-                "uncompressed-sha256": "51bf5f6665e87bac0015217e20fbca2af1912616bf0889834536ff9f67c1f629"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "89344bc0ff4d92d9d08478b57f88a8ed7f5c7e85d742e5c9ad8db33c4a1fa814",
+                "uncompressed-sha256": "6bf9809de1861c95ca19eb062d83088fbd512a4d9d509b590f24555a035f8c7c"
               }
             }
           }
         },
         "powervs": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-powervs.ppc64le.ova.gz",
-                "sha256": "e4606610527305b7fdd4228c49ebc08303897fd50ca97e8118ec561e4491f38b",
-                "uncompressed-sha256": "04b9ac2d0a7afbe556a7fcc002117f4ed385f38ead38899d03e9e40040564d70"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-powervs.ppc64le.ova.gz",
+                "sha256": "cba69ca150e9bf00de80b5fa5783faf438985825864e553f9ab0e06e3ae26388",
+                "uncompressed-sha256": "c784d765d55cb3ba4d0096658df0b7b7a499390a8d7ccce1e55cfddec8452184"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/ppc64le/rhcos-418.94.202510081222-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "bdfa25967ae08a2e6f6e8e12a001ab6888c52852184b54f4fdf5cab58d4e7f27",
-                "uncompressed-sha256": "dbecc23fea9b7c086581e8093a6d10085ae5010bbe047bb7cc0a714af9cd4d17"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "210c23aeee16d51fbabed76b3a914e4bedb51da44c10ac92413db82910c34bdf",
+                "uncompressed-sha256": "d4c549f7aa9000626d1d50a68a45691c021fd82ea3707d60e129d75f2188537d"
               }
             }
           }
@@ -351,64 +351,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "418.94.202510081222-0",
-              "object": "rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202511191518-0",
+              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202510081222-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -417,88 +417,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "ba0f6848226d491dbbfbbabc5d7415d72dbed2ebbcb09a3b5471737aeaff71f3",
-                "uncompressed-sha256": "253eb8c08f1f1127ee2c9f33a7187e06e2ba7a61cddde6adbfc2e5e5f2beff8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "b2d693be21f2eb00cced5f92a50f19622b2f92edb0eb4387ab849d06c189fab8",
+                "uncompressed-sha256": "7f3ef4c34050c54a175a1bb3aa6001335118df0ddd68efcc49cf948e7a7bd9ba"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-metal4k.s390x.raw.gz",
-                "sha256": "84eef3c2c9a6532e34ff97459952504aaaa549dcce320ba25e5fcdce58098b7c",
-                "uncompressed-sha256": "d0150008662246b89c1b5d84871920d59510a4333d833a18f9de577ba6191ea2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-metal4k.s390x.raw.gz",
+                "sha256": "387602fc0f1abff8d0cfefe60633f8d712747bbba08936c96b80e27d262668da",
+                "uncompressed-sha256": "77f3a546f5803c0d7521ea6ee005c4a0279aa9d281304ba0ffc8da6067ab756b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-live.s390x.iso",
-                "sha256": "d8bf3afc4778bb69ffa1f87da7fef34bc10b41abf3f64e4767fdcdf664b613f1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live.s390x.iso",
+                "sha256": "d083b5d11f1c586d0e7d1c337cdbf7f23faa81de8779894942e7011b8097e1c2"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-live-kernel-s390x",
-                "sha256": "20183c9b1dae665450e2322ac1773b945d05423f2db388672aefcd3c579923f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-kernel-s390x",
+                "sha256": "066e80b6d855e36885e9bb2123866f87e5b8d95d2e8e6e1f171b22352cd26483"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-live-initramfs.s390x.img",
-                "sha256": "78856c1a3db7f5f556835f643867a14fdebadb010cb2fcda69be919d1fbeff15"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-initramfs.s390x.img",
+                "sha256": "63ce373f3473a765557800e89d32375a9de9e29509b08699d172b84e41631227"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-live-rootfs.s390x.img",
-                "sha256": "a8bb253b42baa7d51e343041b6703c136fe7a0ca08aa876b75acd6feb491e02f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-rootfs.s390x.img",
+                "sha256": "04f56945dda729baaf71186a517c89795488cc0ddd5847a72a18b9eb9a9086ec"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-metal.s390x.raw.gz",
-                "sha256": "2b1ac3ed68f75e59c9cffc9f5aee627160bac4f1a3e7684ba9b8ae213a864222",
-                "uncompressed-sha256": "0470130fbd8c7b4a6a9cedf7b1f618ec68abdfcc2e5ed304092dbbc62c96df8a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-metal.s390x.raw.gz",
+                "sha256": "0d1409487ae82ac8bafb94c7af9f6c9820d1518b2fa9c0a5c965a771ece1c192",
+                "uncompressed-sha256": "7156333fda980abe7dbf520e82456102be0c6bc4ea28b14d7b6531040434df67"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-openstack.s390x.qcow2.gz",
-                "sha256": "2e546ce37287b30117aeea30ace1fdd2bf8f0dcd6d9589f6eb77803ff0579973",
-                "uncompressed-sha256": "cdfe9fb8af2c8d49d83eff8c7247fc60bf41615449bb142ce03269b427750cd6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-openstack.s390x.qcow2.gz",
+                "sha256": "7d9bfda46a0976a749a03b03a11ec3a1a249511326a831d444adb93627b271e7",
+                "uncompressed-sha256": "f2c3961a0d63b44a5533ce102347d8378a6271ce061fd5a26c6ea665eceb7f8a"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-qemu.s390x.qcow2.gz",
-                "sha256": "eaef53563d96242221c54251c6250910c15373bfc6e7a22639a2a428be48d330",
-                "uncompressed-sha256": "7c962d3213ab85b1d25207fdb4cc10709541379abfc566a9f743450f6585d740"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-qemu.s390x.qcow2.gz",
+                "sha256": "ff22f43801eaf13afa6e400d7260c2301e79014413ecfc9b9dd4806c41b2877c",
+                "uncompressed-sha256": "561dfab8b233afc00c51fd1e30c8a1c76b8dc83c52a48e26e49cd95b0a31ca3e"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/s390x/rhcos-418.94.202510081222-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "6a7adf765af2ce1e2f56892499d79c003e10be192976884e889a166cdd8e9460",
-                "uncompressed-sha256": "b210d7d83fcf1528691141542ac8e99d9845142e016e256a61059c3fac4b5506"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "4ff50a935b8c437308143494ccb96c3118d70870522e17b67425cf3e08a4c39b",
+                "uncompressed-sha256": "54e58b1adcc43f7a502eb5a7c9986f06aa982ef530eb9b1994e37c9a15d407d0"
               }
             }
           }
@@ -509,157 +509,157 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-aws.x86_64.vmdk.gz",
-                "sha256": "32efa8543a070d0ffc91caf687c2869c88b523e14a63ec70f32a53662b3a138b",
-                "uncompressed-sha256": "51963fe9b8a66aeabbc4585b5e57f69fe773b63f5bd10a30f1661b2e994869a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-aws.x86_64.vmdk.gz",
+                "sha256": "79ebc1076804eee170d7f67911cc6ce58241e72083796d91cd0b4d02170bd42e",
+                "uncompressed-sha256": "07ed924d79d74e3598141f22fdad406010752fde8c989fea5a4f43f3235d17a7"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-azure.x86_64.vhd.gz",
-                "sha256": "d67c3dea943f0ea28203dc048ef411339d223e46091817d9a14cc01ac80862e9",
-                "uncompressed-sha256": "5d9659022bd9621a228c68998c5a2a4504e78d91489ff5e9be13c9deaff9fd52"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-azure.x86_64.vhd.gz",
+                "sha256": "f6e4a9011232dd95e4326892234f57d565776b3b6d54abb6d92661bcbfecc25d",
+                "uncompressed-sha256": "4a4d29aa34cb0615de532183cb4268a9305003caa2c5f6174da2338c3b5ab00d"
               }
             }
           }
         },
         "azurestack": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-azurestack.x86_64.vhd.gz",
-                "sha256": "a3dc24ee9135db675ec1708b0ae7886b5219ca18a00a056ee296f10a619ced7f",
-                "uncompressed-sha256": "4e75656a44781bde5d517d44da12f834455796576906e5355420e02bd6ba70a9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-azurestack.x86_64.vhd.gz",
+                "sha256": "288ff8a207733d700a717d415e437c9586c7f2d02a6647e9a10ffd419004c2de",
+                "uncompressed-sha256": "0af0d1c8ae4423a8cbea9590b87289c01723aae5163713965e46f56b88ee655c"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-gcp.x86_64.tar.gz",
-                "sha256": "801803fc28c8ca6fef232b2157778ea4f736c6922085140c04125fc1af14202f",
-                "uncompressed-sha256": "08af2cd4990ce2be767d1d9886c18aa139e0dec9ebc6b56028fdbd4fd86ebd72"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-gcp.x86_64.tar.gz",
+                "sha256": "ca1b735547d6cecc82c8b41e214de8287cdc631fc872187fcb632f884f9e5115",
+                "uncompressed-sha256": "d183fe31d41d2e749b916eef326ad3165a73ae8ae11d23e66639b99f752466e9"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "973b79c67aff74402aeb72a417166877504380b2809c3778c0fe3bb73cbbabcb",
-                "uncompressed-sha256": "3a7b0a07f1078c667819ee150a70123713293872829a942c6458e5a1605113b9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "48b2991ec99acbb2779b6c63f5b894d880300b4f3c3888a97811345a2b47e348",
+                "uncompressed-sha256": "b9eebf52f33bd6e6a7e74aa1bbd35b75dc9cb4d59d2711fdaf73fca7c041a118"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-kubevirt.x86_64.ociarchive",
-                "sha256": "530d5be16e63fcd2078eac0952d63c7d4262cdfa3635eda3606d515defa65343"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-kubevirt.x86_64.ociarchive",
+                "sha256": "de14586b007cd74ba79af3a059d4b061f4ceb6d1e9163ff34119c10a3d56b074"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-metal4k.x86_64.raw.gz",
-                "sha256": "a2af29b4048de0394575988efb3a787b2274ec144e0e13a2f8f3102bd90e08cc",
-                "uncompressed-sha256": "fe1a17d5d38dda55e940247d44ddb30fba5c6caa0163b173379b2d007cf37841"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-metal4k.x86_64.raw.gz",
+                "sha256": "c2253ac340ddcb9363bb43dc2ca8e28039ec94d3b1b2f3e706a571bdfcb25b52",
+                "uncompressed-sha256": "00be817a329cfbef0ccaf9635d7012ec6f9178930ca79086777a1a2d68ea4815"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-live.x86_64.iso",
-                "sha256": "a8c1121ebd186670703b0e6824d7d2a10b6607b12a002bc9f03e774647b3a590"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live.x86_64.iso",
+                "sha256": "a9d26a2736479d26861b1610fa1061043bd964e2529b69d5c49fa99be8e82cb3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-live-kernel-x86_64",
-                "sha256": "74ab08d98be5a87078a2cd663375083e57eabfa445279c86287f41a576949efa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-kernel-x86_64",
+                "sha256": "de017a633c5e93806ab84169486f9ca7e130eac59c65193f3ce9d53a4aa22dec"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-live-initramfs.x86_64.img",
-                "sha256": "17aed388b5bc3c4e89c884784ae5979298df3b1a9830c4bda41306b9620b9c91"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-initramfs.x86_64.img",
+                "sha256": "9ccbfc191ad3ce4875a9182d15f70926aee430cbe2b08c0a9c8e28c259d4c7ba"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-live-rootfs.x86_64.img",
-                "sha256": "a6a45a4054ab151b5e68bf9d692a2c7ee8ee2311d68bcff47ff53f8240622d76"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-rootfs.x86_64.img",
+                "sha256": "cbc027a70ff8774ea7e2be3d6e8f8ce96b0b22be93f89b440f70291d3ffaee19"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-metal.x86_64.raw.gz",
-                "sha256": "916621c7108ab112545b300934f1046f7d7aeaca5d664df6b9566169a7f8520c",
-                "uncompressed-sha256": "b60a2bb84d7b5ee57805d1f9d0160e9b1294dea29d296bab7638247bfbb42038"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-metal.x86_64.raw.gz",
+                "sha256": "d0319cb89e2be92fe429bd1c2ada98975e42e4878b0418afd9e35b2a48fe1223",
+                "uncompressed-sha256": "5efe1858493814b13c7af47ca1fe89ec4b0530dc46fc50fb2ed80427aa1ef52e"
               }
             }
           }
         },
         "nutanix": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-nutanix.x86_64.qcow2",
-                "sha256": "98a1fcafeeb9f53e99e0ee459f15e0a89f54221961bb02c7ed659e63854a2823"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-nutanix.x86_64.qcow2",
+                "sha256": "cbc87baf78f13374081c852e753746c73f75e6170f248ddabd26555da070c496"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-openstack.x86_64.qcow2.gz",
-                "sha256": "6eab91eb4fd75365d568362de6b953eb03832ebdfa28d74893763b5d80a43db5",
-                "uncompressed-sha256": "0088d7f5d6e4090fe5e850c0bcfeced93e7daef55908037cad4f848a8d55ebda"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-openstack.x86_64.qcow2.gz",
+                "sha256": "801cf80c248178e920eeaa3a50c2caa855e98c95ef1744bffce9804d59ee5d58",
+                "uncompressed-sha256": "1c6466f515aedaab4bd3c3ba04f0d3966fad1d71e8497789211447c981055740"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-qemu.x86_64.qcow2.gz",
-                "sha256": "c316d8a03ca296d40afed5f3babc7410b4d4e3a2739e4368bc32f1a0d5f19d86",
-                "uncompressed-sha256": "a6f870c3fb8f5039962978980cf6a5a11cd2973a35fc2b2938106658983b18d6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-qemu.x86_64.qcow2.gz",
+                "sha256": "a674e7b1c39b2ce1ffcac8003574f13091658efe8bda9f854f9603cccd141dea",
+                "uncompressed-sha256": "45bb97ae4127f7868a0405d2ed9ba7a90f8ef324c726a3d276ec059ecf271979"
               }
             }
           }
         },
         "vmware": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202510081222-0/x86_64/rhcos-418.94.202510081222-0-vmware.x86_64.ova",
-                "sha256": "c12f8ccff06843f1583f43f17e2f2ac2b363c1ff5d2fc09643f1b7e51bc024ca"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-vmware.x86_64.ova",
+                "sha256": "631654a19597e1640ef7a58228efe297a336cc1a0ee4741bb9ad69598771a53a"
               }
             }
           }
@@ -669,166 +669,166 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-01b22446e9a86b763"
+              "release": "418.94.202511191518-0",
+              "image": "ami-02552a7435888e77f"
             },
             "ap-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0886274d5173ce90d"
+              "release": "418.94.202511191518-0",
+              "image": "ami-00a52c01467e5009c"
             },
             "ap-east-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0fce6c634ad46ed2e"
+              "release": "418.94.202511191518-0",
+              "image": "ami-009dec07208df3d53"
             },
             "ap-northeast-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-067d5b1721ead543a"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0af1f1b5512f0cdf0"
             },
             "ap-northeast-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-034f5dc3ee08ca34f"
+              "release": "418.94.202511191518-0",
+              "image": "ami-060c9dba5cb61b7a5"
             },
             "ap-northeast-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0f7485779d2053677"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0f74b31c0467082e8"
             },
             "ap-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-05f1251b58c9752c1"
+              "release": "418.94.202511191518-0",
+              "image": "ami-00fb24e003ecad70c"
             },
             "ap-south-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0d9271a99e1e29ef0"
+              "release": "418.94.202511191518-0",
+              "image": "ami-01aa65eac7f33c61f"
             },
             "ap-southeast-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-081de534f65db9be2"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0d72009d4118a5a1a"
             },
             "ap-southeast-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-07c48df867315302e"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0730d4339571de61b"
             },
             "ap-southeast-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-057a376038efa830e"
+              "release": "418.94.202511191518-0",
+              "image": "ami-057c294ce57b7c018"
             },
             "ap-southeast-4": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0c96ec087664003a2"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0e30e4ac62769daa3"
             },
             "ap-southeast-5": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0cfc864e9d6838bf6"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0216b19f36a1678ad"
             },
             "ap-southeast-6": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0f47118e5ac89fc68"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0d2de3e58cdd9ac49"
             },
             "ap-southeast-7": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0680aeaf5548887b4"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0c6772f15bf6335d0"
             },
             "ca-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-06b16c6d768ed84ac"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0809d3a0a5e0ea0dc"
             },
             "ca-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0431d40e421f29a2b"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0c21f1e5823e2f8b0"
             },
             "eu-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0c513f87329629378"
+              "release": "418.94.202511191518-0",
+              "image": "ami-03cff1786a40a302f"
             },
             "eu-central-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-05d2ab8e2d5b98d06"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0144f3082fe73dfd0"
             },
             "eu-north-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-00058564ac70fb915"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0a2d65e335322aaff"
             },
             "eu-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0854744b0c11f1978"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0684bc7d8d1c4b6d5"
             },
             "eu-south-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-09a5d51bc1448cbbb"
+              "release": "418.94.202511191518-0",
+              "image": "ami-00783b7145483d3bf"
             },
             "eu-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-084a060746129fd83"
+              "release": "418.94.202511191518-0",
+              "image": "ami-09f384c4bbb2970e7"
             },
             "eu-west-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-00de0374d12842ea5"
+              "release": "418.94.202511191518-0",
+              "image": "ami-06534328a9bcd4046"
             },
             "eu-west-3": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-07ef81c7450346bdc"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0eff1a05bed6583a5"
             },
             "il-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-01d24cf6ce901e820"
+              "release": "418.94.202511191518-0",
+              "image": "ami-011ff3703892cc3c3"
             },
             "me-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-01005151d5af69df6"
+              "release": "418.94.202511191518-0",
+              "image": "ami-007607fc650d240f4"
             },
             "me-south-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0c336e4548dcda782"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0691ccb6db498e06d"
             },
             "mx-central-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-096e38878ff485b7b"
+              "release": "418.94.202511191518-0",
+              "image": "ami-06c5f210cc1441aea"
             },
             "sa-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0117beb76cc027785"
+              "release": "418.94.202511191518-0",
+              "image": "ami-02145eba366a8a7e8"
             },
             "us-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-08bfb7a5587f21b9d"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0ccb061ea4996e851"
             },
             "us-east-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-04756c1a4f51bb2c9"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0a611e6a24a551a2b"
             },
             "us-gov-east-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-03b7c8f435b92c7ce"
+              "release": "418.94.202511191518-0",
+              "image": "ami-0bbcbfdc4a2326f03"
             },
             "us-gov-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-03fa5d6930ca7b839"
+              "release": "418.94.202511191518-0",
+              "image": "ami-01a6878b9c2144dbd"
             },
             "us-west-1": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0ca31e45e572cbb0c"
+              "release": "418.94.202511191518-0",
+              "image": "ami-067330529ffc1277e"
             },
             "us-west-2": {
-              "release": "418.94.202510081222-0",
-              "image": "ami-0b4e0d217fe8eb079"
+              "release": "418.94.202511191518-0",
+              "image": "ami-077660cf51d514ed3"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202510081222-0-gcp-x86-64"
+          "name": "rhcos-418-94-202511191518-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "418.94.202510081222-0",
+          "release": "418.94.202511191518-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.18-9.4-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3408ed0a5caef3cda4271da2836cd01677f130d12d5c4dd53faccf619e020114"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cc4c27c1b5e1516361e513a39e2cdcd77d009240aba30155f70a16268a8b451e"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202510081222-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202510081222-0-azure.x86_64.vhd"
+          "release": "418.94.202511191518-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202511191518-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
The changes done here will update the RHCOS 4.18 bootimage metadata and address the following issues:

- OCPBUGS-64613: [4.18] coreos-boot-disk link not working with multipath on early boot

This change was generated using:

```
plume cosa2stream \
    --target data/data/coreos/rhcos.json \
    --distro rhcos \
    --no-signatures \
    --name 4.18-9.4 \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=418.94.202511191518-0 \
    aarch64=418.94.202511191518-0 \
    s390x=418.94.202511191518-0 \
    ppc64le=418.94.202511191518-0
```
