### PR TITLE
OCPBUGS-60668: Update RHCOS-release-4.16 bootimage metadata to 416.94.202601221345-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.16",
   "metadata": {
-    "last-modified": "2025-10-16T14:17:39Z",
-    "generator": "plume cosa2stream acb829c"
+    "last-modified": "2026-01-29T22:24:45Z",
+    "generator": "plume cosa2stream d044c8e"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-aws.aarch64.vmdk.gz",
-                "sha256": "b007e6f282d7eee82e142ba2aaaf4912bc13f539f91bc07ffa28147cbeb50d33",
-                "uncompressed-sha256": "a629c6970fd7e384372438ecacb5ca87cb4f3d527799deb305e8cce19b71e016"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-aws.aarch64.vmdk.gz",
+                "sha256": "c957bfc5463d20a6dfcb5e215011b42af4a3f0fc1165001a3653466aab7d73e1",
+                "uncompressed-sha256": "2b3d106a728119808231e2a94864b11b8d8586e7f6d30f3c1af21752e8c6f222"
               }
             }
           }
         },
         "azure": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-azure.aarch64.vhd.gz",
-                "sha256": "2b05bc045f8e8abe62eda371b7755eff119401a8c3c46b6d95fb9a65ecc4b1bb",
-                "uncompressed-sha256": "ec9cd80096700639832e99067e504459fb1ac87b0b369f828a35b7abb0ec01a4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-azure.aarch64.vhd.gz",
+                "sha256": "10f3cc488091cdbd9e486d87600fcf6b70a2203dff4cbab1556ca891844b90af",
+                "uncompressed-sha256": "31edb7583e26e2b1c9d0bb8dbdc94149804baa25de291fc84dc9b89df79bf670"
               }
             }
           }
         },
         "gcp": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-gcp.aarch64.tar.gz",
-                "sha256": "ea8f650ccaac3799d6ddeaa3702534a67c126e2e38855857c6c31429c3a7cf94",
-                "uncompressed-sha256": "c3d9fc5aca7f06f695abc43823e210c47ee7c9d1ab8cf3189de77f216ae50b33"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-gcp.aarch64.tar.gz",
+                "sha256": "ced54ad413ef490c8a7ba7a7ba8b104f428449e5ac845ed074aadbad14c0bc49",
+                "uncompressed-sha256": "4b63fc2204952a9920b4390df32cab9e7a92d700e454e633e27cef958d678ad9"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-metal4k.aarch64.raw.gz",
-                "sha256": "f312995bb68b553fc56a7afb20cb38bc9d707a8a1c83136e9304c68b6acecaf6",
-                "uncompressed-sha256": "35458e2cb6a1760d3c834913e4165e763e5025397b6d5a5babaded11801567ac"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-metal4k.aarch64.raw.gz",
+                "sha256": "01d2e9b5fa2eec9a5ca262485b13a1413ad927926e6b6cc2fec6da26ca14c933",
+                "uncompressed-sha256": "b4ae8acef70045968c12d6d9d8a5d504ea85496343d685b4ac545b31701ff006"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-live.aarch64.iso",
-                "sha256": "c7c475b5a14814a82ffaabe15e3c9096fb1c7a0ea555ec329162382fa9a36696"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-live.aarch64.iso",
+                "sha256": "69ee337ce5b6850723155ecac9398cea90ed70ac5441e9ed5fe4e49723d4f0c4"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-live-kernel-aarch64",
-                "sha256": "27d1978bb3f9effdda32e99bf02c114cf7173cc4a4733b37aefcd2b79631e27d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-live-kernel-aarch64",
+                "sha256": "f7ac08aea81b4c327aeb659543df971763cf6f2a2209e991f1411e7a0ea6e08d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-live-initramfs.aarch64.img",
-                "sha256": "7164f03b24872d6957424c06fb421f0e8e5c6bcc16bc860f65320de8cb9491fa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-live-initramfs.aarch64.img",
+                "sha256": "3aa88df67790291a207fa14d04f0c2d817dba168b9ef5be9c0c30be7966cc584"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-live-rootfs.aarch64.img",
-                "sha256": "ddfb232823ba2c58ace52599f5c16fb4d7b78386c794bc5e18dd1e25bd2b38ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-live-rootfs.aarch64.img",
+                "sha256": "a3a5d204abaf84dd33c1fcbf919ebf68269633b2f7c4db48c8ab5391d07efd1c"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-metal.aarch64.raw.gz",
-                "sha256": "d8dd144e1a226c73a1691593238d8dc108a0c472be1dcf97119dff426e0cfc5c",
-                "uncompressed-sha256": "36f20e4ba98204f82c0168a8ac1d67bc6e7664b4cc64fb86a6cb960eb12e56e4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-metal.aarch64.raw.gz",
+                "sha256": "dff62648dc991849f622c9cc37a26891e2c86a7da061467b0e305c11a65d9259",
+                "uncompressed-sha256": "2d16a5ca58f1585d0f4c0d0062df11b22fe556d8ca8dca53befeade0de5bbc28"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-openstack.aarch64.qcow2.gz",
-                "sha256": "2443a481b2f1f87f9d43196fc0574dfc365b46db1ebbecbd40dae9c6d4906684",
-                "uncompressed-sha256": "29f52618733b86986a473df2cffc9307c194474f3201b564e1a0a503cc45d81e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-openstack.aarch64.qcow2.gz",
+                "sha256": "2816291045ae4be9f9902b8c0994f33bdbd753fc0b3ed49b8c993f71ee35a6e2",
+                "uncompressed-sha256": "605b12506018b8a8b65fa27949cfdb48d857b1a79074476049ef4af88e5edb66"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/aarch64/rhcos-416.94.202510081640-0-qemu.aarch64.qcow2.gz",
-                "sha256": "c419bf9a0763bb013b7708f18cb0c52e152cad8ab18afa0f7f7478aa2ce4567b",
-                "uncompressed-sha256": "c049b8d6f0ea81781ef9b66f48f71e4a3760257c434bf0366dc4d4cd40bcd120"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/aarch64/rhcos-416.94.202601221345-0-qemu.aarch64.qcow2.gz",
+                "sha256": "248b67152029f48652c112db01e509cd2de0edbfdc6ae2fe8258918cb3b8deea",
+                "uncompressed-sha256": "4b4d63c3876418a1c6f034c5b4b8950794f3a1789edacd89605c6ebd4b4ffed5"
               }
             }
           }
@@ -110,238 +110,102 @@
       "images": {
         "aws": {
           "regions": {
-            "af-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-068b25e78da2330fc"
-            },
-            "ap-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0a58853fd67c919f9"
-            },
-            "ap-east-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-04f71b27df2784216"
-            },
-            "ap-northeast-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0202c96b277e27b46"
-            },
-            "ap-northeast-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0873b124043bab88d"
-            },
-            "ap-northeast-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0c11faef44e7539ef"
-            },
-            "ap-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0e4cd3f1d59fbdf70"
-            },
-            "ap-south-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-070673daacf184194"
-            },
-            "ap-southeast-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-052f0064e3b68dcaa"
-            },
-            "ap-southeast-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f1b01727c4a7d1d7"
-            },
-            "ap-southeast-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-011666a57b0348d87"
-            },
-            "ap-southeast-4": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-091a598a97e8bd216"
-            },
-            "ap-southeast-5": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0cc8cfce06ace0e5d"
-            },
-            "ap-southeast-6": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-07466156fedc8dabc"
-            },
-            "ap-southeast-7": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0c14a209d28703460"
-            },
-            "ca-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f5733b565507ee57"
-            },
-            "ca-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-09e10aac2970f49d8"
-            },
-            "eu-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-03ba6c777a7df872b"
-            },
-            "eu-central-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0ed65e919aa24a203"
-            },
-            "eu-north-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0a25aee295a762f2e"
-            },
-            "eu-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-061aedbf6245c25c4"
-            },
-            "eu-south-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-01db18de65432ac68"
-            },
-            "eu-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-041bdff4d6da653ce"
-            },
-            "eu-west-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-05330d2138f0bad76"
-            },
-            "eu-west-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-07e3aad922d4ee3c9"
-            },
-            "il-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0158f72e5fb8cd3af"
-            },
-            "me-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0d60f7dec854b7300"
-            },
-            "me-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f6b1c8323720ab00"
-            },
-            "mx-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-028a8caddb6adfb7a"
-            },
-            "sa-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0476040292cd324fc"
-            },
             "us-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0750a7841594757eb"
-            },
-            "us-east-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0af1e6e1c328c940d"
-            },
-            "us-gov-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0320f439fbb3d516a"
+              "release": "416.94.202601221345-0",
+              "image": "ami-0b01e0a1768646d66"
             },
             "us-gov-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-09e1b86d29bfb2775"
-            },
-            "us-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0b6117f37e6309404"
-            },
-            "us-west-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-080c226661ac6c2e5"
+              "release": "416.94.202601221345-0",
+              "image": "ami-051d547ca7d987854"
             }
           }
         },
         "gcp": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-416-94-202510081640-0-gcp-aarch64"
+          "name": "rhcos-416-94-202601221345-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "416.94.202510081640-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202510081640-0-azure.aarch64.vhd"
+          "release": "416.94.202601221345-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202601221345-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-metal4k.ppc64le.raw.gz",
-                "sha256": "18e377e9caede02b3a2afbd85888e241cbfcb019332ae09a63a1c1b2638472a9",
-                "uncompressed-sha256": "fe80a505b9516e30a8cf696f50cec2afa92a94ac2d581d6b06cbe60276697312"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-metal4k.ppc64le.raw.gz",
+                "sha256": "33040522571e99cf238f4cece63c363512f8078ffb343cbaad0cfe377a70bf88",
+                "uncompressed-sha256": "93be3e4a9eb02fe23ab7eca74c24b074233c4d0d9dffb9d4a70bea67ed970a0f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-live.ppc64le.iso",
-                "sha256": "ae7729b966bc892bc1580b63ae317707a6c1d41048c0989707bb6cb412f929f3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-live.ppc64le.iso",
+                "sha256": "a09eb43433498579f5a8125d87869785d16d7f0d7276fe16a188fca16d546cff"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-live-kernel-ppc64le",
-                "sha256": "7703d8e7d74a4b5ca10bc8df688be05019c0cc06174ae01991be5898bb89b213"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-live-kernel-ppc64le",
+                "sha256": "b10d46cc8fa8d9c3d63646260c7f226b1fd64aa9c64c084c457745e09080f4f9"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-live-initramfs.ppc64le.img",
-                "sha256": "0c0a4871d1607f48a474e7e013a17756bbee806d8f31bbc33727668f7893204f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-live-initramfs.ppc64le.img",
+                "sha256": "81774537883c562923d443f9de78e29b8e6908094471f04d077244a7300b838f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-live-rootfs.ppc64le.img",
-                "sha256": "f8996740400adf3e212026ce1a14b28b67eb52c943dfa536ce3896e40c494a12"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-live-rootfs.ppc64le.img",
+                "sha256": "dc59b478f49150025b99d8d4ec47236888de676880bec5f7e7259b0bf8c29a19"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-metal.ppc64le.raw.gz",
-                "sha256": "266d56592207b39e80226766f169b5b552aa802cc717142f6d9fd373df286dd0",
-                "uncompressed-sha256": "8e829ceb5acc04e323022a4ac05e769e5676f89a5fea00b1975dde4b242f9a00"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-metal.ppc64le.raw.gz",
+                "sha256": "a18c2a6026300d70c30bd379ee734d8cca528f993078021bf5f0921fbebb8aed",
+                "uncompressed-sha256": "e53db85f2611e6e273a2d610164fd37db151c39529c89696837ab1d6438363a5"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "a266bf661ce42c0cc050f1eb1c38265bbd18a605b88e2524cca4285a1264e9da",
-                "uncompressed-sha256": "2b659947afefc81e866c4698d5031ab2e9dc613ef3d8dbf35a6e67d64026b878"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "1071f5928b98dce293deee15ad158bc21fcdb92c7a01d19a0d3ad0a19cb4e981",
+                "uncompressed-sha256": "83cb46dce629758726694d64241b956707f069e8fd914b0ef3af52e78401ee9d"
               }
             }
           }
         },
         "powervs": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-powervs.ppc64le.ova.gz",
-                "sha256": "cd468a9f7a6f738a6a1404c6a3951ae36faf44452433df71d623471cfa966ee8",
-                "uncompressed-sha256": "a53737d969f7b21155a34ec7047e1c1e346b5cc472ec33da27c48c00c301aee6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-powervs.ppc64le.ova.gz",
+                "sha256": "d1c50e8f8553dcaba719e8e5c0727a8aa871b1c7630f4175b4fa015b9ff6b9d7",
+                "uncompressed-sha256": "abd634d6c2088d911f2ea9a1c15549bcb192be3efea6ff3f22a206564d04d77c"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/ppc64le/rhcos-416.94.202510081640-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "61bc653cdcb5f98e2cdac31ab15bbc66736182bf50545a16ac3b7c180b475906",
-                "uncompressed-sha256": "137723bada3fdc02babeae53557def1d268c1f06256908137153627466c47809"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/ppc64le/rhcos-416.94.202601221345-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "71bceb6fe30c478853db71764b8a646087f17e9b713bd5fdd53baec9b39d1d34",
+                "uncompressed-sha256": "f6f3ec77885ffbda55316ed875b12dacba6c642e50f94c46e81ba86db27d649b"
               }
             }
           }
@@ -350,65 +214,11 @@
       "images": {
         "powervs": {
           "regions": {
-            "au-syd": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "br-sao": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "ca-tor": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-de": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-es": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-gb": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-osa": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-tok": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
             "us-east": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
+              "release": "416.94.202601221345-0",
+              "object": "rhcos-416-94-202601221345-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
-            },
-            "us-south": {
-              "release": "416.94.202510081640-0",
-              "object": "rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-416-94-202510081640-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-416-94-202601221345-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -417,88 +227,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "ce04881b88132033aa521200be9247628da899bfb7d1fad93732fb8ad1a0361a",
-                "uncompressed-sha256": "eb95dfbdc9010ec7912d145df3108bad88b6d92b53046201f865762b750b5086"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "219c0a7048115d29fe9049f689f6dd04417cd4945116992661419d73868db4e4",
+                "uncompressed-sha256": "0e42b8de2332c22d00e83baae83b29e58760cfd602b49505510a3bea2337335b"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-metal4k.s390x.raw.gz",
-                "sha256": "e2c49fcc8e32af03d70c52caa02acc5bbe1423d8437f45a7f938cc3fb9be65c4",
-                "uncompressed-sha256": "715606e87a2c7adfabf78ea07e17f9cc22783fc858e17ca2add3588c80f8978a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-metal4k.s390x.raw.gz",
+                "sha256": "d340d8e44c74b3679cfd5ded14f8a0bcc24c9fc856948baa1ee6e6d5ce9896c5",
+                "uncompressed-sha256": "21f68526f2af8967e5a32243375b832b8319a990b450a6d32b10f2749e00a279"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-live.s390x.iso",
-                "sha256": "13f36395728aa4aed73e70fe6520f7a25d1b6cea7a7d8521ed77462fd875539e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-live.s390x.iso",
+                "sha256": "28b0d44ceaaa76240b79578267f331e4be62aaee3ad7ce8ccdca259a5336c478"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-live-kernel-s390x",
-                "sha256": "20183c9b1dae665450e2322ac1773b945d05423f2db388672aefcd3c579923f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-live-kernel-s390x",
+                "sha256": "ac6244c7a8ba5fb42c7f053971484a2843a5eff99714c2e969432dc4e9b2ca21"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-live-initramfs.s390x.img",
-                "sha256": "2eb15e876f9a9c359f13a3be78d17a6fb45b741c357e4bc8e797090d7cf2bcc2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-live-initramfs.s390x.img",
+                "sha256": "27c7d29db7935275ef80668140756bcf54e760474016ba349024b50d11912af0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-live-rootfs.s390x.img",
-                "sha256": "2fddd399871ebe4e008e011601e27acd7550740d70b1bc3c998d840be95ecb74"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-live-rootfs.s390x.img",
+                "sha256": "8f2bd562133015ecfba7bbb933b9d6cee10e99566fa1227e7742669720701b74"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-metal.s390x.raw.gz",
-                "sha256": "5750f4f444b731c439e0752d817bd83a18247dec638f4915751d6a475d02b655",
-                "uncompressed-sha256": "12ac6a3575a474e0856e54e0f44999b75d2327110853d247e8cc03b108ddea10"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-metal.s390x.raw.gz",
+                "sha256": "a36efd6327137bba5290a1854eb0f097428463e13c2273598422bab1bac7e121",
+                "uncompressed-sha256": "f70b6481f45c6f8f7885a72641037c68f5dcc6762e3b395a799ded540df7acde"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-openstack.s390x.qcow2.gz",
-                "sha256": "eb7544fe5a9065fde2ffe7a696f27bf4e304984267daec4f3658255016413a54",
-                "uncompressed-sha256": "782973b0b359eb79f94e3b1f22b092ac127b9868602d874662f8152c0e06c864"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-openstack.s390x.qcow2.gz",
+                "sha256": "5e71a8b2248dc6c5ffac8b424f1c2fbe4c2132b7a7422f8ddd998e01d3534c9d",
+                "uncompressed-sha256": "b3d97ccb2abe2c6f68d9c59a69efdfa9a9faec68008d20eeb24f96aa03f5115a"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-qemu.s390x.qcow2.gz",
-                "sha256": "e319cabde7e6c171bd1c397b9a48854f01df5fe74f5059c2a3d096b35c3b4e33",
-                "uncompressed-sha256": "fb93df4403cfd788fb07d4e900bafa87893649a1c29f5c443ebaaeab0ac3334a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-qemu.s390x.qcow2.gz",
+                "sha256": "e2c67ec6087827623674ea067fa8256dae1c5e784f3cba2f1e51460651a0f789",
+                "uncompressed-sha256": "ce45efecfa0a4eeebd2b6f8e00e4a4aa60002685dc5481d4636a2db71f3eee43"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/s390x/rhcos-416.94.202510081640-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "e3d6c5dab3deb58ac25e29897f8527c80bec0e3c6a8dfd2f859950d8c42f034c",
-                "uncompressed-sha256": "6583a849c46bc2d3701d0c2d0e6ea37adec8c961175a4742a998951a985ec65a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/s390x/rhcos-416.94.202601221345-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "795d2a257de4ccbd3198ab284958821ceae5b6ac9f73f6a4a5b9bf4258986043",
+                "uncompressed-sha256": "336a03af4d5f53c0d33f554720cfb5726847cc0e9889c53d842c9c9639225059"
               }
             }
           }
@@ -509,157 +319,157 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-aws.x86_64.vmdk.gz",
-                "sha256": "fa5ac29f7d8deb82b3b9eb997aec96f44a6ef5584ae870a62b5d4eeee0e155f5",
-                "uncompressed-sha256": "38781c076afa6d991e295d68063b3e53e17ed9c1f95effd9f671ff168b07310b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-aws.x86_64.vmdk.gz",
+                "sha256": "84ac22698caa30f45bbee761d6b7e5881b81ce02c0b07f5eef4f0a5fc7a3e1a6",
+                "uncompressed-sha256": "1cb9ab6970bde0e58ecfb374440c166d1532b4199d638b31575dd72c1805c9c4"
               }
             }
           }
         },
         "azure": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-azure.x86_64.vhd.gz",
-                "sha256": "b8433ca640115db0bcee047096710cc1c3b8c8b3f80e0a5adfc6b826438c5b8c",
-                "uncompressed-sha256": "2aa4bfafb8dd02626a4eba59aab33baa31920b6a44a7a9ce3ff16d65ec9f3127"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-azure.x86_64.vhd.gz",
+                "sha256": "989d1448865fb28e90d23dbb3f204183352ee85a13c9d42d7f9c006a56a7edad",
+                "uncompressed-sha256": "260a8d24b862e762a4101679f6936841dca14e5adb42677112bb44118e40baae"
               }
             }
           }
         },
         "azurestack": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-azurestack.x86_64.vhd.gz",
-                "sha256": "2bcab204733ab64a965c230fd277e5a02861221bc1f6647ea5330b80daeb03e3",
-                "uncompressed-sha256": "b6699787d64200c773821c76a83df163ea060eb2468cc0e2e2876fbee4ea5043"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-azurestack.x86_64.vhd.gz",
+                "sha256": "ee7c723b7426cb76efe4a30ae24da844684a273d45c9539b8dbdd9d5481db929",
+                "uncompressed-sha256": "34ddbdc11fcb71efbe259b674a3d7117369227ad3adff5c5d0ab807758f9fc82"
               }
             }
           }
         },
         "gcp": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-gcp.x86_64.tar.gz",
-                "sha256": "99663feef0fd1db366897302feec9aedac2fa3fbc682195a1b0398e000493f1d",
-                "uncompressed-sha256": "c729d83e52ab06b09eb071ec9c1ae509c140f0bdfebddbb9622699b3dcad8d22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-gcp.x86_64.tar.gz",
+                "sha256": "143bd80c366b5c713cb53c469b1b38e725fba93873791a3b9be6a8db9b042635",
+                "uncompressed-sha256": "7acf898b41d018fb7bcd0a05892a1604b9bfe1cd9a6b3a5cdb59476829a52357"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "7bcfc231f3d41621a9a0167e679fae0e150e60c02a429afc39b46afb0299a0be",
-                "uncompressed-sha256": "b18ad2bfa74fa48dc9a8b9fa9f3cef6e29b61aecabd051109b50de28339c80dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "12723100dfa55e2d55ba62a36ac55f424a64eadad64c05157b5805c4a1770ea8",
+                "uncompressed-sha256": "9fb4678c512261b88b292cfb7bd1aa5474c33191914802f57f08a8e753fe1525"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-kubevirt.x86_64.ociarchive",
-                "sha256": "45e7169871e3ddcbc605c65496ed86c4932675b5da71da8b524a47d2eb43fd1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-kubevirt.x86_64.ociarchive",
+                "sha256": "f09ea98b6c18f0d5697f4546bd5f2a42cb0ca8516e4d4c27382bb137906f6db5"
               }
             }
           }
         },
         "metal": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-metal4k.x86_64.raw.gz",
-                "sha256": "8e351097dfb7644fc33b42a2346a174a59b317f51652d9f9f4b76e237b4e2eb4",
-                "uncompressed-sha256": "a08707d0d8c57c4ee5cab05ff6cb498d10501033aa3e634bb12875cdc60e8d9f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-metal4k.x86_64.raw.gz",
+                "sha256": "98d06ad1fc58c7e5a8c54026c22755046600de952663650cf0ffc1011731d1bd",
+                "uncompressed-sha256": "1f77883653a70dd938814d34fc14b3dcde5f76f16e59b1ce2a45e77a5d1ac622"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-live.x86_64.iso",
-                "sha256": "dc57e7f5d36f876e2b9d1c7398f3053db093850f7a246c23ede6af7ebe3ab332"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-live.x86_64.iso",
+                "sha256": "106a63663347c12e2778a8eed969b2256ebc03cf84bd6eadafb7d251914f5a5f"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-live-kernel-x86_64",
-                "sha256": "74ab08d98be5a87078a2cd663375083e57eabfa445279c86287f41a576949efa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-live-kernel-x86_64",
+                "sha256": "a349d85ce7becf0356dc14704e3f4f1f53320564b4a3a31fd333ae7d91aaadcf"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-live-initramfs.x86_64.img",
-                "sha256": "6b6797e20be4aee1fb6bbaa47ba45db90ff77a493066d837cefe487900a9d641"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-live-initramfs.x86_64.img",
+                "sha256": "03a2f2b0fc1728a738a66a4fc418d41cc37d8355796d656a04605f5f7ea6b03c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-live-rootfs.x86_64.img",
-                "sha256": "167c2fbdf18cbd474567597a762f0b365f4d3824d434da612e5d5a24e8705236"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-live-rootfs.x86_64.img",
+                "sha256": "3ad1f14b7b669421e863d8b868142994c0249f80ca6a8b69d410fdb2f9fd8197"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-metal.x86_64.raw.gz",
-                "sha256": "b2d609a17b264b79c9de10c5bd3dd9459b05a672c0d64ae0b59e4e9628e80dea",
-                "uncompressed-sha256": "d24965239ccb44a323c134377640925bcc7cad899471f1350c459262b4dfb60e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-metal.x86_64.raw.gz",
+                "sha256": "2ca0acc0f664cbcb190d0191acf563717528d1a29461f3ecd6be5f62109f6de7",
+                "uncompressed-sha256": "787da0bfa729fd0824065dd84d3081429b5be6feb80ec5289c721dfeea8a0fb9"
               }
             }
           }
         },
         "nutanix": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-nutanix.x86_64.qcow2",
-                "sha256": "4d231d87ca94c1ebc1c34f78e02fc5e1a79305ed98ee000b0454bcfecc84a6fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-nutanix.x86_64.qcow2",
+                "sha256": "44724323146010dc72e65d661e8a23cd092bec5444c6e56aca1afd04b30dc041"
               }
             }
           }
         },
         "openstack": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-openstack.x86_64.qcow2.gz",
-                "sha256": "00d6cab276244f159273b7afba11cc73fd8a302a2a007d1e81143f8ba061ea1f",
-                "uncompressed-sha256": "fab9d9355c8fd05ddc8cc6185020c9c60b1a1ad86489776409e2a3f9df9f89ed"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-openstack.x86_64.qcow2.gz",
+                "sha256": "02d55942a3be70dcb942f7e8c2fd582027b2d7c48a24f1a4544525bf3829b1ab",
+                "uncompressed-sha256": "737b4fe95a4c4568c21be76a66c5f593ace734a5dbf499a93f6aed411794c269"
               }
             }
           }
         },
         "qemu": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-qemu.x86_64.qcow2.gz",
-                "sha256": "92880764c1b3b61940bc209ee021b97474c4db2d9a36abcece55ddd6d8c17c95",
-                "uncompressed-sha256": "d03128234c5dc6217bd37ee0caf6f192107d42d39a8a6b5c9b6148b0f4f92399"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-qemu.x86_64.qcow2.gz",
+                "sha256": "2245b50194ac36a3771bc0f51f00565b961f13758bbb25ccb66a2063400edac4",
+                "uncompressed-sha256": "b17fe1dcadee6a9734aaa7ada2c6957ebe1ccf523837f94c406b476e7c86ec09"
               }
             }
           }
         },
         "vmware": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202510081640-0/x86_64/rhcos-416.94.202510081640-0-vmware.x86_64.ova",
-                "sha256": "13e9afebd991fef4f3b43abbdc7dbb45696a6ef3349784463eae8b874430e47c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.16-9.4/builds/416.94.202601221345-0/x86_64/rhcos-416.94.202601221345-0-vmware.x86_64.ova",
+                "sha256": "d81521260e5b1ef4dce674b452faf11115a8e231dd6a664bd388be97964e6443"
               }
             }
           }
@@ -668,167 +478,31 @@
       "images": {
         "aws": {
           "regions": {
-            "af-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0ef5025fac110a76e"
-            },
-            "ap-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0d1baba6173506e6d"
-            },
-            "ap-east-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-05e53b97763fb6d8c"
-            },
-            "ap-northeast-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f0f3790a9274d6e0"
-            },
-            "ap-northeast-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f3db4db046423aa7"
-            },
-            "ap-northeast-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0825839ef87bbf279"
-            },
-            "ap-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-04cab5af943bc23ff"
-            },
-            "ap-south-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-01932ab4251ecc1c3"
-            },
-            "ap-southeast-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-02c5756267b3ae26f"
-            },
-            "ap-southeast-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0d957984249694ff4"
-            },
-            "ap-southeast-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0dffcc2da9dd8c4cf"
-            },
-            "ap-southeast-4": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-02b41dcd69d6f1203"
-            },
-            "ap-southeast-5": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0265f707f3262f1ac"
-            },
-            "ap-southeast-6": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0a005f3cd4fa83c2a"
-            },
-            "ap-southeast-7": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-06042b99a59e3008e"
-            },
-            "ca-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-01242e27d99198753"
-            },
-            "ca-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0891f6575718d877c"
-            },
-            "eu-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-093e25064f9477591"
-            },
-            "eu-central-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0b54a3447d3c7aa71"
-            },
-            "eu-north-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0dab1a84ce37c4212"
-            },
-            "eu-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0f4babdba99ef3b74"
-            },
-            "eu-south-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0962e90dd2aa32d63"
-            },
-            "eu-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-09e554287aaf06d75"
-            },
-            "eu-west-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-02589c838c9354fef"
-            },
-            "eu-west-3": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-02b4f55e4f176cbcb"
-            },
-            "il-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0389107ec9e8cb970"
-            },
-            "me-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0fd2a3fdbe3135cd4"
-            },
-            "me-south-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-00454210850910a9a"
-            },
-            "mx-central-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0c1acd32475291f94"
-            },
-            "sa-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-04c5b1690ca639a20"
-            },
             "us-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-009f29d08fb2f839b"
-            },
-            "us-east-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-03c0f42e69e0f6758"
-            },
-            "us-gov-east-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0e572b341c3645a71"
+              "release": "416.94.202601221345-0",
+              "image": "ami-0dc20f14f3c0bca00"
             },
             "us-gov-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-08cd49b77fdc19686"
-            },
-            "us-west-1": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0caf4d54275a8f3a7"
-            },
-            "us-west-2": {
-              "release": "416.94.202510081640-0",
-              "image": "ami-0bb8419a3938ef4be"
+              "release": "416.94.202601221345-0",
+              "image": "ami-0eb05aee72252f849"
             }
           }
         },
         "gcp": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-416-94-202510081640-0-gcp-x86-64"
+          "name": "rhcos-416-94-202601221345-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "416.94.202510081640-0",
+          "release": "416.94.202601221345-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.16-9.4-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:05c9f421163f7362e5e9e857201d9f43aaf9d5af0854daa7d4d2c02c85c9ade5"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:058bbca89ec08323c965a8c81c10ddaacf44304ec66f91a89ecff3b0cf9d562a"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "416.94.202510081640-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202510081640-0-azure.x86_64.vhd"
+          "release": "416.94.202601221345-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-416.94.202601221345-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

Update RHCOS release-4.16 bootimage metadata to 416.94.202601221345-0

The changes done here will update the RHCOS release-4.16 bootimage metadata and address the following issues:

 [RHEL-135348](https://issues.redhat.com//browse/RHEL-135348) Backport https://github.com/coreos/coreos-installer/pull/1699 [rhel-9.4.z]
[COS-3518](https://issues.redhat.com//browse/COS-3518) [coreos/coreos-installer] Args passed via `--firstboot-args` are lost if also using `--config-file`

This change was generated using:

```
plume cosa2stream --target data/data/coreos/rhcos.json                 \n    --distro rhcos --no-signatures --name 4.16-9.4                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=416.94.202601221345-0                                       \n    aarch64=416.94.202601221345-0                                      \n    s390x=416.94.202601221345-0                                        \n    ppc64le=416.94.202601221345-0

```
                    