### PR TITLE
NO-JIRA: use v2 config for go-lint

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -6,4 +6,4 @@ podman run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
     docker.io/golangci/golangci-lint:v2.3.1 \
-    golangci-lint run -v --new-from-rev=dcf8122 "${@}"
+    golangci-lint run -c .golangci-lint-v2.yaml -v --new-from-rev=dcf8122 "${@}"


### PR DESCRIPTION
Follow up https://github.com/openshift/installer/pull/10121, golangci-lint is updated to v2.3.1 from v1.64.8, `hack/go-lint.sh` does not work any more.
```
$ ./hack/go-lint.sh 
level=info msg="golangci-lint has version 2.3.1 built with go1.24.5 from 5256574b on 2025-08-02T21:24:45Z"
level=info msg="[config_reader] Config search paths: [./ /go/src/github.com/openshift/installer /go/src/github.com/openshift /go/src/github.com /go/src /go / /root]"
level=info msg="[config_reader] Used config file .golangci.yaml"
Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
The command is terminated due to an error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
```
So use v2 config for the golint tools to make it work again.

BTW, prow ci update is being tracked in https://github.com/openshift/release/pull/72011