### PR TITLE
OTA-1861: data/bootstrap/files/usr/local/bin/bootkube: Pass CVO render --cluster-version-manifest-path

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -203,6 +203,7 @@ then
 		render \
 			--output-dir=/assets/cvo-bootstrap \
 			--release-image="${RELEASE_IMAGE_DIGEST}" \
+			--cluster-version-manifest-path=/assets/manifests/cvo-overrides.yaml \
 			--feature-gate-manifest-path=/assets/manifests/99_feature-gate.yaml
 
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/


### PR DESCRIPTION
Like 9bbe172d4f (#8813), but for the ClusterVersion manifest [laid down by `pkg/asset/ignition/bootstrap/cvoignore.go`][0].  To populate the new flag provided by openshift/cluster-version-operator#1315.

[0]: https://github.com/openshift/installer/blob/69f3d1db71131332934012e4f9e9cfd64c4d4d8c/pkg/asset/ignition/bootstrap/cvoignore.go#L23