### PR TITLE
OCPBUGS-67203: Update the RHCOS 4.18 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,107 +1,107 @@
 {
   "stream": "rhcos-4.18",
   "metadata": {
-    "last-modified": "2025-11-20T12:15:58Z",
+    "last-modified": "2026-02-09T14:01:21Z",
     "generator": "plume cosa2stream 5d742df"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-aws.aarch64.vmdk.gz",
-                "sha256": "8f6e175d0c2111ea61541a936dc51bf7e28a19b69ac7486cab9940e931627918",
-                "uncompressed-sha256": "019f89acc86935e105dc91a6fd30e9d536d919b0605086cae81116b08f23515b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-aws.aarch64.vmdk.gz",
+                "sha256": "d24ea0b7b2a05fea087b2ff1f715d7d962bb6cd5dba20eabe74f46111db458ef",
+                "uncompressed-sha256": "bf068d1e9f54f4eb292f6873102c9e9fba8bce31548c5170d398fcd5d16a62da"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-azure.aarch64.vhd.gz",
-                "sha256": "1d29cf342533460505ddc0653b9128e3540954cf751aa41b9e5145fe857aa940",
-                "uncompressed-sha256": "4c9d16220605ec5db1ecc880568a3be5ca790782d5a225e145e0c24db8d94ec2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-azure.aarch64.vhd.gz",
+                "sha256": "39812372d52f83d65dc0a0044692ddf48c9b5590902bb8d9d5a0cb0bbd0389f9",
+                "uncompressed-sha256": "c5d2e0b6c630dce23901759ec1138dc560903d00f81b140342f4be2db4cda567"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-gcp.aarch64.tar.gz",
-                "sha256": "d0d297e3631e033da97de9dc91915290d0795ceee8024d6aeeb4499152d7ea28",
-                "uncompressed-sha256": "768f4f2dfa1aad2bf05917ee723e639b0117ac512de421d15902b93034778eac"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-gcp.aarch64.tar.gz",
+                "sha256": "cee1ca5a067b0dc7aee3621078e1983f00236f5bf6301a3b00d5ea5fcddf5a3b",
+                "uncompressed-sha256": "6144e3d15298fb75a29de07ab06bcdc72cffbe3fe42a8399312ec6d73617a7f3"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-metal4k.aarch64.raw.gz",
-                "sha256": "3520604348872b9a5fd0c51e34301ae2fefe5039000d49ae884236ef795bdba5",
-                "uncompressed-sha256": "a069453caaa53f10899dc6f18a923e931a1bd47fa2eb620b3a48b12a434b8360"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-metal4k.aarch64.raw.gz",
+                "sha256": "e9f1a9bf9e222abf8474c1d4bce79c34d1de03c440d2c2e3e501b42483dff81b",
+                "uncompressed-sha256": "85dd7022dde2516c9ee3a9e5c4e9c25bdc6ef19eb25053ccebbbc52b07580e39"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live.aarch64.iso",
-                "sha256": "512a1667ac3b905da45c971b5c5ca4f20c10c291ad122e0e19e6c922ce94896b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-live.aarch64.iso",
+                "sha256": "d88ca05b6e4e38e67918d3c3a34d9e437b6074c2e65c1da591ad175721ecd087"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-kernel-aarch64",
-                "sha256": "edcad7cc2acb04389a9ba8d8f837dca534008a5d274e5c51d8608e02afb8485b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-live-kernel-aarch64",
+                "sha256": "57f0f51f56a003358282d278a57fc73abf0c4ad6325291d0c6309d0d432d5808"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-initramfs.aarch64.img",
-                "sha256": "2214713975d2257efa63095db5bf2352a907e513a1e49a8b3e6fd20ad14f4297"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-live-initramfs.aarch64.img",
+                "sha256": "6ad44b0abe1dc47f0a097345d15c6aae84927a1b3b91530235edab24e8820f72"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-live-rootfs.aarch64.img",
-                "sha256": "5fc51974a7cf1b6be68ec73aefd5d66501e7ada8d53b27ef1ef51b7b2318946d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-live-rootfs.aarch64.img",
+                "sha256": "cdff073cf72eb09d03dcf3c1318a6685a366b510d23c65e756d6d9dc63f0a351"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-metal.aarch64.raw.gz",
-                "sha256": "49bc651e9fd7e7971860608109b8f13bce36b18f6c00ac7573d45325f861be7e",
-                "uncompressed-sha256": "9b6fbf74b2af23fd0fd8244ab842aaec8558f2d7e3e56ff498ab51b07c773279"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-metal.aarch64.raw.gz",
+                "sha256": "b098bae59aff0a8beec41b8ab5c26790e780cd891583286a43092815c9b21e1b",
+                "uncompressed-sha256": "54451dd7df79d229f6f2195e30a124ad6e832ea05506a2262cf3d972622414c7"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-openstack.aarch64.qcow2.gz",
-                "sha256": "e8c2c3d9fdb8a536600b2e30bf5321f2d03f6eca8abc9609681db53f27a36086",
-                "uncompressed-sha256": "cfe9ebca376fa87a0e6d09bb32369d79c43353d1be6ad8091fe37e0d6a0bf6db"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-openstack.aarch64.qcow2.gz",
+                "sha256": "43e46f3f489d2dd7a80a70d40c73fae4a1e2dbe16420560cb17153d4a910a19b",
+                "uncompressed-sha256": "6c5c76ff7dcdf5cd5efda0a9e585d68edf35988ac320544b8e9d506202cb1b1b"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/aarch64/rhcos-418.94.202511191518-0-qemu.aarch64.qcow2.gz",
-                "sha256": "93d690bfb4f043ce2d6c609d0cb29d36947f30c82eb8e260f5ce22cbfb719258",
-                "uncompressed-sha256": "153339efd1652128640d87d3d184127eba93cd7b46f48128e0d3013296873eb5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-qemu.aarch64.qcow2.gz",
+                "sha256": "d31d37494010fe5bb71daae681e0697d5bad8d8cfac49a8ebeab5d421c9d28a1",
+                "uncompressed-sha256": "afd4101d8bda465c1d7ff752d4a2f77601abbc45044f224df9a422e7cf6ed4c5"
               }
             }
           }
@@ -111,237 +111,237 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-05457218b93924a1b"
+              "release": "418.94.202602022246-0",
+              "image": "ami-03e31d26d5154b7a5"
             },
             "ap-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0c00cb6d08c75e584"
+              "release": "418.94.202602022246-0",
+              "image": "ami-01e938c062a6f8ff4"
             },
             "ap-east-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0bde509eea8a5a001"
+              "release": "418.94.202602022246-0",
+              "image": "ami-065b6d49dcd2844ff"
             },
             "ap-northeast-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-09b5ef37857ce7f09"
+              "release": "418.94.202602022246-0",
+              "image": "ami-097df88ba730a7c7e"
             },
             "ap-northeast-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0e3d83a57853ab680"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0ac4690d28a6e6214"
             },
             "ap-northeast-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-085de759aba52d089"
+              "release": "418.94.202602022246-0",
+              "image": "ami-038eebeb62ea30f00"
             },
             "ap-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0e4ebbcc134fa8e8d"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0b266e35a474093b5"
             },
             "ap-south-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-01783057e4deaaf36"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0cd894acdcf222f5d"
             },
             "ap-southeast-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0416c2f0b26f59b09"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0a3a53dae1e6378ee"
             },
             "ap-southeast-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-01bffeaf91cf3497d"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0cc78b5220fd5ae19"
             },
             "ap-southeast-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0cc0002570e11f538"
+              "release": "418.94.202602022246-0",
+              "image": "ami-018a30cf8c5d222d4"
             },
             "ap-southeast-4": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-09779e41beff513f1"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08ebb648a9581c347"
             },
             "ap-southeast-5": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-04f8e1a5b2f7d7887"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08dfedbe4afb68800"
             },
             "ap-southeast-6": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-07df9710dc7cec116"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e6fda88e0654faf7"
             },
             "ap-southeast-7": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0962bbe6781c54e30"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e7fa6f737dd95d0e"
             },
             "ca-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-045cc23fb5d28e555"
+              "release": "418.94.202602022246-0",
+              "image": "ami-088189680edb44767"
             },
             "ca-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-041acba9d9a5d19cb"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08414b1dce5e311de"
             },
             "eu-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-06139d7ec6134180d"
+              "release": "418.94.202602022246-0",
+              "image": "ami-036bf6b16cd8121f0"
             },
             "eu-central-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-00ad559fc930398e5"
+              "release": "418.94.202602022246-0",
+              "image": "ami-01ed98df89dbd0772"
             },
             "eu-north-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-02e805b1b4cfab2e7"
+              "release": "418.94.202602022246-0",
+              "image": "ami-04baabf33a772ebb2"
             },
             "eu-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0770985d740e28d8a"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0a0e610ba86a31684"
             },
             "eu-south-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0925f45015194a3cd"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08f66019c2c7ba6f1"
             },
             "eu-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-099fe0e81e4eab17f"
+              "release": "418.94.202602022246-0",
+              "image": "ami-076ed6d93e6ab916a"
             },
             "eu-west-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-030d19b1fd9364be9"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0c93540ead01152bb"
             },
             "eu-west-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-00f338e6e710d7c5e"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0803f93a7c016ba0d"
             },
             "il-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0535fac6e664ce43e"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0fcdc46643dbf086d"
             },
             "me-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0bb1409cb2a27e3af"
+              "release": "418.94.202602022246-0",
+              "image": "ami-06950547830d0d50a"
             },
             "me-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0a6664f7743cd3e65"
+              "release": "418.94.202602022246-0",
+              "image": "ami-01c509962a8a46824"
             },
             "mx-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-01e941f94a7a1e14b"
+              "release": "418.94.202602022246-0",
+              "image": "ami-09aa26ac235fba345"
             },
             "sa-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-076cc67cb438fe315"
+              "release": "418.94.202602022246-0",
+              "image": "ami-05623d7810a6248ac"
             },
             "us-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-05aa7e1d4ac758a5f"
+              "release": "418.94.202602022246-0",
+              "image": "ami-03a3de9c8a0c7104a"
             },
             "us-east-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0370be55ebca09a9b"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0f8d8bb2d4cc7681a"
             },
             "us-gov-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0a47f24f68cc4c924"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e680db6395193978"
             },
             "us-gov-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-004e11fd06d5cc890"
+              "release": "418.94.202602022246-0",
+              "image": "ami-09200d22da320c148"
             },
             "us-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-02a09bbfa063f461c"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0bfb71633a8ffe3b5"
             },
             "us-west-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0b76526e37ab59b22"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0c0c49a5c592add62"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202511191518-0-gcp-aarch64"
+          "name": "rhcos-418-94-202602022246-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202511191518-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202511191518-0-azure.aarch64.vhd"
+          "release": "418.94.202602022246-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202602022246-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-metal4k.ppc64le.raw.gz",
-                "sha256": "327aa7d125ceb1990aa721f52927bd078dbeccb5f6a5b9d7e75a55eebf8feb9a",
-                "uncompressed-sha256": "7915191e56951a31280166e4e2d7c7ed58ec8cb272561c835a59dea6b5f0ea5d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-metal4k.ppc64le.raw.gz",
+                "sha256": "50160969f451ceb10b77e9b724327cff83d52fb161797e2dd1acdf219013c414",
+                "uncompressed-sha256": "00a9ebb6e68edd33f825df16678649d572f357806d52bccb1e985ed643012a1b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live.ppc64le.iso",
-                "sha256": "5332f8ef4e26bdfdf539b9e80b1c2fd5d092843c2714defa6bceab6b33f29009"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-live.ppc64le.iso",
+                "sha256": "148f8a4c7a16c07edd9d52961eea5d946ecc2e7e97c50dbc6cbc9e9aa15926da"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-kernel-ppc64le",
-                "sha256": "33802298e5217e0aef4dcd66310d7340be28b264d506c1368504224efa4500e1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-live-kernel-ppc64le",
+                "sha256": "dec1815392a0a12c4caedce78ebd3f1fd91760a7e9c6e0977517d1021e6f1f52"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-initramfs.ppc64le.img",
-                "sha256": "c25d2b87974c38105b0c94c99ceb5c5ed3eee86520348b44258e60a2b4dffb30"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-live-initramfs.ppc64le.img",
+                "sha256": "2f46db7ab3c275adfe27de8d8b3963459ea7879c0ea7319c8dca62dd0eed00b4"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-live-rootfs.ppc64le.img",
-                "sha256": "053c46c274180385d279351dacc78ada7a8d55b356d964007068e938d818be61"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-live-rootfs.ppc64le.img",
+                "sha256": "468982806833eaaa3e234e7a0aa372756ef10226777e5a8e228ddfccf195d5ef"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-metal.ppc64le.raw.gz",
-                "sha256": "e484fbc818d02535e47d9197d64ef67a741a6584118605481b165dc4c67f978b",
-                "uncompressed-sha256": "884545c3c0ab6c400d64e8ea9ba188e5fd980d97b955fa0d93bdbed0fd15cbe0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-metal.ppc64le.raw.gz",
+                "sha256": "bc290883c0f96f66232a068e0f677df99355d7532a241d92347d4c5a433c25d4",
+                "uncompressed-sha256": "765ea1f12b3bbd9362df5c3d420776d28b42dcd0fe8e49d66ab158505c617896"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "89344bc0ff4d92d9d08478b57f88a8ed7f5c7e85d742e5c9ad8db33c4a1fa814",
-                "uncompressed-sha256": "6bf9809de1861c95ca19eb062d83088fbd512a4d9d509b590f24555a035f8c7c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "006b3c69cec1ab375030d3bd3c0fb37434700f0e0d64f1a1cc51cdc364928dd0",
+                "uncompressed-sha256": "bc4be5c4bdfe7d76cceb814d45d2e5dd9760e82a228f3b9b31dff2590feb0d05"
               }
             }
           }
         },
         "powervs": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-powervs.ppc64le.ova.gz",
-                "sha256": "cba69ca150e9bf00de80b5fa5783faf438985825864e553f9ab0e06e3ae26388",
-                "uncompressed-sha256": "c784d765d55cb3ba4d0096658df0b7b7a499390a8d7ccce1e55cfddec8452184"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-powervs.ppc64le.ova.gz",
+                "sha256": "bf27430d27accaed37b70f64113d474fefa5b093ac296e453da63c3974385ddd",
+                "uncompressed-sha256": "44439c33b36ee85e3628c7dec51d2a3a07610c3dc720b49cd031f3fb2d0a637c"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/ppc64le/rhcos-418.94.202511191518-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "210c23aeee16d51fbabed76b3a914e4bedb51da44c10ac92413db82910c34bdf",
-                "uncompressed-sha256": "d4c549f7aa9000626d1d50a68a45691c021fd82ea3707d60e129d75f2188537d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "1ac096406d82673618e00a0a90ea28acd79553ef477eeb155942629f8f4f033c",
+                "uncompressed-sha256": "9658cacc9d34c4bba10f21e0b26729766d99e9d9432957735be3283af914f851"
               }
             }
           }
@@ -351,64 +351,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "418.94.202511191518-0",
-              "object": "rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz",
+              "release": "418.94.202602022246-0",
+              "object": "rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202511191518-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-418-94-202602022246-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -417,88 +417,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "b2d693be21f2eb00cced5f92a50f19622b2f92edb0eb4387ab849d06c189fab8",
-                "uncompressed-sha256": "7f3ef4c34050c54a175a1bb3aa6001335118df0ddd68efcc49cf948e7a7bd9ba"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "7fe2787843f1bf1aafe1fd53fc2e1e17d0f1cb0e9c4012645da0b643d06225b4",
+                "uncompressed-sha256": "5201f5cf8c568da0615d0e25499cfc9ed9a0cf6c2421f83a21f4dc497b6aabbd"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-metal4k.s390x.raw.gz",
-                "sha256": "387602fc0f1abff8d0cfefe60633f8d712747bbba08936c96b80e27d262668da",
-                "uncompressed-sha256": "77f3a546f5803c0d7521ea6ee005c4a0279aa9d281304ba0ffc8da6067ab756b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-metal4k.s390x.raw.gz",
+                "sha256": "994b8e140915fa90ed8a53774138afa811295373f80370239df218cc470c00e0",
+                "uncompressed-sha256": "b0a3bb0ac6ef395aa42ea5e97c05cc7ad72540b8ee4b4f637240712e4dc190f3"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live.s390x.iso",
-                "sha256": "d083b5d11f1c586d0e7d1c337cdbf7f23faa81de8779894942e7011b8097e1c2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-live.s390x.iso",
+                "sha256": "0b11b9e3522c240e1ba68c3560bca0f6559e9644f81c3da9212a124d32798065"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-kernel-s390x",
-                "sha256": "066e80b6d855e36885e9bb2123866f87e5b8d95d2e8e6e1f171b22352cd26483"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-live-kernel-s390x",
+                "sha256": "6b52d0c66ccad23a93c4653f4752da5ff3ef783197aa1972dc0fcd76ad652aae"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-initramfs.s390x.img",
-                "sha256": "63ce373f3473a765557800e89d32375a9de9e29509b08699d172b84e41631227"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-live-initramfs.s390x.img",
+                "sha256": "cb84aba7255b17bc56d43848ef803da599c42af60b1c977450c340254f307adf"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-live-rootfs.s390x.img",
-                "sha256": "04f56945dda729baaf71186a517c89795488cc0ddd5847a72a18b9eb9a9086ec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-live-rootfs.s390x.img",
+                "sha256": "eb2d1f283c99b1fa779d9c224e51605593b91bb0f51b497913360f8927597507"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-metal.s390x.raw.gz",
-                "sha256": "0d1409487ae82ac8bafb94c7af9f6c9820d1518b2fa9c0a5c965a771ece1c192",
-                "uncompressed-sha256": "7156333fda980abe7dbf520e82456102be0c6bc4ea28b14d7b6531040434df67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-metal.s390x.raw.gz",
+                "sha256": "80c568e3bd11e1f5adfb97f0d87028dc38b3fe5d8840dea57152988891ded390",
+                "uncompressed-sha256": "1976293e63f5b615e480f3d2d9ad97b7434748d783ab6cddb752fe91148657d2"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-openstack.s390x.qcow2.gz",
-                "sha256": "7d9bfda46a0976a749a03b03a11ec3a1a249511326a831d444adb93627b271e7",
-                "uncompressed-sha256": "f2c3961a0d63b44a5533ce102347d8378a6271ce061fd5a26c6ea665eceb7f8a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-openstack.s390x.qcow2.gz",
+                "sha256": "76be9e2d0a0691999195c57079d2041dfe67b6ff340202015c9734aeb340c223",
+                "uncompressed-sha256": "b9d7ba0bd42dcfb01c9b535785491d6a88798f8cd6aae2c37416821ff333a013"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-qemu.s390x.qcow2.gz",
-                "sha256": "ff22f43801eaf13afa6e400d7260c2301e79014413ecfc9b9dd4806c41b2877c",
-                "uncompressed-sha256": "561dfab8b233afc00c51fd1e30c8a1c76b8dc83c52a48e26e49cd95b0a31ca3e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-qemu.s390x.qcow2.gz",
+                "sha256": "afa3cb6db65d5b161acc5247cc540fe6a4767b936b97cd6317fc90b7e1ec8c01",
+                "uncompressed-sha256": "7e5420b0c5d3064a4f60ec795607cb164c5d5d3e6d4ae18a27a5211aa89142f9"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/s390x/rhcos-418.94.202511191518-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "4ff50a935b8c437308143494ccb96c3118d70870522e17b67425cf3e08a4c39b",
-                "uncompressed-sha256": "54e58b1adcc43f7a502eb5a7c9986f06aa982ef530eb9b1994e37c9a15d407d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "4d7d542e401424a20aa6065212ccc1253ce8771b6dc080dc9b9bef4a3dce5f41",
+                "uncompressed-sha256": "64a3724e67f69e020ed44a57e158e0703ee071db2887672d7b83d76e5fbc752a"
               }
             }
           }
@@ -509,157 +509,157 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-aws.x86_64.vmdk.gz",
-                "sha256": "79ebc1076804eee170d7f67911cc6ce58241e72083796d91cd0b4d02170bd42e",
-                "uncompressed-sha256": "07ed924d79d74e3598141f22fdad406010752fde8c989fea5a4f43f3235d17a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-aws.x86_64.vmdk.gz",
+                "sha256": "24dc362bfd2f487bc2444c1c723a7f2b84a1895c5e4aedde1dac8d92597768ba",
+                "uncompressed-sha256": "f62addeebac02d5a9ba93bfbf074825203f7c0f9ca0f48320537a6711159e083"
               }
             }
           }
         },
         "azure": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-azure.x86_64.vhd.gz",
-                "sha256": "f6e4a9011232dd95e4326892234f57d565776b3b6d54abb6d92661bcbfecc25d",
-                "uncompressed-sha256": "4a4d29aa34cb0615de532183cb4268a9305003caa2c5f6174da2338c3b5ab00d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-azure.x86_64.vhd.gz",
+                "sha256": "a61a1f6a65391cc29796bd82101d92d79d3e1a20bae2ce35f74afd940d109843",
+                "uncompressed-sha256": "f46a7c65cac97046489a865337896dcc5a2975fca97c94ac613503f83a6a9f69"
               }
             }
           }
         },
         "azurestack": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-azurestack.x86_64.vhd.gz",
-                "sha256": "288ff8a207733d700a717d415e437c9586c7f2d02a6647e9a10ffd419004c2de",
-                "uncompressed-sha256": "0af0d1c8ae4423a8cbea9590b87289c01723aae5163713965e46f56b88ee655c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-azurestack.x86_64.vhd.gz",
+                "sha256": "5075b072f353a492a1f18dbfd0491a2cf8f8ce2a5790a06720e54ea10a13a26b",
+                "uncompressed-sha256": "80c757eb0e3730729cf7eb64ed4ae3e51b17026ae91d289827afa634fa226d40"
               }
             }
           }
         },
         "gcp": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-gcp.x86_64.tar.gz",
-                "sha256": "ca1b735547d6cecc82c8b41e214de8287cdc631fc872187fcb632f884f9e5115",
-                "uncompressed-sha256": "d183fe31d41d2e749b916eef326ad3165a73ae8ae11d23e66639b99f752466e9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-gcp.x86_64.tar.gz",
+                "sha256": "916f0cadb762cc03e7b68dab9b2b56e0626c59d3328b274b49607925c8d5b318",
+                "uncompressed-sha256": "c97df7c52a822a471319e98e9ae59084e57ec5782e1dd28206630d444caf1bb9"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "48b2991ec99acbb2779b6c63f5b894d880300b4f3c3888a97811345a2b47e348",
-                "uncompressed-sha256": "b9eebf52f33bd6e6a7e74aa1bbd35b75dc9cb4d59d2711fdaf73fca7c041a118"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "58d6f2c0ac812dd0290774fde1ee1114b6c652723535acda30193d9964f511d3",
+                "uncompressed-sha256": "fa498a81cfc7da9aba15c8bdb3a16330f33fe236940b1cd947aaef6e1f101711"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-kubevirt.x86_64.ociarchive",
-                "sha256": "de14586b007cd74ba79af3a059d4b061f4ceb6d1e9163ff34119c10a3d56b074"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-kubevirt.x86_64.ociarchive",
+                "sha256": "c3ce95c9454e1b30f712171be8308c1f45d2bd03b09985aa283b765f16354229"
               }
             }
           }
         },
         "metal": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-metal4k.x86_64.raw.gz",
-                "sha256": "c2253ac340ddcb9363bb43dc2ca8e28039ec94d3b1b2f3e706a571bdfcb25b52",
-                "uncompressed-sha256": "00be817a329cfbef0ccaf9635d7012ec6f9178930ca79086777a1a2d68ea4815"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-metal4k.x86_64.raw.gz",
+                "sha256": "8c9922521d75b50f02a70ebf6e917d49b957cd220266bf54de84440b1e966547",
+                "uncompressed-sha256": "2e2fbb1d1927827b4ad782dcc15725e305820a8c340cd131c2dff192e9ccd608"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live.x86_64.iso",
-                "sha256": "a9d26a2736479d26861b1610fa1061043bd964e2529b69d5c49fa99be8e82cb3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-live.x86_64.iso",
+                "sha256": "261eb3137e3bc874142083363b437976319975be3d076891d9634c9340fd3c0e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-kernel-x86_64",
-                "sha256": "de017a633c5e93806ab84169486f9ca7e130eac59c65193f3ce9d53a4aa22dec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-live-kernel-x86_64",
+                "sha256": "f3a7b2e3bdeb7d9ce4dcb3a40436ed6fdeb13a017f0e9182769d6eb3ec5dbd0e"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-initramfs.x86_64.img",
-                "sha256": "9ccbfc191ad3ce4875a9182d15f70926aee430cbe2b08c0a9c8e28c259d4c7ba"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-live-initramfs.x86_64.img",
+                "sha256": "8ef0975e86576f60f78d63c1c9e212ad21615e237c4420ec44616d45748cec32"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-live-rootfs.x86_64.img",
-                "sha256": "cbc027a70ff8774ea7e2be3d6e8f8ce96b0b22be93f89b440f70291d3ffaee19"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-live-rootfs.x86_64.img",
+                "sha256": "002071983073ddf2f6d9f0e7a382744ff64fdb9a01efbeedb4ce1f5ca4f37d47"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-metal.x86_64.raw.gz",
-                "sha256": "d0319cb89e2be92fe429bd1c2ada98975e42e4878b0418afd9e35b2a48fe1223",
-                "uncompressed-sha256": "5efe1858493814b13c7af47ca1fe89ec4b0530dc46fc50fb2ed80427aa1ef52e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-metal.x86_64.raw.gz",
+                "sha256": "d8b8bc3f7d308d9611c68ceef4ebe40e0c10d30fc1b521c27591265702db168b",
+                "uncompressed-sha256": "a137ba813aeec05bf253f51a9a9ab1e3ef70605f5da762e3eb88943a89a19aed"
               }
             }
           }
         },
         "nutanix": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-nutanix.x86_64.qcow2",
-                "sha256": "cbc87baf78f13374081c852e753746c73f75e6170f248ddabd26555da070c496"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-nutanix.x86_64.qcow2",
+                "sha256": "54cae81124e8d8ad714cb8f81b9c8961378fde508a0081d18a71be9b19408de4"
               }
             }
           }
         },
         "openstack": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-openstack.x86_64.qcow2.gz",
-                "sha256": "801cf80c248178e920eeaa3a50c2caa855e98c95ef1744bffce9804d59ee5d58",
-                "uncompressed-sha256": "1c6466f515aedaab4bd3c3ba04f0d3966fad1d71e8497789211447c981055740"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-openstack.x86_64.qcow2.gz",
+                "sha256": "49abecbc4b03e6816d5a064dc6b1655e59688c635e9e25bbf7edab340576ddf1",
+                "uncompressed-sha256": "27150af170e4e25a7c1984f5ef6776f8f52e66bc01c991c3bda7f6810cc5959e"
               }
             }
           }
         },
         "qemu": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-qemu.x86_64.qcow2.gz",
-                "sha256": "a674e7b1c39b2ce1ffcac8003574f13091658efe8bda9f854f9603cccd141dea",
-                "uncompressed-sha256": "45bb97ae4127f7868a0405d2ed9ba7a90f8ef324c726a3d276ec059ecf271979"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-qemu.x86_64.qcow2.gz",
+                "sha256": "0225879132719857069327e265f6c3452afb8212b8923c7f6346da9075d73e37",
+                "uncompressed-sha256": "65b21f8ff5899d7e3e8a677190520d2f27456004f0ce8e0196d2b1e7367c7243"
               }
             }
           }
         },
         "vmware": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202511191518-0/x86_64/rhcos-418.94.202511191518-0-vmware.x86_64.ova",
-                "sha256": "631654a19597e1640ef7a58228efe297a336cc1a0ee4741bb9ad69598771a53a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-vmware.x86_64.ova",
+                "sha256": "1b5ff2b0b50ff76cb81042abcd5746641fd577dac31f6e5d8671df8cc4c9db92"
               }
             }
           }
@@ -669,166 +669,166 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-02552a7435888e77f"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0b1e53b298bb89ca5"
             },
             "ap-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-00a52c01467e5009c"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0771989cb2c2b3682"
             },
             "ap-east-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-009dec07208df3d53"
+              "release": "418.94.202602022246-0",
+              "image": "ami-07d5ef88fa44001ca"
             },
             "ap-northeast-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0af1f1b5512f0cdf0"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0f636e5cf5bc8cf13"
             },
             "ap-northeast-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-060c9dba5cb61b7a5"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e0b9dcbd75795014"
             },
             "ap-northeast-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0f74b31c0467082e8"
+              "release": "418.94.202602022246-0",
+              "image": "ami-05d7fe5d037989b44"
             },
             "ap-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-00fb24e003ecad70c"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0bf578680989c0eed"
             },
             "ap-south-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-01aa65eac7f33c61f"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0d17f99c61ea2344f"
             },
             "ap-southeast-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0d72009d4118a5a1a"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e12c120ce402c52c"
             },
             "ap-southeast-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0730d4339571de61b"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0ce14ee99f96da4f9"
             },
             "ap-southeast-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-057c294ce57b7c018"
+              "release": "418.94.202602022246-0",
+              "image": "ami-09b7b0b30690e4e84"
             },
             "ap-southeast-4": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0e30e4ac62769daa3"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0b978bdd37efc3452"
             },
             "ap-southeast-5": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0216b19f36a1678ad"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08edd400f94985bc1"
             },
             "ap-southeast-6": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0d2de3e58cdd9ac49"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0a564f369a4097439"
             },
             "ap-southeast-7": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0c6772f15bf6335d0"
+              "release": "418.94.202602022246-0",
+              "image": "ami-03b1c3f8f188e425f"
             },
             "ca-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0809d3a0a5e0ea0dc"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0b6b3ba1e4a56e3e8"
             },
             "ca-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0c21f1e5823e2f8b0"
+              "release": "418.94.202602022246-0",
+              "image": "ami-096bfa39043262f2c"
             },
             "eu-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-03cff1786a40a302f"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0962695de0d1d9d62"
             },
             "eu-central-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0144f3082fe73dfd0"
+              "release": "418.94.202602022246-0",
+              "image": "ami-065feb463aab7159b"
             },
             "eu-north-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0a2d65e335322aaff"
+              "release": "418.94.202602022246-0",
+              "image": "ami-08598f7e6026af9ab"
             },
             "eu-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0684bc7d8d1c4b6d5"
+              "release": "418.94.202602022246-0",
+              "image": "ami-089edc581a56fd2f6"
             },
             "eu-south-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-00783b7145483d3bf"
+              "release": "418.94.202602022246-0",
+              "image": "ami-041c43b6161bd3dd4"
             },
             "eu-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-09f384c4bbb2970e7"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0ad051930fd091869"
             },
             "eu-west-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-06534328a9bcd4046"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0962c107a25a34211"
             },
             "eu-west-3": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0eff1a05bed6583a5"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0c3e9ffe96bf94642"
             },
             "il-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-011ff3703892cc3c3"
+              "release": "418.94.202602022246-0",
+              "image": "ami-022d211eee29d55b2"
             },
             "me-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-007607fc650d240f4"
+              "release": "418.94.202602022246-0",
+              "image": "ami-05d255de81ad24688"
             },
             "me-south-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0691ccb6db498e06d"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0e629ecf0e9cdade1"
             },
             "mx-central-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-06c5f210cc1441aea"
+              "release": "418.94.202602022246-0",
+              "image": "ami-01299cfec87dbd95f"
             },
             "sa-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-02145eba366a8a7e8"
+              "release": "418.94.202602022246-0",
+              "image": "ami-01746267bc490b2bc"
             },
             "us-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0ccb061ea4996e851"
+              "release": "418.94.202602022246-0",
+              "image": "ami-06ba758975c79332b"
             },
             "us-east-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0a611e6a24a551a2b"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0b9fcc2f8bed8771e"
             },
             "us-gov-east-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-0bbcbfdc4a2326f03"
+              "release": "418.94.202602022246-0",
+              "image": "ami-03c8d07be84ec8a21"
             },
             "us-gov-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-01a6878b9c2144dbd"
+              "release": "418.94.202602022246-0",
+              "image": "ami-00f64a223ccd3e189"
             },
             "us-west-1": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-067330529ffc1277e"
+              "release": "418.94.202602022246-0",
+              "image": "ami-05c00f3714a9a9f68"
             },
             "us-west-2": {
-              "release": "418.94.202511191518-0",
-              "image": "ami-077660cf51d514ed3"
+              "release": "418.94.202602022246-0",
+              "image": "ami-0901ab5ccceffa3ae"
             }
           }
         },
         "gcp": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-418-94-202511191518-0-gcp-x86-64"
+          "name": "rhcos-418-94-202602022246-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "418.94.202511191518-0",
+          "release": "418.94.202602022246-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.18-9.4-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cc4c27c1b5e1516361e513a39e2cdcd77d009240aba30155f70a16268a8b451e"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2576502838e6025b6aed388a39e72df9be49c84db8c082e49565bbf1b90bf9fa"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "418.94.202511191518-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202511191518-0-azure.x86_64.vhd"
+          "release": "418.94.202602022246-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-418.94.202602022246-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
The changes done here will update the RHCOS 4.18 bootimage metadata and address the following issues:

- OCPBUGS-65974: Cannot use auto-forward kargs (like ip=) with coreos-installer (iso|pxe) customize

This change was generated using:
```
plume cosa2stream \
    --target data/data/coreos/rhcos.json \
    --distro rhcos \
    --no-signatures \
    --name 4.18-9.4 \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams \
    x86_64=418.94.202602022246-0 \
    aarch64=418.94.202602022246-0 \
    s390x=418.94.202602022246-0 \
    ppc64le=418.94.202602022246-0
```