### PR TITLE
NO-JIRA: Fix UPI Gate

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -674,7 +674,7 @@ As mentioned before due to Nova user data size limit, we will need to create a n
 
 Create a file called `$INFRA_ID-bootstrap-ignition.json` (fill in your `infraID`) with the following contents:
 <!--- e2e-openstack-upi: INCLUDE START --->
-```${INFRA_ID}-bootstrap-ignition.json
+```sh
 cat << EOF > $INFRA_ID-bootstrap-ignition.json
 {
   "ignition": {


### PR DESCRIPTION
The change was made to this in #10149 broke the upi job as it was treating it as a file that should be written and not as a script to run. fix that.