### PR TITLE
OCPBUGS-74631: Add validation to reject userProvisionedDNS on Azure Stack Hub

### DIFF
--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -311,5 +311,8 @@ func validateAzureStack(p *azure.Platform, fldPath *field.Path) field.ErrorList 
 	if p.OutboundType != azure.LoadbalancerOutboundType {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("outboundType"), p.OutboundType, "Azure Stack does not support this routing currently"))
 	}
+	if p.UserProvisionedDNS != "" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("userProvisionedDNS"), p.UserProvisionedDNS, "userProvisionedDNS is not supported on Azure Stack Hub"))
+	}
 	return allErrs
 }

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -278,6 +278,17 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			expected: `^test-path\.ipFamily: Unsupported value: "DualStack"`,
 		},
+		{
+			name: "Azure Stack Hub with userProvisionedDNS enabled",
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.CloudName = azure.StackCloud
+				p.ARMEndpoint = "https://management.local.azurestack.external"
+				p.UserProvisionedDNS = "Enabled"
+				return p
+			}(),
+			expected: `^test-path\.userProvisionedDNS: Invalid value: "Enabled": userProvisionedDNS is not supported on Azure Stack Hub$`,
+		},
 	}
 	ic := types.InstallConfig{}
 	for _, tc := range cases {


### PR DESCRIPTION
Custom DNS (userProvisionedDNS) is not supported on Azure Stack Hub. 
This change adds validation to prevent users from setting userProvisionedDNS on Azure Stack Hub.