### PR TITLE
OCPBUGS-112027: update to Google Cloud SDK 563.0.0

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -53,7 +53,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \      
       gettext \
-      google-cloud-cli-447.0.0-1 \
+      google-cloud-cli-563.0.0-1 \
       gzip \
       jq \
       unzip \


### PR DESCRIPTION
- update to Google Cloud SDK 563.0.0, for using GCP Infrastructure Manager (see https://github.com/openshift/release/pull/76144)