### PR TITLE
NO-JIRA: pkg/types/nutanix: warn about unused context

### DIFF
--- a/pkg/types/nutanix/client.go
+++ b/pkg/types/nutanix/client.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	nutanixclient "github.com/nutanix-cloud-native/prism-go-client"
 	nutanixclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+	"github.com/sirupsen/logrus"
 )
 
 // CreateNutanixClient creates a Nutanix V3 Client.
 func CreateNutanixClient(ctx context.Context, prismCentral, port, username, password string) (*nutanixclientv3.Client, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
+
+	// This function previously took a context that went unused.
+	logrus.Warn("context passed to CreateNutanixClient is dropped with no effect")
 
 	cred := nutanixclient.Credentials{
 		URL:      fmt.Sprintf("%s:%s", prismCentral, port),


### PR DESCRIPTION
`CreateNutanixClient()` takes a `context.Context` as its first argument, adds a 60-second timeout, and then never touches the `context.Context` again. `prism-go-client/v3.NewV3Client()` does not take a `context.Context()`, and does not make actual requests to the Nutanix API. Instead, the indivdual functions on `prism-go-client/v3.Client.V3` individually take their own `context.Context` on each request.

I don't want to make a breaking change to `CreateNutanixClient()`, so instead of removing the `context.Context` from the function signature I've added a log warning using "logrus", which is the preferred logging library used in other packages beneath `pkg/types`.