### PR TITLE
no-jira: Remove the GCP Custom Endpoints Feature Gate

### DIFF
--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -1,9 +1,6 @@
 package validation
 
 import (
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
-	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/featuregates"
 )
@@ -11,12 +8,5 @@ import (
 // GatedFeatures determines all of the install config fields that should
 // be validated to ensure that the proper featuregate is enabled when the field is used.
 func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
-	g := c.GCP
-	return []featuregates.GatedInstallConfigFeature{
-		{
-			FeatureGateName: features.FeatureGateGCPCustomAPIEndpointsInstall,
-			Condition:       g.Endpoint != nil,
-			Field:           field.NewPath("platform", "gcp", "endpoint"),
-		},
-	}
+	return []featuregates.GatedInstallConfigFeature{}
 }

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/dns"
-	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -20,18 +19,6 @@ func TestFeatureGates(t *testing.T) {
 		installConfig *types.InstallConfig
 		expected      string
 	}{
-		{
-			name: "GCP Custom API Endpoints is not allowed without Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.GCP = validGCPPlatform()
-				c.GCP.Endpoint = &gcptypes.PSCEndpoint{
-					Name: "test-endpoint",
-				}
-				return c
-			}(),
-			expected: `^platform.gcp.endpoint: Forbidden: this field is protected by the GCPCustomAPIEndpointsInstall feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
 		{
 			name: "AWS UserProvisionedDNS is not allowed without Feature Gates",
 			installConfig: func() *types.InstallConfig {


### PR DESCRIPTION
** Remove the validation when the `endpoint` field is filled out in install-config. The feature has been tested and the feature gate should no longer be required.

** Remove the test for the featuregate.