### PR TITLE
CORS-3893: Create nat rule and associate to NIC

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -652,6 +652,39 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 				return fmt.Errorf("failed to set public ipv6 to outbound ipv6 lb: %w", err)
 			}
 			logrus.Debugf("updated outbound ipv6 lb %s with public ipv6: %s", outboundLBName, *publicIPv6outbound.ID)
+			frontendIPv6ConfigName := "public-lb-ip-v6"
+			sshRuleNameV6 := fmt.Sprintf("%s_ssh_in_v6", in.InfraID)
+			frontendIPv6ConfigID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s",
+				subscriptionID,
+				p.ResourceGroupName,
+				loadBalancerName,
+				frontendIPv6ConfigName,
+			)
+
+			inboundNatRuleV6, err := addInboundNatRuleToLoadBalancer(ctx, &inboundNatRuleInput{
+				resourceGroupName:    p.ResourceGroupName,
+				loadBalancerName:     loadBalancerName,
+				frontendIPConfigID:   frontendIPv6ConfigID,
+				inboundNatRuleName:   sshRuleNameV6,
+				inboundNatRulePort:   22,
+				networkClientFactory: p.NetworkClientFactory,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create IPv6 SSH inbound nat rule: %w", err)
+			}
+			_, err = associateInboundNatRuleToInterface(ctx, &inboundNatRuleInput{
+				resourceGroupName:    p.ResourceGroupName,
+				loadBalancerName:     loadBalancerName,
+				bootstrapNicName:     fmt.Sprintf("%s-bootstrap-nic", in.InfraID),
+				frontendIPConfigID:   frontendIPv6ConfigID,
+				inboundNatRuleID:     *inboundNatRuleV6.ID,
+				inboundNatRuleName:   sshRuleNameV6,
+				inboundNatRulePort:   22,
+				networkClientFactory: p.NetworkClientFactory,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to associate IPv6 SSH inbound nat rule to interface: %w", err)
+			}
 		}
 	}
 
@@ -733,6 +766,15 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 		})
 		if err != nil {
 			return fmt.Errorf("failed to delete inbound nat rule: %w", err)
+		}
+		err = deleteInboundNatRule(ctx, &inboundNatRuleInput{
+			resourceGroupName:    resourceGroupName,
+			loadBalancerName:     in.Metadata.InfraID,
+			inboundNatRuleName:   fmt.Sprintf("%s_v6", sshRuleName),
+			networkClientFactory: networkClientFactory,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete inbound IPv6 nat rule: %w", err)
 		}
 	}
 	return nil

--- a/pkg/infrastructure/azure/network.go
+++ b/pkg/infrastructure/azure/network.go
@@ -2,7 +2,9 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 
@@ -497,6 +499,10 @@ func deleteInboundNatRule(ctx context.Context, in *inboundNatRuleInput) error {
 		nil,
 	)
 	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("failed to delete inbound nat rule: %w", err)
 	}
 	_, err = inboundNatRulesPoller.PollUntilDone(ctx, nil)


### PR DESCRIPTION
Adding IPv6 NAT rule for bootstrap SSH access and updating NAT rules to the correct IP version on the bootstrap NIC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled creation and cleanup of IPv6 SSH inbound NAT rules for dual-stack setups with public API endpoints, restoring SSH access via the public load balancer.
  * Treat deletion of missing NAT resources as a successful no-op to avoid errors when cleanup targets are already absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->