### PR TITLE
OCPBUGS-69923: ensure deterministic zone ordering for control plane machines

### DIFF
--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -159,6 +159,9 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			if err != nil {
 				logrus.Warn(errors.Wrap(err, "failed to filter zone list"))
 			}
+			// Sort the zones by lexical order to ensure CAPI and MAPI machines
+			// are distributed to zones in the same order.
+			slices.Sort(mpool.Zones)
 		}
 
 		tags, err := aws.CapaTagsFromUserTags(clusterID.InfraID, installConfig.Config.Platform.AWS.UserTags)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -253,6 +253,9 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 			if err != nil {
 				logrus.Warn(errors.Wrap(err, "failed to filter zone list"))
 			}
+			// Sort the zones by lexical order to ensure CAPI and MAPI machines
+			// are distributed to zones in the same order.
+			slices.Sort(mpool.Zones)
 		}
 
 		pool.Platform.AWS = &mpool


### PR DESCRIPTION
Control plane machines were intermittently being created in different availability zones than specified in their machine specs. This occurred because the zone list returned from FilterZonesBasedOnInstanceType used a set's UnsortedList() func, which has a non-deterministic order.

When CAPI and MAPI manifest generation independently called this func, they could receive zones in different orders, causing a mismatch in machine zone placements between CAPI and MAPI manifests.

This PR ensures that we sort the zone slices before further processing.