### PR TITLE
MCO-2164: use machine-config-osimagestream to avoid hard-coding image tag names

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
@@ -12,12 +12,35 @@ done
 
 # Create temporary directory for binary extraction
 TEMP_DIR=$(mktemp -d)
+
+MCO_CONTAINER_ID=
+
+cleanup_mco() {
+    # Ensure that the MCO container is removed.
+    if [[ -n "${MCO_CONTAINER_ID}" ]]; then
+        podman container rm -f "${MCO_CONTAINER_ID}" >/dev/null 2>&1 || true
+        MCO_CONTAINER_ID=
+    fi
+
+    # Delete the MCO container image to conserve memory.
+    if [[ -n "${MCO_IMAGE}" ]]; then
+        podman image rm -f "${MCO_IMAGE}" >/dev/null 2>&1 || true
+        MCO_IMAGE=
+    fi
+
+    # Delete the tempdir.
+    if [[ -n "${TEMP_DIR}" ]]; then
+        rm -rf "${TEMP_DIR}"
+        TEMP_DIR=
+    fi
+}
+trap cleanup_mco EXIT
+
 echo "Extracting machine-config-osimagestream binary to ${TEMP_DIR}"
 
+MCO_CONTAINER_ID="$(podman create "${MCO_IMAGE}")"
 # Extract the machine-config-osimagestream binary from the MCO image. This avoids having to munge podman args, paths, env vars, etc.
-podman create --name mco-osimagestream "${MCO_IMAGE}"
-podman cp mco-osimagestream:/usr/bin/machine-config-osimagestream "${TEMP_DIR}/machine-config-osimagestream"
-podman rm mco-osimagestream
+podman cp "${MCO_CONTAINER_ID}":/usr/bin/machine-config-osimagestream "${TEMP_DIR}/machine-config-osimagestream"
 
 # Execute the binary to get the CoreOS image pullspec
 # Note: Proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are
@@ -34,8 +57,8 @@ until COREOS_IMAGE=$("${TEMP_DIR}/machine-config-osimagestream" \
     sleep 10
 done
 
-# Clean up temporary directory
-rm -rf "${TEMP_DIR}"
+# Clean up the MCO container, image, and temp dir now that we have the pullspec.
+cleanup_mco
 
 # need to use rpm-ostree here since `bootc status` doesn't work in the live ISO currently
 # https://github.com/containers/bootc/issues/1043

--- a/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-pull.sh.template
@@ -4,12 +4,38 @@ set -euo pipefail
 # shellcheck source=release-image.sh.template
 . /usr/local/bin/release-image.sh
 
-# yuck... this is a good argument for renaming the node image to just `node` in both OCP and OKD
-coreos_img={{.StreamTag}}
-until COREOS_IMAGE=$(image_for ${coreos_img}); do
-    echo 'Failed to query release image; retrying...'
+# Get the Machine Config Operator image from the release payload
+until MCO_IMAGE=$(image_for 'machine-config-operator'); do
+    echo 'Failed to query MCO image from release; retrying...'
     sleep 10
 done
+
+# Create temporary directory for binary extraction
+TEMP_DIR=$(mktemp -d)
+echo "Extracting machine-config-osimagestream binary to ${TEMP_DIR}"
+
+# Extract the machine-config-osimagestream binary from the MCO image. This avoids having to munge podman args, paths, env vars, etc.
+podman create --name mco-osimagestream "${MCO_IMAGE}"
+podman cp mco-osimagestream:/usr/bin/machine-config-osimagestream "${TEMP_DIR}/machine-config-osimagestream"
+podman rm mco-osimagestream
+
+# Execute the binary to get the CoreOS image pullspec
+# Note: Proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are
+# automatically inherited from the environment if set via /etc/profile.d/proxy.sh
+until COREOS_IMAGE=$("${TEMP_DIR}/machine-config-osimagestream" \
+    get os-image-pullspec \
+    --release-image "${RELEASE_IMAGE_DIGEST}" \
+    --authfile /root/.docker/config.json \
+    --per-host-certs /etc/containers/certs.d \
+    --osimagestream-name '{{ .OSImageStream }}' \
+    --trust-bundle /etc/pki/ca-trust/source/anchors \
+    --registry-config /etc/containers/registries.conf); do
+    echo 'Failed to query for OS image pullspec; retrying...'
+    sleep 10
+done
+
+# Clean up temporary directory
+rm -rf "${TEMP_DIR}"
 
 # need to use rpm-ostree here since `bootc status` doesn't work in the live ISO currently
 # https://github.com/containers/bootc/issues/1043

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -40,9 +40,9 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
-	"github.com/openshift/installer/pkg/asset/rhcos"
+	rhcosAsset "github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/asset/tls"
-	rhcosutils "github.com/openshift/installer/pkg/rhcos"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	aztypes "github.com/openshift/installer/pkg/types/azure"
@@ -99,7 +99,7 @@ type bootstrapTemplateData struct {
 	FeatureSet            configv1.FeatureSet
 	Invoker               string
 	ClusterDomain         string
-	StreamTag             string
+	OSImageStream         types.OSImageStream
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -177,7 +177,7 @@ func (a *Common) Dependencies() []asset.Asset {
 		&tls.ServiceAccountKeyPair{},
 		&tls.IronicTLSCert{},
 		&releaseimage.Image{},
-		new(rhcos.Image),
+		new(rhcosAsset.Image),
 	}
 }
 
@@ -287,7 +287,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 	installConfig := &installconfig.InstallConfig{}
 	proxy := &manifests.Proxy{}
 	releaseImage := &releaseimage.Image{}
-	rhcosImage := new(rhcos.Image)
+	rhcosImage := new(rhcosAsset.Image)
 	bootstrapSSHKeyPair := &tls.BootstrapSSHKeyPair{}
 	ironicCreds := &baremetal.IronicCreds{}
 	dependencies.Get(installConfig, proxy, releaseImage, rhcosImage, bootstrapSSHKeyPair, ironicCreds)
@@ -399,6 +399,11 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		pullSecret = merged
 	}
 
+	osImageStream := installConfig.Config.OSImageStream
+	if osImageStream == "" {
+		osImageStream = rhcos.DefaultOSImageStream
+	}
+
 	return &bootstrapTemplateData{
 		AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
 		FIPS:                  installConfig.Config.FIPS,
@@ -422,7 +427,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		FeatureSet:            installConfig.Config.FeatureSet,
 		Invoker:               openshiftInstallInvoker,
 		ClusterDomain:         installConfig.Config.ClusterDomain(),
-		StreamTag:             rhcosutils.GetPayloadImageStreamTag(installConfig.Config.OSImageStream),
+		OSImageStream:         osImageStream,
 	}
 }
 

--- a/pkg/rhcos/stream_scos.go
+++ b/pkg/rhcos/stream_scos.go
@@ -4,8 +4,8 @@ package rhcos
 
 import "github.com/openshift/installer/pkg/types"
 
-// DefaultOSImageStream Not used in SCOS
-const DefaultOSImageStream types.OSImageStream = ""
+// DefaultOSImageStream Not (yet) used in SCOS
+const DefaultOSImageStream types.OSImageStream = "centos-10"
 
 func getStreamFileName(_ types.OSImageStream) string {
 	return "coreos/scos.json"


### PR DESCRIPTION
This makes use of the new `machine-config-osimagestream` binary helper that was [added to the MCO](https://github.com/openshift/machine-config-operator/pull/5770). The intent is to use this binary to look up the OS image pullspec for the default OS ImageStream.