### PR TITLE
Revert "OCPBUGS-77965: Update RHCOS-release-4.22 bootimage metadata to 10.2.20260405-0 / 9.8.20260403-0"

### DIFF
--- a/data/data/coreos/coreos-rhel-10.json
+++ b/data/data/coreos/coreos-rhel-10.json
@@ -1,117 +1,106 @@
 {
   "stream": "rhcos-4.22",
   "metadata": {
-    "last-modified": "2026-04-08T16:31:45Z",
-    "generator": "plume cosa2stream b23d8cf"
+    "last-modified": "2026-02-01T20:59:12Z",
+    "generator": "plume cosa2stream 0.17.0+456-ge818f36f5-dirty"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-aws.aarch64.vmdk.gz",
-                "sha256": "a80d57a5bbdb63000bca66497e214653b36c01a8ff6329451a1525328609d605",
-                "uncompressed-sha256": "3640de771b7db25c37496d386b333fde82c9029c4297bbc0beef30c9384bec99"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-aws.aarch64.vmdk.gz",
+                "sha256": "94d0d3e67f4315162b8e9d0f04f336d1862e13c7f6fe25b69b13fce1e3715657",
+                "uncompressed-sha256": "8b23f43f0f611f4d9463165902f445d6ef513e1b46bdb91794e5cc646faa0164"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-azure.aarch64.vhd.gz",
-                "sha256": "797b0ef113420d87f4e3a31c528baa2be2f27c3152d3daaa7089a01899ef33a9",
-                "uncompressed-sha256": "20b031a0237b96c90eceaf6b8cd523388245ab12d28022b7639cda2badb06e7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-azure.aarch64.vhd.gz",
+                "sha256": "f382e6ba509c755564fc167b601acc4544bd1453790cdad624918fbcafa7a119",
+                "uncompressed-sha256": "1e1f1234e386655f042d932902716f20b61e01efa9e8f5f20411ebb43c52b801"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-gcp.aarch64.tar.gz",
-                "sha256": "8c81c2ddb100a21cd290870e3f62c3e57d4c08d781c6817bf0143985aac32130"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-gcp.aarch64.tar.gz",
+                "sha256": "7848485a4b07f9b910f102667aec11d1eaa6be20d2364a07c9038828c5842dec"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-metal4k.aarch64.raw.gz",
-                "sha256": "a786da18e195dc45d359a04f7147f8b70edcb97a146be1419601c59727b84847",
-                "uncompressed-sha256": "9f1333aba4f943b89de83de75afcacb5e194bc67d4ec3b59e5fc5032c3b791a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-metal4k.aarch64.raw.gz",
+                "sha256": "50395711dc5931abe5643070b60e8b176f1b692d68db6b206b01916486c21b1f",
+                "uncompressed-sha256": "0f9dc98520b41f7ee80120cef046e2283e9bb3b06a74d8515d17de2485e9b9fc"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-iso.aarch64.iso",
-                "sha256": "7ea8be2989e85ad7c089144716dd6e30343185dca004871649468ecf27c46308"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-live-iso.aarch64.iso",
+                "sha256": "37ce26e2052bbaaeab2abee4d96eb25a79995a09f1dbc71ed470e8eb090a2546"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-kernel.aarch64",
-                "sha256": "365986469730ef6cd2317a3a098dd6bb3d128a24d28c028d65f3e538399eaa25"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-live-kernel.aarch64",
+                "sha256": "e2e17799e63c7c7e3775def4afedb8ed8461acb42b1acbfb6efd5e04c6a28ef0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-initramfs.aarch64.img",
-                "sha256": "f04ad979c167753e72faca1d6df4a6188023497ed1cae27d50d26d3c0530f539"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-live-initramfs.aarch64.img",
+                "sha256": "4d6752243d3515fe057296b1b5a1c96d133f664c05af1671049fc5d86318ef91"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-rootfs.aarch64.img",
-                "sha256": "0ea68f6187d4964e966531f3237619f814d58b384eec2e47645347bed9f3ad84"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-live-rootfs.aarch64.img",
+                "sha256": "3dbbd480dd2f2d0b5d3fc200e622f3bc563712f329b7914ff605c48e850559a2"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-metal.aarch64.raw.gz",
-                "sha256": "94bc161ba65840d7c28704e2e03ee6ebfa8fa52b97ba032dda43f87db84f8e63",
-                "uncompressed-sha256": "2d89587937641365a1c9eb5a1701ad501b2978320e77e41ad7496170ab217c9a"
-              }
-            }
-          }
-        },
-        "nvidiabluefield": {
-          "release": "10.2.20260405-0",
-          "formats": {
-            "bfb": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "9972628d17ebd585edaff81aeb624c1d1dc75a9ebc9858c53da8cda4aa6e2fec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-metal.aarch64.raw.gz",
+                "sha256": "6b5c99c2c9bf2fed8a6896611048df502ed8cfe7282341c816acf3758091f59e",
+                "uncompressed-sha256": "ce15eae65ec11fe8082fed6173fee86f6a3fe7e6c962c6050fd2beaa1ee0cb9c"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-openstack.aarch64.qcow2.gz",
-                "sha256": "6d534cd2f188970920ff2b506321ce947c4520992c9608d0a7ad812a9d059c1f",
-                "uncompressed-sha256": "e241eef78bd60d6a24b2fb8d2abaad91ef94f48ee0b7ecee570f169c174bb923"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-openstack.aarch64.qcow2.gz",
+                "sha256": "8d2c0d49c7791fd18811a1893b6fb3fa6f318bb8bc6b7a0304be578f9df1caf7",
+                "uncompressed-sha256": "0a815209fca9d5313be9d1def3ce6220e45b61253544fe559ad5ad05d58cdb08"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-qemu.aarch64.qcow2.gz",
-                "sha256": "46289adada5d2819332fe54757f230ccb7430203b84c6d461064b412e7d9f6bd",
-                "uncompressed-sha256": "48d2d6e217032457086bfeb4b26ab17b428f276c8aa9dfb2173f691cad14c19c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/aarch64/rhcos-10.2.20260217-0-qemu.aarch64.qcow2.gz",
+                "sha256": "21dc4ceccf70409df6c522bc67b5eb03d58d516ddfe9ada709aa61155c33b69b",
+                "uncompressed-sha256": "4d1d6ec4c6dbf7dee8dceaa53a7dfde3d1bfc008573a6308358e7242f1219ffa"
               }
             }
           }
@@ -120,230 +109,102 @@
       "images": {
         "aws": {
           "regions": {
-            "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01edee0bc30a94bb5"
-            },
-            "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03a09cb0a80c9dfe1"
-            },
-            "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-008848ad3ce515986"
-            },
-            "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09fe07667320a3c7b"
-            },
-            "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-031c6e2d2e91d81e8"
-            },
-            "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d9ea1a9c9fd8993d"
-            },
-            "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ce5d7cd569f7ddcf"
-            },
-            "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e55b9a5ee91005b3"
-            },
-            "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-022fe13ec4f6b448d"
-            },
-            "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0766cd9c6911c4d4a"
-            },
-            "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0824c47c0c332a0d6"
-            },
-            "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ad64701471c4a4a8"
-            },
-            "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08ebba59f462478cc"
-            },
-            "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09dedbd99dbfd4e53"
-            },
-            "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-037ddf8344ba74866"
-            },
-            "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-056d2edf0ec039382"
-            },
-            "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-073af394c3ead0b10"
-            },
-            "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09b4f847184438c31"
-            },
-            "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05811424b806e1bfe"
-            },
-            "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08ddd9e4086c3b5da"
-            },
-            "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05358d3d407992467"
-            },
-            "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-076272842238056ec"
-            },
-            "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0fd49af85fc4b0121"
-            },
-            "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0dc571ee0a20af3bc"
-            },
-            "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09ae32c4d26889a54"
-            },
-            "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-077b9594541c0343f"
-            },
-            "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e35888f9497eedf6"
-            },
-            "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ad422d84cfba3c5b"
-            },
             "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d7237e6b04d9a9e1"
-            },
-            "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a3e0f0816d1ba247"
-            },
-            "us-gov-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e1f7f148cda4206a"
+              "release": "10.2.20260217-0",
+              "image": "ami-07877fd1847842532"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-043dc05714b5fea29"
-            },
-            "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-069d992efa13b2d3a"
-            },
-            "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-067c61e7fb4d54a67"
+              "release": "10.2.20260217-0",
+              "image": "ami-03f4778aa0e2961c4"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260405-0-gcp-aarch64"
+          "name": "rhcos-10-2-20260217-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "10.2.20260405-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.aarch64.vhd"
+          "release": "10.2.20260217-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260217-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-metal4k.ppc64le.raw.gz",
-                "sha256": "3db1e37f29293017c38459e0189f3d98ad62509539cd33b6ec36c52944971b59",
-                "uncompressed-sha256": "5a68828266eb29b75423b8693ecfcb70d694e441a52ab3599206f6de805e6a70"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-metal4k.ppc64le.raw.gz",
+                "sha256": "3932bd1c177447477e04c85679731af2d9b43abc5dc765c814b203c320f99492",
+                "uncompressed-sha256": "ac2f92f0c0ac659218946d7a4099a82901eff0c408c2d5fbcd49c3dbff7dc226"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-iso.ppc64le.iso",
-                "sha256": "cc57a556b882fd67cb333bcbb7a4e52acd9af3e153029d8c07b2cd6266c619a8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-live-iso.ppc64le.iso",
+                "sha256": "f6a017c9613ebde85436a6e16864630b6f5aa34efbc48fba5688111d592136af"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-kernel.ppc64le",
-                "sha256": "00d01662a7b9da0e27916100111fe671b79ff3fc1ab50f64e4f0559341e85b3a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-live-kernel.ppc64le",
+                "sha256": "304a4d09528fa99cd2f073c6c9f8a15d4b99ebbedc5ac981248789b04295d5fe"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-initramfs.ppc64le.img",
-                "sha256": "643ec38650f2d40fd7960b14e7ac47b7ce0927a1e5c3b5dd8c23f88da736b49c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-live-initramfs.ppc64le.img",
+                "sha256": "e22b0b64ae2b2aa95a949866ca74ccdd0b6ae8ce42cb8f3899be50c6b1a5cd50"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-rootfs.ppc64le.img",
-                "sha256": "f78f178ee7c3d4971a1a764ae0ed5be78605d4bfae87b97fbd6e4a12623a4967"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-live-rootfs.ppc64le.img",
+                "sha256": "ebc8f7df58cd5909e1c001d6e04cd28143be4be760b69828c8a5acd3c8d7f242"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-metal.ppc64le.raw.gz",
-                "sha256": "e9f85318686415d62ba0b7224349fb3b4369421abedc148104a9613ea5ceebf5",
-                "uncompressed-sha256": "23c2ea9288b23c56f676838578565dbe082b4227606521c022c36f0911993d21"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-metal.ppc64le.raw.gz",
+                "sha256": "6037725e749f1880e3ce18d8dd5aa73a775298653c8afe8cd40306c9612e881b",
+                "uncompressed-sha256": "cc294844175478ce8a1bab8e5f5dcb482c62b4807784f5e413f991f5607af8dc"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "8c1edfc4372ad8c544103c512a8fe1b856c2dfc87cbefd4100c3d46c9e849a90",
-                "uncompressed-sha256": "918dac1deee062bd20eb3af6ab8134a73f9bfdd7bd071fe9f774967126373b8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "ece1141c7e758c03d23da3b6ad8f4dab56dec0e2c6e1543aefbb35edf702ffe4",
+                "uncompressed-sha256": "ff3f56377208d0a40354790fc00f0e1babb4997bcfd40f5cf374a1440f8c9f13"
               }
             }
           }
         },
         "powervs": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-powervs.ppc64le.ova.gz",
-                "sha256": "c679883122fa6d563d42198c5f0ca133996eec7c0e9592fc767e1f42e5cfa29d",
-                "uncompressed-sha256": "4ab60d42ce6023f8012183458d16aad90a868feb862a0ac0f2b8721bf61e39b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-powervs.ppc64le.ova.gz",
+                "sha256": "a3eddc1616bf24f887837d05552c5677d1fd48886588f063521d3e85f4a9f53e",
+                "uncompressed-sha256": "cc6e3a8f41960ce35bf1c9695281f9ef5a719f9192f83afed9583f1c995033a7"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "f41180d5e74c0218247c5ceb91c4e5defd2d63189ba41b6387eba02a377b1ce0",
-                "uncompressed-sha256": "65b0dd052304567fbfff2aa5bc65cbca99cdd438f6fff861c41dca740b606ef2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/ppc64le/rhcos-10.2.20260212-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "96c414c1e8e4f0333d2667394135a7fb8f93104ed47627ddfb7a4b1ce9462e2f",
+                "uncompressed-sha256": "a40edaf5e4779cf2bcc511b75aa634bc5050ba2c520d6de60495955434a8d0df"
               }
             }
           }
@@ -352,65 +213,11 @@
       "images": {
         "powervs": {
           "regions": {
-            "au-syd": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "br-sao": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "ca-tor": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-de": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-es": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-gb": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-osa": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-tok": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
             "us-east": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260212-0",
+              "object": "rhcos-10-2-20260212-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
-            },
-            "us-south": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260212-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +226,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "9e9d4ff1a0913e009eedf914c2fc2126c0aec6dfefc874ebcede62001093328d",
-                "uncompressed-sha256": "09805367e90b08ade16e67f5683b16c7796588d885ae7fd0893ba56c373d0c22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "47679475914f04df2f66b63eded31e1d2db5f4a8bb33f685c1ab96fd6e3e06db",
+                "uncompressed-sha256": "0fae57d2446a31b21aaf26159a5d2e5f77b1aa99c296583068581e022893f8f4"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-kubevirt.s390x.ociarchive",
-                "sha256": "4f79d84853a69d3abab5faf450a588c1afbd0f2c54a26645761c2ce0361df8c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-kubevirt.s390x.ociarchive",
+                "sha256": "d3963b935882a8e5d638155f7620498923877c6e6bdbf23c309c9d3b8dbf083a"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-metal4k.s390x.raw.gz",
-                "sha256": "fece30e2d4a8dea9e0d3ecd6360f45fed1aee0f38ea4ca6ce554e68cdc04ddae",
-                "uncompressed-sha256": "470e5b44a0533dc6806d11888eaa39f81982968631d86d5d8d94840786b9f512"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-metal4k.s390x.raw.gz",
+                "sha256": "aa10a33002a289f6022c8ab0293d327bee5d8ad53e905d2ef43f37020a386cfa",
+                "uncompressed-sha256": "64d092ac9b39a5c2fe2ca30802528429b85964adc063f2e057ad534f5b900d89"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-iso.s390x.iso",
-                "sha256": "d97e25fcb0517e0dbed1cf63759b3d6fbe64df238184316e207d9b2902a38320"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-live-iso.s390x.iso",
+                "sha256": "292311733efb35d95c28a4b5e48fd98ad61ddcf91b1cf0c201a08f5401f76a63"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-kernel.s390x",
-                "sha256": "692867f01e6be50813a1f00a28155e849f767668898245cd14a72178b5b2b370"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-live-kernel.s390x",
+                "sha256": "5f0bbce3d4e614554a1e6440709351ed729b57ac94a5809eada9670e5df6b433"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-initramfs.s390x.img",
-                "sha256": "48c35995ce47b8c68ce255f4d0043ba699c15d26f9ab04790d017f5cd00a816f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-live-initramfs.s390x.img",
+                "sha256": "635e4982e630cf9d51eb7fb5a80710e53c42590bd41b2a63f9826738575583f7"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-rootfs.s390x.img",
-                "sha256": "1c60c8d4bd13471f823cf32fd9b24f6529108e2f5334ba83483b2214e6a16839"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-live-rootfs.s390x.img",
+                "sha256": "f96376602649d449dd6597abd47c171903fd6cd9d836ae97a797ab12ec574437"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-metal.s390x.raw.gz",
-                "sha256": "eaab142f77bb854538f96bd0b81e7c06fab25b3351328f31d3ecd83dc149fafa",
-                "uncompressed-sha256": "e69bdc89f9a1192a5e5a09a0861a25599200da247a919818acb36b686665ec3f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-metal.s390x.raw.gz",
+                "sha256": "337a498ad78813b8e57b880d355484bbe9a5c73db5ab6662ea8c00765e838639",
+                "uncompressed-sha256": "03519e53b7d4cf0429f80d0e6bb5c5170a2de546731dfa9ad0d7bbe86f4f53ff"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-openstack.s390x.qcow2.gz",
-                "sha256": "973c7bdf2aa8c689a7051faac86fac21956483ee7ed4cc526e0b8e922787ba07",
-                "uncompressed-sha256": "5d2a22391b6ced0b413be125dc8e910fc971a467fb208203db895f5b68cc60f2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-openstack.s390x.qcow2.gz",
+                "sha256": "560fe62fdccb13d5c06503059ccd299142d63a68ce2ae5b556f726495e511c35",
+                "uncompressed-sha256": "35421f4f4f5f7148188db1ee64e1f6c85f41b47da387af2c3847d2d9c52823c6"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-qemu.s390x.qcow2.gz",
-                "sha256": "2d47d448d7e075d9148c222f81f0949f018fffb1c0ac77f1cbbb8c7719b5e6c5",
-                "uncompressed-sha256": "5bddbe9212f636422543d480c5bc4bdc14845a256390af584979cfb14003a515"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-qemu.s390x.qcow2.gz",
+                "sha256": "d95335ae0e56f59f28bf7d79a00e2fb47d5ad5dbffea1ef7b1c41081086feb48",
+                "uncompressed-sha256": "18dd34fd2c77f8a627e6929bd9bfbc4793c7ffc2c1e195c2322dfc7d37447e50"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "c709b6e7ffeef0ca18c504b0387566f030676085b405ba1df24fe8df05bfd292",
-                "uncompressed-sha256": "70805c9e62412a1a013a0fde226cbefe2703f07838f60c4dd69804d92d747b34"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260212-0/s390x/rhcos-10.2.20260212-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "87db47b492ac122caa8fe81bf21371105b3cb58e5a096b94d5dbfaf457ac448f",
+                "uncompressed-sha256": "4be93bbe2f537d12122b85b169a99726fa85bc16a4d9e42189f9ddf38660facc"
               }
             }
           }
@@ -519,165 +326,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260212-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f78f955810dcae8bb94dd7d3349459d847099e6cdeb8da2ffdb37fd1c040d336"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c61c0c34f3b53d13a4fecb4c70545965979b0cfa362c0cd9cf7dd6ac532ac5ef"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-aws.x86_64.vmdk.gz",
-                "sha256": "0e79a40deeeb833f14ab4e520e5fb576b373ca69046834b157100aa0de818872",
-                "uncompressed-sha256": "f9c0544e959bcb31cda7a3381188634db56ab04723fcf7239f72ec0c57683ee1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-aws.x86_64.vmdk.gz",
+                "sha256": "0a10200768c63f678896937ebb2a5b3fb60150c1a7804e3991eec6e9a0a10bf5",
+                "uncompressed-sha256": "e36ec2e412c1384640f08cda98685d4ce0f804f3a6412339259a4e2ce5dcabdd"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-azure.x86_64.vhd.gz",
-                "sha256": "f28a0995b7d20fb7928d7b8a1752a983ea881d7b7f497c40ae5548bd17f05187",
-                "uncompressed-sha256": "55b910b5f0459add2b86863280e8c56f47d3f3097a4c145391608261b9a0a33e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-azure.x86_64.vhd.gz",
+                "sha256": "45fff162db0518030fd1966725e97a2caf34084aa87893caa0907f703c46dcf1",
+                "uncompressed-sha256": "fc1e1c6c3b3743c0c1f5f6bb2aeeb0187da855c5aa183642a1eade34389b9602"
               }
             }
           }
         },
         "azurestack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-azurestack.x86_64.vhd.gz",
-                "sha256": "987efaddd9535237c9c8a41a98d346f55c4cbaa5cd4f48fbf57aec6e6179bc13",
-                "uncompressed-sha256": "8e93444ec5b40f31089a2483d31db4a46c31696cbb65ece9e549f2201a983639"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-azurestack.x86_64.vhd.gz",
+                "sha256": "451143594b74b14fe73e7fa2d300373c30ec85d59ccee3c0017075edd1644099",
+                "uncompressed-sha256": "5ce10ac6cd9876fe22a61327b85c1d908880426886575f3fd80a317eee47b61b"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-gcp.x86_64.tar.gz",
-                "sha256": "2a05fbf5872c95ac72d591868a12bd679d7f99a34a130ab661f8132cab55a783"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-gcp.x86_64.tar.gz",
+                "sha256": "7e496aca563687231384fce9a18494ea7872c372876964b698a7552e3ccf0d41"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "f9613fadca1caaacf21c5005b0c8ef20345ce3d7b36add9226ba2c5dd87354b1",
-                "uncompressed-sha256": "113ea1c5a1bfcbbecb5c8202b590f17b4a73a594543d756007f8065efb34b98d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "b79fa56e8974e3c6bb49b5a6827308701cc33435afcf0a5478f810a807f67a6e",
+                "uncompressed-sha256": "eba6004f1de7c85813fa06567c34449ff93ca912d416e4cbd8505638071dab67"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-kubevirt.x86_64.ociarchive",
-                "sha256": "16372a2e36fc8a73f9f1fb6a8c0d987ef3b30a9dfd687221e3d82def2e781a48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-kubevirt.x86_64.ociarchive",
+                "sha256": "4ebecb5635b6ce01536263859d3635a613cb9a03e53c502c5f93c021c8e601ec"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-metal4k.x86_64.raw.gz",
-                "sha256": "d98bbb3c46ed61797650785862c3c7d27bad0c729982d965cdb59fb5f666bf6e",
-                "uncompressed-sha256": "02d571be69fdd8f50ead1323ae472e543c107042cf75c917499b465fa7117982"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-metal4k.x86_64.raw.gz",
+                "sha256": "9c38b65157340d053b546fc098a05593715d0d2e34d565d2fc24077a3c76138f",
+                "uncompressed-sha256": "8a4c12a53e03fdc3b735f3e06918dfe4e123a8dc4e79f9c25ca0f38b91374598"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-iso.x86_64.iso",
-                "sha256": "bc134e07147abe5420a7e7e59d041984a0b94593787cfcc87efc52e159ad04c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-live-iso.x86_64.iso",
+                "sha256": "0e5a5de2824e6853381191a13997aa059e3728f365da1737d072280a9ab1f1c5"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-kernel.x86_64",
-                "sha256": "62f6c048aef362c496f6f7cd3b0bb07d9a648fbacb212e2d1951979dcbe72f75"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-live-kernel.x86_64",
+                "sha256": "dfaeefb21530722f3816f11971d5e465fe5524873318ddfb1812a4630c343203"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-initramfs.x86_64.img",
-                "sha256": "af9ee3295284d439c99d36ea0508b8162279bef7271087375c98547ea132f05f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-live-initramfs.x86_64.img",
+                "sha256": "deb95a7772fab17a6ac36007d2a7ebf6520bf1fa5353def9b488a0be24c56b2f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-rootfs.x86_64.img",
-                "sha256": "59d7394ec157b50b73b08ea373cbcee4b4897bd36dcbd31d24862f95659f355b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-live-rootfs.x86_64.img",
+                "sha256": "c5611cfc2ed608b7d6114080e7fe44e5c6b976e3dcb612c1c2092390b4975d97"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-metal.x86_64.raw.gz",
-                "sha256": "199b3ab66e1713a816e6f7c303dce08858d6bc945e5228a2cdc8c38ec22b1d7b",
-                "uncompressed-sha256": "b3ccfed4e71dff91c67e82a19a90079f88f988f673e7f0b596bf299640b34fb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-metal.x86_64.raw.gz",
+                "sha256": "75de16d12742e769d6afaf15b37ff19673a26f8adb4853bad4377db4bed7bdac",
+                "uncompressed-sha256": "ab3daa967b3745df10ced9b33123b28241de741ccb079c400b9117b696718f6d"
               }
             }
           }
         },
         "nutanix": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-nutanix.x86_64.qcow2",
-                "sha256": "30526d7a30ee239f4ccf8e763f4d98921408fca42b8cde569cc03d4f1afc16fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-nutanix.x86_64.qcow2",
+                "sha256": "98e6dce8049d369354b0b8f255ef8d55cb4c74ee2421dbc07ddc0781ce0cb3bc"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-openstack.x86_64.qcow2.gz",
-                "sha256": "baa7d50598d76c76e65342d38fd5e90e34e9874ae1f6e82c3f2ad8303747a3ca",
-                "uncompressed-sha256": "a502fba4cc14d2c057f0f37635b9269d78bce51e2f0ec4d51d2ba18f33abcd8a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-openstack.x86_64.qcow2.gz",
+                "sha256": "0b09817efb6ea589d5310f8e0e734c2d7702a5001d6023cc4b06756f7733d59e",
+                "uncompressed-sha256": "3f4c135c55032218fc3a99c2df3b2d642e2b4fa9c2512db71068c5c736068502"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-qemu.x86_64.qcow2.gz",
-                "sha256": "644727600b591043068abb973ddbc4a9edf5c8339f57b5d9b52f2bf3c7f7933f",
-                "uncompressed-sha256": "895aa8e700b46cfbf37fdd78eacaa2265df03ee54cd17dfa1ed08a6eac052537"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-qemu.x86_64.qcow2.gz",
+                "sha256": "9bccc97f893859fb344605e770afbc9808535ddd88059641a818e84aa41cad16",
+                "uncompressed-sha256": "962920307016beaa89f44f9226ecb1848e2882652531ea173e4e12f95fae805b"
               }
             }
           }
         },
         "vmware": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-vmware.x86_64.ova",
-                "sha256": "4803d8cbf8daaa10f313fbb8d9ec32a8475ff39e99f4cb4e9a0109aacab5b44d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260217-0/x86_64/rhcos-10.2.20260217-0-vmware.x86_64.ova",
+                "sha256": "2b1dd7f4aee7f2a60ac3f590c9b128350e39ed0fb7f6a117f753ac823c17a576"
               }
             }
           }
@@ -686,291 +493,31 @@
       "images": {
         "aws": {
           "regions": {
-            "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a5186e691de81b43"
-            },
-            "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-095dbd24b0328d8f2"
-            },
-            "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0120ea02d72754898"
-            },
-            "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0119e1aa14e77f023"
-            },
-            "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-063029f6170f5fb08"
-            },
-            "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07c023a841de3abbb"
-            },
-            "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01f8e80ccf33fb439"
-            },
-            "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0182cb1899dad4230"
-            },
-            "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06fe46f545f4adb4e"
-            },
-            "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05d070204653b863b"
-            },
-            "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-037682477b7eee3f7"
-            },
-            "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0c8818d4996139914"
-            },
-            "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06fc5006bc10caf7d"
-            },
-            "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a52ddb2fcc8fe88f"
-            },
-            "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d19766e284c5f89f"
-            },
-            "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07d662acb724c625f"
-            },
-            "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0724849b24d060479"
-            },
-            "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0db356ac3398f089e"
-            },
-            "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0616753f8aef330d7"
-            },
-            "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-070b4ab25ead43ee0"
-            },
-            "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e8d492e620ed47fe"
-            },
-            "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e08f4b72e21951fd"
-            },
-            "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d04bd5213ffc3375"
-            },
-            "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-016640529413d5d07"
-            },
-            "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08febdec5fd6a355b"
-            },
-            "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ebb642433bf20836"
-            },
-            "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f7dbfb82a920a17e"
-            },
-            "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-095accdf292e4bef1"
-            },
             "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-04b3d999e39d62c5b"
-            },
-            "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01f66c80fbd6ec318"
-            },
-            "us-gov-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09fae5aa44aaa25ce"
+              "release": "10.2.20260217-0",
+              "image": "ami-0f498601fb4eedad7"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-036ce6462af177ac4"
-            },
-            "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06bf0843dc9cefeb9"
-            },
-            "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07e365adf44ca432a"
+              "release": "10.2.20260217-0",
+              "image": "ami-09ae7a3678baea073"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260405-0-gcp-x86-64"
+          "name": "rhcos-10-2-20260217-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260217-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:843e75c16c01218cae95c74a879934a1f3ad80a2149963510a51b1f45c712c56"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9aa57d49c3d2408c94335f4f250ed037a2edb7cf123d6409a9c6447388a91584"
         }
       },
       "rhel-coreos-extensions": {
-        "aws-winli": {
-          "regions": {
-            "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f00691d8919286c4"
-            },
-            "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-02085d30468be6719"
-            },
-            "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0b96642864753f697"
-            },
-            "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0b5b4c2fe3e88be4c"
-            },
-            "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0be7d6848e2b14148"
-            },
-            "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03fb1d841af122247"
-            },
-            "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0609e9fa550a150e4"
-            },
-            "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0036e48df55f3a921"
-            },
-            "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03f094834eda476c7"
-            },
-            "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-00cfb331b864e5fbe"
-            },
-            "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0042f8ac85b52471b"
-            },
-            "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0824247384380ad67"
-            },
-            "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-048aacf6d224a325c"
-            },
-            "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03253e81cb2e25e2e"
-            },
-            "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01cb1c80408928303"
-            },
-            "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0589bafba30fe4c4b"
-            },
-            "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f4dc7e47df2182a4"
-            },
-            "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d2f1dd6ae6c1fdbe"
-            },
-            "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-032877114a3719bda"
-            },
-            "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-031b0c6271a807e8e"
-            },
-            "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0690f5cbf014a02d0"
-            },
-            "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09ae00621ff968d46"
-            },
-            "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09b17993cb4bf253c"
-            },
-            "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-02dff4f6a9f6c5ff2"
-            },
-            "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d1d7fc52c042403b"
-            },
-            "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03bb42b35d1200c2a"
-            },
-            "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06bb2a8ffc898e0ad"
-            },
-            "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0fe32d1a681daeb35"
-            },
-            "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d7d1fceead28e9d8"
-            },
-            "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01125c8cf99da2698"
-            },
-            "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07c4334822b5d5674"
-            },
-            "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-086ae350505bf8d38"
-            }
-          }
-        },
         "azure-disk": {
-          "release": "10.2.20260405-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.x86_64.vhd"
+          "release": "10.2.20260217-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260217-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/coreos/coreos-rhel-9.json
+++ b/data/data/coreos/coreos-rhel-9.json
@@ -1,117 +1,106 @@
 {
   "stream": "rhcos-4.21",
   "metadata": {
-    "last-modified": "2026-04-08T16:31:47Z",
-    "generator": "plume cosa2stream b23d8cf"
+    "last-modified": "2025-10-28T23:18:17Z",
+    "generator": "plume cosa2stream 3cc4eb9"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-aws.aarch64.vmdk.gz",
-                "sha256": "f92520243568674701e13d0164b33a4c93b133ec50ede26ebd0c59c4fe8c1cec",
-                "uncompressed-sha256": "f48495aa27ffb9247f0328cd7c0854df637f4eb49a650d004a60020111375f6d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-aws.aarch64.vmdk.gz",
+                "sha256": "aa39612e06774e31f94358fe962561f4fc384f34343c487e8720bd89af2b7324",
+                "uncompressed-sha256": "8cee2831f921c70693507c74effcc0a0191aa16b6ca5d0cbf59108b0fc7c914b"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-azure.aarch64.vhd.gz",
-                "sha256": "875e90b2b3c268b7909382f6731a15e73a70cc0ed6f7798cdb777312934a7d9c",
-                "uncompressed-sha256": "0494b3adddc84f998fc98968db7430c734935d1b6770692fb653d3e71d383b7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-azure.aarch64.vhd.gz",
+                "sha256": "bea6a3c5543edd47a216ff1e726c58cd09c5e7bbc385cad161340fefdd364a3a",
+                "uncompressed-sha256": "bf840fd71ce853b01bb222a5b8f947c94b8c6c76a98b4ed4d47db0f3f617a05f"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-gcp.aarch64.tar.gz",
-                "sha256": "05d123a1d851ed32ea8179078565ed5c4a2eb0c782bf5a72b0abf39ec7c5eb4e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-gcp.aarch64.tar.gz",
+                "sha256": "ed2a0990b70318e0ff0a36936bb0d19651d85afc34f7e8158d22bfd097994ad8"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-metal4k.aarch64.raw.gz",
-                "sha256": "37d7793d9f2d000e5568f751ebfe0693f2f05493513ba76927dda42d57ed261e",
-                "uncompressed-sha256": "d6021e58aa6e3dc7e94eed702af3b3193e8224af7fda7264159f22fc3ae88992"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-metal4k.aarch64.raw.gz",
+                "sha256": "4c693b218af1b55036ceefb2db9732b823bb7a95d7f5ab10d66e7d3f07905572",
+                "uncompressed-sha256": "b6390ecce7394ad1064779896f13abfb0eee47371c7f626e79e6dc6feb81cdf0"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-iso.aarch64.iso",
-                "sha256": "238ee82cc6e364d70972fffae5c20edb178ef7dfea2ece5c980b97bf13109f1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-live-iso.aarch64.iso",
+                "sha256": "5d4aaeb84591a1cfb8585ec4a00520cbf8d950a7796213af95bc1be8faa59578"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-kernel.aarch64",
-                "sha256": "3a1ba2ce594fffa19b8b6a0ade9257093b77f96087a370b6364b95813f80ba63"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-live-kernel.aarch64",
+                "sha256": "b5ea6189785c9b2a5fa7520d9893a7f51418bcd8586c62e65a034bb741b3aa00"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-initramfs.aarch64.img",
-                "sha256": "09052303db582c06bc725fd6dfebca109f598a79694aec934b0f9cef4135f8f6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-live-initramfs.aarch64.img",
+                "sha256": "d726cbeb275b7b5f2d5a5177f3866f80acbeb6e3566af7dac1895a625373fcb7"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-rootfs.aarch64.img",
-                "sha256": "324c6ee893727c46201c5e91f56cb91c6c46a4733bba5ddbcafa8239827f8873"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-live-rootfs.aarch64.img",
+                "sha256": "66078a363d4e76540c4cedc8e4756f67a852c90964e8af5ac4dec8a18995ec5b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-metal.aarch64.raw.gz",
-                "sha256": "a2fff4fd6a9274ef86cd5504b441f44cb61f9f2396da852c71ff366e21251265",
-                "uncompressed-sha256": "6229720930e4eeaa033a5e88dba6593f1219c483f2142d59728807ac603b3c1b"
-              }
-            }
-          }
-        },
-        "nvidiabluefield": {
-          "release": "9.8.20260403-0",
-          "formats": {
-            "bfb": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "d45339ff7b01fb848ca4961dbc8ea2cf83ad4071e2c49d8daa76c1e22b5d12b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-metal.aarch64.raw.gz",
+                "sha256": "2e437d5618f045d2b31115031198afdcb4ee7b2930976e6845fbd4445c1f377c",
+                "uncompressed-sha256": "3099dcc2bc833794a63dfcddf51901ccd67a232c34ac840c25d845c10721ab7a"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-openstack.aarch64.qcow2.gz",
-                "sha256": "9132bed288761f6df76605bcccd2ac0c58a371ca64097e5fb876e01f3c20dfe2",
-                "uncompressed-sha256": "d6ae130c04e2347994a73a05080e857622cf9ea0ed424b01cd9181ef885cb451"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-openstack.aarch64.qcow2.gz",
+                "sha256": "15fa7110a04dd223f9c76fa536a3223029f76cdbb3e4ea502218c0b02235865f",
+                "uncompressed-sha256": "c0def555de5d179a2c104d4daccaa9079f893de9cabff386442ec3be0315ba1a"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-qemu.aarch64.qcow2.gz",
-                "sha256": "95b3d98022f93934a0bf8f2e157dc4565f449f5ab8e11a69106aff2023c34300",
-                "uncompressed-sha256": "dfa03aa6084420d2d4c12e57823f93476be83adebb2292effe0df5104274d231"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/aarch64/rhcos-9.6.20251023-0-qemu.aarch64.qcow2.gz",
+                "sha256": "f31a610474a7216ee8f7f76303ee3acafb601c70d1284845b2d9bb878bbf8461",
+                "uncompressed-sha256": "5af1a1d6c6dbf17de392b1efcebbfe43f32d20b6bd0a15c47160ef45d9a04261"
               }
             }
           }
@@ -121,229 +110,237 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f2fcde0f89e82126"
+              "release": "9.6.20251023-0",
+              "image": "ami-0f0ad867853b6a164"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f0e6c777fb84dea1"
+              "release": "9.6.20251023-0",
+              "image": "ami-0941cd5e8bedae537"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cebeb66cae0ad43b"
+              "release": "9.6.20251023-0",
+              "image": "ami-0ead94f5ec52ba646"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f02f9df51c3b2466"
+              "release": "9.6.20251023-0",
+              "image": "ami-03604b1d12493b653"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ef42150f8ed8724b"
+              "release": "9.6.20251023-0",
+              "image": "ami-090aa5e21b14c93d9"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07cd4dbc84110b760"
+              "release": "9.6.20251023-0",
+              "image": "ami-089e37e019d2e4a92"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0eebbda1924f5b27a"
+              "release": "9.6.20251023-0",
+              "image": "ami-03c5697f9a0b458d8"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09beb7722571337fb"
+              "release": "9.6.20251023-0",
+              "image": "ami-0bc35fc049cb469ac"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-00cbb34289088361f"
+              "release": "9.6.20251023-0",
+              "image": "ami-092bdbddde71990a0"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-03b9e25a16e8e8d25"
+              "release": "9.6.20251023-0",
+              "image": "ami-08f2b43ca0e3f6075"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01b713db435c0cffd"
+              "release": "9.6.20251023-0",
+              "image": "ami-0e51154cf56b1be19"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0424bef7aff7cb9fa"
+              "release": "9.6.20251023-0",
+              "image": "ami-03d987359dbb00984"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fce5133c9050abf2"
+              "release": "9.6.20251023-0",
+              "image": "ami-03fd33c2e45aaa893"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07fd5fc0595c329c5"
+              "release": "9.6.20251023-0",
+              "image": "ami-004f24204fcf1f9d2"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-073b3d2c641f0ef50"
+              "release": "9.6.20251023-0",
+              "image": "ami-014fc8615e034e33a"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-074572ee3cb06afd2"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a446e46e1ee037db"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-04a43529b09c3e688"
+              "release": "9.6.20251023-0",
+              "image": "ami-0b744eae96c8a079b"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a1cff59535f01a5d"
+              "release": "9.6.20251023-0",
+              "image": "ami-04ae961842e2912df"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07900f4ccd36aacb6"
+              "release": "9.6.20251023-0",
+              "image": "ami-0cda0e12c874e9351"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ff829266b0454a46"
+              "release": "9.6.20251023-0",
+              "image": "ami-092b2b8017d7b53e8"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-043e0e38e3d788fbc"
+              "release": "9.6.20251023-0",
+              "image": "ami-0ff36a21094797b8c"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f773283ae135ca1e"
+              "release": "9.6.20251023-0",
+              "image": "ami-015f8993d0d4eb748"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-018a69310b9046c03"
+              "release": "9.6.20251023-0",
+              "image": "ami-0726ba77ca3cd5aa5"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ae39fd2e812b280a"
+              "release": "9.6.20251023-0",
+              "image": "ami-0405d819c3404d5f7"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fb75dbad40175071"
+              "release": "9.6.20251023-0",
+              "image": "ami-0bc7437510c183cb8"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d5d839a1fae35bce"
+              "release": "9.6.20251023-0",
+              "image": "ami-0abcddcb1c820a83b"
+            },
+            "me-central-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-0475df8e53b40f321"
+            },
+            "me-south-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-0a2935f6a91fdb254"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d36d9902213c350b"
+              "release": "9.6.20251023-0",
+              "image": "ami-0c146705aa788484d"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09b618abde46f25e2"
+              "release": "9.6.20251023-0",
+              "image": "ami-04f72397412a9b414"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e73a95fb409d8abd"
+              "release": "9.6.20251023-0",
+              "image": "ami-08e3890b24e081680"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0bd8dcdde4641811e"
+              "release": "9.6.20251023-0",
+              "image": "ami-08c722d26e3aa59ea"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-062e02fb7b255a2aa"
+              "release": "9.6.20251023-0",
+              "image": "ami-0efd1b20a2003cfca"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-00f8b2108f37fa11c"
+              "release": "9.6.20251023-0",
+              "image": "ami-01a629f0635cdaec0"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ddc9a437d26c97ba"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a0a119a582440dbb"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f4439b005ce8bb83"
+              "release": "9.6.20251023-0",
+              "image": "ami-08f057655f733ad89"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260403-0-gcp-aarch64"
+          "name": "rhcos-9-6-20251023-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.8.20260403-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.aarch64.vhd"
+          "release": "9.6.20251023-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20251023-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-metal4k.ppc64le.raw.gz",
-                "sha256": "f71f7577123278cb7b49307b19f81feaf62a1541521544b558f318c2c7dcf542",
-                "uncompressed-sha256": "7789eedcfba552af13e839e71e0606b1a4a380b5519e53062d19824bcc9ebddc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-metal4k.ppc64le.raw.gz",
+                "sha256": "243562bc8a9b1c8a43f74b34affbffd1b7ac3fed6a2bc457f35139521e3b5bb5",
+                "uncompressed-sha256": "f3cde59fe9dec6a2af4af0b59acb32b9994af25d3145df6b837a1fe64ecdd3b8"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-iso.ppc64le.iso",
-                "sha256": "c0ec496f02a0c1fe52d8b3ca6cbc6f43fac718bbf758faf45fe668bf45ba635a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-live-iso.ppc64le.iso",
+                "sha256": "eb9fe7b819ff51cac2d91ff32f8bbb03a0b2b2e40cee78e3b0bf305fa1d5d086"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-kernel.ppc64le",
-                "sha256": "0a80cc120e5493a5d198cdcd04214552c57f90adbd21899cd54e6a7f561c37d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-live-kernel.ppc64le",
+                "sha256": "59305427836422e6dd7e14cccaa768eedfe418408eaea01c25f8a6e1901e7374"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-initramfs.ppc64le.img",
-                "sha256": "60d272fac65b5b66787429b8aa7b8734343a91237650023cacb7203e2564b3de"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-live-initramfs.ppc64le.img",
+                "sha256": "47644be368bbe380ff6eb1676fa3983fac7fb0b77a1387753f7e53b8bbfea1db"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-rootfs.ppc64le.img",
-                "sha256": "1f82ecbc4a5c4478b549277e8ddc5acb005e423f71bb044fc69e5b70be0da9c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-live-rootfs.ppc64le.img",
+                "sha256": "04362329924431eae9d0176ee370e688117fcc3f0ba82f8ee299511f07a68516"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-metal.ppc64le.raw.gz",
-                "sha256": "0b2d07ede4ddbb3cb3e318ebe9d8c131491485761d11c17b71bde183f68a2f30",
-                "uncompressed-sha256": "54986f20c07f0e4b7db8bfa30710f6349b802284fc38ded3d0efc089dc4ca37a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-metal.ppc64le.raw.gz",
+                "sha256": "54fa94f8fe062db2a72eedc353f859f3ef3dc5159e7bdd5609721e439471bf30",
+                "uncompressed-sha256": "80249c148b72a9c200ab8f1980d833b9c1406948aea4a1221f246f003a6bbbf0"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "098d862bbe8ea4bade551bbb7d0b1b39c009c51bc6e07a360fd5f21ef15a5781",
-                "uncompressed-sha256": "7088202adf16433b1fdf82f75d276b39e12559f0e80564ef26bda1558557d92f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "ac9f159a7e86937af3f3944ddd464547f779913c365a930b8db11dc4a6d823f6",
+                "uncompressed-sha256": "6f40c859a47b7deaee3ad8021e8e254254e1bead1635e697169e80237ab7fd55"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-powervs.ppc64le.ova.gz",
-                "sha256": "1129b85d576de1c4faede1f671009fe9b50c824a7b58a72dcde3636f26edfbfb",
-                "uncompressed-sha256": "c023130cb317959cfba262c871d3f32106830622aa406ace684ae0579314f7f0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-powervs.ppc64le.ova.gz",
+                "sha256": "afc10c0b469968132648624694265bec1e52541d19863a6d38b76a6cc80d7bf3",
+                "uncompressed-sha256": "52f7a6779c7ccf38547ccd856421ee5314274a26962a7760f7aba36788efea46"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "428dc3a8045400c3faf0118779b861213314b7f08f671710a71fdb9555991988",
-                "uncompressed-sha256": "a0f30b5d08d05754531abc61a6500ba0929db0fda12ed4f85508b2074f9be9cb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/ppc64le/rhcos-9.6.20251023-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "dcb96a1cc6d76f88e027c3c6b07981433bee38ad4fe2659e37ba51033f693519",
+                "uncompressed-sha256": "339ec3fe965e1852b6719f0aca0404917ea1c9b96fa813314ae8eea04aa148ac"
               }
             }
           }
@@ -353,64 +350,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20251023-0",
+              "object": "rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20251023-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +416,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "8bb71320fe3905ee74325f8ded2e509b9b4305cc6afef33303aa785a7b925326",
-                "uncompressed-sha256": "0e4e13ff0ca54b0d268ba9fd55e09c7d7f3fa922d8333eaab76cd7fd98ddfd50"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "c9b429817d0261179c811d58acfff3f41f97a36a74b09a19a9d1ecd100b94b04",
+                "uncompressed-sha256": "35f288a6a4004847c0b5c0212f2c41513919716fc1188d482504e017bec53843"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-kubevirt.s390x.ociarchive",
-                "sha256": "ec1986ba649cbc6005f3602c16842739b2d630f9c7ec722b866bc160b5c52c9b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-kubevirt.s390x.ociarchive",
+                "sha256": "1f729a145186b8f682e1882ae806c43fa4e5aef846db8158a033cf9dde8c5d91"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-metal4k.s390x.raw.gz",
-                "sha256": "c5a9346092db8fea8d2618abaedfa66adbebb39dc53aa325fdb4d58489b09e51",
-                "uncompressed-sha256": "544719e47c0fc90b144bcfc82be518763b529a37a04d7ceabfad78e743ea439a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-metal4k.s390x.raw.gz",
+                "sha256": "675de492382c0bd727ced8f77666a7f76dc35344d295d5e548b823fde33bbc35",
+                "uncompressed-sha256": "3dbac094ebba3b048696e135767565a7bb926dbd2bef6f98589d27f31a00a6ae"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-iso.s390x.iso",
-                "sha256": "6417aa2f40ad6b4800bbe310ddecc70c0edb8039352bb1dd14cc03fb2942e2c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-live-iso.s390x.iso",
+                "sha256": "8533bfa6fe4d32cb7a303f437029deabc38161a6a5b185baeee18bc35d3222e2"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-kernel.s390x",
-                "sha256": "d09356ff4b21476c37848d2762757fc7bfadb8269a9d56fc869bb30679d5beb3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-live-kernel.s390x",
+                "sha256": "edaec798e7c832bfe732f1bf4eccf78565643128e4ed06980f215724553c435b"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-initramfs.s390x.img",
-                "sha256": "0a160c204567edbbf50a18c5e7a948be4db48e7ad57e9f6f7afa9b977031358c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-live-initramfs.s390x.img",
+                "sha256": "b958a2cd19698422e6add94c82fc04bf39ff9b052c7403fd0f685e1a548f5dd9"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-rootfs.s390x.img",
-                "sha256": "358edeed9e75dd0cce60b518c52039c18ff217396c7a55973e463d2fa2efb865"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-live-rootfs.s390x.img",
+                "sha256": "70e1700d313a9724baaba9b421aafa1fe49f38cf132672b607c9468d841054f1"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-metal.s390x.raw.gz",
-                "sha256": "a9e0f963454b2c4e3bcfdae91b8010496277b16b7d80220a59fb68b9731863bf",
-                "uncompressed-sha256": "398e08f441eafaf90f5d6290cc67b89194ee4009d0c8ea0edbe02a37064b44b7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-metal.s390x.raw.gz",
+                "sha256": "42874e324403e233a2ebf7d463464dc3c523939b8585f4c3f22d35d42f70b45c",
+                "uncompressed-sha256": "f8df7675d86ba5e697c0c241a2c9f7fa07f1c3e104b65a2fc08ee46fcc8ccc40"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-openstack.s390x.qcow2.gz",
-                "sha256": "82d18e03bed79f6f5b477f5a1358826626953c43d177ac6cb23b8285e660667d",
-                "uncompressed-sha256": "cf909c4a91bbc71ec452fa1a3530d4a5931c3bf5b48a28feabbbcbb040b3c2f7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-openstack.s390x.qcow2.gz",
+                "sha256": "51c1756a7036406e51e079d1147eb9fadb4cb89eec351107ef360fead078149a",
+                "uncompressed-sha256": "c770cedc1d69880299bf0a53cdc0809c074a618f8b99eb827f30f9ff5bceaea1"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-qemu.s390x.qcow2.gz",
-                "sha256": "b49a2d3a9e5d2b3c1c38ebd226ff306089aa3ace175bdae275aa05e196894684",
-                "uncompressed-sha256": "863d63ec221171552023ee0558b9ff0282697b9c2dc9b2ed88ccf3363bf6fc86"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-qemu.s390x.qcow2.gz",
+                "sha256": "fbf22880d0eeafa53c7116dd4310cd647c811d9898baeb69f459475c2057e64d",
+                "uncompressed-sha256": "20dd20a1e7403f14d8df8544215baf7e6f090f7ecd39f8ad45853224e806f384"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "ed0297535feb7300cafebe68a356c29c50a16c7d46273478a9c7d223974c6327",
-                "uncompressed-sha256": "13abc5144bab6311cad7fd34ff8c75398c8e0e9c2b8ce9211ce02a0578765e6c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/s390x/rhcos-9.6.20251023-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "ac37be46fa99275650b86dffcccebeaca0184bdf1209f8c6cb6cfa5b46357994",
+                "uncompressed-sha256": "d5b4faa46291db3a459da96f6599a7e63f9925e8cbbbfa33b70cbc890d4339e4"
               }
             }
           }
@@ -519,165 +516,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.8.20260403-0",
-          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b341d5f935078919094314551b6feefba5b3d640e71cc3cc08c6e63e14cddf15"
+          "release": "9.6.20251023-0",
+          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ef22f7e6862e849e5ffaa2fe49b949c6a0f3405f5b0c142e495c9b2adc44972b"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-aws.x86_64.vmdk.gz",
-                "sha256": "02a831ca684a403177d0d8fca6de5627360cbf5fe99652ee6bc228152298d2d7",
-                "uncompressed-sha256": "c4ebcb48d77c57141711b2294317cf4502f3de52ffcf4518334f20de0446f0c8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-aws.x86_64.vmdk.gz",
+                "sha256": "a77448cdce8186487120680c8b61f07e9571014a7123fe4c86f942be1772b85d",
+                "uncompressed-sha256": "43f3b7a95b5310d0226a9dfe1e21c1094d983853a8a12be1209c7fe2ca8d1445"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-azure.x86_64.vhd.gz",
-                "sha256": "10e4adcb1e1469faef4a3fde5fd80c41c697b7b9fa7c8867366e679751fe74a2",
-                "uncompressed-sha256": "068b1cbb92e6e2c49a3e6330d1d0f36271a0a8744a292806a7970936b85a6803"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-azure.x86_64.vhd.gz",
+                "sha256": "9d3a1aa3a7615b9f35e3b97b1c6643e82bb021b6fa2fd4d24336e5333fbdefbe",
+                "uncompressed-sha256": "35c6d6d414cd82778cb55fd365fce2c2bcc10b74f30ab67d5cb4613509bc8bf2"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-azurestack.x86_64.vhd.gz",
-                "sha256": "79afc03df966bbfac192888d02ca599e78a8f9e5e18ae7fa5d2dceed52adcf2a",
-                "uncompressed-sha256": "de3aa7fbb6f770e8ff7295b168919b46a62a67f7a1fc51b02fccd2044137f20f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-azurestack.x86_64.vhd.gz",
+                "sha256": "35310cc82653eff9405c31d3d89de71149a3c0e4de27dca20e3911bbd85d8d63",
+                "uncompressed-sha256": "f860a6002114eb82fb0ebbb3f963aaeb80a772010e7a3649d970e52eaf813b9a"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-gcp.x86_64.tar.gz",
-                "sha256": "f23211117ef449d5ac61cf22f0879a1a7036a0a2354e0d401c616c01c59e8777"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-gcp.x86_64.tar.gz",
+                "sha256": "ccf19e175f553244e9a0422e3a8255c3938f2d624ae7d6e2b71dd3e0f06671e7"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "986c0af62b00e447a4c5df9c6daf31877b8c7da6c6b0db622e47ec616faef9bc",
-                "uncompressed-sha256": "75947ae3f0d72f223ce03d3422360a51c339d4edee96e91f176bb38ee513f579"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "6baf690cff7752b126f4fd875df3b4cf3fc5ad1451080db314d2f97a1d6f7900",
+                "uncompressed-sha256": "a2053e1cb20347ac18e18baf99852971c1be375a53651150241ef9291fc26910"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-kubevirt.x86_64.ociarchive",
-                "sha256": "1429c5556d2f2cba57f66b8df775f093e94b297de85a7a820edce601c144b72e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-kubevirt.x86_64.ociarchive",
+                "sha256": "8e857d944935be2cf9816f80fef4e63bdf38891d44aa3addbcd809ae4cebd154"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-metal4k.x86_64.raw.gz",
-                "sha256": "6e2fc5eb4a1cfcea7400029808e10fd7618935e41914035dcecdd3b11f504f75",
-                "uncompressed-sha256": "e9f983d01eebab07fa429b6c570bbf9b9b704f6d418af8164befbfc6385dcd9d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-metal4k.x86_64.raw.gz",
+                "sha256": "f459c1c0d4086fddc5b306ff077589e424ea2c989b6a14fb2db43544909bc776",
+                "uncompressed-sha256": "ce94851873b4b2f16fa914e5e7dc184f9ad0aa886c4951464360286056e1d170"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-iso.x86_64.iso",
-                "sha256": "61528a9344940565875f7c9d1f7ee0274fa4dc56d014f5e8b8af4759545d15dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-live-iso.x86_64.iso",
+                "sha256": "dad64dad115fa61cf0e674b559478a1aa485261319b1b7f2e2260f329cf7f36a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-kernel.x86_64",
-                "sha256": "702d1d7f999f5036e79c2b223f9a77089453b7677a504ed38e7182009f34338c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-live-kernel.x86_64",
+                "sha256": "9e0972beaccd9a92a2b88cf9dacf709b90b249838a683a4d396220547732dea2"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-initramfs.x86_64.img",
-                "sha256": "aa2c109aab062b8fab3b76293e413be3b264ee02182a79c594fd3f49968ed7af"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-live-initramfs.x86_64.img",
+                "sha256": "7beaf1118010c1b4792f0af91e78bc35a43830d984d08c5716dc922da3fd0c7f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-rootfs.x86_64.img",
-                "sha256": "a874ce2a7ee0a294a9cdcd3427b1ec19e1756c8ecd32803b4efec7a6b0d5f63f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-live-rootfs.x86_64.img",
+                "sha256": "bc30f5e1fee143b3af4bacafc8bfb2e1e21f8730c5bd9c3a120a10d5b96a3eb8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-metal.x86_64.raw.gz",
-                "sha256": "6bffa8c2c1b86effced25f319ec8e702bb3462b060d74e801beeab80dfb66c8a",
-                "uncompressed-sha256": "cf1585f0c1941bea5b44a0b9e1225831a37ef591d14ed29b19b7643a45048d37"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-metal.x86_64.raw.gz",
+                "sha256": "dd602910d2c18a70acebae2582ada8a1d33290f1044fb42bed64d331a19a7e08",
+                "uncompressed-sha256": "d38602459f6f0ed0421d20ea83e0fc044e6e6e2260cabbfeb49ea429ee8fe8de"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-nutanix.x86_64.qcow2",
-                "sha256": "ff84dfe5905abce5cfb7f232dd3c6e664eeb9a592f51ecb87dde34e73a03c8ad"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-nutanix.x86_64.qcow2",
+                "sha256": "1402609fc0f6f05bfe6dacf5bd0235c627f23b9a05a7bc78dcdcbfba4a83f4f9"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-openstack.x86_64.qcow2.gz",
-                "sha256": "d774960b396372c0ed2ea00a4d98151b1cfea9c5bcfc106d3e51566b4e9cce33",
-                "uncompressed-sha256": "4664af3a371164888f096806e4b6e887f49e74d36e01c3a3a187600143a7d6e3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-openstack.x86_64.qcow2.gz",
+                "sha256": "ff029b9af536440f07859be6f8a0b3f998ffc0dd43d252ca34595473dd2135ac",
+                "uncompressed-sha256": "8919caf54ddb023cc59f9ae1eb546d76a001cc406ebe2fb71a0e5fb6206d765f"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-qemu.x86_64.qcow2.gz",
-                "sha256": "210a19fcab5cb6bf28bb6420b667d85c64ec285d3e0916345cfe3454f635f673",
-                "uncompressed-sha256": "6da93544aafec90c9508b8640d4177b93f31454d2b193d03e27ee4f1b8437296"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-qemu.x86_64.qcow2.gz",
+                "sha256": "214f4c5c69b329fa54162f92c2ff00a5c7648ea2400118b6c0d73447fb2c1a4b",
+                "uncompressed-sha256": "f8c740c1b49bcd9ce2d6eab139aad0fb10c4d10587853431ce8190686a7a5dd5"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-vmware.x86_64.ova",
-                "sha256": "4bfb9fd5e32cc9c7359bcaa3a5c40d1349f835002b71a6f2c982c5356c7a62ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251023-0/x86_64/rhcos-9.6.20251023-0-vmware.x86_64.ova",
+                "sha256": "14fa549bb83b2e730de22312419b503bc1ce85adf72269582f0af60e366d87ff"
               }
             }
           }
@@ -687,290 +684,306 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d24483687640c868"
+              "release": "9.6.20251023-0",
+              "image": "ami-02b635b723d34ca34"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0b982b69062cb9819"
+              "release": "9.6.20251023-0",
+              "image": "ami-03a29f9c7568b1bf4"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e882d9c9e56d6fbc"
+              "release": "9.6.20251023-0",
+              "image": "ami-05e6c5cc662b0a9dc"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-047e7046d36611ff2"
+              "release": "9.6.20251023-0",
+              "image": "ami-079c1ac914c0f193f"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-04841d66b7208f8ca"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a8030726bf8dba51"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0778d8a1880c38ee4"
+              "release": "9.6.20251023-0",
+              "image": "ami-00daaddc1f8f79e50"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01294dabc8c0127b6"
+              "release": "9.6.20251023-0",
+              "image": "ami-04d1dcb37d29f4da0"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07badd02ceff000f3"
+              "release": "9.6.20251023-0",
+              "image": "ami-05f51c4e15f80fab4"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0be438eda2558f0aa"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a73161b4674fb35b"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6829d91db059d1a"
+              "release": "9.6.20251023-0",
+              "image": "ami-0b70b5589f0eeb52e"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-020151b078dcdc39c"
+              "release": "9.6.20251023-0",
+              "image": "ami-0d5ed37a3d4f30343"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cc605bf74e3eadaa"
+              "release": "9.6.20251023-0",
+              "image": "ami-00689bf88f790ae87"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c304d1a7e122441d"
+              "release": "9.6.20251023-0",
+              "image": "ami-0b121fe63b4abd01e"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-02906f55476b5b91a"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a09de03c1abedc2b"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07654903d4359f7df"
+              "release": "9.6.20251023-0",
+              "image": "ami-0df1812a2fe02fd74"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01eff3b02fbce2e99"
+              "release": "9.6.20251023-0",
+              "image": "ami-0416dff56fcd3f883"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07929cf6af39cc81b"
+              "release": "9.6.20251023-0",
+              "image": "ami-0d32adb712e423739"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f88f035461228c4f"
+              "release": "9.6.20251023-0",
+              "image": "ami-00c618d1720e71ad4"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6ca397c49baeabc"
+              "release": "9.6.20251023-0",
+              "image": "ami-00f1625c7dda4189f"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cf034bf85e475a31"
+              "release": "9.6.20251023-0",
+              "image": "ami-003528ff047007af1"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ce7a965198aeb7b2"
+              "release": "9.6.20251023-0",
+              "image": "ami-02da86927320114b5"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fce61e66c5fc156a"
+              "release": "9.6.20251023-0",
+              "image": "ami-02be3f87e81f49542"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0779f0391446c8f73"
+              "release": "9.6.20251023-0",
+              "image": "ami-0b8c325b7499597c6"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0df53a0a3146e4b8c"
+              "release": "9.6.20251023-0",
+              "image": "ami-0349819c5b180e2ed"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08f1857856d26df1b"
+              "release": "9.6.20251023-0",
+              "image": "ami-0d998c35aceffaecd"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-077867c48f6d9f479"
+              "release": "9.6.20251023-0",
+              "image": "ami-091ae052ab614c24e"
+            },
+            "me-central-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-02b0525219e43bcdb"
+            },
+            "me-south-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-058efa54734665edb"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-031b16d06c7060827"
+              "release": "9.6.20251023-0",
+              "image": "ami-03378d9120688f673"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e8e6aa6db575d1a2"
+              "release": "9.6.20251023-0",
+              "image": "ami-02177e4818225ecda"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06a6b025350ff1e23"
+              "release": "9.6.20251023-0",
+              "image": "ami-01095d1967818437c"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0839b9b12d88de612"
+              "release": "9.6.20251023-0",
+              "image": "ami-0bc8dda494f111572"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c5b30e6119ef988a"
+              "release": "9.6.20251023-0",
+              "image": "ami-0500b54d2292bbb66"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6785d6f2a17ccab"
+              "release": "9.6.20251023-0",
+              "image": "ami-0cf5a956169273e68"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-068a9cb3ccfa0ef0f"
+              "release": "9.6.20251023-0",
+              "image": "ami-0deb728ed53f1e5f4"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-087857c3acb318eac"
+              "release": "9.6.20251023-0",
+              "image": "ami-09a01afdd3a3a9e81"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.6.20251023-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260403-0-gcp-x86-64"
+          "name": "rhcos-9-6-20251023-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
-          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:833cbd9ad76a1dfae732741380fbca39220e9b123123995cc93ba0702a497d65"
+          "release": "9.6.20251023-0",
+          "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d6f7de2cc6c6bc49486533a2550d8180c30c7a8b2ec9cd8ec069c5d92bffd11a"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c10eabe1eaf19070"
+              "release": "9.6.20251023-0",
+              "image": "ami-052cd89eea0843cd6"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0000a100764a57637"
+              "release": "9.6.20251023-0",
+              "image": "ami-087080143cc89188a"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d0a9b4f768e40721"
+              "release": "9.6.20251023-0",
+              "image": "ami-0c34729fc8835843e"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06bccded362a4e123"
+              "release": "9.6.20251023-0",
+              "image": "ami-01fc91f24daef35eb"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-074a3c1013b645e2b"
+              "release": "9.6.20251023-0",
+              "image": "ami-004019c7da49d4f35"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a973131ad159455f"
+              "release": "9.6.20251023-0",
+              "image": "ami-07d8b127b3773686f"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01a91ed16e6fe8c42"
+              "release": "9.6.20251023-0",
+              "image": "ami-021f0b44336043fba"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-088c4f18c1ba6d16f"
+              "release": "9.6.20251023-0",
+              "image": "ami-09a48fe45735ff776"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0aa3b2c76834dfc35"
+              "release": "9.6.20251023-0",
+              "image": "ami-073187f37e811f7f6"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e3287c7017d769e6"
+              "release": "9.6.20251023-0",
+              "image": "ami-00529627a08c64914"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01a6db14a61da69d2"
+              "release": "9.6.20251023-0",
+              "image": "ami-030642b0eb6d779ea"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06bfcd79e173b66fc"
+              "release": "9.6.20251023-0",
+              "image": "ami-0d87ec608094215c3"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-05d555e5f6ca0351b"
+              "release": "9.6.20251023-0",
+              "image": "ami-087eb4849a1fd2dc5"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-003fa9bac974b122f"
+              "release": "9.6.20251023-0",
+              "image": "ami-0ea064a1aae6ce590"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a4ae56adf95a7571"
+              "release": "9.6.20251023-0",
+              "image": "ami-02226877bc604251a"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0753bb5559cfe8de7"
+              "release": "9.6.20251023-0",
+              "image": "ami-01267b4c33f4aea38"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cdc9f4fd19c77c20"
+              "release": "9.6.20251023-0",
+              "image": "ami-03e89de4758b00b88"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-070d80434ccbb1fa8"
+              "release": "9.6.20251023-0",
+              "image": "ami-079ac34fffba93161"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c9b3aaa71a563f6d"
+              "release": "9.6.20251023-0",
+              "image": "ami-0f40a0d4085a590a9"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-061e33ce3cf0d8f30"
+              "release": "9.6.20251023-0",
+              "image": "ami-08702215e826239d4"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-060a1299d1a87244e"
+              "release": "9.6.20251023-0",
+              "image": "ami-0496b553ed53e0f27"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09d986ef8bc88b3ce"
+              "release": "9.6.20251023-0",
+              "image": "ami-0d6ec68a7c2fec60a"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0abacf8acd414929a"
+              "release": "9.6.20251023-0",
+              "image": "ami-025e9290bb166442e"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d52292d89797f1dc"
+              "release": "9.6.20251023-0",
+              "image": "ami-054300aa2b91b2ae1"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08cf1b6d46bea0b36"
+              "release": "9.6.20251023-0",
+              "image": "ami-0e5b53a6b11784ea9"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08f660deb548ef5d3"
+              "release": "9.6.20251023-0",
+              "image": "ami-0617f605ece0db2db"
+            },
+            "me-central-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-06b674feeb72022c3"
+            },
+            "me-south-1": {
+              "release": "9.6.20251023-0",
+              "image": "ami-0b5af4152d2f43015"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-028dd27c939e3d1e9"
+              "release": "9.6.20251023-0",
+              "image": "ami-02cd7274ba8158afa"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cbff95e01bb72566"
+              "release": "9.6.20251023-0",
+              "image": "ami-0aae14bec696286cc"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07fb473b3b815c46a"
+              "release": "9.6.20251023-0",
+              "image": "ami-0a997f2085e8e29f0"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0b57bb61d7bd17440"
+              "release": "9.6.20251023-0",
+              "image": "ami-0344ed0955767258f"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ab712daedccb957a"
+              "release": "9.6.20251023-0",
+              "image": "ami-01ba945b906e1b205"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-076797a55a7d516dc"
+              "release": "9.6.20251023-0",
+              "image": "ami-011bdcc840c1ffb86"
             }
           }
         },
         "azure-disk": {
-          "release": "9.8.20260403-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.x86_64.vhd"
+          "release": "9.6.20251023-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20251023-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
Reverts openshift/installer#10482

Testing regarding [TRT-2630](https://redhat.atlassian.net/browse/TRT-2630)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CoreOS RHEL 10 and RHEL 9 build release versions
  * Updated artifact checksums and image references across supported architectures and cloud platforms (AWS, Azure, GCP, IBM Cloud, OpenStack, and others)
  * Refreshed metadata timestamps and platform-specific configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->