### PR TITLE
OCPBUGS-69870: rename "var-ostree\x2dcontainer.mount" to something more computer-friendly

### DIFF
--- a/data/data/bootstrap/files/etc/systemd/system/node-image-pull.service
+++ b/data/data/bootstrap/files/etc/systemd/system/node-image-pull.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Node Image Pull
-Wants=var-ostree\x2dcontainer.mount
+Wants=var-ostreecontainer.mount
 Requires=network.target NetworkManager.service
-After=network.target var-ostree\x2dcontainer.mount
+After=network.target var-ostreecontainer.mount
 
 [Service]
 Type=oneshot

--- a/data/data/bootstrap/files/etc/systemd/system/var-ostreecontainer.mount
+++ b/data/data/bootstrap/files/etc/systemd/system/var-ostreecontainer.mount
@@ -5,6 +5,6 @@ ConditionPathExists=/run/ostree-live
 
 [Mount]
 What=tmpfs
-Where=/var/ostree-container
+Where=/var/ostreecontainer
 Type=tmpfs
 Options=size=4G

--- a/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ostree_checkout=/ostree/repo/tmp/node-image
 if [ ! -d "${ostree_checkout}" ]; then
-    ostree_checkout=/var/ostree-container/checkout
+    ostree_checkout=/var/ostreecontainer/checkout
 fi
 
 echo "Overlaying node image content"

--- a/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
@@ -29,8 +29,8 @@ ostree_checkout="${ostree_repo}/tmp/node-image"
 hardlink='-H'
 # this is the CoreOS API for "are we in a live environment", i.e. PXE or ISO
 if test -f /run/ostree-live; then
-    ostree_repo=/var/ostree-container/repo
-    ostree_checkout=/var/ostree-container/checkout
+    ostree_repo=/var/ostreecontainer/repo
+    ostree_checkout=/var/ostreecontainer/checkout
     mkdir -p "${ostree_repo}"
     echo "In live environment; creating temporary repo to pull node image"
     ostree init --mode=bare --repo="${ostree_repo}"


### PR DESCRIPTION
xref: OCPBUGS-69870

```bash
$ go get github.com/openshift/installer@v1.4.21-pre2
go: github.com/openshift/installer@v1.4.21-pre2: verifying go.mod: github.com/openshift/installer@v1.4.21-pre2/go.mod: reading https://sum.golang.org/lookup/github.com/openshift/installer@v1.4.21-pre2: 404 Not Found
	server response: not found: create zip: data/data/bootstrap/files/etc/systemd/system/var-ostree\x2dcontainer.mount: malformed file path "data/data/bootstrap/files/etc/systemd/system/var-ostree\\x2dcontainer.mount": invalid char '\\'
```

/cc @2uasimojo 
/assign @patrickdillon 