### PR TITLE
[release-4.19] OCPBUGS-65610: Azure UPI ARM template: use storageAccountId 

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -68,7 +68,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-10-01",
+              "apiVersion": "2022-03-03",
               "type": "versions",
               "name": "[variables('imageRelease')]",
               "location": "[variables('location')]",
@@ -88,7 +88,7 @@
                 "storageProfile": {
                   "osDiskImage": {
                     "source": {
-                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
                       "uri": "[parameters('vhdBlobURL')]"
                     }
                   }
@@ -118,7 +118,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-10-01",
+              "apiVersion": "2022-03-03",
               "type": "versions",
               "name": "[variables('imageRelease')]",
               "location": "[variables('location')]",
@@ -138,7 +138,7 @@
                 "storageProfile": {
                   "osDiskImage": {
                     "source": {
-                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
                       "uri": "[parameters('vhdBlobURL')]"
                     }
                   }


### PR DESCRIPTION
manually backport the change from https://github.com/openshift/installer/pull/10103 and https://github.com/openshift/installer/pull/10069