### PR TITLE
OCPBUGS-56770: Honor user-specified bootDiagnostics on Azure Stack Hub

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -204,13 +204,16 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 		}
 
 		if in.Platform.CloudName == aztypes.StackCloud {
-			azureMachine.Spec.Diagnostics = &capz.Diagnostics{
-				Boot: &capz.BootDiagnostics{
-					StorageAccountType: capz.UserManagedDiagnosticsStorage,
-					UserManaged: &capz.UserManagedBootDiagnostics{
-						StorageAccountURI: fmt.Sprintf("https://%s.blob.%s", storageAccountName, in.StorageSuffix),
+			// For Azure Stack Cloud, apply default diagnostics only if user hasn't specified bootDiagnostics
+			if mpool.BootDiagnostics == nil {
+				azureMachine.Spec.Diagnostics = &capz.Diagnostics{
+					Boot: &capz.BootDiagnostics{
+						StorageAccountType: capz.UserManagedDiagnosticsStorage,
+						UserManaged: &capz.UserManagedBootDiagnostics{
+							StorageAccountURI: fmt.Sprintf("https://%s.blob.%s", storageAccountName, in.StorageSuffix),
+						},
 					},
-				},
+				}
 			}
 		}
 
@@ -278,13 +281,16 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 	}
 
 	if in.Platform.CloudName == aztypes.StackCloud {
-		bootstrapAzureMachine.Spec.Diagnostics = &capz.Diagnostics{
-			Boot: &capz.BootDiagnostics{
-				StorageAccountType: capz.UserManagedDiagnosticsStorage,
-				UserManaged: &capz.UserManagedBootDiagnostics{
-					StorageAccountURI: fmt.Sprintf("https://%s.blob.%s", storageAccountName, in.StorageSuffix),
+		// For Azure Stack Cloud, apply default diagnostics only if user hasn't specified bootDiagnostics
+		if mpool.BootDiagnostics == nil {
+			bootstrapAzureMachine.Spec.Diagnostics = &capz.Diagnostics{
+				Boot: &capz.BootDiagnostics{
+					StorageAccountType: capz.UserManagedDiagnosticsStorage,
+					UserManaged: &capz.UserManagedBootDiagnostics{
+						StorageAccountURI: fmt.Sprintf("https://%s.blob.%s", storageAccountName, in.StorageSuffix),
+					},
 				},
-			},
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixed issue where user-specified `bootDiagnostics` configuration was ignored on Azure Stack Hub.

The fix checks whether the user has explicitly configured bootDiagnostics via either defaultMachinePlatform.bootDiagnostics or the machine pool's bootDiagnostics field. If configured, the user's settings are respected. If not configured, the Azure Stack Hub default is applied.
