### PR TITLE
METAL-1731: baremetal: Add coreos.openshift.io/stream label to BMH and hostSelector

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -12,9 +12,21 @@ import (
 	"sigs.k8s.io/yaml"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 )
+
+const streamLabelKey = "coreos.openshift.io/stream"
+
+// streamLabelValue returns the OS image stream string to use as the BMH label value.
+// Falls back to the default stream if the install-config doesn't specify one.
+func streamLabelValue(config *types.InstallConfig) string {
+	if config.OSImageStream != "" {
+		return string(config.OSImageStream)
+	}
+	return string(rhcos.DefaultOSImageStream)
+}
 
 // HostSettings hold the information needed to build the manifests to
 // register hosts with the cluster.
@@ -31,7 +43,6 @@ type HostSettings struct {
 }
 
 func createNetworkConfigSecret(host *baremetal.Host) (*corev1.Secret, error) {
-
 	yamlNetworkConfig, err := yaml.Marshal(host.NetworkConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error while creating network config secret")
@@ -80,7 +91,6 @@ func createSecret(host *baremetal.Host) (*corev1.Secret, baremetalhost.BMCDetail
 }
 
 func createBaremetalHost(host *baremetal.Host, bmc baremetalhost.BMCDetails) baremetalhost.BareMetalHost {
-
 	// Map string 'default' to hardware.DefaultProfileName
 	if host.HardwareProfile == "default" {
 		host.HardwareProfile = hardware.DefaultProfileName
@@ -134,7 +144,6 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 	}
 
 	for _, host := range config.Platform.BareMetal.Hosts {
-
 		// We only infer arbiter hosts if we are in an arbiter deployment
 		if config.IsArbiterEnabled() {
 			// If we know the host is an arbiter and the role isn't an empty value (i.e. explicitly defined by user)
@@ -178,6 +187,7 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 
 			newHost.ObjectMeta.Labels = map[string]string{
 				"installer.openshift.io/role": "control-plane",
+				streamLabelKey:                streamLabelValue(config),
 			}
 
 			// Link the new host to the currently available machine
@@ -196,6 +206,9 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 			numMasters++
 		} else {
 			newHost.Spec.Architecture = computeArch
+			newHost.ObjectMeta.Labels = map[string]string{
+				streamLabelKey: streamLabelValue(config),
+			}
 			// Pause workers until the real control plane is up.
 			newHost.ObjectMeta.Annotations = map[string]string{
 				"baremetalhost.metal3.io/paused": "",
@@ -279,6 +292,7 @@ func ArbiterHosts(config *types.InstallConfig, machines []machineapi.Machine, us
 
 			newHost.ObjectMeta.Labels = map[string]string{
 				"installer.openshift.io/role": "control-plane",
+				streamLabelKey:                streamLabelValue(config),
 			}
 
 			// Link the new host to the currently available machine

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestHosts(t *testing.T) {
-
 	nmstate := `interfaces:
 - name: eth0
   type: ethernet
@@ -62,7 +61,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64")).build(),
+				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "default-norole",
@@ -71,7 +70,7 @@ routes:
 
 			ExpectedSetting: settings().
 				secrets(secret("master-0-bmc-secret").creds("usr0", "pwd0")).
-				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64")).build(),
+				hosts(host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "network-config",
@@ -87,6 +86,7 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						consumerRef("machine-0").
 						userDataRef("user-data-secret").
 						preprovisioningNetworkDataName("master-0-network-config-secret").
@@ -110,9 +110,9 @@ routes:
 					secret("master-1-bmc-secret").creds("usr1", "pwd1"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines",
@@ -133,10 +133,10 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("usr3", "pwd3")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -158,10 +158,10 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -185,11 +185,11 @@ routes:
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0"),
 					secret("worker-1-bmc-secret").creds("wrk1", "pwd1")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
-					host("worker-1").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("worker-1").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -213,11 +213,11 @@ routes:
 					secret("master-0-bmc-secret").creds("usr0", "pwd0"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
-					host("worker-1").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("worker-1").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-master",
@@ -238,10 +238,10 @@ routes:
 					secret("master-1-bmc-secret").creds("usr1", "pwd1"),
 					secret("master-2-bmc-secret").creds("usr2", "pwd2")).
 				hosts(
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "4-hosts-3-machines-norole-worker",
@@ -262,10 +262,10 @@ routes:
 					secret("master-2-bmc-secret").creds("usr2", "pwd2"),
 					secret("worker-0-bmc-secret").creds("wrk0", "pwd0")).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64")).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "3-hosts-2-masters-no-arbiter-render",
@@ -284,8 +284,8 @@ routes:
 					secret("master-1-bmc-secret").creds("usr1", "pwd1"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64")).build(),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64")).build(),
 		},
 		{
 			Scenario: "3-hosts-2-masters-1-arbiter",
@@ -307,9 +307,9 @@ routes:
 					secret("arbiter-0-bmc-secret").creds("usr2", "pwd2"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -332,9 +332,9 @@ routes:
 					secret("arbiter-0-bmc-secret").creds("usr2", "pwd2"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -357,9 +357,9 @@ routes:
 					secret("arbiter-0-bmc-secret").creds("usr2", "pwd2"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -382,9 +382,9 @@ routes:
 					secret("arbiter-0-bmc-secret").creds("usr2", "pwd2"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -413,11 +413,11 @@ routes:
 					secret("arbiter-1-bmc-secret").creds("usr4", "pwd4"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("master-2").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-3").customDeploy().architecture("x86_64"),
-					host("arbiter-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-4").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("master-2").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-3").customDeploy().architecture("x86_64"),
+					host("arbiter-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-4").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -442,10 +442,10 @@ routes:
 					secret("arbiter-0-bmc-secret").creds("usr2", "pwd2"),
 				).
 				hosts(
-					host("master-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
-					host("master-1").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
-					host("worker-0").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
-					host("arbiter-0").label("installer.openshift.io/role", "control-plane").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
+					host("master-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-0").customDeploy().architecture("x86_64"),
+					host("master-1").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret").consumerRef("machine-1").customDeploy().architecture("x86_64"),
+					host("worker-0").label("coreos.openshift.io/stream", "rhel-9").annotation("baremetalhost.metal3.io/paused", "").architecture("x86_64"),
+					host("arbiter-0").label("installer.openshift.io/role", "control-plane").label("coreos.openshift.io/stream", "rhel-9").userDataRef("user-data-secret-arbiter").consumerRef("machine-2").customDeploy().architecture("x86_64"),
 				).build(),
 		},
 		{
@@ -461,6 +461,7 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
@@ -480,6 +481,7 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
@@ -506,11 +508,13 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("x86_64"),
 					host("worker-0").
+						label("coreos.openshift.io/stream", "rhel-9").
 						annotation("baremetalhost.metal3.io/paused", "").
 						architecture("x86_64"),
 				).build(),
@@ -535,11 +539,13 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("aarch64"),
 					host("worker-0").
+						label("coreos.openshift.io/stream", "rhel-9").
 						annotation("baremetalhost.metal3.io/paused", "").
 						architecture("aarch64"),
 				).build(),
@@ -557,6 +563,7 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
@@ -576,6 +583,7 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
@@ -610,18 +618,21 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("x86_64"),
 					host("master-1").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-1").
 						customDeploy().
 						architecture("x86_64"),
 					host("arbiter-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret-arbiter").
 						consumerRef("machine-2").
 						customDeploy().
@@ -656,18 +667,21 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("x86_64"),
 					host("master-1").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-1").
 						customDeploy().
 						architecture("x86_64"),
 					host("arbiter-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret-arbiter").
 						consumerRef("machine-2").
 						customDeploy().
@@ -702,18 +716,21 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("x86_64"),
 					host("master-1").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-1").
 						customDeploy().
 						architecture("x86_64"),
 					host("arbiter-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret-arbiter").
 						consumerRef("machine-2").
 						customDeploy().
@@ -748,18 +765,21 @@ routes:
 				hosts(
 					host("master-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-0").
 						customDeploy().
 						architecture("x86_64"),
 					host("master-1").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret").
 						consumerRef("machine-1").
 						customDeploy().
 						architecture("x86_64"),
 					host("arbiter-0").
 						label("installer.openshift.io/role", "control-plane").
+						label("coreos.openshift.io/stream", "rhel-9").
 						userDataRef("user-data-secret-arbiter").
 						consumerRef("machine-2").
 						customDeploy().
@@ -921,7 +941,9 @@ func (htb *hostTypeBuilder) bmc(user, password string) *hostTypeBuilder {
 }
 
 func (htb *hostTypeBuilder) networkConfig(config string) *hostTypeBuilder {
-	yaml.Unmarshal([]byte(config), &htb.NetworkConfig)
+	if err := yaml.Unmarshal([]byte(config), &htb.NetworkConfig); err != nil {
+		panic(err)
+	}
 	return htb
 }
 
@@ -990,11 +1012,6 @@ func host(name string) *hostBuilder {
 
 func (hb *hostBuilder) build() *baremetalhost.BareMetalHost {
 	return &hb.BareMetalHost
-}
-
-func (hb *hostBuilder) externallyProvisioned() *hostBuilder {
-	hb.Spec.ExternallyProvisioned = true
-	return hb
 }
 
 func (hb *hostBuilder) customDeploy() *hostBuilder {

--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -11,6 +11,7 @@ import (
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	baremetalprovider "github.com/openshift/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	utils "github.com/openshift/installer/pkg/utils"
@@ -30,7 +31,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider, err := provider(platform, userDataSecret)
+	provider, err := provider(platform, userDataSecret, config.OSImageStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}
@@ -64,7 +65,12 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(platform *baremetal.Platform, userDataSecret string) (*baremetalprovider.BareMetalMachineProviderSpec, error) {
+func provider(platform *baremetal.Platform, userDataSecret string, osImageStream types.OSImageStream) (*baremetalprovider.BareMetalMachineProviderSpec, error) {
+	stream := string(osImageStream)
+	if stream == "" {
+		stream = string(rhcos.DefaultOSImageStream)
+	}
+
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "baremetal.cluster.k8s.io/v1alpha1",
@@ -74,6 +80,11 @@ func provider(platform *baremetal.Platform, userDataSecret string) (*baremetalpr
 			Method: "install_coreos",
 		},
 		UserData: &corev1.SecretReference{Name: userDataSecret},
+		HostSelector: baremetalprovider.HostSelector{
+			MatchLabels: map[string]string{
+				"coreos.openshift.io/stream": stream,
+			},
+		},
 	}
 	return config, nil
 }

--- a/pkg/asset/machines/baremetal/machinesets.go
+++ b/pkg/asset/machines/baremetal/machinesets.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
@@ -33,7 +33,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider, err := provider(platform, userDataSecret)
+	provider, err := provider(platform, userDataSecret, config.OSImageStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}
@@ -53,7 +53,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			},
 		},
 		Spec: machineapi.MachineSetSpec{
-			Replicas: pointer.Int32Ptr(int32(total)),
+			Replicas: ptr.To(int32(total)),
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"machine.openshift.io/cluster-api-machineset": name,


### PR DESCRIPTION
Set the coreos.openshift.io/stream label on all generated BareMetalHost objects (control-plane, worker, and arbiter) based on the install-config's OSImageStream setting, defaulting to rhel-9. Configure HostSelector on BareMetalMachineProviderSpec so MachineSets only claim BMHs with the matching stream label.

### How it works

The `coreos.openshift.io/stream` label on a BareMetalHost determines
which kernel, initrd, and rootfs files are used during PXE boot. For
example, a BMH labeled `coreos.openshift.io/stream: rhel-10` will PXE
boot with `ironic-python-agent-rhel-10.kernel`,
`ironic-python-agent-rhel-10.initramfs`, and
`ironic-python-agent-rhel-10.rootfs` instead of the unqualified defaults.

The per-node `coreos.live.rootfs_url` kernel parameter set via ICC's
`ExtraKernelParams` overrides the global one from ironic-image because
dracut's `getarg` returns the last value for duplicate parameters.

### Changes across repos

**installer** ([openshift/installer#10502](https://github.com/openshift/installer/pull/10502))
— `pkg/asset/machines/baremetal/`: Sets the `coreos.openshift.io/stream`
label on all generated BareMetalHost objects (control-plane, worker,
arbiter) based on the install-config's `OSImageStream` setting, defaulting
to `rhel-9`. Configures `hostSelector.matchLabels` on
BareMetalMachineProviderSpec so MachineSets only claim BMHs with the
matching stream label.

**cluster-baremetal-operator** ([openshift/cluster-baremetal-operator#590](https://github.com/openshift/cluster-baremetal-operator/pull/590))
— `provisioning/image_customization.go`: Passes three new environment
variables to the ICC container: `DEPLOY_KERNEL` (path to the kernel file),
`IMAGE_SHARED_DIR` (path to the shared images directory where
stream-prefixed files are discovered), and `IRONIC_ROOTFS_URL` (base URL
for the rootfs served by httpd). These enable ICC to discover multi-stream
images and construct per-node kernel/rootfs URLs.

**machine-os-images** ([openshift/machine-os-images#83](https://github.com/openshift/machine-os-images/pull/83))
— `scripts/copy-metal`: Creates stream-prefixed IPA symlinks (e.g.
`ironic-python-agent-rhel-9.iso`, `ironic-python-agent-rhel-10.kernel`)
for all available CoreOS versions, allowing ICC to discover images by
stream. Also fixes missing initramfs symlinks in the `fixed=true` (PXE)
block — without these, a stream-specific kernel would be paired with the
default-stream initrd, causing a version mismatch that crashes immediately
on PXE boot.

**image-customization-controller** ([openshift/image-customization-controller#175](https://github.com/openshift/image-customization-controller/pull/175))
— `pkg/imagehandler/`, `pkg/imageprovider/rhcos.go`: Adds OS stream
selection so ICC can serve different CoreOS base images based on the
`coreos.openshift.io/stream` label. Images are indexed by (stream,
architecture) and discovered from stream-prefixed filenames. Key changes:

- `streamArchSpecificURL()` transforms the base rootfs URL into a stream-
  and arch-specific URL
- `BuildImage()` passes the stream to `ServeKernel()` and uses the
  stream-specific rootfs URL in `ExtraKernelParams`
- `imageKey()` includes the stream in the cache key so that changing a
  BMH's stream label invalidates the cached image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved OS image stream configuration handling for bare metal hosts, ensuring consistent stream selection and label application across control-plane, worker, and arbiter host types. OS image stream is now properly propagated throughout host creation and machine provider specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->