### PR TITLE
SPLAT-2719: vsphere - remove HostGroup zonal feature gate checks

### DIFF
--- a/pkg/asset/manifests/vsphere/infrastructure.go
+++ b/pkg/asset/manifests/vsphere/infrastructure.go
@@ -52,22 +52,18 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig, clusterID string) *co
 				},
 			}
 
-			if ic.Config.Enabled(features.FeatureGateVSphereHostVMGroupZonal) {
-				logrus.Debug("Host VM Group based zonal feature gate enabled")
-
-				if failureDomain.ZoneType == vsphere.HostGroupFailureDomain {
-					vmGroupAndRuleName := fmt.Sprintf("%s-%s", clusterID, failureDomain.Name)
-					failureDomainSpec.RegionAffinity = &configv1.VSphereFailureDomainRegionAffinity{
-						Type: configv1.VSphereFailureDomainRegionType(failureDomain.RegionType),
-					}
-					failureDomainSpec.ZoneAffinity = &configv1.VSphereFailureDomainZoneAffinity{
-						Type: configv1.VSphereFailureDomainZoneType(failureDomain.ZoneType),
-						HostGroup: &configv1.VSphereFailureDomainHostGroup{
-							HostGroup:  failureDomain.Topology.HostGroup,
-							VMGroup:    vmGroupAndRuleName,
-							VMHostRule: vmGroupAndRuleName,
-						},
-					}
+			if failureDomain.ZoneType == vsphere.HostGroupFailureDomain {
+				vmGroupAndRuleName := fmt.Sprintf("%s-%s", clusterID, failureDomain.Name)
+				failureDomainSpec.RegionAffinity = &configv1.VSphereFailureDomainRegionAffinity{
+					Type: configv1.VSphereFailureDomainRegionType(failureDomain.RegionType),
+				}
+				failureDomainSpec.ZoneAffinity = &configv1.VSphereFailureDomainZoneAffinity{
+					Type: configv1.VSphereFailureDomainZoneType(failureDomain.ZoneType),
+					HostGroup: &configv1.VSphereFailureDomainHostGroup{
+						HostGroup:  failureDomain.Topology.HostGroup,
+						VMGroup:    vmGroupAndRuleName,
+						VMHostRule: vmGroupAndRuleName,
+					},
 				}
 			}
 

--- a/pkg/asset/manifests/vsphere/infrastructure_test.go
+++ b/pkg/asset/manifests/vsphere/infrastructure_test.go
@@ -1,0 +1,69 @@
+package vsphere
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	vsphereconfig "github.com/openshift/installer/pkg/types/vsphere"
+)
+
+func TestGetInfraPlatformSpecHostGroupAffinity(t *testing.T) {
+	ic := installconfig.MakeAsset(&types.InstallConfig{
+		Networking: &types.Networking{
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+			},
+		},
+		Platform: types.Platform{
+			VSphere: &vsphereconfig.Platform{
+				VCenters: []vsphereconfig.VCenter{
+					{
+						Server:      "test-vcenter",
+						Port:        443,
+						Datacenters: []string{"test-datacenter"},
+					},
+				},
+				FailureDomains: []vsphereconfig.FailureDomain{
+					{
+						Name:       "fd-a",
+						Region:     "region-a",
+						Zone:       "zone-a",
+						Server:     "test-vcenter",
+						RegionType: vsphereconfig.ComputeClusterFailureDomain,
+						ZoneType:   vsphereconfig.HostGroupFailureDomain,
+						Topology: vsphereconfig.Topology{
+							Datacenter:     "test-datacenter",
+							ComputeCluster: "/test-datacenter/host/test-cluster",
+							Datastore:      "/test-datacenter/datastore/test-datastore",
+							Networks:       []string{"test-portgroup"},
+							HostGroup:      "host-group-a",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	platformSpec := GetInfraPlatformSpec(ic, "cluster-id")
+	if !assert.Len(t, platformSpec.FailureDomains, 1) {
+		return
+	}
+
+	fd := platformSpec.FailureDomains[0]
+	if assert.NotNil(t, fd.RegionAffinity) {
+		assert.Equal(t, configv1.ComputeClusterFailureDomainRegion, fd.RegionAffinity.Type)
+	}
+	if assert.NotNil(t, fd.ZoneAffinity) {
+		assert.Equal(t, configv1.HostGroupFailureDomainZone, fd.ZoneAffinity.Type)
+		if assert.NotNil(t, fd.ZoneAffinity.HostGroup) {
+			assert.Equal(t, "host-group-a", fd.ZoneAffinity.HostGroup.HostGroup)
+			assert.Equal(t, "cluster-id-fd-a", fd.ZoneAffinity.HostGroup.VMGroup)
+			assert.Equal(t, "cluster-id-fd-a", fd.ZoneAffinity.HostGroup.VMHostRule)
+		}
+	}
+}

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -121,6 +121,19 @@ func TestFeatureGates(t *testing.T) {
 			}(),
 		},
 		{
+			name: "vSphere HostGroup zonal configuration is allowed with default Feature Set",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.FeatureSet = v1.Default
+				c.AWS = nil // validInstallConfig defaults to AWS
+				c.VSphere = validVSpherePlatform()
+				c.VSphere.FailureDomains[0].RegionType = vsphere.ComputeClusterFailureDomain
+				c.VSphere.FailureDomains[0].ZoneType = vsphere.HostGroupFailureDomain
+				c.VSphere.FailureDomains[0].Topology.HostGroup = "host-group-a"
+				return c
+			}(),
+		},
+		{
 			name: "Azure user-assigned identities (control plane) > 1 requires MachineAPIMigration feature gate",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()

--- a/pkg/types/vsphere/validation/featuregates.go
+++ b/pkg/types/vsphere/validation/featuregates.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/featuregates"
-	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 // GatedFeatures determines all of the vSphere install config fields that should
@@ -37,17 +36,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
 			Condition:       nodeNetworkingDefined,
 			Field:           field.NewPath("platform", "vsphere", "nodeNetworking"),
-		},
-		{
-			FeatureGateName: features.FeatureGateVSphereHostVMGroupZonal,
-			Condition: func(v *vsphere.Platform) bool {
-				for _, fd := range v.FailureDomains {
-					if fd.ZoneType == vsphere.HostGroupFailureDomain || fd.Topology.HostGroup != "" {
-						return true
-					}
-				}
-				return false
-			}(v),
 		},
 		{
 			FeatureGateName: features.FeatureGateVSphereMultiDisk,


### PR DESCRIPTION
Make HostGroup-based zonal failure domain handling always available in installer-owned validation and infrastructure manifest generation so users no longer need to enable VSphereHostVMGroupZonal.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * vSphere host group zonal affinity configuration is now generally available without requiring feature gate activation. Host-VM-group-based zonal and regional affinity settings are automatically applied when using host group failure domain topology.

* **Tests**
  * Added test coverage for host group affinity configuration validation and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->