### PR TITLE
OCPBUGS-67310: azure: allow hive to pass empty rhcos image string

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -60,7 +60,8 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 	if err != nil {
 		return nil, fmt.Errorf("failed to create machineapi.TagSpecifications from UserTags: %w", err)
 	}
-	image := capzImage(mpool.OSImage, in.Environment, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
+	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
+	image := capzImage(mpool.OSImage, in.Environment, confidentialVM, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
 	// Set up OSDisk
 	osDisk := capz.OSDisk{
 		OSType:     "Linux",
@@ -354,7 +355,7 @@ func bootDiagStorageURIBuilder(diag *aztypes.BootDiagnostics, storageEndpointSuf
 	return ""
 }
 
-func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
+func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
 	switch {
 	case osImage.Publisher != "":
 		return &capz.Image{
@@ -386,11 +387,11 @@ func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, gen, rg,
 				ThirdPartyImage: false,
 			},
 		}
-	case rhcosImg == "":
+	case rhcosImg == "" && !confidentialVM:
 		// hive calls the machines function, but may pass an empty
 		// string for rhcos. In which case, allow MAO to choose default.
 		return nil
-	default: // Installer-created image gallery, should only be OKD.
+	default: // Installer-created image gallery, for OKD && confidential VMs.
 		// image gallery names cannot have dashes
 		galleryName := strings.ReplaceAll(infraID, "-", "_")
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s", sub, rg, galleryName, infraID)

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -179,7 +179,8 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	}
 	rg := platform.ClusterResourceGroupName(clusterID)
 
-	image := mapiImage(mpool.OSImage, platform.CloudName, hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
+	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
+	image := mapiImage(mpool.OSImage, platform.CloudName, confidentialVM, hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
 
 	if mpool.OSDisk.DiskType == "" {
 		mpool.OSDisk.DiskType = "Premium_LRS"
@@ -430,14 +431,14 @@ func generateSecurityProfile(mpool *azure.MachinePool) *machineapi.SecurityProfi
 	return securityProfile
 }
 
-func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
+func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
 	mImg := machineapi.Image{}
 	// hive uses this package, but may pass an empty string for rhcosImg,
 	// in which case we want to depend on MAO default, so return empty.
 	if rhcosImg == "" {
 		return mImg
 	}
-	cImg := capzImage(osImage, azEnv, gen, rg, sub, infraID, rhcosImg)
+	cImg := capzImage(osImage, azEnv, confidentialVM, gen, rg, sub, infraID, rhcosImg)
 
 	if cImg.ID != nil {
 		mImg.ResourceID = trimSubscriptionPrefix(*cImg.ID)


### PR DESCRIPTION
hive does not know the rhcos image value and will pass an empty string for azure machines. In this case, we can leave the image empty so that it will use the default from MAPI.