### PR TITLE
OCPEDGE-2276: Add support for platform None and External in TNA clusters

### DIFF
--- a/pkg/asset/machines/arbiter.go
+++ b/pkg/asset/machines/arbiter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	externaltypes "github.com/openshift/installer/pkg/types/external"
 	nonetypes "github.com/openshift/installer/pkg/types/none"
 	ibmcloudapi "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis"
 	ibmcloudprovider "github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1"
@@ -116,8 +117,8 @@ func (m *Arbiter) Generate(ctx context.Context, dependencies asset.Parents) erro
 	if ic.Arbiter == nil {
 		return nil
 	}
-	if ic.Platform.Name() != baremetaltypes.Name && ic.Platform.Name() != nonetypes.Name {
-		return fmt.Errorf("only BareMetal and None platforms are supported for Arbiter deployments")
+	if ic.Platform.Name() != baremetaltypes.Name && ic.Platform.Name() != externaltypes.Name && ic.Platform.Name() != nonetypes.Name {
+		return fmt.Errorf("only BareMetal, External, and None platforms are supported for Arbiter deployments")
 	}
 
 	pool := *ic.Arbiter

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -779,8 +779,8 @@ func validateControlPlane(installConfig *types.InstallConfig, fldPath *field.Pat
 
 func validateArbiter(platform *types.Platform, arbiterPool, masterPool *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if platform != nil && platform.BareMetal == nil && platform.None == nil {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("platform"), platform.Name(), []string{baremetal.Name, none.Name}))
+	if platform != nil && platform.BareMetal == nil && platform.External == nil && platform.None == nil {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("platform"), platform.Name(), []string{baremetal.Name, external.Name, none.Name}))
 	}
 	if arbiterPool.Name != types.MachinePoolArbiterRoleName {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("name"), arbiterPool.Name, []string{types.MachinePoolArbiterRoleName}))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -3234,6 +3234,20 @@ func TestValidateArbiter(t *testing.T) {
 		},
 		{
 			config: installConfig().
+				PlatformExternal().
+				MachinePoolArbiter(
+					machinePool().
+						Name("arbiter").
+						Hyperthreading(types.HyperthreadingEnabled).
+						Architecture(types.ArchitectureAMD64)).
+				MachinePoolCP(machinePool()).
+				ArbiterReplicas(1).
+				CpReplicas(2).build(),
+			name:     "valid_platform_external",
+			expected: "",
+		},
+		{
+			config: installConfig().
 				PlatformAWS().
 				MachinePoolArbiter(machinePool().
 					Name("arbiter").
@@ -3243,7 +3257,7 @@ func TestValidateArbiter(t *testing.T) {
 				ArbiterReplicas(1).
 				CpReplicas(2).build(),
 			name:     "invalid_platform",
-			expected: `supported values: "baremetal", "none"`,
+			expected: `supported values: "baremetal", "external", "none"`,
 		},
 		{
 			config: installConfig().


### PR DESCRIPTION
## Summary

This PR extends the TNA (Two-Node Arbiter) cluster support to include `platform: external`  in addition to the existing `none` and `baremetal` support.

Verified via UnitTest