### PR TITLE
OCPBUGS-91976, OCPBUGS-91975: Include bootstrap gather in agent-gather archive

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -120,6 +120,13 @@ function gather_bootstrap_status() {
 		mkdir -p "${ARTIFACTS_DIR}/var/log/"
 		cp -a /var/log/openshift "${ARTIFACTS_DIR}/var/log/"
 	fi
+	( >&2 echo -n ".")
+	if [ -f /usr/local/bin/installer-gather.sh ]; then
+		local bs_gather="${ARTIFACTS_DIR}/bootstrap-gather.tar.gz"
+		TAR_FILE="${bs_gather}" /usr/local/bin/installer-gather.sh --id "$(date '+%Y%m%d%H%M%S')" >/dev/null
+		( >&2 echo -n ".")
+		[ -f "${bs_gather}" ] && gunzip "${bs_gather}"
+	fi
 	( >&2 echo " Done")
 }
 

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -82,6 +82,7 @@ find "${ARTIFACTS}/rendered-assets" -name "*secret*" -print0 | xargs -0 rm -rf
 find "${ARTIFACTS}/rendered-assets" -name "*kubeconfig*" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name "*.key" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name ".kube" -print0 | xargs -0 rm -rf
+grep -Rl '^kind: Secret' "${ARTIFACTS}/rendered-assets" | xargs rm
 
 # Collect system information specific to IBM Linux Z (s390x) systems. The dbginfo
 # script is available by default as part of the s390-utils rpm package


### PR DESCRIPTION
If the rendezvous host is in the process of bootstrapping the cluster, collect the same logs that would be collected by the 'gather bootstrap' installer command and incorporate them into the agent-gather archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced bootstrap data gathering to collect additional system diagnostics information during the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->