### PR TITLE
OCPBUGS-65938: increase IAM waiter timeout and remove custom delay options

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/iam.go
+++ b/pkg/infrastructure/aws/clusterapi/iam.go
@@ -188,11 +188,7 @@ func createIAMRoles(ctx context.Context, infraID string, ic *installconfig.Insta
 			}
 
 			waiter := iam.NewInstanceProfileExistsWaiter(client)
-			if err := waiter.Wait(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: profileName}, 2*time.Minute,
-				func(o *iam.InstanceProfileExistsWaiterOptions) {
-					o.MaxDelay = 5 * time.Second
-					o.MinDelay = 1 * time.Second
-				}); err != nil {
+			if err := waiter.Wait(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: profileName}, 15*time.Minute); err != nil {
 				return fmt.Errorf("failed to wait for %s instance profile to exist: %w", role, err)
 			}
 
@@ -253,11 +249,7 @@ func getOrCreateIAMRole(ctx context.Context, nodeRole, infraID, assumePolicy str
 			return "", fmt.Errorf("failed to create %s role: %w", nodeRole, err)
 		}
 		waiter := iam.NewRoleExistsWaiter(svc)
-		if err := waiter.Wait(ctx, &iam.GetRoleInput{RoleName: roleName}, 2*time.Minute,
-			func(o *iam.RoleExistsWaiterOptions) {
-				o.MaxDelay = 5 * time.Second
-				o.MinDelay = 1 * time.Second
-			}); err != nil {
+		if err := waiter.Wait(ctx, &iam.GetRoleInput{RoleName: roleName}, 15*time.Minute); err != nil {
 			return "", fmt.Errorf("failed to wait for %s role to exist: %w", nodeRole, err)
 		}
 	}


### PR DESCRIPTION
The AWS IAM role and instance profile waiters had a 2 minute timeout with custom delay options (1-5 seconds). This timeout was insufficient in CI environment where IAM calls can be throttled.

Increased the timeout to 15 minutes and removed the custom delay options to use the AWS SDK defaults (min 1s and max 120s). This allows the installer to "rest" and avoid aggressive retry.

See a sample failed run: [https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-[…]perator-release-4.21-periodics-e2e-aws/1992830755360739328](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.21-periodics-e2e-aws/1992830755360739328)