### PR TITLE
Add TLS certificates for internal release registry in agent installer

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -13,6 +13,14 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
+# Restart the local registry service if it's running to pick up new TLS certificates
+# This is needed for agent-based installs where the registry.service may already be
+# running with localhost-only certs and needs to switch to api-int certs
+if systemctl is-active --quiet registry.service; then
+    echo "Restarting registry.service to pick up new TLS certificates..."
+    systemctl restart registry.service
+fi
+
 {{- if .BootstrapInPlace }}
 BOOTSTRAP_INPLACE=true
 {{ else }}

--- a/pkg/asset/tls/registry.go
+++ b/pkg/asset/tls/registry.go
@@ -1,0 +1,132 @@
+package tls
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+)
+
+// InternalReleaseRegistrySignerCertKey is a key/cert pair that signs the internal release registry server certs.
+type InternalReleaseRegistrySignerCertKey struct {
+	SelfSignedCertKey
+	LoadedFromDisk bool
+}
+
+var _ asset.WritableAsset = (*InternalReleaseRegistrySignerCertKey)(nil)
+
+// Dependencies returns the dependency of the root-ca, which is empty.
+func (c *InternalReleaseRegistrySignerCertKey) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+// Generate generates the root-ca key and cert pair.
+func (c *InternalReleaseRegistrySignerCertKey) Generate(ctx context.Context, parents asset.Parents) error {
+	cfg := &CertCfg{
+		Subject:   pkix.Name{CommonName: "internal-release-registry-signer", OrganizationalUnit: []string{"openshift"}},
+		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		Validity:  ValidityTenYears(),
+		IsCA:      true,
+	}
+
+	return c.SelfSignedCertKey.Generate(ctx, cfg, "internal-release-registry-signer")
+}
+
+// Load reads the asset files from disk.
+func (c *InternalReleaseRegistrySignerCertKey) Load(f asset.FileFetcher) (bool, error) {
+	loaded, err := c.loadCertKey(f, "internal-release-registry-signer")
+	if err != nil {
+		return false, err
+	}
+	c.LoadedFromDisk = loaded
+	return loaded, nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (c *InternalReleaseRegistrySignerCertKey) Name() string {
+	return "Certificate (internal-release-registry-signer)"
+}
+
+// InternalReleaseRegistryCertKey is the asset that generates the internal release registry
+// serving key/cert pair for both localhost and api-int.
+type InternalReleaseRegistryCertKey struct {
+	SignedCertKey
+}
+
+var _ asset.Asset = (*InternalReleaseRegistryCertKey)(nil)
+
+// Dependencies returns the dependency of the cert/key pair.
+func (a *InternalReleaseRegistryCertKey) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&InternalReleaseRegistrySignerCertKey{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the cert/key pair based on its dependencies.
+func (a *InternalReleaseRegistryCertKey) Generate(ctx context.Context, dependencies asset.Parents) error {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+	installConfig := &installconfig.InstallConfig{}
+	dependencies.Get(ca, installConfig)
+
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "internal-release-registry", Organization: []string{"openshift"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Validity:     ValidityTenYears(),
+		DNSNames: []string{
+			"localhost",
+			internalAPIAddress(installConfig.Config),
+		},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	return a.SignedCertKey.Generate(ctx, cfg, ca, "internal-release-registry", AppendParent)
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *InternalReleaseRegistryCertKey) Name() string {
+	return "Certificate (internal-release-registry)"
+}
+
+// InternalReleaseRegistryLocalhostCertKey is the asset that generates the internal release registry
+// serving key/cert pair for localhost only (used in unconfigured-ignition before cluster name is known).
+type InternalReleaseRegistryLocalhostCertKey struct {
+	SignedCertKey
+}
+
+var _ asset.Asset = (*InternalReleaseRegistryLocalhostCertKey)(nil)
+
+// Dependencies returns the dependency of the cert/key pair.
+func (a *InternalReleaseRegistryLocalhostCertKey) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&InternalReleaseRegistrySignerCertKey{},
+	}
+}
+
+// Generate generates the cert/key pair based on its dependencies.
+func (a *InternalReleaseRegistryLocalhostCertKey) Generate(ctx context.Context, dependencies asset.Parents) error {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+	dependencies.Get(ca)
+
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "internal-release-registry-localhost", Organization: []string{"openshift"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Validity:     ValidityTenYears(),
+		DNSNames: []string{
+			"localhost",
+		},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	return a.SignedCertKey.Generate(ctx, cfg, ca, "internal-release-registry-localhost", AppendParent)
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *InternalReleaseRegistryLocalhostCertKey) Name() string {
+	return "Certificate (internal-release-registry-localhost)"
+}

--- a/pkg/asset/tls/registry_test.go
+++ b/pkg/asset/tls/registry_test.go
@@ -1,0 +1,202 @@
+package tls
+
+import (
+	"context"
+	"crypto/x509"
+	"net"
+	"testing"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInternalReleaseRegistrySignerCertKeyGenerate(t *testing.T) {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+	parents := asset.Parents{}
+
+	if err := ca.Generate(context.TODO(), parents); err != nil {
+		t.Fatalf("failed to generate internal release registry signer cert key: %v", err)
+	}
+
+	if len(ca.Cert()) == 0 {
+		t.Error("expected certificate data")
+	}
+	if len(ca.Key()) == 0 {
+		t.Error("expected key data")
+	}
+
+	cert, err := PemToCertificate(ca.Cert())
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("expected certificate to be a CA")
+	}
+	if cert.Subject.CommonName != "internal-release-registry-signer" {
+		t.Errorf("expected CommonName to be 'internal-release-registry-signer', got %s", cert.Subject.CommonName)
+	}
+}
+
+func TestInternalReleaseRegistryCertKeyGenerate(t *testing.T) {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+	if err := ca.Generate(context.TODO(), asset.Parents{}); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	installConfig := &installconfig.InstallConfig{}
+	installConfig.Config = &types.InstallConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		BaseDomain: "test.example.com",
+		Networking: &types.Networking{
+			MachineNetwork: []types.MachineNetworkEntry{{
+				CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+			}},
+			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+		},
+	}
+
+	parents := asset.Parents{}
+	parents.Add(ca, installConfig)
+
+	serverCert := &InternalReleaseRegistryCertKey{}
+	if err := serverCert.Generate(context.TODO(), parents); err != nil {
+		t.Fatalf("failed to generate server certificate: %v", err)
+	}
+
+	if len(serverCert.Cert()) == 0 {
+		t.Error("expected certificate data")
+	}
+	if len(serverCert.Key()) == 0 {
+		t.Error("expected key data")
+	}
+
+	cert, err := PemToCertificate(serverCert.Cert())
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	// Check SANs include localhost and api-int
+	expectedDNSNames := map[string]bool{
+		"localhost":                         true,
+		"api-int.test-cluster.test.example.com": true,
+	}
+
+	for _, dnsName := range cert.DNSNames {
+		if !expectedDNSNames[dnsName] {
+			t.Errorf("unexpected DNS name in certificate: %s", dnsName)
+		}
+		delete(expectedDNSNames, dnsName)
+	}
+
+	if len(expectedDNSNames) > 0 {
+		t.Errorf("missing expected DNS names: %v", expectedDNSNames)
+	}
+
+	// Check IP addresses
+	expectedIPs := map[string]bool{
+		"127.0.0.1": true,
+		"::1":       true,
+	}
+
+	for _, ipAddr := range cert.IPAddresses {
+		ipStr := ipAddr.String()
+		if !expectedIPs[ipStr] {
+			t.Errorf("unexpected IP address in certificate: %s", ipStr)
+		}
+		delete(expectedIPs, ipStr)
+	}
+
+	if len(expectedIPs) > 0 {
+		t.Errorf("missing expected IP addresses: %v", expectedIPs)
+	}
+
+	// Verify ExtKeyUsage includes ServerAuth
+	hasServerAuth := false
+	for _, usage := range cert.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageServerAuth {
+			hasServerAuth = true
+			break
+		}
+	}
+	if !hasServerAuth {
+		t.Error("expected certificate to have ExtKeyUsageServerAuth")
+	}
+}
+
+func TestInternalReleaseRegistryLocalhostCertKeyGenerate(t *testing.T) {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+	if err := ca.Generate(context.TODO(), asset.Parents{}); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	parents := asset.Parents{}
+	parents.Add(ca)
+
+	localhostCert := &InternalReleaseRegistryLocalhostCertKey{}
+	if err := localhostCert.Generate(context.TODO(), parents); err != nil {
+		t.Fatalf("failed to generate localhost certificate: %v", err)
+	}
+
+	if len(localhostCert.Cert()) == 0 {
+		t.Error("expected certificate data")
+	}
+	if len(localhostCert.Key()) == 0 {
+		t.Error("expected key data")
+	}
+
+	cert, err := PemToCertificate(localhostCert.Cert())
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	// Check SANs include only localhost
+	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "localhost" {
+		t.Errorf("expected DNSNames to be [localhost], got %v", cert.DNSNames)
+	}
+
+	// Check IP addresses
+	expectedIPs := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	if len(cert.IPAddresses) != len(expectedIPs) {
+		t.Errorf("expected %d IP addresses, got %d", len(expectedIPs), len(cert.IPAddresses))
+	}
+
+	// Verify ExtKeyUsage includes ServerAuth
+	hasServerAuth := false
+	for _, usage := range cert.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageServerAuth {
+			hasServerAuth = true
+			break
+		}
+	}
+	if !hasServerAuth {
+		t.Error("expected certificate to have ExtKeyUsageServerAuth")
+	}
+}
+
+func TestInternalReleaseRegistrySignerCertKeyLoadFromDisk(t *testing.T) {
+	ca := &InternalReleaseRegistrySignerCertKey{}
+
+	// Before loading, LoadedFromDisk should be false
+	if ca.LoadedFromDisk {
+		t.Error("expected LoadedFromDisk to be false before loading")
+	}
+
+	// Generate a certificate
+	if err := ca.Generate(context.TODO(), asset.Parents{}); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	// LoadedFromDisk should still be false after generation
+	if ca.LoadedFromDisk {
+		t.Error("expected LoadedFromDisk to be false after generation")
+	}
+
+	// Note: Testing actual file loading would require a FileFetcher mock
+	// and is typically done in integration tests
+}


### PR DESCRIPTION
Implement TLS certificate infrastructure to enable secure communication with the built-in registry used by the agent installer. This addresses the need for proper certificate management across the agent ISO boot, bootstrap, and cluster startup phases.

Create three new certificate assets:
- InternalReleaseRegistrySignerCertKey: CA certificate that signs registry server certificates and tracks when loaded from disk
- InternalReleaseRegistryCertKey: Server certificate valid for both localhost and api-int.<cluster-domain> for use during bootstrap
- InternalReleaseRegistryLocalhostCertKey: Server certificate valid only for localhost for use in the unconfigured ignition (ISO phase)

The implementation ensures certificates are distributed appropriately:
- Unconfigured ignition includes CA cert+key in /opt/agent/tls/ for assisted-service to load, CA cert in system trust store, and localhost-only server cert in /opt/registry/tls/
- Bootstrap and master ignitions conditionally include the api-int server certificate when the CA was loaded from disk
- AdditionalTrustBundle ConfigMap automatically includes the CA when loaded from disk to ensure cluster-wide trust
- Bootkube restarts registry.service if running to pick up new certs

All certificate inclusions in bootstrap/master ignitions and trust bundles are conditional on the CA being loaded from disk, ensuring this only affects agent-based installations.