### PR TITLE
OCPBUGS-62870: installing into GCP Shared VPC with minimal permissions

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6315,11 +6315,15 @@ spec:
                     - name
                     type: object
                   firewallRulesManagement:
-                    default: Managed
                     description: |-
-                      FirewallRulesManagement specifies the management policy for the cluster. Managed indicates that
-                      the firewall rules will be created and destroyed by the cluster. Unmanaged indicates that the
-                      user should create and destroy the firewall rules.
+                      FirewallRulesManagement specifies the management policy for the cluster. "Managed" indicates that
+                      the firewall rules will be created and destroyed by the cluster. "Unmanaged" indicates that the
+                      user should create and destroy the firewall rules. For Shared VPC installation, if the installer
+                      credential doesn't have firewall rules management permissions, the "firewallRulesManagement" settings
+                      can be absent or set to "Unmanaged" explicitly. For non-Shared VPC installation, if the installer
+                      credential doesn't have firewall rules management permissions, the "firewallRulesManagement" settings
+                      must be set to "Unmanaged" explicitly. And in this case, the user needs to pre-configure the VPC network
+                      and the firewall rules before the installation.
                     enum:
                     - Managed
                     - Unmanaged

--- a/pkg/asset/installconfig/gcp/permissions.go
+++ b/pkg/asset/installconfig/gcp/permissions.go
@@ -1,0 +1,44 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
+)
+
+const (
+	// CreateFirewallPermission is the permission to create firewall rules in the google cloud provider.
+	CreateFirewallPermission = "compute.firewalls.create" // required to create GCP firewall rules
+
+	// DeleteFirewallPermission is the permission to delete firewall rules in the google cloud provider.
+	DeleteFirewallPermission = "compute.firewalls.delete"
+
+	// UpdateNetworksPermission is the permission to update networks and the network resources in the google cloud provider.
+	UpdateNetworksPermission = "compute.networks.updatePolicy"
+)
+
+// HasPermission determines if the permission exists for the service account in the project.
+func HasPermission(ctx context.Context, projectID string, permissions []string, endpoint *gcptypes.PSCEndpoint) (bool, error) {
+	client, err := NewClient(ctx, endpoint)
+	if err != nil {
+		return false, fmt.Errorf("failed to create client permission check: %w", err)
+	}
+
+	foundPermissions, err := client.GetProjectPermissions(ctx, projectID, permissions)
+	if err != nil {
+		return false, fmt.Errorf("failed to find project permissions: %w", err)
+	}
+
+	permissionsValid := true
+	for _, permission := range permissions {
+		if hasPermission := foundPermissions.Has(permission); !hasPermission {
+			logrus.Debugf("permission %s not found", permission)
+			permissionsValid = false
+		}
+	}
+
+	return permissionsValid, nil
+}

--- a/pkg/types/gcp/defaults/platform.go
+++ b/pkg/types/gcp/defaults/platform.go
@@ -8,10 +8,6 @@ func SetPlatformDefaults(p *gcp.Platform) {
 		return
 	}
 
-	if p.FirewallRulesManagement == "" {
-		p.FirewallRulesManagement = gcp.ManagedFirewallRules
-	}
-
 	if gcpDmp := p.DefaultMachinePlatform; gcpDmp != nil {
 		if ek := gcpDmp.EncryptionKey; ek != nil {
 			if kms := ek.KMSKey; kms != nil {

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -121,10 +121,14 @@ type Platform struct {
 	// +optional
 	DNS *DNS `json:"dns,omitempty"`
 
-	// FirewallRulesManagement specifies the management policy for the cluster. Managed indicates that
-	// the firewall rules will be created and destroyed by the cluster. Unmanaged indicates that the
-	// user should create and destroy the firewall rules.
-	// +default="Managed"
+	// FirewallRulesManagement specifies the management policy for the cluster. "Managed" indicates that
+	// the firewall rules will be created and destroyed by the cluster. "Unmanaged" indicates that the
+	// user should create and destroy the firewall rules. For Shared VPC installation, if the installer
+	// credential doesn't have firewall rules management permissions, the "firewallRulesManagement" settings
+	// can be absent or set to "Unmanaged" explicitly. For non-Shared VPC installation, if the installer
+	// credential doesn't have firewall rules management permissions, the "firewallRulesManagement" settings
+	// must be set to "Unmanaged" explicitly. And in this case, the user needs to pre-configure the VPC network
+	// and the firewall rules before the installation.
 	// +optional
 	FirewallRulesManagement FirewallRulesManagementPolicy `json:"firewallRulesManagement,omitempty"`
 }

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -150,10 +150,6 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path, ic *types.InstallCon
 		if !supportedFirewallRulePolicies.Has(p.FirewallRulesManagement) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("firewallRulesManagement"), p.FirewallRulesManagement, sets.List(supportedFirewallRulePolicies)))
 		}
-
-		if p.FirewallRulesManagement == gcp.UnmanagedFirewallRules && p.Network == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("network"), "a network must be specified when firewall rules are unmanaged"))
-		}
 	}
 
 	return allErrs

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -233,16 +233,6 @@ func TestValidatePlatform(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid firewall management configuration",
-			platform: &gcp.Platform{
-				UserProvisionedDNS:      dns.UserProvisionedDNSEnabled,
-				FirewallRulesManagement: gcp.UnmanagedFirewallRules,
-				Region:                  "us-east1",
-				ProjectID:               "valid-project",
-			},
-			valid: false,
-		},
-		{
 			name: "invalid firewall management",
 			platform: &gcp.Platform{
 				UserProvisionedDNS:      dns.UserProvisionedDNSEnabled,


### PR DESCRIPTION
** Ensure that the feature is backwards compatible for original XPN cases. The new field firewallRulesManagement is an explicit setting of whether the user has the firewall rules or not. In old versions this did not exist but XPN installs did not need firewall rules. Now we will default to checking permissions when no field value is provided. If the rules do not exist, the rules management is set to unmanaged.