### PR TITLE
OCPBUGS-67159: openstack: Reserve addresses for load balancer

### DIFF
--- a/pkg/asset/manifests/openstack/cluster.go
+++ b/pkg/asset/manifests/openstack/cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,10 +82,23 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 			}
 		}
 	} else {
+		networkCIDR := capiutils.CIDRFromInstallConfig(installConfig)
+		allocationStart, err := cidr.Host(&networkCIDR.IPNet, 10)
+		if err != nil {
+			return nil, err
+		}
+		_, broadcastIP := cidr.AddressRange(&networkCIDR.IPNet)
+		allocationEnd := cidr.Dec(broadcastIP)
 		openStackCluster.Spec.ManagedSubnets = []capo.SubnetSpec{
 			{
-				CIDR:           capiutils.CIDRFromInstallConfig(installConfig).String(),
+				CIDR:           networkCIDR.String(),
 				DNSNameservers: openstackInstallConfig.ExternalDNS,
+				AllocationPools: []capo.AllocationPool{
+					{
+						Start: allocationStart.String(),
+						End:   allocationEnd.String(),
+					},
+				},
 			},
 		}
 	}


### PR DESCRIPTION
When using Octavia, we use the `.5` and `.7` addresses on the first machine network [for API and Ingress VIP, respectively](https://github.com/openshift/installer/blob/f7fc26d69c4fc933f1ddd7b5c160021cc1419146/pkg/types/openstack/defaults/platform.go#L36-L66). However, we were not reserving these address when creating the network. This can result in an IP collision if another service happens to allocate one of these two IPs before the load balancer is created. This can happen if DHCP agents are running on the controller/network nodes, as each agent creates its own DHCP port on the subnet.

The solution is to use allocation pools - which are designed exactly for this purpose - and configure one on the subnet we create (via CAPO). We reserve everything < .10 in case we need more addresses down the line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenStack network handling to compute and populate explicit allocation pools (start/end) for subnets while preserving CIDR and DNS nameserver settings, ensuring correct IP allocation bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->