### PR TITLE
AGENT-1425: Local assisted UI url not shown in the terminal console

### DIFF
--- a/data/data/agent/systemd/units/agent-register-infraenv.service.template
+++ b/data/data/agent/systemd/units/agent-register-infraenv.service.template
@@ -23,4 +23,4 @@ RestartSec=30
 RemainAfterExit=true
 
 [Install]
-WantedBy=start-cluster-installation.service agent-add-node.service agent-start-ui.service
+WantedBy=start-cluster-installation.service agent-add-node.service agent-ui.service

--- a/data/data/agent/systemd/units/agent-ui.service.template
+++ b/data/data/agent/systemd/units/agent-ui.service.template
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/assisted/rendezvous-host.env
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=/usr/bin/podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace -d --name=agent-installer-ui --env AIUI_APP_API_URL $INSTALLER_UI_IMAGE
+ExecStart=/usr/bin/podman run --sdnotify=conmon --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace -d --name=agent-installer-ui --env AIUI_APP_API_URL $INSTALLER_UI_IMAGE
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 


### PR DESCRIPTION
The `agent-ui` service was previously updated to `Type=notify` to improve startup ordering and reliability ([Ref](https://github.com/openshift/installer/commit/5326b68fcbe63487010086348ec721c12635ffdf#diff-f5796501318f9aea98055c1066bd4dc1082094a9fa7c233472dbe9c46c6e1edfR22)).
However, the lack of container monitor `--sdnotify=conmon` flag, resulted in UI URL to be not displayed on the TUI.
Without this flag, `agent-ui` systemd waits for a readiness signal which never comes and the service remains in `activating` state.
This causes the TUI availability [check](https://github.com/openshift/installer/blob/main/data/data/agent/files/usr/local/bin/install-status.sh#L56) to fail, making the user only see "Waiting for services" instead of UI URL
( even though the UI is already avaialble via the usual URL)

This commit adds the missing flag, ensuring the notification handshake between the container running UI and the agent-ui systemd completes successfully, unblocking the TUI. This commit also fixes the stale dependency in `agent-register-infraenv` related to `agent-ui` systemd naming.