### PR TITLE
OCPBUGS-79002: [release-4.19] - Allow all instance types in the install config for GCP

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -85,21 +85,18 @@ func validateInstanceAndDiskType(fldPath *field.Path, diskType, instanceType, ar
 		return nil
 	}
 
-	family, _, _ := strings.Cut(instanceType, "-")
-	if family == "custom" {
-		family = gcp.DefaultCustomInstanceType
-	}
-	diskTypes, ok := gcp.InstanceTypeToDiskTypeMap[family]
+	family := gcp.GetGCPInstanceFamily(instanceType)
+	diskTypes, ok := gcp.GetDiskTypes(instanceType)
 	if !ok {
-		return field.NotFound(fldPath.Child("type"), family)
+		logrus.Warnf("unrecognized instance type %s with family %s", instanceType, family)
 	}
 
-	acceptedArmFamilies := sets.New("c4a", "t2a")
+	acceptedArmFamilies := sets.New("c4a", "n4a", "t2a", "a4x")
 	if arch == types.ArchitectureARM64 && !acceptedArmFamilies.Has(family) {
 		return field.NotSupported(fldPath.Child("type"), family, sets.List(acceptedArmFamilies))
 	}
 
-	if diskType != "" {
+	if diskType != "" && len(diskTypes) > 0 {
 		if !sets.New(diskTypes...).Has(diskType) {
 			return field.Invalid(
 				fldPath.Child("diskType"),
@@ -234,6 +231,8 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		defaultInstanceType = ic.GCP.DefaultMachinePlatform.InstanceType
 		if ic.GCP.DefaultMachinePlatform.DiskType != "" {
 			defaultDiskType = ic.GCP.DefaultMachinePlatform.DiskType
+		} else {
+			defaultDiskType = gcp.DefaultDiskTypeForInstance(defaultInstanceType)
 		}
 
 		if ic.GCP.DefaultMachinePlatform.OnHostMaintenance != "" {
@@ -282,6 +281,17 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			}
 			if ic.ControlPlane.Platform.GCP.DiskType != "" {
 				cpDiskType = ic.ControlPlane.Platform.GCP.DiskType
+			} else {
+				// When the user-provided instance type is not recognized and
+				// the disk type is not specified, add an error asking for disk type.
+				family := gcp.GetGCPInstanceFamily(instanceType)
+				if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; !ok {
+					return append(allErrs, field.Required(
+						field.NewPath("controlPlane", "diskType"),
+						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
+					))
+				}
+				cpDiskType = gcp.DefaultDiskTypeForInstance(instanceType)
 			}
 			if ic.ControlPlane.Platform.GCP.OnHostMaintenance != "" {
 				cpOnHostMaintenance = ic.ControlPlane.Platform.GCP.OnHostMaintenance
@@ -343,10 +353,20 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			if compute.Platform.GCP.ConfidentialCompute != "" {
 				confidentialCompute = compute.Platform.GCP.ConfidentialCompute
 			}
-		}
-
-		if compute.Platform.GCP != nil && compute.Platform.GCP.DiskType != "" {
-			diskType = compute.Platform.GCP.DiskType
+			if compute.Platform.GCP.DiskType != "" {
+				diskType = compute.Platform.GCP.DiskType
+			} else {
+				// When the user-provided instance type is not recognized and
+				// the disk type is not specified, add an error asking for disk type.
+				family := gcp.GetGCPInstanceFamily(instanceType)
+				if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; !ok {
+					return append(allErrs, field.Required(
+						field.NewPath(fmt.Sprintf("compute[%d]", idx), "diskType"),
+						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
+					))
+				}
+				diskType = gcp.DefaultDiskTypeForInstance(instanceType)
+			}
 		}
 
 		allErrs = append(allErrs,

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -131,7 +131,7 @@ func (a *InstallConfig) finishAWS() error {
 		if totalEdgeSubnets == 0 {
 			return nil
 		}
-		if edgePool := defaults.CreateEdgeMachinePoolDefaults(a.Config.Compute, a.Config.Platform.Name(), totalEdgeSubnets); edgePool != nil {
+		if edgePool := defaults.CreateEdgeMachinePoolDefaults(a.Config.Compute, &a.Config.Platform, totalEdgeSubnets); edgePool != nil {
 			a.Config.Compute = append(a.Config.Compute, *edgePool)
 		}
 	}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -130,11 +130,12 @@ func defaultAzureMachinePoolPlatform(env azuretypes.CloudEnvironment) azuretypes
 }
 
 func defaultGCPMachinePoolPlatform(arch types.Architecture) gcptypes.MachinePool {
+	instanceType := icgcp.DefaultInstanceTypeForArch(arch)
 	return gcptypes.MachinePool{
-		InstanceType: icgcp.DefaultInstanceTypeForArch(arch),
+		InstanceType: instanceType,
 		OSDisk: gcptypes.OSDisk{
 			DiskSizeGB: powerOfTwoRootVolumeSize,
-			DiskType:   "pd-ssd",
+			DiskType:   gcptypes.DefaultDiskTypeForInstance(instanceType),
 		},
 	}
 }

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -66,11 +66,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		c.ControlPlane = &types.MachinePool{}
 	}
 	c.ControlPlane.Name = "master"
-	SetMachinePoolDefaults(c.ControlPlane, c.Platform.Name())
+	SetMachinePoolDefaults(c.ControlPlane, &c.Platform)
 
 	if c.Arbiter != nil {
 		c.Arbiter.Name = "arbiter"
-		SetMachinePoolDefaults(c.Arbiter, c.Platform.Name())
+		SetMachinePoolDefaults(c.Arbiter, &c.Platform)
 	}
 
 	defaultComputePoolUndefined := true
@@ -84,7 +84,7 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		c.Compute = append(c.Compute, types.MachinePool{Name: types.MachinePoolComputeRoleName})
 	}
 	for i := range c.Compute {
-		SetMachinePoolDefaults(&c.Compute[i], c.Platform.Name())
+		SetMachinePoolDefaults(&c.Compute[i], &c.Platform)
 	}
 
 	if c.CredentialsMode == "" {

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -2,11 +2,13 @@ package defaults
 
 import (
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
+	gcpdefaults "github.com/openshift/installer/pkg/types/gcp/defaults"
 	"github.com/openshift/installer/pkg/version"
 )
 
 // SetMachinePoolDefaults sets the defaults for the machine pool.
-func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
+func SetMachinePoolDefaults(p *types.MachinePool, platform *types.Platform) {
 	defaultReplicaCount := int64(3)
 	if p.Name == types.MachinePoolEdgeRoleName || p.Name == types.MachinePoolArbiterRoleName {
 		defaultReplicaCount = 0
@@ -19,6 +21,15 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	}
 	if p.Architecture == "" {
 		p.Architecture = version.DefaultArch()
+	}
+
+	// Set platform-specific defaults
+	if platform.Name() == gcp.Name {
+		if p.Platform.GCP == nil && platform.GCP.DefaultMachinePlatform != nil {
+			p.Platform.GCP = &gcp.MachinePool{}
+		}
+		gcpdefaults.Apply(platform.GCP.DefaultMachinePlatform, p.Platform.GCP)
+		gcpdefaults.SetMachinePoolDefaults(platform, p.Platform.GCP)
 	}
 }
 
@@ -34,7 +45,7 @@ func hasEdgePoolConfig(pools []types.MachinePool) bool {
 }
 
 // CreateEdgeMachinePoolDefaults create the edge compute pool when it is not already defined.
-func CreateEdgeMachinePoolDefaults(pools []types.MachinePool, platform string, replicas int64) *types.MachinePool {
+func CreateEdgeMachinePoolDefaults(pools []types.MachinePool, platform *types.Platform, replicas int64) *types.MachinePool {
 	if hasEdgePoolConfig(pools) {
 		return nil
 	}

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 func defaultMachinePoolWithReplicaCount(name string, replicaCount int) *types.MachinePool {
@@ -31,7 +32,7 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 	cases := []struct {
 		name     string
 		pool     *types.MachinePool
-		platform string
+		platform *types.Platform
 		expected *types.MachinePool
 	}{
 		{
@@ -125,6 +126,90 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			SetMachinePoolDefaults(tc.pool, tc.platform)
 			assert.Equal(t, tc.expected, tc.pool, "unexpected machine pool")
+		})
+	}
+}
+
+func TestSetMachinePoolDefaultsGCPDefaultMachinePlatform(t *testing.T) {
+	cases := []struct {
+		name     string
+		pool     *types.MachinePool
+		platform *types.Platform
+		expected *gcp.MachinePool
+	}{
+		{
+			name: "diskType from defaultMachinePlatform applied to empty pool",
+			pool: &types.MachinePool{Name: "worker"},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-ssd",
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-ssd",
+				},
+			},
+		},
+		{
+			name: "pool diskType takes precedence over defaultMachinePlatform",
+			pool: &types.MachinePool{
+				Name: "worker",
+				Platform: types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-balanced",
+						},
+					},
+				},
+			},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-ssd",
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-balanced",
+				},
+			},
+		},
+		{
+			name: "multiple fields from defaultMachinePlatform",
+			pool: &types.MachinePool{Name: "master"},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						InstanceType: "n2-standard-4",
+						OSDisk: gcp.OSDisk{
+							DiskType:   "pd-ssd",
+							DiskSizeGB: 256,
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				InstanceType: "n2-standard-4",
+				OSDisk: gcp.OSDisk{
+					DiskType:   "pd-ssd",
+					DiskSizeGB: 256,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetMachinePoolDefaults(tc.pool, tc.platform)
+			assert.Equal(t, tc.expected, tc.pool.Platform.GCP)
 		})
 	}
 }

--- a/pkg/types/gcp/defaults/machinepool.go
+++ b/pkg/types/gcp/defaults/machinepool.go
@@ -1,0 +1,43 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+// Apply applies default machine platform settings to a machine pool.
+// Settings from defaultMachinePlatform are applied first, then explicit
+// machinePool settings override them.
+func Apply(defaultMachinePlatform, machinePool *gcp.MachinePool) {
+	tempMP := &gcp.MachinePool{}
+	tempMP.Set(defaultMachinePlatform)
+	tempMP.Set(machinePool)
+	machinePool.Set(tempMP)
+}
+
+// SetMachinePoolDefaults sets the defaults for the platform.
+func SetMachinePoolDefaults(platform *types.Platform, pool *gcp.MachinePool) {
+	if pool == nil {
+		return
+	}
+
+	if ek := pool.EncryptionKey; ek != nil {
+		if kms := ek.KMSKey; kms != nil {
+			if kms.ProjectID == "" {
+				kms.ProjectID = platform.GCP.ProjectID
+			}
+			if kms.Location == "" {
+				kms.Location = platform.GCP.Region
+			}
+		}
+	}
+
+	// Set the default Disk Type for the Instance type when the instance type is provided
+	// by the user and the Disk type is not.
+	if pool.InstanceType != "" && pool.OSDisk.DiskType == "" {
+		family := gcp.GetGCPInstanceFamily(pool.InstanceType)
+		if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; ok {
+			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstance(pool.InstanceType)
+		}
+	}
+}

--- a/pkg/types/gcp/defaults/machinepool.go
+++ b/pkg/types/gcp/defaults/machinepool.go
@@ -1,0 +1,33 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+// SetMachinePoolDefaults sets the defaults for the platform.
+func SetMachinePoolDefaults(platform *types.Platform, pool *gcp.MachinePool) {
+	if pool == nil {
+		return
+	}
+
+	if ek := pool.EncryptionKey; ek != nil {
+		if kms := ek.KMSKey; kms != nil {
+			if kms.ProjectID == "" {
+				kms.ProjectID = platform.GCP.ProjectID
+			}
+			if kms.Location == "" {
+				kms.Location = platform.GCP.Region
+			}
+		}
+	}
+
+	// Set the default Disk Type for the Instance type when the instance type is provided
+	// by the user and the Disk type is not.
+	if pool.InstanceType != "" && pool.OSDisk.DiskType == "" {
+		family := gcp.GetGCPInstanceFamily(pool.InstanceType)
+		if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; ok {
+			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstance(pool.InstanceType)
+		}
+	}
+}

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -1,6 +1,10 @@
 package gcp
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 // FeatureSwitch indicates whether the feature is enabled or disabled.
 type FeatureSwitch string
@@ -37,22 +41,53 @@ var (
 	// InstanceTypeToDiskTypeMap contains a map where the key is the Instance Type, and the
 	// values are a list of disk types that are supported by the installer and correlate to the Instance Type.
 	InstanceTypeToDiskTypeMap = map[string][]string{
-		"a2":  {PDStandard, PDSSD, PDBalanced},
-		"a3":  {PDSSD, PDBalanced},
-		"c2":  {PDStandard, PDSSD, PDBalanced},
-		"c2d": {PDStandard, PDSSD, PDBalanced},
-		"c3":  {PDSSD, PDBalanced, HyperDiskBalanced},
-		"c3d": {PDSSD, PDBalanced, HyperDiskBalanced},
+		// General Purpose Machine Family
+		// https://docs.cloud.google.com/compute/docs/general-purpose-machines
+		"c4d": {HyperDiskBalanced},
 		"c4":  {HyperDiskBalanced},
 		"c4a": {HyperDiskBalanced},
-		"e2":  {PDStandard, PDSSD, PDBalanced},
-		"m1":  {PDSSD, PDBalanced, HyperDiskBalanced},
-		"n1":  {PDStandard, PDSSD, PDBalanced},
+		"c3":  {PDSSD, PDBalanced, HyperDiskBalanced},
+		"c3d": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"n4":  {HyperDiskBalanced},
+		"n4a": {HyperDiskBalanced},
+		"n4d": {HyperDiskBalanced},
 		"n2":  {PDStandard, PDSSD, PDBalanced},
 		"n2d": {PDStandard, PDSSD, PDBalanced},
-		"n4":  {HyperDiskBalanced},
+		"n1":  {PDStandard, PDSSD, PDBalanced},
+		"e2":  {PDStandard, PDSSD, PDBalanced},
 		"t2a": {PDStandard, PDSSD, PDBalanced},
 		"t2d": {PDStandard, PDSSD, PDBalanced},
+
+		// Storage Optimized Machine Family
+		// https://docs.cloud.google.com/compute/docs/storage-optimized-machines
+		"z3": {PDSSD, PDBalanced, HyperDiskBalanced},
+
+		// Compute Optimized Machine Family
+		// https://docs.cloud.google.com/compute/docs/compute-optimized-machines
+		"h4d": {HyperDiskBalanced},
+		"h3":  {PDBalanced, HyperDiskBalanced},
+		"c2":  {PDStandard, PDSSD, PDBalanced},
+		"c2d": {PDStandard, PDSSD, PDBalanced},
+
+		// Memory Optimized Machine Family
+		// https://docs.cloud.google.com/compute/docs/memory-optimized-machines
+		"x4": {HyperDiskBalanced},
+		"m4": {HyperDiskBalanced},
+		"m3": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"m2": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"m1": {PDSSD, PDBalanced, HyperDiskBalanced},
+
+		// Accelerator Optimized Machine Family
+		// https://docs.cloud.google.com/compute/docs/accelerator-optimized-machines
+		"a4x": {HyperDiskBalanced},
+		"a4":  {HyperDiskBalanced},
+		// A3 machines are separated into A3 Ultra, A3 Mega, A3 High, and A3 Edge machine types. The
+		// A3 Ultra machines only support Hyperdisk Balanced, but all types listed below are available
+		// for the other A3 machine types.
+		"a3": {PDSSD, PDBalanced, HyperDiskBalanced},
+		"a2": {PDStandard, PDSSD, PDBalanced},
+		"g4": {HyperDiskBalanced},
+		"g2": {PDSSD, PDBalanced},
 	}
 )
 
@@ -325,4 +360,49 @@ func (k *KMSKeyReference) Set(required *KMSKeyReference) {
 	if required.Location != "" {
 		k.Location = required.Location
 	}
+}
+
+// GetGCPInstanceFamily extracts the instance family from the instance type (for instance c4-standard-4 returns c4).
+func GetGCPInstanceFamily(instanceType string) string {
+	family, _, _ := strings.Cut(instanceType, "-")
+	if family == "custom" {
+		family = DefaultCustomInstanceType
+	}
+	return family
+}
+
+// DefaultDiskTypeForInstance returns the default disk type for a GCP instance type. If instance type is not
+// recognized, pd-ssd is return.
+func DefaultDiskTypeForInstance(instanceType string) string {
+	defaultDiskType := PDSSD
+	diskTypes, ok := GetDiskTypes(instanceType)
+	if ok {
+		supportedDiskTypes := sets.New(diskTypes...)
+		switch {
+		case supportedDiskTypes.Has(PDSSD):
+			defaultDiskType = PDSSD
+		case supportedDiskTypes.Has(HyperDiskBalanced):
+			defaultDiskType = HyperDiskBalanced
+		default:
+			// this shouldn't happen because all supported instance types
+			// have either pd-ssd or hyperdisk balanced
+			defaultDiskType = diskTypes[0]
+		}
+	}
+	return defaultDiskType
+}
+
+// GetDiskTypes gets the disk types associated with a (supported) GCP instance type.
+func GetDiskTypes(instanceType string) ([]string, bool) {
+	family := GetGCPInstanceFamily(instanceType)
+
+	// https://docs.cloud.google.com/compute/docs/accelerator-optimized-machines#a3-ultra
+	// a3-ultra machines are special, unlike a3-mega, a3-high, and a3-edge the only supported
+	// disk type is hyperdisk-balanced.
+	if family == "a3" && strings.Contains(instanceType, "ultra") {
+		return []string{HyperDiskBalanced}, true
+	}
+
+	diskTypes, ok := InstanceTypeToDiskTypeMap[family]
+	return diskTypes, ok
 }


### PR DESCRIPTION

** validation.go:
Correct the error message to provide all supported instance types when one is not found.

** machinepools.go
Update the map to include all instance types and the supported disk types. The unsupported disk types are in comments in the map. These are to be updated when/if openshift supports these disktypes in the future.