### PR TITLE
CORS-4055: migrate credential provider check to AWS SDK v2

### DIFF
--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -137,19 +136,6 @@ func getCredentialsFromSession(options session.Options) (*credentials.Credential
 	})
 
 	return creds, nil
-}
-
-// IsStaticCredentials returns whether the credentials value provider are
-// static credentials safe for installer to transfer to cluster for use as-is.
-func IsStaticCredentials(credsValue credentials.Value) bool {
-	switch credsValue.ProviderName {
-	case credentials.EnvProviderName, credentials.StaticProviderName, credentials.SharedCredsProviderName, session.EnvProviderName:
-		return credsValue.SessionToken == ""
-	}
-	if strings.HasPrefix(credsValue.ProviderName, "SharedConfigCredentials") {
-		return credsValue.SessionToken == ""
-	}
-	return false
 }
 
 // errCodeEquals returns true if the error matches all these conditions:


### PR DESCRIPTION
This PR is an incremental step to migrate AWS API calls to AWS SDK v2. This focuses on handlers that retrieve the source or provider of credentials, for example, via shared credential file and via environment variables.

**Note**: these logics are to determine whether the credential provider is static, which is safe to transfer to the cluster as-is in `Mint` and `Passthrough` credentialsMode.