### PR TITLE
OCPBUGS-66295: Fix ignition warning about agent-extract-tui.service

### DIFF
--- a/data/data/agent/systemd/units/agent-extract-tui.service
+++ b/data/data/agent/systemd/units/agent-extract-tui.service
@@ -11,3 +11,4 @@ ExecStart=/usr/local/bin/agent-extract-tui.sh
 TimeoutStartSec=300s
 
 [Install]
+WantedBy=agent-interactive-console.service


### PR DESCRIPTION
There must be dependencies in the [Install] section, otherwise we get a big red warning on the hardware console from Ignition.