### PR TITLE
Bug 10108: Copy LoadBalancer config to AgentClusterInstall for BareMetal platform

### DIFF
--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -308,6 +308,13 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.BareMetal.IngressVIPs
 			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.BareMetal.APIVIPs[0]
 			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.BareMetal.IngressVIPs[0]
+
+			// Copy LoadBalancer configuration to allow UserManaged load balancer with same API/Ingress VIPs
+			if installConfig.Config.Platform.BareMetal.LoadBalancer != nil {
+				agentClusterInstall.Spec.LoadBalancer = &hiveext.LoadBalancer{
+					Type: convertLoadBalancerType(installConfig.Config.Platform.BareMetal.LoadBalancer.Type),
+				}
+			}
 		} else if installConfig.Config.Platform.VSphere != nil {
 			vspherePlatform := vsphere.Platform{}
 			if len(installConfig.Config.Platform.VSphere.APIVIPs) > 1 {
@@ -653,4 +660,17 @@ func (a *AgentClusterInstall) validateDiskEncryption() field.ErrorList {
 		}
 	}
 	return allErrs
+}
+
+// convertLoadBalancerType converts the configv1 PlatformLoadBalancerType to hiveext LoadBalancerType.
+func convertLoadBalancerType(lbType configv1.PlatformLoadBalancerType) hiveext.LoadBalancerType {
+	switch lbType {
+	case configv1.LoadBalancerTypeUserManaged:
+		return hiveext.LoadBalancerTypeUserManaged
+	case configv1.LoadBalancerTypeOpenShiftManagedDefault:
+		return hiveext.LoadBalancerTypeClusterManaged
+	default:
+		// Default to ClusterManaged if type is empty or unknown
+		return hiveext.LoadBalancerTypeClusterManaged
+	}
 }

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -156,6 +156,12 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodArbiterACI.Spec.ProvisionRequirements.ArbiterAgents = 1
 	goodArbiterACI.Spec.ProvisionRequirements.WorkerAgents = 0
 
+	installConfigWithUserManagedLB := getValidOptionalInstallConfigWithUserManagedLB()
+	goodUserManagedLBACI := getGoodACI()
+	goodUserManagedLBACI.Spec.LoadBalancer = &hiveext.LoadBalancer{
+		Type: hiveext.LoadBalancerTypeUserManaged,
+	}
+
 	cases := []struct {
 		name           string
 		dependencies   []asset.Asset
@@ -321,6 +327,16 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodArbiterACI,
+		},
+		{
+			name: "valid configuration with UserManaged LoadBalancer",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				installConfigWithUserManagedLB,
+				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
+			},
+			expectedConfig: goodUserManagedLBACI,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -601,6 +602,15 @@ func getInValidAgentHostsConfig() *agentconfig.AgentHosts {
 			},
 		},
 	}
+}
+
+// getValidOptionalInstallConfigWithUserManagedLB returns a valid optional install config with UserManaged load balancer.
+func getValidOptionalInstallConfigWithUserManagedLB() *agent.OptionalInstallConfig {
+	installConfig := getValidOptionalInstallConfig()
+	installConfig.Config.Platform.BareMetal.LoadBalancer = &configv1.BareMetalPlatformLoadBalancer{
+		Type: configv1.LoadBalancerTypeUserManaged,
+	}
+	return installConfig
 }
 
 func getGoodACIDualStack() *hiveext.AgentClusterInstall {


### PR DESCRIPTION
## Summary
  This PR fixes issue #10108 where the `loadBalancer` configuration from `install-config.yaml` was
  not being copied to the `AgentClusterInstall` manifest during agent ISO creation.

  When deploying an OpenShift cluster with `platform: baremetal` and `loadBalancer: type:
  UserManaged`, users should be able to use the same VIP address for both API and Ingress. The
  installer correctly validates this configuration and generates the ISO, but the `assisted-service`
  running on the booted node fails validation because it checks the `AgentClusterInstall` manifest
  for the `loadBalancer` configuration which was missing.

  ## Changes
  - Copy `LoadBalancer` configuration from `install-config.yaml` to
  `AgentClusterInstall.Spec.LoadBalancer` for BareMetal platform
  - Add `convertLoadBalancerType()` helper function to convert between
  `configv1.PlatformLoadBalancerType` and `hiveext.LoadBalancerType`
  - Add unit test for UserManaged LoadBalancer configuration

  ## Testing
  - All existing tests pass
  - Added new test case: "valid configuration with UserManaged LoadBalancer"
  - Manually verified: Generated `agent-cluster-install.yaml` now includes `loadBalancer: type:
  UserManaged`

  Fixes: #10108