### PR TITLE
CORS-4091: Add GCP Install config dual stack selection

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6802,6 +6802,19 @@ spec:
                     - Managed
                     - Unmanaged
                     type: string
+                  ipFamily:
+                    default: IPv4
+                    description: |-
+                      IPFamily specifies the IP address family for the cluster network.
+                      Use "IPv4" for IPv4-only networking, "DualStackIPv4Primary" for dual-stack networking
+                      with IPv4 as the primary address family, or "DualStackIPv6Primary" for dual-stack
+                      networking with IPv6 as the primary address family. When using dual-stack, the VPC
+                      and subnets must be configured with both IPv4 and IPv6 CIDR blocks.
+                    enum:
+                    - IPv4
+                    - DualStackIPv4Primary
+                    - DualStackIPv6Primary
+                    type: string
                   network:
                     description: |-
                       Network specifies an existing VPC where the cluster should be created

--- a/pkg/types/gcp/defaults/platform.go
+++ b/pkg/types/gcp/defaults/platform.go
@@ -1,11 +1,18 @@
 package defaults
 
-import "github.com/openshift/installer/pkg/types/gcp"
+import (
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/network"
+)
 
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *gcp.Platform) {
 	if p == nil {
 		return
+	}
+
+	if p.IPFamily == "" {
+		p.IPFamily = network.IPv4
 	}
 
 	if gcpDmp := p.DefaultMachinePlatform; gcpDmp != nil {

--- a/pkg/types/gcp/defaults/platform_test.go
+++ b/pkg/types/gcp/defaults/platform_test.go
@@ -1,0 +1,55 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/network"
+)
+
+func TestSetPlatformDefaults(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform *gcp.Platform
+		expected *gcp.Platform
+	}{
+		{
+			name:     "empty platform should default IPFamily to IPv4",
+			platform: &gcp.Platform{},
+			expected: &gcp.Platform{
+				IPFamily: network.IPv4,
+			},
+		},
+		{
+			name: "IPFamily already set should not be overridden",
+			platform: &gcp.Platform{
+				IPFamily: network.DualStackIPv4Primary,
+			},
+			expected: &gcp.Platform{
+				IPFamily: network.DualStackIPv4Primary,
+			},
+		},
+		{
+			name: "DualStackIPv6Primary should not be overridden",
+			platform: &gcp.Platform{
+				IPFamily: network.DualStackIPv6Primary,
+			},
+			expected: &gcp.Platform{
+				IPFamily: network.DualStackIPv6Primary,
+			},
+		},
+		{
+			name:     "nil platform should not panic",
+			platform: nil,
+			expected: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetPlatformDefaults(tc.platform)
+			assert.Equal(t, tc.expected, tc.platform)
+		})
+	}
+}

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/openshift/installer/pkg/types/dns"
+	"github.com/openshift/installer/pkg/types/network"
 )
 
 // FirewallRulesManagementPolicy defines the management policy for firewall rules in the cluster.
@@ -130,6 +131,18 @@ type Platform struct {
 	// and the firewall rules before the installation.
 	// +optional
 	FirewallRulesManagement FirewallRulesManagementPolicy `json:"firewallRulesManagement,omitempty"`
+
+	// IPFamily specifies the IP address family for the cluster network.
+	// Use "IPv4" for IPv4-only networking, "DualStackIPv4Primary" for dual-stack networking
+	// with IPv4 as the primary address family, or "DualStackIPv6Primary" for dual-stack
+	// networking with IPv6 as the primary address family. When using dual-stack, the VPC
+	// and subnets must be configured with both IPv4 and IPv6 CIDR blocks.
+	//
+	// +kubebuilder:default:="IPv4"
+	// +default="IPv4"
+	// +kubebuilder:validation:Enum="IPv4";"DualStackIPv4Primary";"DualStackIPv6Primary"
+	// +optional
+	IPFamily network.IPFamily `json:"ipFamily,omitempty"`
 }
 
 // UserLabel is a label to apply to GCP resources created for the cluster.

--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -1,6 +1,9 @@
 package validation
 
 import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/featuregates"
 )
@@ -8,5 +11,13 @@ import (
 // GatedFeatures determines all of the install config fields that should
 // be validated to ensure that the proper featuregate is enabled when the field is used.
 func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
-	return []featuregates.GatedInstallConfigFeature{}
+	gcp := c.GCP
+
+	return []featuregates.GatedInstallConfigFeature{
+		{
+			FeatureGateName: features.FeatureGateGCPDualStackInstall,
+			Condition:       gcp.IPFamily.DualStackEnabled(),
+			Field:           field.NewPath("platform", "gcp", "ipFamily"),
+		},
+	}
 }

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/network"
 )
 
 var (
@@ -145,6 +146,8 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path, ic *types.InstallCon
 		}
 	}
 
+	allErrs = append(allErrs, validateIPFamily(p.IPFamily, fldPath.Child("ipFamily"))...)
+
 	if p.FirewallRulesManagement != "" {
 		supportedFirewallRulePolicies := sets.New(gcp.ManagedFirewallRules, gcp.UnmanagedFirewallRules)
 		if !supportedFirewallRulePolicies.Has(p.FirewallRulesManagement) {
@@ -193,4 +196,23 @@ func validateLabel(key, value string) error {
 		return fmt.Errorf("label key contains restricted prefix. Label key cannot have `kubernetes-io`, `openshift-io` prefixes")
 	}
 	return nil
+}
+
+func validateIPFamily(ipFamily network.IPFamily, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ipFamily == "" {
+		return allErrs
+	}
+	validFamilies := []string{
+		string(network.IPv4),
+		string(network.DualStackIPv4Primary),
+		string(network.DualStackIPv6Primary),
+	}
+	switch ipFamily {
+	case network.IPv4, network.DualStackIPv4Primary, network.DualStackIPv6Primary:
+		// valid
+	default:
+		allErrs = append(allErrs, field.NotSupported(fldPath, ipFamily, validFamilies))
+	}
+	return allErrs
 }

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/network"
 )
 
 func TestValidatePlatform(t *testing.T) {
@@ -239,6 +240,46 @@ func TestValidatePlatform(t *testing.T) {
 				FirewallRulesManagement: "random-test",
 				Region:                  "us-east1",
 				ProjectID:               "valid-project",
+			},
+			valid: false,
+		},
+		{
+			name: "valid ipFamily IPv4",
+			platform: &gcp.Platform{
+				Region:   "us-east1",
+				IPFamily: network.IPv4,
+			},
+			valid: true,
+		},
+		{
+			name: "valid ipFamily DualStackIPv4Primary",
+			platform: &gcp.Platform{
+				Region:   "us-east1",
+				IPFamily: network.DualStackIPv4Primary,
+			},
+			valid: true,
+		},
+		{
+			name: "valid ipFamily DualStackIPv6Primary",
+			platform: &gcp.Platform{
+				Region:   "us-east1",
+				IPFamily: network.DualStackIPv6Primary,
+			},
+			valid: true,
+		},
+		{
+			name: "valid ipFamily empty (defaults to IPv4)",
+			platform: &gcp.Platform{
+				Region:   "us-east1",
+				IPFamily: "",
+			},
+			valid: true,
+		},
+		{
+			name: "invalid ipFamily",
+			platform: &gcp.Platform{
+				Region:   "us-east1",
+				IPFamily: "InvalidValue",
 			},
 			valid: false,
 		},

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -370,6 +370,8 @@ func ipnetworksToStrings(networks []ipnet.IPNet) []string {
 
 // validateNetworkingIPVersion checks parameters for consistency when the user
 // requests single-stack IPv6 or dual-stack modes.
+//
+//nolint:gocyclo
 func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 	var allErrs field.ErrorList
 
@@ -420,6 +422,14 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 				break
 			}
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "DualStack", fmt.Sprintf("dual-stack IPv4/IPv6 can only be specified when platform.aws.ipFamily is %s or %s", network.DualStackIPv4Primary, network.DualStackIPv6Primary)))
+		case p.GCP != nil:
+			if ipFamily := p.GCP.IPFamily; ipFamily.DualStackEnabled() {
+				if ipFamily == network.DualStackIPv6Primary {
+					allowV6Primary = true
+				}
+				break
+			}
+			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "DualStack", fmt.Sprintf("dual-stack IPv4/IPv6 can only be specified when platform.gcp.ipFamily is %s or %s", network.DualStackIPv4Primary, network.DualStackIPv6Primary)))
 		default:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "DualStack", "dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address"))
 		}
@@ -451,6 +461,8 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 		case p.Nutanix != nil:
 		case p.None != nil:
 		case p.External != nil:
+		case p.GCP != nil && p.GCP.IPFamily.DualStackEnabled():
+			allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "serviceNetwork"), strings.Join(ipnetworksToStrings(n.ServiceNetwork), ", "), "when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type"))
 		case p.AWS != nil:
 			// If dual-stack is enabled, there must be both IPv4 and IPv6 service CIDRs
 			if p.AWS.IPFamily.DualStackEnabled() {
@@ -466,6 +478,8 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 
 	case hasIPv4:
 		switch {
+		case p.GCP != nil && p.GCP.IPFamily.DualStackEnabled():
+			allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "serviceNetwork"), strings.Join(ipnetworksToStrings(n.ServiceNetwork), ", "), "when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type"))
 		case p.AWS != nil:
 			// If dual-stack is enabled, there must be both IPv4 and IPv6 service CIDRs
 			if p.AWS.IPFamily.DualStackEnabled() {
@@ -502,6 +516,16 @@ func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, n
 	switch {
 	case p.AWS != nil:
 		ipFamily := p.AWS.IPFamily
+
+		if ipFamily == network.DualStackIPv4Primary && ipAddressType.Primary == corev1.IPv6Protocol {
+			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "DualStackIPv4Primary requires an IPv4 network first in this list"))
+		}
+
+		if ipFamily == network.DualStackIPv6Primary && ipAddressType.Primary == corev1.IPv4Protocol {
+			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "DualStackIPv6Primary requires an IPv6 network first in this list"))
+		}
+	case p.GCP != nil:
+		ipFamily := p.GCP.IPFamily
 
 		if ipFamily == network.DualStackIPv4Primary && ipAddressType.Primary == corev1.IPv6Protocol {
 			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "DualStackIPv4Primary requires an IPv4 network first in this list"))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1791,7 +1791,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid dual-stack configuration, bad platform",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.Platform = types.Platform{IBMCloud: validIBMCloudPlatform()}
 				c.Networking = validDualStackNetworkingConfig()
 				return c
 			}(),
@@ -1822,7 +1822,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid dual-stack configuration, IPv6-primary",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Platform = types.Platform{GCP: &gcp.Platform{}}
+				c.Platform = types.Platform{IBMCloud: validIBMCloudPlatform()}
 				c.Networking = validDualStackNetworkingConfig()
 				c.Networking.ServiceNetwork = []ipnet.IPNet{
 					c.Networking.ServiceNetwork[1],
@@ -1830,7 +1830,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `Invalid value: "ffd1::/112, 172.30.0.0/16": IPv4 addresses must be listed before IPv6 addresses`,
+			expectedError: `Invalid value: "DualStack": dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address`,
 		},
 		{
 			name: "valid dual-stack configuration with mixed-order clusterNetworks",
@@ -2036,6 +2036,108 @@ func TestValidateInstallConfig(t *testing.T) {
 				t.Setenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK", "true")
 				return func() {}
 			},
+		},
+		{
+			name: "gcp: valid dual-stack with DualStackIPv4Primary",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv4Primary
+				c.Networking = validDualStackNetworkingConfig()
+				return c
+			}(),
+		},
+		{
+			name: "gcp: valid dual-stack with DualStackIPv6Primary",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv6Primary
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				return c
+			}(),
+		},
+		{
+			name: "gcp: dual-stack requires GCPDualStackInstall feature gate",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.Platform.GCP.IPFamily = network.DualStackIPv4Primary
+				c.Networking = validDualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `platform\.gcp\.ipFamily: Forbidden: this field is protected by the GCPDualStackInstall feature gate`,
+		},
+		{
+			name: "gcp: invalid dual-stack without ipFamily set",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.Networking = validDualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `networking: Invalid value: "DualStack": dual-stack IPv4/IPv6 can only be specified when platform.gcp.ipFamily is DualStackIPv4Primary or DualStackIPv6Primary`,
+		},
+		{
+			name: "gcp: invalid dual-stack with DualStackIPv4Primary but IPv6-primary networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv4Primary
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `^\Q[networking.clusterNetwork: Invalid value: "ffd2::/48, 192.168.1.0/24": DualStackIPv4Primary requires an IPv4 network first in this list, networking.machineNetwork: Invalid value: "ffd0::/48, 10.0.0.0/16": DualStackIPv4Primary requires an IPv4 network first in this list, networking.serviceNetwork: Invalid value: "ffd1::/112, 172.30.0.0/16": DualStackIPv4Primary requires an IPv4 network first in this list]\E$`,
+		},
+		{
+			name: "gcp: invalid dual-stack with DualStackIPv6Primary but IPv4-primary networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv6Primary
+				c.Networking = validDualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `^\Q[networking.clusterNetwork: Invalid value: "192.168.1.0/24, ffd2::/48": DualStackIPv6Primary requires an IPv6 network first in this list, networking.machineNetwork: Invalid value: "10.0.0.0/16, ffd0::/48": DualStackIPv6Primary requires an IPv6 network first in this list, networking.serviceNetwork: Invalid value: "172.30.0.0/16, ffd1::/112": DualStackIPv6Primary requires an IPv6 network first in this list]\E$`,
+		},
+		{
+			name: "gcp: invalid dual-stack with DualStackIPv4Primary but only IPv4 serviceNetwork",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv4Primary
+				c.Networking = validDualStackNetworkingConfig()
+				// Remove IPv6 service network, leaving only IPv4
+				c.Networking.ServiceNetwork = c.Networking.ServiceNetwork[:1]
+				return c
+			}(),
+			expectedError: `networking.serviceNetwork: Invalid value: "172.30.0.0/16": when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type`,
+		},
+		{
+			name: "gcp: invalid dual-stack with DualStackIPv6Primary but only IPv6 serviceNetwork",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"GCPDualStackInstall=true"}
+				c.Platform.GCP.IPFamily = network.DualStackIPv6Primary
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				// Remove IPv4 service network, leaving only IPv6
+				c.Networking.ServiceNetwork = c.Networking.ServiceNetwork[:1]
+				return c
+			}(),
+			expectedError: `networking.serviceNetwork: Invalid value: "ffd1::/112": when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type`,
 		},
 		{
 			name: "invalid IPv6 hostprefix",


### PR DESCRIPTION
Add the IPFamily field to the GCP platform configuration, mirroring
the existing AWS implementation. This enables users to configure
dual-stack (IPv4/IPv6) networking for GCP clusters by setting
ipFamily to DualStackIPv4Primary or DualStackIPv6Primary.

Includes platform defaults, validation, and cross-platform networking
validation in installconfig.go to allow dual-stack CIDRs when the
GCP ipFamily is set appropriately.