### PR TITLE
OCPBUGS-73879: data/manifests/bootkube/cvo-overrides: Default to eus-4.16

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.16
+  channel: eus-4.16
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
Like 12e711edb2 (#9373) and 6ae7f33edf (#9643), but for 4.16.  I'm a bit late this time, with 4.16 already in EUS since the Maintenance phase ended on 2025-12-27:

```console
$ curl -s 'https://access.redhat.com/product-life-cycles/api/v1/products?name=OpenShift+Container+Platform' | jq -c '.data[].versions[] | select(.name == "4.16").phases[]'
{"name":"General availability","date":"2024-06-27T00:00:00.000Z","date_format":"date","additional_text":""}
{"name":"Full support","date":"2025-01-01T00:00:00.000Z","date_format":"date","additional_text":""}
{"name":"Maintenance support","date":"2025-12-27T00:00:00.000Z","date_format":"date","additional_text":""}
{"name":"Extended update support","date":"2026-06-27T00:00:00.000Z","date_format":"date","additional_text":""}
{"name":"Extended update support Term 2","date":"2027-06-27T00:00:00.000Z","date_format":"date","additional_text":""}
{"name":"Extended update support Term 3","date":"N/A","date_format":"string","additional_text":""}
{"name":"Extended life phase","date":"N/A","date_format":"string"}
```