### PR TITLE
OCPBUGS-70255: backwards compact for S3 API call

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -197,7 +197,11 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 				"--webhook-cert-dir={{.WebhookCertDir}}",
 				"--feature-gates=BootstrapFormatIgnition=true,ExternalResourceGC=true,TagUnmanagedNetworkResources=false,EKS=false,MachinePool=false",
 			},
-			map[string]string{},
+			map[string]string{
+				// We disable checksum for PUT and GET calls (i.e. checksum is optional).
+				"AWS_REQUEST_CHECKSUM_CALCULATION": "WHEN_REQUIRED",
+				"AWS_RESPONSE_CHECKSUM_VALIDATION": "WHEN_REQUIRED",
+			},
 		)
 		if cfg := metadata.AWS; cfg != nil && len(cfg.ServiceEndpoints) > 0 {
 			endpoints := make([]string, 0, len(cfg.ServiceEndpoints))


### PR DESCRIPTION
Recently, the AWS SDK v2 introduces a new data integrity mechanism that enables checksum for PUT/GET calls by default using CRC32 algorithm [[0]](https://github.com/aws/aws-sdk-go-v2/discussions/2960). This is "technically" a breaking change in behaviour.

Thus, this PR aims to restore the previous settings for backwards compactibility.
- Only enable checksums when the API call type requires it (i.e. batch delete objects)
- Set the algorithm type to MD5 for delete calls
- The destroy code is still on SDK v1 so no changes required.