### PR TITLE
OCPBUGS-55407: set DNS zone for Azure Stack Hub private clusters

### DIFF
--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -138,7 +138,15 @@ func (d *DNS) Generate(ctx context.Context, dependencies asset.Parents) error { 
 				ID: dnsConfig.GetDNSZoneID(installConfig.Config.Azure.BaseDomainResourceGroupName, installConfig.Config.BaseDomain),
 			}
 		}
-		if installConfig.Azure.CloudName != azuretypes.StackCloud {
+
+		// Azure Stack Hub only supports "DNS zones"--there is not a private/public zone distinction.
+		// Set PrivateZone to the base domain zone for ASH, or cluster private zone for regular Azure.
+		if installConfig.Azure.CloudName == azuretypes.StackCloud {
+			// Azure Stack Hub uses the base domain zone for all DNS records (api, api-int, *.apps)
+			config.Spec.PrivateZone = &configv1.DNSZone{
+				ID: dnsConfig.GetDNSZoneID(installConfig.Config.Azure.BaseDomainResourceGroupName, installConfig.Config.BaseDomain),
+			}
+		} else {
 			config.Spec.PrivateZone = &configv1.DNSZone{
 				ID: dnsConfig.GetPrivateDNSZoneID(installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID), installConfig.Config.ClusterDomain()),
 			}


### PR DESCRIPTION
Azure Stack Hub only supports a single DNS zone type (not separate public/private zones). When installing a cluster on Azure Stack Hub, the DNS manifest must specify the PrivateZone field pointing to the base domain zone so that the ingress operator can create *.apps DNS records.

Previously, the DNS manifest generation set PrivateZone only for non-ASH clusters, leaving Azure Stack Hub clusters without zone configuration. This caused the ingress operator to fail with DNS resolution errors.