### PR TITLE
OCPBUGS-67816: Revert storage account API version for client

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -446,7 +446,7 @@ func (c *Client) CheckIfExistsStorageAccount(ctx context.Context, resourceGroup,
 	accountClientOptions := arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			// NOTE: the api version must support AzureStack
-			APIVersion: APIVersion,
+			APIVersion: "2019-04-01",
 			Cloud:      c.ssn.CloudConfig,
 		},
 	}


### PR DESCRIPTION
Reverting the API version for storage account in the call to check if exists as it's causing an issue with the boot diagnostics.