### PR TITLE
OCPBUGS-64775: use CAPZ to provision ssh rule

### DIFF
--- a/pkg/asset/manifests/azure/cluster.go
+++ b/pkg/asset/manifests/azure/cluster.go
@@ -93,6 +93,17 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 					Destination:      ptr.To("*"),
 					Action:           capz.SecurityRuleActionAllow,
 				},
+				{
+					Name:             fmt.Sprintf("%s_ssh_in", clusterID.InfraID),
+					Protocol:         capz.SecurityGroupProtocolTCP,
+					Direction:        capz.SecurityRuleDirectionInbound,
+					Priority:         220,
+					SourcePorts:      ptr.To("*"),
+					DestinationPorts: ptr.To("22"),
+					Source:           ptr.To(source),
+					Destination:      ptr.To("*"),
+					Action:           capz.SecurityRuleActionAllow,
+				},
 			},
 		},
 	}

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -537,16 +537,6 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 		}
 
 		sshRuleName := fmt.Sprintf("%s_ssh_in", in.InfraID)
-		if err = addSecurityGroupRule(ctx, &securityGroupInput{
-			resourceGroupName:    p.ResourceGroupName,
-			securityGroupName:    fmt.Sprintf("%s-nsg", in.InfraID),
-			securityRuleName:     sshRuleName,
-			securityRulePort:     "22",
-			securityRulePriority: 220,
-			networkClientFactory: p.NetworkClientFactory,
-		}); err != nil {
-			return fmt.Errorf("failed to add security rule: %w", err)
-		}
 
 		loadBalancerName := in.InfraID
 		frontendIPConfigName := "public-lb-ip-v4"


### PR DESCRIPTION
A change to CAPZ[0], creates an SSH rule if one is not specified in the cluster spec. Prior to this commit, we had been creating the SSH rule with installer SDK hooks, which is still somewhat necessary to add the inbound NAT rules, because we are not yet using CAPZ to provision a public load balancer.

But we can use CAPZ to just create the rule, which will stop CAPZ from preventing a redundant SSH rule which we were leaking during bootstrap destroy.

This change will also result in creating an SSH rule for private clusters which is fine, and something we do on other providers.

0: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525