### PR TITLE
OCPBUGS-83335: dont save CAPI secrets

### DIFF
--- a/pkg/infrastructure/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/clusterapi/clusterapi.go
@@ -621,6 +621,13 @@ func (i *InfraProvider) collectManifests(ctx context.Context, cl client.Client) 
 			errorList = append(errorList, fmt.Errorf("failed to get GVK for manifest %s: %w", m.GetName(), err))
 			continue
 		}
+
+		// Skip secrets to avoid writing sensitive data to disk.
+		if gvk.Kind == "Secret" {
+			logrus.Debugf("Skipping secret manifest %s/%s", m.GetNamespace(), m.GetName())
+			continue
+		}
+
 		fileName := filepath.Join(clusterapi.ArtifactsDir, fmt.Sprintf("%s-%s-%s.yaml", gvk.Kind, m.GetNamespace(), m.GetName()))
 		objData, err := yaml.Marshal(m)
 		if err != nil {


### PR DESCRIPTION
The installer saves all capi manifests to .clusterapi_output for debugging purposes. On some platforms, this may include secrets which is an unnecessary security risk as they don't help with debugging. Our CI scrubs these, but users shouldn't need to handle it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Secrets are no longer written to manifest artifact files during cluster operations, preventing sensitive data from being stored in plaintext files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->