### PR TITLE
[AISOS-358] Implementation for AISOS-358

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /bin/
+
+# Forge workflow state (do not commit)
+.forge/

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -7428,6 +7428,11 @@ spec:
                       type: string
                     maxItems: 2
                     type: array
+                  bootstrapFlavor:
+                    description: |-
+                      BootstrapFlavor is the name of the flavor used for the bootstrap instance.
+                      When not specified, the bootstrap machine will use the control plane flavor.
+                    type: string
                   cloud:
                     description: Cloud is the name of OpenStack cloud to use from
                       clouds.yaml.

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -11,6 +11,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   - [Examples](#examples)
     - [Minimal](#minimal)
     - [Custom machine pools](#custom-machine-pools)
+    - [Bootstrap flavor for NFV/NUMA workloads](#bootstrap-flavor-for-nfvnuma-workloads)
   - [Image Overrides](#image-overrides)
   - [Custom Subnets](#custom-subnets)
   - [Additional Networks](#additional-networks)
@@ -34,6 +35,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `apiVIPs` (optional array of strings): IP address on the machineNetwork that will be assigned to the API VIP. If more than one are set, it must be one IPv4 and one IPv6.
 * `ingressVIPs` (optional array of strings): IP address on the machineNetwork that will be assigned to the ingress VIP. If more than one are set, it must be one IPv4 and one IPv6.
 * `controlPlanePort` (optional object): the UUID and/or Name of an OpenStack Network and its Subnets where to install the nodes of the cluster onto. For more information on how to install with a custom subnet, see the [custom subnets](#custom-subnets) section of the docs.
+* `bootstrapFlavor` (optional string): The OpenStack flavor to use for the temporary bootstrap instance. When not set, the bootstrap instance uses the same flavor as the control plane machines. This is useful in environments where the control plane flavor has special hardware requirements (such as NFV/NUMA pinning) that are incompatible with the general-purpose bootstrap workload — in those cases a standard flavor can be specified here. See [Bootstrap flavor for NFV/NUMA workloads](#bootstrap-flavor-for-nfvnuma-workloads) for details.
 * `defaultMachinePlatform` (optional object): Default [OpenStack-specific machine pool properties](#machine-pools) which apply to [machine pools](../customization.md#machine-pools) that do not define their own OpenStack-specific properties.
 
 ## Machine pools
@@ -56,7 +58,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
 > **Note**
-> The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool.
+> The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool. The bootstrap flavor can be overridden independently using the cluster-scoped `bootstrapFlavor` property.
 
 > **Note**
 > Note when deploying the control-plane machines with `rootVolume`, it is highly suggested to use an [additional ephemeral disk dedicated to etcd](./etcd-ephemeral-disk.md).
@@ -121,6 +123,41 @@ platform:
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```
+
+### Bootstrap flavor for NFV/NUMA workloads
+
+In Network Function Virtualization (NFV) environments, control plane machines are often deployed on flavors with strict NUMA topology policies or CPU pinning to meet latency and throughput requirements. Because the bootstrap node is a temporary machine that runs a standard Kubernetes control plane (not an NFV workload), deploying it on an NFV-optimized flavor can cause scheduling or compatibility issues — for example, flavors with `hw:numa_nodes` or CPU pinning extra specs may not be schedulable on all hypervisor hosts.
+
+The `bootstrapFlavor` field lets you decouple the bootstrap instance from the control plane flavor. When set, the bootstrap instance uses the specified flavor; when omitted, it falls back to the flavor defined in the `controlPlane` machine pool (or `defaultMachinePlatform`).
+
+Example — using a standard flavor for the bootstrap node while the control plane uses an NFV/NUMA-optimized flavor:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: test-cluster
+controlPlane:
+  name: master
+  replicas: 3
+  platform:
+    openstack:
+      type: nfv.numa.xlarge   # NFV-optimized flavor for production control plane nodes
+platform:
+  openstack:
+    cloud: mycloud
+    externalNetwork: external
+    apiFloatingIP: 128.0.0.1
+    bootstrapFlavor: m1.xlarge  # Standard flavor for the temporary bootstrap instance
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+> **Note**
+> The bootstrap instance is temporary and is removed once the cluster is fully operational. The `bootstrapFlavor` has no effect on control plane or worker machine flavors.
+
+> **Note**
+> If `bootstrapFlavor` is not set, the bootstrap instance uses the flavor from the `controlPlane` machine pool. If that is also unset, it falls back to `defaultMachinePlatform.type`.
 
 ## Image Overrides
 

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -193,6 +193,19 @@ func (ci *CloudInfo) collectInfo(ctx context.Context, ic *types.InstallConfig) e
 			}
 		}
 	}
+
+	// Get bootstrap flavor info if specified
+	if flavorName := ic.OpenStack.BootstrapFlavor; flavorName != "" {
+		if _, seen := ci.Flavors[flavorName]; !seen {
+			flavor, err := ci.getFlavor(ctx, flavorName)
+			if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+				if err != nil {
+					return err
+				}
+				ci.Flavors[flavorName] = flavor
+			}
+		}
+	}
 	if ic.OpenStack.ControlPlanePort != nil {
 		controlPlanePort := ic.OpenStack.ControlPlanePort
 		ci.ControlPlanePortSubnets, err = ci.getSubnets(ctx, controlPlanePort)

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -45,6 +45,9 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate custom cluster os image
 	allErrs = append(allErrs, validateClusterOSImage(p, ci, fldPath)...)
 
+	// validate bootstrap flavor
+	allErrs = append(allErrs, validateBootstrapFlavor(p, ci, fldPath)...)
+
 	return allErrs
 }
 
@@ -199,6 +202,19 @@ func validateVIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (al
 				}
 			}
 		}
+	}
+
+	return allErrs
+}
+
+// validateBootstrapFlavor validates the bootstrap flavor if specified, ensuring it exists in OpenStack.
+func validateBootstrapFlavor(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
+	if p.BootstrapFlavor == "" {
+		return
+	}
+
+	if _, ok := ci.Flavors[p.BootstrapFlavor]; !ok {
+		allErrs = append(allErrs, field.NotFound(fldPath.Child("bootstrapFlavor"), p.BootstrapFlavor))
 	}
 
 	return allErrs

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu"
@@ -721,6 +722,76 @@ func TestMachineSubnet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			aggregatedErrors := ValidatePlatform(tc.platform, tc.networking, tc.cloudInfo).ToAggregate()
 			if tc.expectedErrMsg != "" {
+				assert.Regexp(t, tc.expectedErrMsg, aggregatedErrors)
+			} else {
+				assert.NoError(t, aggregatedErrors)
+			}
+		})
+	}
+}
+
+func TestBootstrapFlavor(t *testing.T) {
+	const (
+		validBootstrapFlavor   = "valid-bootstrap-flavor"
+		invalidBootstrapFlavor = "invalid-bootstrap-flavor"
+	)
+
+	cases := []struct {
+		name           string
+		platform       *openstack.Platform
+		cloudInfo      *CloudInfo
+		networking     *types.Networking
+		expectedError  bool
+		expectedErrMsg string // NOTE: this is a REGEXP
+	}{
+		{
+			name:           "bootstrap flavor not specified",
+			platform:       validPlatform(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name: "valid bootstrap flavor",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.BootstrapFlavor = validBootstrapFlavor
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.Flavors = map[string]Flavor{
+					validBootstrapFlavor: {
+						Flavor: flavors.Flavor{
+							Name: validBootstrapFlavor,
+						},
+					},
+				}
+				return ci
+			}(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name: "bootstrap flavor not found in OpenStack",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.BootstrapFlavor = invalidBootstrapFlavor
+				return p
+			}(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  true,
+			expectedErrMsg: `platform.openstack.bootstrapFlavor: Not found: "invalid-bootstrap-flavor"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aggregatedErrors := ValidatePlatform(tc.platform, tc.networking, tc.cloudInfo).ToAggregate()
+			if tc.expectedError {
 				assert.Regexp(t, tc.expectedErrMsg, aggregatedErrors)
 			} else {
 				assert.NoError(t, aggregatedErrors)

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -251,12 +251,20 @@ func generateProviderSpec(ctx context.Context, clusterID string, config *types.I
 		serverGroupName += "-" + failureDomain.AvailabilityZone
 	}
 
+	// Determine the flavor to use for this machine.
+	// Bootstrap machines use BootstrapFlavor when specified; otherwise fall back to the
+	// control plane flavor from the machine pool. Master machines always use FlavorName.
+	flavorName := mpool.FlavorName
+	if role == bootstrapRole && platform.BootstrapFlavor != "" {
+		flavorName = platform.BootstrapFlavor
+	}
+
 	spec := machinev1alpha1.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: machinev1alpha1.GroupVersion.String(),
 			Kind:       "OpenstackProviderSpec",
 		},
-		Flavor:           mpool.FlavorName,
+		Flavor:           flavorName,
 		CloudName:        CloudName,
 		CloudsSecret:     &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
 		UserDataSecret:   &corev1.SecretReference{Name: userDataSecret},

--- a/pkg/asset/machines/openstack/machines_test.go
+++ b/pkg/asset/machines/openstack/machines_test.go
@@ -1,11 +1,13 @@
 package openstack
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	machinev1 "github.com/openshift/api/machine/v1"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -286,4 +288,81 @@ func TestFailureDomains(t *testing.T) {
 }
 
 func TestPruneFailureDomains(t *testing.T) {
+}
+
+// TestMAPIBootstrapFlavorSelection verifies that generateProviderSpec selects the correct
+// flavor for bootstrap and master roles in the MAPI code path:
+//   - Bootstrap with BootstrapFlavor set   → BootstrapFlavor is used
+//   - Bootstrap with BootstrapFlavor empty → control plane FlavorName is used (fallback)
+//   - Master with BootstrapFlavor set      → FlavorName is used (master is unaffected)
+func TestMAPIBootstrapFlavorSelection(t *testing.T) {
+	const (
+		controlPlaneFlavor = "m1.xlarge"
+		bootstrapFlavor    = "m1.medium"
+		clusterID          = "test-cluster"
+		osImage            = "rhcos"
+		userDataSecret     = "user-data"
+	)
+
+	emptyFD := machinev1.OpenStackFailureDomain{RootVolume: &machinev1.RootVolume{}}
+	configDrive := false
+
+	tests := []struct {
+		name            string
+		role            string
+		bootstrapFlavor string // value placed in platform.BootstrapFlavor
+		wantFlavor      string
+	}{
+		{
+			name:            "bootstrap uses BootstrapFlavor when specified",
+			role:            bootstrapRole,
+			bootstrapFlavor: bootstrapFlavor,
+			wantFlavor:      bootstrapFlavor,
+		},
+		{
+			name:            "bootstrap falls back to control plane flavor when BootstrapFlavor is empty",
+			role:            bootstrapRole,
+			bootstrapFlavor: "",
+			wantFlavor:      controlPlaneFlavor,
+		},
+		{
+			name:            "master always uses FlavorName regardless of BootstrapFlavor",
+			role:            masterRole,
+			bootstrapFlavor: bootstrapFlavor,
+			wantFlavor:      controlPlaneFlavor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &types.InstallConfig{
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{
+						BootstrapFlavor: tt.bootstrapFlavor,
+					},
+				},
+			}
+			mpool := &openstack.MachinePool{
+				FlavorName: controlPlaneFlavor,
+			}
+
+			spec, err := generateProviderSpec(
+				context.Background(),
+				clusterID,
+				config,
+				mpool,
+				osImage,
+				tt.role,
+				userDataSecret,
+				emptyFD,
+				&configDrive,
+			)
+			if err != nil {
+				t.Fatalf("generateProviderSpec() unexpected error: %v", err)
+			}
+			if got := spec.Flavor; got != tt.wantFlavor {
+				t.Errorf("Flavor = %q, want %q", got, tt.wantFlavor)
+			}
+		})
+	}
 }

--- a/pkg/asset/machines/openstack/openstackmachines.go
+++ b/pkg/asset/machines/openstack/openstackmachines.go
@@ -195,8 +195,16 @@ func generateMachineSpec(clusterID string, config *types.InstallConfig, mpool *o
 		securityGroups = nil
 	}
 
+	// Determine the flavor to use for this machine.
+	// Bootstrap machines use BootstrapFlavor when specified; otherwise fall back to the
+	// control plane flavor from the machine pool. Master machines always use FlavorName.
+	flavorName := mpool.FlavorName
+	if role == bootstrapRole && platform.BootstrapFlavor != "" {
+		flavorName = platform.BootstrapFlavor
+	}
+
 	spec := capo.OpenStackMachineSpec{
-		Flavor: ptr.To(mpool.FlavorName),
+		Flavor: ptr.To(flavorName),
 		IdentityRef: &capo.OpenStackIdentityReference{
 			Name:      clusterID + "-cloud-config",
 			CloudName: CloudName,

--- a/pkg/asset/machines/openstack/openstackmachines_test.go
+++ b/pkg/asset/machines/openstack/openstackmachines_test.go
@@ -4,8 +4,10 @@ import (
 	"net"
 	"testing"
 
+	machinev1 "github.com/openshift/api/machine/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 func TestIsSingleStackIPv6(t *testing.T) {
@@ -76,6 +78,95 @@ func TestIsSingleStackIPv6(t *testing.T) {
 			result := isSingleStackIPv6(tt.machineNetwork)
 			if result != tt.expected {
 				t.Errorf("isSingleStackIPv6() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// newMinimalInstallConfig builds a minimal *types.InstallConfig for use in unit tests.
+// It sets only the fields required by generateMachineSpec so that tests stay focused.
+func newMinimalInstallConfig(platform *openstack.Platform) *types.InstallConfig {
+	return &types.InstallConfig{
+		Platform: types.Platform{
+			OpenStack: platform,
+		},
+	}
+}
+
+// newMinimalMachinePool builds a minimal *openstack.MachinePool for use in unit tests.
+func newMinimalMachinePool(flavorName string) *openstack.MachinePool {
+	return &openstack.MachinePool{
+		FlavorName: flavorName,
+	}
+}
+
+// TestBootstrapFlavorSelection verifies that generateMachineSpec selects the correct
+// flavor for bootstrap and master roles:
+//   - Bootstrap with BootstrapFlavor set  → BootstrapFlavor is used
+//   - Bootstrap with BootstrapFlavor empty → control plane FlavorName is used (fallback)
+//   - Master with BootstrapFlavor set     → FlavorName is used (master is unaffected)
+func TestBootstrapFlavorSelection(t *testing.T) {
+	const (
+		controlPlaneFlavor = "m1.xlarge"
+		bootstrapFlavor    = "m1.medium"
+	)
+
+	// A minimal failure domain with no zones — generateMachineSpec needs this to
+	// determine the root volume AZ (none here, since RootVolume is nil).
+	emptyFD := machinev1.OpenStackFailureDomain{}
+	configDrive := false
+
+	tests := []struct {
+		name            string
+		role            string
+		bootstrapFlavor string // value placed in platform.BootstrapFlavor
+		wantFlavor      string
+	}{
+		{
+			name:            "bootstrap uses BootstrapFlavor when specified",
+			role:            bootstrapRole,
+			bootstrapFlavor: bootstrapFlavor,
+			wantFlavor:      bootstrapFlavor,
+		},
+		{
+			name:            "bootstrap falls back to control plane flavor when BootstrapFlavor is empty",
+			role:            bootstrapRole,
+			bootstrapFlavor: "",
+			wantFlavor:      controlPlaneFlavor,
+		},
+		{
+			name:            "master always uses FlavorName regardless of BootstrapFlavor",
+			role:            masterRole,
+			bootstrapFlavor: bootstrapFlavor,
+			wantFlavor:      controlPlaneFlavor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platform := &openstack.Platform{
+				BootstrapFlavor: tt.bootstrapFlavor,
+			}
+			config := newMinimalInstallConfig(platform)
+			mpool := newMinimalMachinePool(controlPlaneFlavor)
+
+			spec, err := generateMachineSpec(
+				"test-cluster",
+				config,
+				mpool,
+				"rhcos",
+				tt.role,
+				emptyFD,
+				&configDrive,
+			)
+			if err != nil {
+				t.Fatalf("generateMachineSpec() unexpected error: %v", err)
+			}
+			if spec.Flavor == nil {
+				t.Fatal("generateMachineSpec() returned spec with nil Flavor")
+			}
+			if got := *spec.Flavor; got != tt.wantFlavor {
+				t.Errorf("Flavor = %q, want %q", got, tt.wantFlavor)
 			}
 		})
 	}

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -124,6 +124,11 @@ type Platform struct {
 	// +optional
 	ControlPlanePort *PortTarget `json:"controlPlanePort,omitempty"`
 
+	// BootstrapFlavor is the name of the flavor used for the bootstrap instance.
+	// When not specified, the bootstrap machine will use the control plane flavor.
+	// +optional
+	BootstrapFlavor string `json:"bootstrapFlavor,omitempty"`
+
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
 	// +optional
 	LoadBalancer *configv1.OpenStackPlatformLoadBalancer `json:"loadBalancer,omitempty"`


### PR DESCRIPTION
## Summary

This PR introduces a new `bootstrapFlavor` configuration option for OpenStack deployments, enabling users to specify a separate flavor for the bootstrap machine independent of the control plane flavor. This addresses NFV/NUMA-constrained deployments where control plane flavors with CPU pinning or NUMA node requirements may cause scheduling issues for the temporary bootstrap node, which doesn't require these specialized resources.

## Changes

### Type Definition
- Added `BootstrapFlavor` field to `Platform` struct in `pkg/types/openstack/platform.go` with `json:"bootstrapFlavor,omitempty"` tag for backward compatibility

### Validation
- `pkg/asset/openstack/validation/cloudinfo.go`: Extended flavor fetching to include bootstrapFlavor from OpenStack Compute API
- `pkg/asset/openstack/validation/platform.go`: Added `validateBootstrapFlavor()` function that returns `field.NotFound` error when specified flavor doesn't exist
- `pkg/asset/openstack/validation/platform_test.go`: Added `TestBootstrapFlavor` covering not specified, valid, and invalid flavor scenarios

### CAPI Machine Generation
- `pkg/asset/machines/openstack/openstackmachines.go`: Modified `generateMachineSpec()` to use `BootstrapFlavor` for bootstrap machines when specified, falling back to control plane flavor
- `pkg/asset/machines/openstack/openstackmachines_test.go`: Added `TestBootstrapFlavorSelection` with table-driven tests

### MAPI Machine Generation
- `pkg/asset/machines/openstack/machines.go`: Updated `generateProviderSpec()` with same bootstrap flavor selection logic for consistency across both code paths
- `pkg/asset/machines/openstack/machines_test.go`: Added `TestMAPIBootstrapFlavorSelection` with parallel test coverage

### Documentation
- `docs/user/openstack/customization.md`: Added `bootstrapFlavor` to cluster-scoped properties, documented NFV/NUMA use case with example configuration, updated machine pools section to reference the new field

## Implementation Notes

- The `BootstrapFlavor` field is a plain `string` type, so no deepcopy generation changes were required—existing `*out = *in` handling covers scalar fields
- Validation follows the established pattern: fetch flavor from OpenStack API, record absence if 404, validator reports `field.NotFound`
- Both CAPI and MAPI paths use identical flavor selection logic: check `platform.BootstrapFlavor` for bootstrap role, fall back to `mpool.FlavorName` when empty
- Full backward compatibility maintained—empty `bootstrapFlavor` preserves existing behavior of using control plane flavor

## Testing

- Unit tests added for validation covering: no flavor specified (backward compatible), valid flavor present, invalid flavor absent
- Unit tests added for CAPI machine generation covering bootstrap with flavor set, bootstrap with fallback, and master unaffected
- Unit tests added for MAPI machine generation with same coverage as CAPI
- All existing unit tests continue to pass
- Build verification: `go build`, `go vet`, and `gofmt` all pass cleanly

## Related Tickets

- [AISOS-358](https://redhat.atlassian.net/browse/AISOS-358)
- [AISOS-360](https://redhat.atlassian.net/browse/AISOS-360)
- [AISOS-361](https://redhat.atlassian.net/browse/AISOS-361)
- [AISOS-362](https://redhat.atlassian.net/browse/AISOS-362)
- [AISOS-363](https://redhat.atlassian.net/browse/AISOS-363)
- [AISOS-364](https://redhat.atlassian.net/browse/AISOS-364)
- [AISOS-365](https://redhat.atlassian.net/browse/AISOS-365)

---
*Generated by [Forge](https://github.com/eshulman2/forge) SDLC Orchestrator*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bootstrapFlavor to control the OpenStack flavor used for the temporary bootstrap instance; bootstrap now respects this field and falls back to the control-plane flavor when unset.

* **Documentation**
  * Added docs and examples describing bootstrapFlavor behavior and scope (bootstrap-only), including NFV/NUMA guidance.

* **Tests**
  * Added unit tests covering bootstrapFlavor selection and validation behavior.

* **Chores**
  * Updated ignore rules to exclude local workflow state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->