### PR TITLE
NO-JIRA: remove pod-infra-container-image flag from kubelet

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
@@ -21,5 +21,4 @@
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
     --v=2 \
-    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
-    --pod-infra-container-image="${MACHINE_CONFIG_INFRA_IMAGE}"
+    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec


### PR DESCRIPTION
Remove the --pod-infra-container-image flag from the bootstrap kubelet startup script. This change only applies to bootstrap node as cluster nodes are managed by MCO.

Background: The --pod-infra-container-image kubelet flag has been deprecated and will be fully removed in k8s v1.35. Attempting to set this flag will result in kubelet crashing.