### PR TITLE
RFE-9036: Add topology labels to vSphere MachineSet templates

### DIFF
--- a/pkg/asset/machines/vsphere/machinesets.go
+++ b/pkg/asset/machines/vsphere/machinesets.go
@@ -82,6 +82,8 @@ func getMachineSetWithPlatform(
 						"machine.openshift.io/cluster-api-cluster":      clusterID,
 						"machine.openshift.io/cluster-api-machine-role": role,
 						"machine.openshift.io/cluster-api-machine-type": role,
+						"topology.kubernetes.io/zone":                   failureDomain.Zone,
+						"topology.kubernetes.io/region":                 failureDomain.Region,
 					},
 				},
 				Spec: machineapi.MachineSpec{

--- a/pkg/asset/machines/vsphere/machinesets_test.go
+++ b/pkg/asset/machines/vsphere/machinesets_test.go
@@ -282,3 +282,39 @@ func TestConfigMachinesets(t *testing.T) {
 		})
 	}
 }
+
+func TestMachineSetTopologyLabels(t *testing.T) {
+	clusterID := "test"
+	installConfig, err := parseInstallConfig()
+	if err != nil {
+		t.Fatalf("unable to parse sample install config: %v", err)
+	}
+
+	machineSets, err := MachineSets(clusterID, installConfig, &machineComputePoolValidZones, "worker", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedLabels := []struct {
+		zone   string
+		region string
+	}{
+		{zone: "us-east-1a", region: "us-east"},
+		{zone: "us-east-2a", region: "us-east"},
+		{zone: "us-east-3a", region: "us-east"},
+	}
+
+	if len(machineSets) != len(expectedLabels) {
+		t.Fatalf("expected %d machinesets, got %d", len(expectedLabels), len(machineSets))
+	}
+
+	for i, ms := range machineSets {
+		labels := ms.Spec.Template.ObjectMeta.Labels
+		if labels["topology.kubernetes.io/zone"] != expectedLabels[i].zone {
+			t.Errorf("machineset %d: expected zone label %q, got %q", i, expectedLabels[i].zone, labels["topology.kubernetes.io/zone"])
+		}
+		if labels["topology.kubernetes.io/region"] != expectedLabels[i].region {
+			t.Errorf("machineset %d: expected region label %q, got %q", i, expectedLabels[i].region, labels["topology.kubernetes.io/region"])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Hi, this is my first PR to the installer repo. I raised [RFE-9036](https://redhat.atlassian.net/browse/RFE-9036) based on an issue we've been seeing in our labs and wanted to take a shot at fixing it.

When failure domains are defined in `install-config.yaml`, the installer creates one MachineSet per failure domain and correctly sets the workspace (datacenter, datastore, etc.) but does not add `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels to the MachineSet template.

Right now these labels only get stamped by the vSphere CCM at node boot time. The problem is if CCM is slow or degraded when a new node joins, the node comes up without topology labels. Workloads using `topologySpreadConstraints` or zone-aware scheduling then break silently with no obvious indication of why.

## What this PR does

- Adds `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels to the MachineSet template in `pkg/asset/machines/vsphere/machinesets.go`
- The values come directly from the failure domain's `zone` and `region` fields which are already passed into the MachineSet generation function
- Added a unit test to verify the labels are correctly set
- All existing tests continue to pass

## Why

- Nodes get topology labels at install time instead of depending solely on CCM runtime behavior
- Day-2 scaling becomes less error-prone since new MachineSets carry the right labels from the start
- MachineSet specs become self-documenting about which zone they belong to
- CCM still works as before, this just ensures the labels are present even if CCM is unavailable

## Test plan

- [x] `go test ./pkg/asset/machines/vsphere/` — all existing + new tests pass
- [ ] Deploy a multi-zone vSphere IPI cluster and verify topology labels appear on MachineSet templates
- [ ] Verify nodes provisioned from the MachineSet inherit the topology labels

See: https://issues.redhat.com/browse/RFE-9036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MachineSets now include topology awareness labels for zone and region information from failure domains.

* **Tests**
  * Added validation for topology labels on MachineSets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->