### PR TITLE
MCO-2031: OS Image Stream to install-config schema

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4885,6 +4885,13 @@ spec:
                 - Internal
                 type: string
             type: object
+          osImageStream:
+            description: OSImageStream is the global OS Image Stream to be used for
+              all machines in the cluster.
+            enum:
+            - rhel-9
+            - rhel-10
+            type: string
           platform:
             description: |-
               Platform is the configuration for the specific platform upon which to

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -135,6 +135,10 @@ the cluster.
     operatorPublishingStrategy <object>
       OperatorPublishingStrategy controls the visibility of ingress and apiserver. Defaults to public.
 
+    osImageStream <string>
+      Valid Values: "rhel-9","rhel-10"
+      OSImageStream is the global OS Image Stream to be used for all machines in the cluster.
+
     platform <object> -required-
       Platform is the configuration for the specific platform upon which to
 perform the installation.

--- a/pkg/types/defaults/validation/featuregates.go
+++ b/pkg/types/defaults/validation/featuregates.go
@@ -35,5 +35,10 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 			}(),
 			Field: field.NewPath("compute", "diskSetup"),
 		},
+		{
+			FeatureGateName: features.FeatureGateOSStreams,
+			Condition:       len(c.OSImageStream) != 0,
+			Field:           field.NewPath("osImageStream"),
+		},
 	}
 }

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -228,6 +228,10 @@ type InstallConfig struct {
 	// E.g. "featureGates": ["FeatureGate1=true", "FeatureGate2=false"].
 	// +optional
 	FeatureGates []string `json:"featureGates,omitempty"`
+
+	// OSImageStream is the global OS Image Stream to be used for all machines in the cluster.
+	// +optional
+	OSImageStream OSImageStream `json:"osImageStream,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.
@@ -657,3 +661,14 @@ func (c *InstallConfig) PublicIngress() bool {
 	}
 	return false
 }
+
+// OSImageStream represents the name of an OS Image Stream to use in a pool.
+// +kubebuilder:validation:Enum=rhel-9;rhel-10
+type OSImageStream string
+
+const (
+	// OSImageStreamRHCOS9 represents the RHEL 9 OS Image Stream.
+	OSImageStreamRHCOS9 OSImageStream = "rhel-9"
+	// OSImageStreamRHCOS10 represents the RHEL 10 OS Image Stream.
+	OSImageStreamRHCOS10 OSImageStream = "rhel-10"
+)


### PR DESCRIPTION
This change introduces the OS Image Stream concept to the install-config to facilitate day-zero stream selection. The change adds an optional global field that can be used to set the OS Image Stream to pick for all the pools and a per pool field to override it or to just set the stream in a specific pool.

The install-config, consumer later by the machine-config operator will be used by the operator to render the MCPs using the correct stream at bootstrap time.