### PR TITLE
CORS-4055: migrate default region check to AWS SDK v2

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -58,7 +58,7 @@ func (a *platform) Generate(ctx context.Context, _ asset.Parents) error {
 
 	switch platform {
 	case aws.Name:
-		a.AWS, err = awsconfig.Platform()
+		a.AWS, err = awsconfig.Platform(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The PR is an incremental step to migrate AWS API calls to AWS SDK v2. This only focuses on logics to get the default region from loaded config for the survey.

**Note**: This code path is applicable for the survey that asks the users for the install region.
