### PR TITLE
OCPBUGS-65847: vsphere: add SkipIPAllocation to network devices

### DIFF
--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -105,8 +105,8 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			}
 			deviceSpec := capv.NetworkDeviceSpec{
 				NetworkName:      networkName,
-				DHCP4:            false,
-				DHCP6:            false,
+				DHCP4:            true,
+				DHCP6:            true,
 				SkipIPAllocation: true,
 			}
 


### PR DESCRIPTION
Set SkipIPAllocation: true and disable DHCP4/DHCP6 on VSphereMachine network devices to prevent CAPV from waiting for VMware Tools to report IP addresses. This is appropriate when IP allocation is handled externally or when VMware Tools may not reliably report IPs to vCenter.