### PR TITLE
OCPBUGS-74363: Remove region option for the GCP Private Service Connect Endpoint

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6332,11 +6332,6 @@ spec:
                         description: Name contains the name of the private service
                           connect endpoint.
                         type: string
-                      region:
-                        description: |-
-                          Region is the region where the endpoint resides.
-                          When the region is empty, the location is assumed to be global.
-                        type: string
                     required:
                     - name
                     type: object

--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -770,13 +770,7 @@ func GetPrivateServiceConnectEndpoint(client *compute.Service, project string, e
 		return nil, nil
 	}
 
-	var forwardingRules *compute.ForwardingRuleList
-	var forwardingRuleErr error
-	if endpoint.Region != "" {
-		forwardingRules, forwardingRuleErr = client.ForwardingRules.List(project, endpoint.Region).Do()
-	} else {
-		forwardingRules, forwardingRuleErr = client.GlobalForwardingRules.List(project).Do()
-	}
+	forwardingRules, forwardingRuleErr := client.GlobalForwardingRules.List(project).Do()
 	if forwardingRuleErr != nil {
 		return nil, fmt.Errorf("failed to list forwarding rules: %w", forwardingRuleErr)
 	}

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -45,11 +45,6 @@ type PSCEndpoint struct {
 	// Name contains the name of the private service connect endpoint.
 	Name string `json:"name"`
 
-	// Region is the region where the endpoint resides.
-	// When the region is empty, the location is assumed to be global.
-	// +optional
-	Region string `json:"region,omitempty"`
-
 	// ClusterUseOnly should be set to true when the installer should use
 	// the public api endpoints and all cluster operators should use the
 	// api endpoint overrides. The value should be false when the installer


### PR DESCRIPTION
** While the regional support is valid, we will not be using this in openshift. Regional support requires that each api have its own endpoint. Only one api is associated with an endpoint, and managing this access will be difficult and unnessary at this time.