### PR TITLE
SPLAT-2452: Add SetSecurityGroups IAM permission to master nodes for BYO SG support for AWS NLBs

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/iam.go
+++ b/pkg/infrastructure/aws/clusterapi/iam.go
@@ -71,6 +71,7 @@ var (
 						"elasticloadbalancing:RegisterTargets",
 						"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
 						"elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+						"elasticloadbalancing:SetSecurityGroups",
 						"kms:DescribeKey",
 					},
 					Resource: iamv1.Resources{

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -542,6 +542,7 @@ Resources:
             - "elasticloadbalancing:RegisterTargets"
             - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
             - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+            - "elasticloadbalancing:SetSecurityGroups"
             - "kms:DescribeKey"
             Resource: "*"
 


### PR DESCRIPTION
## Context

As part of the new Bring Your Own Security Groups (BYO SG) for AWS Network Load Balancers (NLBs) feature currently [under review in upstream](https://github.com/kubernetes/cloud-provider-aws/pull/1379), it is required to add a new `elasticloadbalancing:SetSecurityGroups` permission to the role used by AWS CCM to interact with AWS APIs.

The `elasticloadbalancing:SetSecurityGroups` permission is required to enable AWS CCM to change the security groups associated with Network Load Balancers without deleting and recreating the NLB, which is not viable.

Without this permission, the following operations are not possible:

- Changing BYO security groups
- Transition from managed to BYO Security Group
- Transition from BYO Security Group to managed

The new permission is similar to `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer` which is already present and required to edit BYO Security Groups associated with Classic Load Balancers (CLBs).

The upstream `kOps` Kubernetes infrastructure provisioning tool has been already updated to add the required permission: https://github.com/kubernetes/kops/pull/18211 

## References:

- Upstream PR to add the BYO SG feature (currently pending review): https://github.com/kubernetes/cloud-provider-aws/pull/1379
- Upstream PR to `kOps` to add to the Kubernetes cluster install tool support for the new permission (already merged):  https://github.com/kubernetes/kops/pull/18211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing AWS load balancer security group management permission for cluster master nodes, resolving failures when updating or assigning security groups to load balancers and improving reliability of cluster load balancer operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->