### PR TITLE
OCPBUGS-79536: Removing AWS security group OVNDB ports as they are no longer used

### DIFF
--- a/pkg/asset/manifests/aws/cluster.go
+++ b/pkg/asset/manifests/aws/cluster.go
@@ -98,12 +98,6 @@ func GenerateClusterAssets(ic *installconfig.InstallConfig, clusterID *installco
 							ToPort:      -1,
 						},
 						{
-							Description: "Port 6441-6442 (TCP) for ovndb",
-							Protocol:    capa.SecurityGroupProtocolTCP,
-							FromPort:    6441,
-							ToPort:      6442,
-						},
-						{
 							Description: "Port 9000-9999 for node ports (TCP)",
 							Protocol:    capa.SecurityGroupProtocolTCP,
 							FromPort:    9000,


### PR DESCRIPTION
The security group created in AWS using IPI installation was having ports mentioned as 6441 &  6442 , as these ports are no longer needed because they are not used so removing it from the installer
Making the changes as per the Bug https://redhat.atlassian.net/browse/OCPBUGS-79536