### PR TITLE
Reviewers Claude Command

### DIFF
--- a/.claude/commands/reviewers.md
+++ b/.claude/commands/reviewers.md
@@ -1,0 +1,8 @@
+## Task
+
+Find reviewers for the $1 commit:
+
+- Find all files edited in the $1 commit
+- Run a git blame on all files
+- From the previous step, find users that have made similar changes to the files
+- Select 2 users that have the most recent commits that do not include the author of $1


### PR DESCRIPTION
Adding a claude slash command that will allow the user to find reivewers for their commits. The user should provide a argument like /reviewers $1 where $1 is the commit id of the commit that is to be analyzed. The most recent editors of the same files will be considered as reviewers.

Design choice:
Select a single commit.
Did not allow a branch to be added to the command because it may require the user install gh locally. This should not be a requirement.