### PR TITLE
OCPEDGE-2383: feat: update sno minimum to 4vcpu

### DIFF
--- a/data/data/agent/files/usr/local/bin/configure-assisted-hw-requirements.sh
+++ b/data/data/agent/files/usr/local/bin/configure-assisted-hw-requirements.sh
@@ -14,7 +14,7 @@ if [ -f /etc/assisted/extra-manifests/internalreleaseimage.yaml ]; then
 fi
 
 # Build requirements with variables
-HW_VALIDATOR_REQUIREMENTS="[{\"version\":\"default\",\"master\":{\"cpu_cores\":4,\"ram_mib\":16384,\"disk_size_gb\":${MASTER_DISK_SIZE},\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":100,\"packet_loss_percentage\":0},\"arbiter\":{\"cpu_cores\":2,\"ram_mib\":8192,\"disk_size_gb\":50,\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":1000,\"packet_loss_percentage\":0},\"worker\":{\"cpu_cores\":2,\"ram_mib\":8192,\"disk_size_gb\":100,\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":1000,\"packet_loss_percentage\":10},\"sno\":{\"cpu_cores\":8,\"ram_mib\":16384,\"disk_size_gb\":${SNO_DISK_SIZE},\"installation_disk_speed_threshold_ms\":10}}]"
+HW_VALIDATOR_REQUIREMENTS="[{\"version\":\"default\",\"master\":{\"cpu_cores\":4,\"ram_mib\":16384,\"disk_size_gb\":${MASTER_DISK_SIZE},\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":100,\"packet_loss_percentage\":0},\"arbiter\":{\"cpu_cores\":2,\"ram_mib\":8192,\"disk_size_gb\":50,\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":1000,\"packet_loss_percentage\":0},\"worker\":{\"cpu_cores\":2,\"ram_mib\":8192,\"disk_size_gb\":100,\"installation_disk_speed_threshold_ms\":10,\"network_latency_threshold_ms\":1000,\"packet_loss_percentage\":10},\"sno\":{\"cpu_cores\":4,\"ram_mib\":16384,\"disk_size_gb\":${SNO_DISK_SIZE},\"installation_disk_speed_threshold_ms\":10}}]"
 
 # Replace the final value in the env file
 sed -i "s|^HW_VALIDATOR_REQUIREMENTS=.*|HW_VALIDATOR_REQUIREMENTS=$HW_VALIDATOR_REQUIREMENTS|" "$ASSISTED_SERVICE_ENV_FILE"


### PR DESCRIPTION
This lowers the CPU min for SNO to 4vCPU, this allows for deployment in scenarios where smaller computer is required for edge deployments. Utilized with Capabilities this gives users more flexibility with deployments.

Docs for update:
https://issues.redhat.com/browse/OSDOCS-18615