### PR TITLE
OCPBUGS-75250: Use correct Project ID with GCP Shared VPC

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/ignition.go
+++ b/pkg/infrastructure/gcp/clusterapi/ignition.go
@@ -48,12 +48,11 @@ func editIgnition(ctx context.Context, in clusterapi.IgnitionInput) (*clusterapi
 	}
 
 	project := in.InstallConfig.Config.GCP.ProjectID
-	if in.InstallConfig.Config.GCP.NetworkProjectID != "" {
-		project = in.InstallConfig.Config.GCP.NetworkProjectID
-	}
 
 	apiIntIPAddress := *gcpCluster.Status.Network.APIInternalAddress
 	addressIntCut := apiIntIPAddress[strings.LastIndex(apiIntIPAddress, "/")+1:]
+	// The LoadBalancer's IP address which is part of the frontend configuration, would be located in
+	// the service project even in the case of Shared VPC (XPN) installs.
 	computeIntAddressObj, err := svc.Addresses.Get(project, in.InstallConfig.Config.GCP.Region, addressIntCut).Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get compute address: %w", err)


### PR DESCRIPTION
Problem: When userProvisionedDNS is enabled on GCP, the Installer tries to get the Load balancer IP address from the correct project. This LB IP is then used to update the bootstrap ignition file. When Shared VPC (XPN) was configured, Installer was trying to get the LB IP addresses from the Network Project ID and failing to get the LB IPs. 
Solution: This LB IP is a front end configuration that should be read from the service project that is available in projectID.