### PR TITLE
bootstrap: override registries.d sigstore configs when image policy is disabled

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -229,6 +229,10 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 
 	a.addParentFiles(dependencies)
 
+	if IsImagePolicyDisabled() {
+		addRegistriesDOverrides(a.Config)
+	}
+
 	a.Config.Passwd.Users = append(
 		a.Config.Passwd.Users,
 		igntypes.PasswdUser{Name: "core", SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
@@ -817,4 +821,30 @@ func warnIfCertificatesExpired(config *igntypes.Config) error {
 		return fmt.Errorf("%d certificates expired", expiredCerts)
 	}
 	return nil
+}
+
+// addRegistriesDOverrides replaces the RHEL-shipped registries.d sigstore
+// configuration files with empty versions. Without this, skopeo attempts
+// sigstore lookups via the registries.d endpoints even when policy.json is
+// set to insecureAcceptAnything, which can cause deadlocks in older skopeo
+// versions (pre-1.22.2) when pulling multi-arch images.
+func addRegistriesDOverrides(config *igntypes.Config) {
+	logrus.Info("Overriding registries.d sigstore configs (OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY is set)")
+
+	minimalDefault := []byte("default-docker:\n")
+	emptyYaml := []byte("{}\n")
+
+	overrides := []struct {
+		path     string
+		contents []byte
+	}{
+		{"/etc/containers/registries.d/default.yaml", minimalDefault},
+		{"/etc/containers/registries.d/registry.access.redhat.com.yaml", emptyYaml},
+		{"/etc/containers/registries.d/registry.redhat.io.yaml", emptyYaml},
+	}
+
+	for _, o := range overrides {
+		file := ignition.FileFromBytes(o.path, "root", 0644, o.contents)
+		config.Storage.Files = replaceOrAppend(config.Storage.Files, file)
+	}
 }

--- a/pkg/asset/ignition/bootstrap/cvoignore.go
+++ b/pkg/asset/ignition/bootstrap/cvoignore.go
@@ -159,3 +159,12 @@ func getClusterVersionOperatorOverrides() []interface{} {
 
 	return overrides
 }
+
+// IsImagePolicyDisabled returns true when OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY
+// is set non-empty, indicating that sigstore image signature verification should be skipped.
+func IsImagePolicyDisabled() bool {
+	if v, ok := os.LookupEnv("OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY"); ok && v != "" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

When `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY` is set, the installer now also overrides the RHEL-shipped `registries.d` sigstore configuration files in the bootstrap ignition with empty/minimal versions. This prevents `skopeo` from attempting sigstore lookups that deadlock on older RHCOS boot images.

## Problem

The existing `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY` flag only disables the `ClusterImagePolicy` CVO override. It does NOT modify `/etc/containers/registries.d/*.yaml` files shipped by the RHEL base image. These files configure sigstore lookup endpoints:

```yaml
# /etc/containers/registries.d/registry.access.redhat.com.yaml
docker:
     registry.access.redhat.com:
         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
```

Older `skopeo` versions (pre-1.22.2) shipped in RHCOS boot images (e.g., `9.8.20260403-0`) attempt sigstore lookups via these `registries.d` endpoints even when:
- `policy.json` is set to `insecureAcceptAnything`
- The pull uses the `ostree-unverified-image:` prefix

This causes `skopeo` to deadlock during `node-image-pull` on the bootstrap node, blocking the entire bootstrap process indefinitely.

## Debug Evidence

Captured via `strace` and `/proc` on a live bootstrap with the hang:

- `skopeo` (PID 1928) has one ESTAB connection to `23.61.255.239:443` (Akamai CDN for `access.redhat.com`)
- All 7 `skopeo` threads are in `FUTEX_WAIT_PRIVATE` - complete deadlock
- Zero syscalls completed in 30 seconds of strace
- Zero network payload transferred (only keepalive bytes)
- `bootc` parent process blocked reading from `skopeo` pipes
- Container policy is `insecureAcceptAnything` - the deadlock is triggered by `registries.d`, not `policy.json`

Full debug report: captured during [OCPSTRAT-2830](https://redhat.atlassian.net/browse/OCPSTRAT-2830) GCP UPI verification.

Related: OCPBUGS-83826 (multi-arch RHCOS Sigstore vs rpm-ostree on older boot images), MCO PR #5867

## Changes

- `pkg/asset/ignition/bootstrap/cvoignore.go`: Added `IsImagePolicyDisabled()` helper
- `pkg/asset/ignition/bootstrap/common.go`: Added `addRegistriesDOverrides()` that replaces `registries.d` sigstore configs with empty versions when the flag is set

## Scope

This fix addresses the **bootstrap node** only. Masters and workers fetch their config from MCS and need the MCO-side fix (PR #5867) for the same issue.

## Test plan

- [ ] Build installer with this change
- [ ] Set `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true`
- [ ] Generate ignition configs
- [ ] Verify `bootstrap.ign` contains overridden `registries.d` files
- [ ] Deploy bootstrap on GCP with RHCOS `9.8.20260403-0` boot image
- [ ] Verify `node-image-pull` completes without hanging


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for an experimental option to disable image policy enforcement. When enabled, the system automatically configures registry settings during cluster bootstrap to reflect this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->