### PR TITLE
OCPBUGS-63133: PowerVS: Error out if VPC does not exist

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -301,6 +301,8 @@ func (cpc *CloudProviderConfig) Generate(ctx context.Context, dependencies asset
 			vpcExists = true
 		} else if vpc, err = client.GetVPCByName(ctx, vpcNameOrID); err == nil {
 			vpcExists = true
+		} else {
+			return err
 		}
 
 		vpcSubnets := installConfig.Config.PowerVS.VPCSubnets


### PR DESCRIPTION
Currently if an invalid VPC name is provided in platform.powervs.vpcName, the installer ends up in a segmentation violation. This PR causes the installer to instead error out which is the expected behaviour.