### PR TITLE
OCPBUGS-63710: PowerVS: Fix all zones invalid in lon region

### DIFF
--- a/pkg/asset/installconfig/powervs/regions.go
+++ b/pkg/asset/installconfig/powervs/regions.go
@@ -136,6 +136,9 @@ func GetZone(region string, defaultZone string) (string, error) {
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				choice := zoneTransform(ans).(core.OptionAnswer).Value
+				sort.Slice(zones, func(i, j int) bool {
+					return strings.ToLower(zones[i]) < strings.ToLower(zones[j])
+				})
 				i := sort.SearchStrings(zones, choice)
 				if i == len(zones) || zones[i] != choice {
 					return fmt.Errorf("invalid zone %q", choice)


### PR DESCRIPTION
Any zone selected in the `lon` region shows "Invalid" when selected. This PR fixes it.