### PR TITLE
OCPBUGS-79792, OCPBUGS-79793, OCPBUGS-79779: Bump google.golang.org/grpc to v1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	google.golang.org/api v0.126.0
 	google.golang.org/genproto v0.0.0-20230913181813-007df8e322eb
 	google.golang.org/genproto/googleapis/api v0.0.0-20230803162519-f966b187b2e5
-	google.golang.org/grpc v1.58.3
+	google.golang.org/grpc v1.79.3
 	gopkg.in/ini.v1 v1.66.6
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9224,7 +9224,7 @@ google.golang.org/genproto/googleapis/api/monitoredres
 google.golang.org/genproto/googleapis/rpc/code
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.58.3 => google.golang.org/grpc v1.57.2
+# google.golang.org/grpc v1.79.3 => google.golang.org/grpc v1.57.2
 ## explicit; go 1.17
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
This PR is part of an automated process.

The commands used to generate this PR were:

```
go get google.golang.org/grpc@v1.79.3 toolchain@none
go mod tidy
go mod vendor
```

A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.