### PR TITLE
OCPBUGS-77760: verify FIPS mode after installation completes

### DIFF
--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	agentpkg "github.com/openshift/installer/pkg/agent"
+	agentasset "github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
+	assetstore "github.com/openshift/installer/pkg/asset/store"
 )
 
 // NewWaitForCmd create the commands for waiting the completion of the agent based cluster installation.
@@ -110,7 +112,26 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				handleBootstrapError(ctx, cluster.API.Kube.Config, cluster, err)
 			}
 
-			if err = command.WaitForInstallComplete(ctx, cluster.API.Kube.Config, command.WaitOptions{}); err != nil {
+			assetStore, err := assetstore.NewStore(command.RootOpts.Dir)
+			if err != nil {
+				logrus.Error(err)
+				logrus.Exit(command.ExitCodeInstallFailed)
+			}
+
+			// Load install-config to check if FIPS verification is needed
+			var fipsEnabled bool
+			if installConfigAsset, err := assetStore.Load(&agentasset.OptionalInstallConfig{}); err == nil && installConfigAsset != nil {
+				ic := installConfigAsset.(*agentasset.OptionalInstallConfig)
+				if ic.Config != nil {
+					fipsEnabled = ic.Config.FIPS
+				}
+			}
+
+			options := command.WaitOptions{
+				VerifyFIPS: fipsEnabled,
+			}
+
+			if err = command.WaitForInstallComplete(ctx, cluster.API.Kube.Config, options); err != nil {
 				logrus.Error(err)
 				err2 := command.LogClusterOperatorConditions(ctx, cluster.API.Kube.Config)
 				if err2 != nil {

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	agentpkg "github.com/openshift/installer/pkg/agent"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
-	assetstore "github.com/openshift/installer/pkg/asset/store"
 )
 
 // NewWaitForCmd create the commands for waiting the completion of the agent based cluster installation.
@@ -111,13 +110,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				handleBootstrapError(ctx, cluster.API.Kube.Config, cluster, err)
 			}
 
-			assetStore, err := assetstore.NewStore(command.RootOpts.Dir)
-			if err != nil {
-				logrus.Error(err)
-				logrus.Exit(command.ExitCodeInstallFailed)
-			}
-
-			if err = command.WaitForInstallComplete(ctx, cluster.API.Kube.Config, assetStore); err != nil {
+			if err = command.WaitForInstallComplete(ctx, cluster.API.Kube.Config, command.WaitOptions{}); err != nil {
 				logrus.Error(err)
 				err2 := command.LogClusterOperatorConditions(ctx, cluster.API.Kube.Config)
 				if err2 != nil {

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -54,7 +54,7 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			assetDir := cmd.Flags().Lookup("dir").Value.String()
+			assetDir := command.RootOpts.Dir
 			logrus.Debugf("asset directory: %s", assetDir)
 			if len(assetDir) == 0 {
 				logrus.Fatal("No cluster installation directory found")
@@ -62,13 +62,18 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 
 			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
 
-			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			assetStore, err := assetstore.NewStore(assetDir)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvousIPAndSSHKeyFromAssetStore(assetStore)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetStore, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(command.ExitCodeBootstrapFailed)
 			}
@@ -89,7 +94,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			assetDir := cmd.Flags().Lookup("dir").Value.String()
+			assetDir := command.RootOpts.Dir
 			logrus.Debugf("asset directory: %s", assetDir)
 			if len(assetDir) == 0 {
 				logrus.Fatal("No cluster installation directory found")
@@ -97,25 +102,24 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 
 			kubeconfigPath := filepath.Join(assetDir, "auth", "kubeconfig")
 
-			rendezvousIP, sshKey, err := agentpkg.FindRendezvouIPAndSSHKeyFromAssetStore(assetDir)
+			assetStore, err := assetstore.NewStore(assetDir)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			rendezvousIP, sshKey, err := agentpkg.FindRendezvousIPAndSSHKeyFromAssetStore(assetStore)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
 			ctx := context.Background()
-			cluster, err := agentpkg.NewCluster(ctx, assetDir, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
+			cluster, err := agentpkg.NewCluster(ctx, assetStore, rendezvousIP, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeInstall)
 			if err != nil {
 				logrus.Exit(command.ExitCodeBootstrapFailed)
 			}
 
 			if err := agentpkg.WaitForBootstrapComplete(cluster); err != nil {
 				handleBootstrapError(ctx, cluster.API.Kube.Config, cluster, err)
-			}
-
-			assetStore, err := assetstore.NewStore(command.RootOpts.Dir)
-			if err != nil {
-				logrus.Error(err)
-				logrus.Exit(command.ExitCodeInstallFailed)
 			}
 
 			// Load install-config to check if FIPS verification is needed

--- a/cmd/openshift-install/command/waitfor.go
+++ b/cmd/openshift-install/command/waitfor.go
@@ -31,11 +31,7 @@ import (
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
-	"github.com/openshift/installer/pkg/asset/installconfig"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
-	"github.com/openshift/installer/pkg/types/aws"
-	"github.com/openshift/installer/pkg/types/baremetal"
-	"github.com/openshift/installer/pkg/types/dns"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/route/routeapihelpers"
 )
@@ -62,10 +58,18 @@ const (
 // SkipPasswordPrintFlag when true means do not print the generated user password.
 var SkipPasswordPrintFlag bool
 
+// WaitOptions contains options for WaitForInstallComplete.
+type WaitOptions struct {
+	// ExtendTimeoutForBaremetal extends the initialization timeout for baremetal platforms.
+	ExtendTimeoutForBaremetal bool
+	// UserProvisionedDNSEnabled extends the initialization timeout for user-provisioned DNS.
+	UserProvisionedDNSEnabled bool
+}
+
 // WaitForInstallComplete waits for cluster to complete installation, checks for operator stability
 // and logs cluster information when successful.
-func WaitForInstallComplete(ctx context.Context, config *rest.Config, assetstore asset.Store) error {
-	if err := waitForInitializedCluster(ctx, config, assetstore); err != nil {
+func WaitForInstallComplete(ctx context.Context, config *rest.Config, options WaitOptions) error {
+	if err := waitForInitializedCluster(ctx, config, options.ExtendTimeoutForBaremetal || options.UserProvisionedDNSEnabled); err != nil {
 		return err
 	}
 
@@ -87,23 +91,15 @@ func WaitForInstallComplete(ctx context.Context, config *rest.Config, assetstore
 
 // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
 // that the cluster has been initialized.
-func waitForInitializedCluster(ctx context.Context, config *rest.Config, assetstore asset.Store) error {
+func waitForInitializedCluster(ctx context.Context, config *rest.Config, extendTimeout bool) error {
 	// TODO revert this value back to 30 minutes.  It's currently at the end of 4.6 and we're trying to see if the
 	timeout := 40 * time.Minute
 
-	if installConfig, err := assetstore.Load(&installconfig.InstallConfig{}); err == nil && installConfig != nil {
-		switch installConfig.(*installconfig.InstallConfig).Config.Platform.Name() {
-		case baremetal.Name:
-			// Wait longer for baremetal, due to length of time it takes to boot
-			timeout = 60 * time.Minute
-		case aws.Name:
-			// Wait longer for AWS with userProvisionedDNS enabled.
-			// Tests show that with this feature enabled, MCO needs additional time to complete tasks
-			if installConfig.(*installconfig.InstallConfig).Config.AWS != nil &&
-				installConfig.(*installconfig.InstallConfig).Config.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
-				timeout = 60 * time.Minute
-			}
-		}
+	// Wait longer for baremetal, due to length of time it takes to boot
+	// Wait longer for AWS with userProvisionedDNS enabled.
+	// Tests show that with this feature enabled, MCO needs additional time to complete tasks
+	if extendTimeout {
+		timeout = 60 * time.Minute
 	}
 
 	untilTime := time.Now().Add(timeout)

--- a/cmd/openshift-install/command/waitfor.go
+++ b/cmd/openshift-install/command/waitfor.go
@@ -28,6 +28,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
@@ -64,6 +65,52 @@ type WaitOptions struct {
 	ExtendTimeoutForBaremetal bool
 	// UserProvisionedDNSEnabled extends the initialization timeout for user-provisioned DNS.
 	UserProvisionedDNSEnabled bool
+	// VerifyFIPS verifies that FIPS mode is enabled on the cluster before completing.
+	VerifyFIPS bool
+}
+
+// verifyFIPSEnabled checks that the cluster has FIPS enabled by querying
+// the rendered MachineConfigs for both worker and master pools.
+// Returns an error if verification fails.
+func verifyFIPSEnabled(ctx context.Context, config *rest.Config) error {
+	// Create MachineConfig client
+	mcClient, err := machineconfigclient.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "failed to create machine config client")
+	}
+
+	// Check both worker and master pools
+	pools := []string{"worker", "master"}
+	for _, poolName := range pools {
+		// Get the MachineConfigPool to find the rendered config
+		pool, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("FIPS was enabled in install-config but %s MachineConfigPool not found", poolName)
+			}
+			return errors.Wrapf(err, "failed to retrieve %s MachineConfigPool", poolName)
+		}
+
+		// Get the rendered MachineConfig from the pool's status
+		renderedConfigName := pool.Status.Configuration.Name
+		if renderedConfigName == "" {
+			return fmt.Errorf("FIPS was enabled in install-config but %s MachineConfigPool has no rendered configuration yet", poolName)
+		}
+
+		renderedConfig, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(ctx, renderedConfigName, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve rendered MachineConfig %s for %s pool", renderedConfigName, poolName)
+		}
+
+		if !renderedConfig.Spec.FIPS {
+			return fmt.Errorf("FIPS was enabled in install-config but rendered MachineConfig %s for %s pool has FIPS=false", renderedConfigName, poolName)
+		}
+
+		logrus.Debugf("Verified FIPS mode is enabled on %s pool (rendered config: %s)", poolName, renderedConfigName)
+	}
+
+	logrus.Info("Verified FIPS mode is enabled on cluster")
+	return nil
 }
 
 // WaitForInstallComplete waits for cluster to complete installation, checks for operator stability
@@ -79,6 +126,12 @@ func WaitForInstallComplete(ctx context.Context, config *rest.Config, options Wa
 
 	if err := waitForStableOperators(ctx, config); err != nil {
 		return err
+	}
+
+	if options.VerifyFIPS {
+		if err := verifyFIPSEnabled(ctx, config); err != nil {
+			return err
+		}
 	}
 
 	consoleURL, err := getConsole(ctx, config)

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -36,6 +36,7 @@ import (
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -211,7 +212,15 @@ func clusterCreatePostRun(ctx context.Context) (int, error) {
 		logrus.Exit(command.ExitCodeInstallFailed)
 	}
 
-	err = command.WaitForInstallComplete(ctx, config, assetStore)
+	// Load install-config to determine wait options
+	var ic *types.InstallConfig
+	if installConfigAsset, err := assetStore.Load(&installconfig.InstallConfig{}); err == nil && installConfigAsset != nil {
+		ic = installConfigAsset.(*installconfig.InstallConfig).Config
+	}
+
+	options := getWaitOptionsFromInstallConfig(ic)
+
+	err = command.WaitForInstallComplete(ctx, config, options)
 	if err != nil {
 		if err2 := command.LogClusterOperatorConditions(ctx, config); err2 != nil {
 			logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -10,9 +10,31 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/installer/cmd/openshift-install/command"
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/dns"
 )
+
+// getWaitOptionsFromInstallConfig constructs WaitOptions from an InstallConfig.
+func getWaitOptionsFromInstallConfig(ic *types.InstallConfig) command.WaitOptions {
+	options := command.WaitOptions{}
+	if ic != nil {
+		switch ic.Platform.Name() {
+		case baremetal.Name:
+			options.ExtendTimeoutForBaremetal = true
+		case aws.Name:
+			if ic.AWS != nil &&
+				ic.AWS.UserProvisionedDNS == dns.UserProvisionedDNSEnabled {
+				options.UserProvisionedDNSEnabled = true
+			}
+		}
+	}
+	return options
+}
 
 func newWaitForCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -92,7 +114,15 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				logrus.Exit(command.ExitCodeInstallFailed)
 			}
 
-			err = command.WaitForInstallComplete(ctx, config, assetStore)
+			// Load install-config to determine wait options
+			var ic *types.InstallConfig
+			if installConfigAsset, err := assetStore.Load(&installconfig.InstallConfig{}); err == nil && installConfigAsset != nil {
+				ic = installConfigAsset.(*installconfig.InstallConfig).Config
+			}
+
+			options := getWaitOptionsFromInstallConfig(ic)
+
+			err = command.WaitForInstallComplete(ctx, config, options)
 			if err != nil {
 				if err2 := command.LogClusterOperatorConditions(ctx, config); err2 != nil {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -21,7 +21,9 @@ import (
 
 // getWaitOptionsFromInstallConfig constructs WaitOptions from an InstallConfig.
 func getWaitOptionsFromInstallConfig(ic *types.InstallConfig) command.WaitOptions {
-	options := command.WaitOptions{}
+	options := command.WaitOptions{
+		VerifyFIPS: false, // IPI/UPI installer doesn't verify FIPS
+	}
 	if ic != nil {
 		switch ic.Platform.Name() {
 		case baremetal.Name:

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/gencrypto"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
 )
@@ -21,7 +22,6 @@ import (
 type Cluster struct {
 	Ctx                    context.Context
 	API                    *clientSet
-	assetDir               string
 	clusterConsoleRouteURL string
 	clusterID              *strfmt.UUID
 	clusterInfraEnvID      *strfmt.UUID
@@ -59,7 +59,7 @@ type clusterInstallStatusHistory struct {
 }
 
 // NewCluster initializes a Cluster object
-func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, sshKey string, workflowType workflow.AgentWorkflowType) (*Cluster, error) {
+func NewCluster(ctx context.Context, assetStore asset.Store, rendezvousIP, kubeconfigPath, sshKey string, workflowType workflow.AgentWorkflowType) (*Cluster, error) {
 	czero := &Cluster{}
 	capi := &clientSet{}
 
@@ -68,7 +68,7 @@ func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, ssh
 
 	switch workflowType {
 	case workflow.AgentWorkflowTypeInstall:
-		watcherAuthToken, err = FindAuthTokenFromAssetStore(assetDir)
+		watcherAuthToken, err = FindAuthTokenFromAssetStore(assetStore)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +118,6 @@ func NewCluster(ctx context.Context, assetDir, rendezvousIP, kubeconfigPath, ssh
 	czero.workflow = workflowType
 	czero.clusterID = nil
 	czero.clusterInfraEnvID = nil
-	czero.assetDir = assetDir
 	czero.clusterConsoleRouteURL = ""
 	czero.installHistory = cinstallstatushistory
 	czero.installHistory.ValidationResults = cvalidationresults

--- a/pkg/agent/rest.go
+++ b/pkg/agent/rest.go
@@ -14,12 +14,12 @@ import (
 	"github.com/openshift/assisted-service/client/events"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
 	"github.com/openshift/installer/pkg/asset/agent/gencrypto"
 	"github.com/openshift/installer/pkg/asset/agent/image"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	assetstore "github.com/openshift/installer/pkg/asset/store"
 	"github.com/openshift/installer/pkg/types/agent"
 )
 
@@ -60,17 +60,12 @@ func NewNodeZeroRestClient(ctx context.Context, rendezvousIP, sshKey, watcherAut
 	return restClient
 }
 
-// FindRendezvouIPAndSSHKeyFromAssetStore returns the rendezvousIP and public ssh key.
-func FindRendezvouIPAndSSHKeyFromAssetStore(assetDir string) (string, string, error) {
+// FindRendezvousIPAndSSHKeyFromAssetStore returns the rendezvousIP and public ssh key.
+func FindRendezvousIPAndSSHKeyFromAssetStore(assetStore asset.Store) (string, string, error) {
 	agentConfigAsset := &agentconfig.AgentConfig{}
 	agentManifestsAsset := &manifests.AgentManifests{}
 	installConfigAsset := &installconfig.InstallConfig{}
 	agentHostsAsset := &agentconfig.AgentHosts{}
-
-	assetStore, err := assetstore.NewStore(assetDir)
-	if err != nil {
-		return "", "", errors.Wrap(err, "failed to create asset store")
-	}
 
 	agentConfig, agentConfigError := assetStore.Load(agentConfigAsset)
 	agentManifests, manifestError := assetStore.Load(agentManifestsAsset)
@@ -120,13 +115,8 @@ func FindRendezvouIPAndSSHKeyFromAssetStore(assetDir string) (string, string, er
 }
 
 // FindAuthTokenFromAssetStore returns the auth token from asset store.
-func FindAuthTokenFromAssetStore(assetDir string) (string, error) {
+func FindAuthTokenFromAssetStore(assetStore asset.Store) (string, error) {
 	authConfigAsset := &gencrypto.AuthConfig{}
-
-	assetStore, err := assetstore.NewStore(assetDir)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create asset store")
-	}
 
 	authConfig, authConfigError := assetStore.Load(authConfigAsset)
 

--- a/pkg/nodejoiner/monitoraddnodes.go
+++ b/pkg/nodejoiner/monitoraddnodes.go
@@ -5,11 +5,17 @@ import (
 
 	agentpkg "github.com/openshift/installer/pkg/agent"
 	"github.com/openshift/installer/pkg/asset/agent/workflow"
+	assetstore "github.com/openshift/installer/pkg/asset/store"
 )
 
 // NewMonitorAddNodesCommand creates a new command for monitor add nodes.
 func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) error {
 	err := saveParams(directory, kubeconfigPath)
+	if err != nil {
+		return err
+	}
+
+	assetStore, err := assetstore.NewStore(directory)
 	if err != nil {
 		return err
 	}
@@ -20,7 +26,7 @@ func NewMonitorAddNodesCommand(directory, kubeconfigPath string, ips []string) e
 	clusters := []*agentpkg.Cluster{}
 	ctx := context.Background()
 	for _, ip := range ips {
-		cluster, err := agentpkg.NewCluster(ctx, directory, ip, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeAddNodes)
+		cluster, err := agentpkg.NewCluster(ctx, assetStore, ip, kubeconfigPath, sshKey, workflow.AgentWorkflowTypeAddNodes)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When install-config specifies fips: true, verify
that FIPS mode was actually enabled on the cluster before declaring an ABI
installation successful.

The verification queries both worker and master MachineConfigPools to
retrieve their rendered MachineConfigs (the combined configs that
machine-config-operator actually applies to nodes), and verifies that
FIPS is enabled in each.

This verification only runs for the agent wait-for install-complete
command. Regular installations are unchanged.