### PR TITLE
OCPBUGS-74940: Increase agent-installer pre-network-manager timeout

### DIFF
--- a/data/data/agent/systemd/units/pre-network-manager-config.service
+++ b/data/data/agent/systemd/units/pre-network-manager-config.service
@@ -6,7 +6,7 @@ DefaultDependencies=no
 [Service]
 User=root
 ExecStart=/usr/local/bin/pre-network-manager-config.sh
-TimeoutSec=60
+TimeoutSec=300
 KillMode=none
 Type=oneshot
 PrivateTmp=true


### PR DESCRIPTION
We have a report that a baremetal installation with VLAN interfaces can require longer than the current setting for the timeout of the pre-network-manager-config service. Increasing it to 300 seconds.

This is a backport of https://github.com/openshift/installer/pull/10199