### PR TITLE
OCPBUGS-69735: handle SSH rule deletion for Azure private

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -641,7 +641,15 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 		if err != nil {
 			return fmt.Errorf("failed to delete security rule: %w", err)
 		}
-
+	}
+	_, err = networkClientFactory.NewInboundNatRulesClient().Get(
+		ctx,
+		resourceGroupName,
+		in.Metadata.InfraID,
+		sshRuleName,
+		nil,
+	)
+	if err == nil {
 		err = deleteInboundNatRule(ctx, &inboundNatRuleInput{
 			resourceGroupName:    resourceGroupName,
 			loadBalancerName:     in.Metadata.InfraID,
@@ -652,7 +660,6 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 			return fmt.Errorf("failed to delete inbound nat rule: %w", err)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
In private clusters, no inbound nat rule is created for SSH; this commit handles that scenario gracefully, using the same approach we are using to check if the ssh rule itself should be deleted.

Depends on #10212 for testing