### PR TITLE
bugs: aws: fix SOA minimum TTL field index in Route53

### DIFF
--- a/pkg/asset/installconfig/aws/route53.go
+++ b/pkg/asset/installconfig/aws/route53.go
@@ -318,7 +318,7 @@ func (c *Route53Client) CreateHostedZone(ctx context.Context, input *HostedZoneI
 	if len(fields) != 7 {
 		return nil, fmt.Errorf("SOA record value has %d fields, expected 7", len(fields))
 	}
-	fields[0] = "60"
+	fields[6] = "60"
 	record.Value = aws.String(strings.Join(fields, " "))
 	req, err := c.client.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: res.HostedZone.Id,


### PR DESCRIPTION
The code was incorrectly modifying `fields[0]` (primary nameserver) instead of `fields[6]` (minimum TTL) when setting the SOA record for private hosted zones. This would attempt to set the nameserver to "60", which AWS likely rejected silently, preventing the minimum TTL from being lowered to 60 seconds as intended.

This fix ensures the minimum TTL is actually set to 60 seconds, allowing DNS changes to propagate faster during cluster creation.

/label platform/aws

## References

See [RFC1035](https://datatracker.ietf.org/doc/html/rfc1035) for SOA record value specifications.

In 4.15, the index is correctly set to `6`.

https://github.com/openshift/installer/blob/83c823bf5cb70c42dcbbc93306a570759ac6aaf8/pkg/infrastructure/aws/dns.go#L134

But in 4.16+ (after migration to CAPI), the value is incorrectly changed to `0`.

https://github.com/openshift/installer/blob/441e0e5469d5698ce147c092c7c802d7c44b1557/pkg/asset/installconfig/aws/route53.go#L281