### PR TITLE
CORS-3895: Add IPv6 backend pools and load balancing rules for dual-stack

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -558,6 +558,18 @@ func validateSubnet(client API, fieldPath *field.Path, subnet *aznetwork.Subnet,
 	return allErrs
 }
 
+func subnetHasIPv6Prefix(subnet *aznetwork.Subnet) bool {
+	if subnet == nil || subnet.SubnetPropertiesFormat == nil || subnet.AddressPrefixes == nil {
+		return false
+	}
+	for _, prefix := range *subnet.AddressPrefixes {
+		if strings.Contains(prefix, ":") {
+			return true
+		}
+	}
+	return false
+}
+
 func validateMachineNetworksContainIP(fldPath *field.Path, networks []types.MachineNetworkEntry, subnetName string, ip net.IP) field.ErrorList {
 	for _, network := range networks {
 		if network.CIDR.Contains(ip) {
@@ -1096,6 +1108,10 @@ func validateCustomSubnets(client API, fldPath *field.Path, ic *types.InstallCon
 		} else {
 			allErrs = append(allErrs, validateSubnet(client, fldPath.Child("subnets"), value, subnet.Name, ic.MachineNetwork)...)
 			allErrs = append(allErrs, validateSubnetNatGateway(client, fldPath, value, ic.Azure.OutboundType, subnet.Role, networkResourceGroupName, virtualNetwork)...)
+			if ic.Azure.IPFamily.DualStackEnabled() && !subnetHasIPv6Prefix(value) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("subnets"), subnet.Name,
+					"subnet does not have an IPv6 address prefix, which is required when ipFamily is dual-stack"))
+			}
 		}
 	}
 	if ic.Azure.OutboundType == aztypes.NATGatewayMultiZoneOutboundType {

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/network"
 )
 
 type editFunctions []func(ic *types.InstallConfig)
@@ -223,6 +224,28 @@ var (
 			AddressPrefix: &validControlPlaneSubnetCIDR,
 		},
 	}
+
+	dualStackVirtualNetworkAPIResult = &aznetwork.VirtualNetwork{
+		Name: &validVirtualNetwork,
+		VirtualNetworkPropertiesFormat: &aznetwork.VirtualNetworkPropertiesFormat{
+			Subnets: &[]aznetwork.Subnet{{
+				Name: &validComputeSubnet,
+				SubnetPropertiesFormat: &aznetwork.SubnetPropertiesFormat{
+					AddressPrefixes: &[]string{"10.0.0.0/24", "fd00::/64"},
+				},
+			}, {
+				Name: &validControlPlaneSubnet,
+				SubnetPropertiesFormat: &aznetwork.SubnetPropertiesFormat{
+					AddressPrefixes: &[]string{"10.0.1.0/24", "fd00:1::/64"},
+				},
+			}},
+		},
+	}
+
+	enableDualStack = func(ic *types.InstallConfig) {
+		ic.Azure.IPFamily = network.DualStackIPv4Primary
+	}
+
 	locationsAPIResult = func() *[]azsubs.Location {
 		r := []azsubs.Location{}
 		for i := 0; i < len(validRegionsList); i++ {
@@ -586,6 +609,11 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			errorMsg: `platform.azure.subnetSpec.subnets: Invalid value: "invalid-compute-subnet": subnet does not exist in the vnet, platform.azure.subnetSpec.subnets: Invalid value: "invalid-controlplane-subnet": subnet does not exist in the vnet`,
 		},
 		{
+			name:     "Dual-stack with IPv4-only subnets",
+			edits:    editFunctions{enableDualStack},
+			errorMsg: "subnet does not have an IPv6 address prefix, which is required when ipFamily is dual-stack",
+		},
+		{
 			name:     "Valid instance types",
 			edits:    editFunctions{validInstanceTypes},
 			errorMsg: "",
@@ -793,6 +821,37 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateDualStackSubnets(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	azureClient := mock.NewMockAPI(mockCtrl)
+
+	for _, value := range instanceTypeSku {
+		azureClient.EXPECT().GetVirtualMachineSku(gomock.Any(), to.String(value.Name), gomock.Any()).Return(value, nil).AnyTimes()
+	}
+	azureClient.EXPECT().GetVirtualMachineSku(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	for key, value := range vmCapabilities {
+		azureClient.EXPECT().GetVMCapabilities(gomock.Any(), key, validRegion).Return(value, nil).AnyTimes()
+	}
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), gomock.Any()).Return(vmCapabilities["Standard_D8s_v3"], nil).AnyTimes()
+	azureClient.EXPECT().GetVirtualNetwork(gomock.Any(), validNetworkResourceGroup, validVirtualNetwork).Return(dualStackVirtualNetworkAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().GetVirtualNetwork(gomock.Any(), gomock.Any(), gomock.Not(validVirtualNetwork)).Return(&aznetwork.VirtualNetwork{}, fmt.Errorf("invalid virtual network")).AnyTimes()
+	azureClient.EXPECT().ListLocations(gomock.Any()).Return(locationsAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().GetResourcesProvider(gomock.Any(), validResourceGroupNamespace).Return(resourcesProviderAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().GetDiskSkus(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	azureClient.EXPECT().GetAvailabilityZones(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"1", "2", "3"}, nil).AnyTimes()
+	azureClient.EXPECT().GetVirtualMachineFamily(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	ic := validInstallConfig()
+	ic.Azure.IPFamily = network.DualStackIPv4Primary
+
+	metadata := NewMetadata(ic.Azure, ic.ControlPlane, ic.WorkerMachinePool())
+	metadata.UseMockClient(azureClient)
+	err := Validate(azureClient, metadata, ic)
+	assert.NoError(t, err)
 }
 
 var validGroupResult = &azres.Group{

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -442,7 +442,9 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	}
 	logrus.Debugf("updated internal load balancer: %s", *intLoadBalancer.ID)
 
+	// Collect backend pools from internal load balancer - control plane VMs need to be in these pools
 	var lbBaps []*armnetwork.BackendAddressPool
+	lbBaps = append(lbBaps, intLoadBalancer.Properties.BackendAddressPools...)
 	var extLBFQDN string
 	if in.InstallConfig.Config.PublicAPI() {
 		var publicIPv6 *armnetwork.PublicIPAddress
@@ -492,7 +494,8 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 		}
 
 		logrus.Debugf("updated external load balancer: %s", *loadBalancer.ID)
-		lbBaps = loadBalancer.Properties.BackendAddressPools
+		// Append external load balancer backend pools to the list (internal pools already added)
+		lbBaps = append(lbBaps, loadBalancer.Properties.BackendAddressPools...)
 		extLBFQDN = *publicIP.Properties.DNSSettings.Fqdn
 		p.publicLBIP = *publicIP.Properties.IPAddress
 		if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
@@ -526,6 +529,20 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	p.NetworkClientFactory = networkClientFactory
 	p.lbBackendAddressPools = lbBaps
 
+	// Add IPv6 frontend and load balancing rule for internal LB in dual-stack mode.
+	// The frontend must be added first so addIPv6InternalLBRule can reference it.
+	if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
+		lbInput.loadBalancerName = fmt.Sprintf("%s-internal", in.InfraID)
+		if err := addIPv6InternalLBFrontend(ctx, lbInput); err != nil {
+			return fmt.Errorf("failed to add IPv6 frontend to internal load balancer: %w", err)
+		}
+		logrus.Debugf("added IPv6 frontend to internal load balancer")
+
+		if err := addIPv6InternalLBRule(ctx, in, networkClientFactory, resourceGroupName); err != nil {
+			return fmt.Errorf("failed to add IPv6 internal LB rule: %w", err)
+		}
+	}
+
 	if in.InstallConfig.Config.Azure.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
 		if err := createDNSEntries(ctx, in, extLBFQDN, p.publicLBIP, resourceGroupName, p.clientOptions); err != nil {
 			return fmt.Errorf("error creating DNS records: %w", err)
@@ -543,24 +560,6 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 		return fmt.Errorf("error retrieving Azure session: %w", err)
 	}
 	subscriptionID := ssn.Credentials.SubscriptionID
-
-	// Add IPv6 frontend IP to internal LB after CAPZ finishes machine reconciliation.
-	if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
-		lbClient := p.NetworkClientFactory.NewLoadBalancersClient()
-		lbInput := &lbInput{
-			loadBalancerName: fmt.Sprintf("%s-internal", in.InfraID),
-			infraID:          in.InfraID,
-			region:           in.InstallConfig.Config.Azure.Region,
-			resourceGroup:    p.ResourceGroupName,
-			subscriptionID:   subscriptionID,
-			lbClient:         lbClient,
-			tags:             p.Tags,
-		}
-		if err := addIPv6InternalLBFrontend(ctx, lbInput); err != nil {
-			return fmt.Errorf("failed to add IPv6 frontend to internal load balancer: %w", err)
-		}
-		logrus.Debugf("added IPv6 frontend to internal load balancer")
-	}
 
 	if in.InstallConfig.Config.PublicAPI() {
 		vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, ssn.TokenCreds, p.computeClientOptions)
@@ -968,4 +967,131 @@ func getMachinePoolSecurityType(installConfig *types.InstallConfig) string {
 		return confidentialVMST
 	}
 	return ""
+}
+
+// addIPv6InternalLBRule adds an IPv6 load balancing rule for port 6443 on the internal load balancer.
+// CAPZ only creates a single LBRuleHTTPS that uses the first (IPv4) frontend IP.
+// For dual-stack, we need an additional rule for the IPv6 frontend IP.
+func addIPv6InternalLBRule(ctx context.Context, in clusterapi.InfraReadyInput, networkClientFactory *armnetwork.ClientFactory, resourceGroup string) error {
+	lbClient := networkClientFactory.NewLoadBalancersClient()
+	internalLBName := fmt.Sprintf("%s-internal", in.InfraID)
+
+	lb, err := lbClient.Get(ctx, resourceGroup, internalLBName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get internal load balancer: %w", err)
+	}
+
+	if lb.Properties == nil {
+		return fmt.Errorf("internal load balancer has no properties")
+	}
+
+	// Check if the IPv6 rules already exist
+	for _, rule := range lb.Properties.LoadBalancingRules {
+		if rule.Name != nil && *rule.Name == "LBRuleHTTPS-v6" {
+			logrus.Infof("IPv6 load balancing rules already exist")
+			return nil
+		}
+	}
+
+	// Find the IPv6 frontend IP configuration
+	var ipv6FrontendID string
+	for _, frontend := range lb.Properties.FrontendIPConfigurations {
+		if frontend.Properties != nil &&
+			frontend.Properties.PrivateIPAddressVersion != nil &&
+			*frontend.Properties.PrivateIPAddressVersion == armnetwork.IPVersionIPv6 {
+			ipv6FrontendID = *frontend.ID
+			break
+		}
+	}
+	if ipv6FrontendID == "" {
+		return fmt.Errorf("no IPv6 frontend IP configuration found on internal load balancer")
+	}
+
+	// Find the IPv6 backend pool
+	var ipv6BackendPoolID string
+	for _, pool := range lb.Properties.BackendAddressPools {
+		if pool.Name != nil && strings.HasSuffix(*pool.Name, "-v6") {
+			ipv6BackendPoolID = *pool.ID
+			break
+		}
+	}
+	if ipv6BackendPoolID == "" {
+		return fmt.Errorf("no IPv6 backend pool found on internal load balancer")
+	}
+
+	// Find the HTTPS probe (API server) and MCS probe
+	var httpsProbeID, mcsProbeID string
+	for _, probe := range lb.Properties.Probes {
+		if probe.Name != nil {
+			switch *probe.Name {
+			case "HTTPSProbe":
+				httpsProbeID = *probe.ID
+			case "sint-probe":
+				mcsProbeID = *probe.ID
+			}
+		}
+	}
+	if httpsProbeID == "" {
+		return fmt.Errorf("HTTPS probe not found on internal load balancer")
+	}
+	if mcsProbeID == "" {
+		return fmt.Errorf("MCS probe (sint-probe) not found on internal load balancer")
+	}
+
+	// Add the IPv6 API server load balancing rule (port 6443)
+	lb.Properties.LoadBalancingRules = append(lb.Properties.LoadBalancingRules, &armnetwork.LoadBalancingRule{
+		Name: to.Ptr("LBRuleHTTPS-v6"),
+		Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+			Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
+			FrontendPort:         to.Ptr(int32(6443)),
+			BackendPort:          to.Ptr(int32(6443)),
+			EnableFloatingIP:     to.Ptr(false),
+			IdleTimeoutInMinutes: to.Ptr(int32(30)),
+			LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
+			FrontendIPConfiguration: &armnetwork.SubResource{
+				ID: to.Ptr(ipv6FrontendID),
+			},
+			BackendAddressPool: &armnetwork.SubResource{
+				ID: to.Ptr(ipv6BackendPoolID),
+			},
+			Probe: &armnetwork.SubResource{
+				ID: to.Ptr(httpsProbeID),
+			},
+		},
+	})
+
+	// Add the IPv6 MCS load balancing rule (port 22623)
+	lb.Properties.LoadBalancingRules = append(lb.Properties.LoadBalancingRules, &armnetwork.LoadBalancingRule{
+		Name: to.Ptr("sint-v6"),
+		Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+			Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
+			FrontendPort:         to.Ptr(int32(22623)),
+			BackendPort:          to.Ptr(int32(22623)),
+			EnableFloatingIP:     to.Ptr(false),
+			IdleTimeoutInMinutes: to.Ptr(int32(30)),
+			LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
+			FrontendIPConfiguration: &armnetwork.SubResource{
+				ID: to.Ptr(ipv6FrontendID),
+			},
+			BackendAddressPool: &armnetwork.SubResource{
+				ID: to.Ptr(ipv6BackendPoolID),
+			},
+			Probe: &armnetwork.SubResource{
+				ID: to.Ptr(mcsProbeID),
+			},
+		},
+	})
+
+	poller, err := lbClient.BeginCreateOrUpdate(ctx, resourceGroup, internalLBName, lb.LoadBalancer, nil)
+	if err != nil {
+		return fmt.Errorf("failed to update internal load balancer with IPv6 rule: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to update internal load balancer with IPv6 rule: %w", err)
+	}
+
+	logrus.Infof("Successfully added IPv6 load balancing rule for port 6443 on internal load balancer")
+	return nil
 }

--- a/pkg/infrastructure/azure/network.go
+++ b/pkg/infrastructure/azure/network.go
@@ -176,6 +176,47 @@ func createAPILoadBalancer(ctx context.Context, pip, pipv6 *armnetwork.PublicIPA
 					PublicIPAddress:           pipv6,
 				},
 			})
+		backendAddressPoolsv6 := []*armnetwork.BackendAddressPool{
+			{Name: to.Ptr(fmt.Sprintf("%s-v6", in.backendAddressPoolName))},
+			{Name: to.Ptr(fmt.Sprintf("%s-outbound-lb-outboundBackendPool-v6", in.backendAddressPoolName))},
+		}
+		loadBalancer.Properties.BackendAddressPools = append(loadBalancer.Properties.BackendAddressPools, backendAddressPoolsv6...)
+		loadBalancerv6Rule := armnetwork.LoadBalancingRule{
+			Name: to.Ptr("api-v6"),
+			Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+				DisableOutboundSnat:  to.Ptr(true),
+				Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
+				FrontendPort:         to.Ptr[int32](6443),
+				BackendPort:          to.Ptr[int32](6443),
+				IdleTimeoutInMinutes: to.Ptr[int32](30),
+				EnableFloatingIP:     to.Ptr(false),
+				LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
+				FrontendIPConfiguration: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s", in.idPrefix, in.loadBalancerName, *frontendIPv6Name)),
+				},
+				BackendAddressPool: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, fmt.Sprintf("%s-v6", in.backendAddressPoolName))),
+				},
+				Probe: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/probes/%s", in.idPrefix, in.loadBalancerName, probeName)),
+				},
+			},
+		}
+		loadBalancer.Properties.LoadBalancingRules = append(loadBalancer.Properties.LoadBalancingRules, &loadBalancerv6Rule)
+		loadBalancer.Properties.OutboundRules = append(loadBalancer.Properties.OutboundRules, &armnetwork.OutboundRule{
+			Name: to.Ptr("OutboundNATRulev6"),
+			Properties: &armnetwork.OutboundRulePropertiesFormat{
+				Protocol: to.Ptr(armnetwork.LoadBalancerOutboundRuleProtocolAll),
+				FrontendIPConfigurations: []*armnetwork.SubResource{
+					{
+						ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s", in.idPrefix, in.loadBalancerName, *frontendIPv6Name)),
+					},
+				},
+				BackendAddressPool: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, fmt.Sprintf("%s-outbound-lb-outboundBackendPool-v6", in.backendAddressPoolName))),
+				},
+			},
+		})
 	}
 	pollerResp, err := in.lbClient.BeginCreateOrUpdate(ctx,
 		in.resourceGroup,
@@ -252,6 +293,52 @@ func updateOutboundLoadBalancerToAPILoadBalancer(ctx context.Context, pip, pipv6
 				},
 			},
 		})
+
+	if in.isDualstack {
+		frontendIPv6Name := to.Ptr(fmt.Sprintf("%s-v6", in.frontendIPConfigName))
+		backendAddressPoolsv6 := []*armnetwork.BackendAddressPool{
+			{Name: to.Ptr(fmt.Sprintf("%s-v6", in.backendAddressPoolName))},
+			{Name: to.Ptr(fmt.Sprintf("%s-outbound-lb-outboundBackendPool-v6", in.backendAddressPoolName))},
+		}
+		extLB.Properties.BackendAddressPools = append(extLB.Properties.BackendAddressPools,
+			backendAddressPoolsv6...)
+		loadBalancerv6Rule := armnetwork.LoadBalancingRule{
+			Name: to.Ptr("api-v6"),
+			Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+				DisableOutboundSnat:  to.Ptr(true),
+				Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
+				FrontendPort:         to.Ptr[int32](6443),
+				BackendPort:          to.Ptr[int32](6443),
+				IdleTimeoutInMinutes: to.Ptr[int32](30),
+				EnableFloatingIP:     to.Ptr(false),
+				LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
+				FrontendIPConfiguration: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s", in.idPrefix, in.loadBalancerName, *frontendIPv6Name)),
+				},
+				BackendAddressPool: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, fmt.Sprintf("%s-v6", in.backendAddressPoolName))),
+				},
+				Probe: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/probes/%s", in.idPrefix, in.loadBalancerName, probeName)),
+				},
+			},
+		}
+		extLB.Properties.LoadBalancingRules = append(extLB.Properties.LoadBalancingRules, &loadBalancerv6Rule)
+		extLB.Properties.OutboundRules = append(extLB.Properties.OutboundRules, &armnetwork.OutboundRule{
+			Name: to.Ptr("OutboundNATRulev6"),
+			Properties: &armnetwork.OutboundRulePropertiesFormat{
+				Protocol: to.Ptr(armnetwork.LoadBalancerOutboundRuleProtocolAll),
+				FrontendIPConfigurations: []*armnetwork.SubResource{
+					{
+						ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s", in.idPrefix, in.loadBalancerName, *frontendIPv6Name)),
+					},
+				},
+				BackendAddressPool: &armnetwork.SubResource{
+					ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, fmt.Sprintf("%s-outbound-lb-outboundBackendPool-v6", in.backendAddressPoolName))),
+				},
+			},
+		})
+	}
 
 	pollerResp, err := in.lbClient.BeginCreateOrUpdate(ctx,
 		in.resourceGroup,
@@ -345,6 +432,16 @@ func updateInternalLoadBalancer(ctx context.Context, in *lbInput) (*armnetwork.L
 	intLB.Properties.Probes = append(intLB.Properties.Probes, mcsProbe)
 	intLB.Properties.LoadBalancingRules = append(intLB.Properties.LoadBalancingRules, mcsRule)
 
+	// For dual-stack, add IPv6 backend pool. The IPv6 frontend, MCS rule (sint-v6),
+	// and API rule (LBRuleHTTPS-v6) are added later by addIPv6InternalLBFrontend
+	// and addIPv6InternalLBRule, after this function returns.
+	if in.isDualstack {
+		backendPoolV6 := fmt.Sprintf("%s-v6", in.backendAddressPoolName)
+		intLB.Properties.BackendAddressPools = append(intLB.Properties.BackendAddressPools,
+			&armnetwork.BackendAddressPool{
+				Name: to.Ptr(backendPoolV6),
+			})
+	}
 	pollerResp, err := in.lbClient.BeginCreateOrUpdate(ctx,
 		in.resourceGroup,
 		in.loadBalancerName,
@@ -429,7 +526,22 @@ func associateVMToBackendPool(ctx context.Context, in vmInput) error {
 				return fmt.Errorf("failed to get nic for vm %s: %w", vmName, err)
 			}
 			for _, ipconfig := range nic.Properties.IPConfigurations {
-				ipconfig.Properties.LoadBalancerBackendAddressPools = append(ipconfig.Properties.LoadBalancerBackendAddressPools, in.backendAddressPools...)
+				ipversion := armnetwork.IPVersionIPv4
+				if ipconfig.Properties.PrivateIPAddressVersion != nil {
+					ipversion = *ipconfig.Properties.PrivateIPAddressVersion
+				}
+				for _, pool := range in.backendAddressPools {
+					poolAddressVersion := armnetwork.IPVersionIPv4
+					if pool.Name != nil && strings.HasSuffix(*pool.Name, "-v6") {
+						poolAddressVersion = armnetwork.IPVersionIPv6
+					}
+					if ipversion == poolAddressVersion {
+						ipconfig.Properties.LoadBalancerBackendAddressPools = append(
+							ipconfig.Properties.LoadBalancerBackendAddressPools,
+							pool,
+						)
+					}
+				}
 			}
 			pollerResp, err := in.nicClient.BeginCreateOrUpdate(ctx, in.resourceGroup, nicName, nic.Interface, nil)
 			if err != nil {


### PR DESCRIPTION
Adding IPv6 backend address pools, load balancing rules, and outbound rules to external and internal load balancers when dual-stack is enabled. Adding the LBRuleHTTPS-v6 rule on the CAPZ-managed internal LB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded IPv6 dual‑stack support: IPv6 frontends, IPv6 backend pools, API/service load‑balancing rules (TCP/6443 and MCS/TCP/22623) and IPv6 outbound NAT.

* **Bug Fixes / Improvements**
  * Backend pool aggregation now preserves both internal and external pools.
  * NIC assignments now match backend pools to the NIC IP version to prevent mismatches.
  * Internal IPv6 LB rule creation moved earlier to ensure reliable rule provisioning and avoid duplicate IPv6 HTTPS rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->