### PR TITLE
[release-4.22] OCPBUGS-85503: PowerVS: Fix supported system types retrieval

### DIFF
--- a/cluster-api/providers/ibmcloud/go.mod
+++ b/cluster-api/providers/ibmcloud/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/onsi/gomega v1.38.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db // indirect
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20260320143638-bc9d769bbbfc // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/cluster-api/providers/ibmcloud/go.sum
+++ b/cluster-api/providers/ibmcloud/go.sum
@@ -211,8 +211,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db h1:Fy2pmDLfLq2H0N77KD2LpNoCWbDGP0BknZU/odPx2+c=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20260320143638-bc9d769bbbfc h1:SWIY4l7NmQMrNuEwL01R5dHcSowtVu9oVV/HKO1pALI=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20260320143638-bc9d769bbbfc/go.mod h1:APQVGiVIdJ3HuzYdQS0319Xsk08Y8S/bbbJYLoDwYvw=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/cluster-api/providers/ibmcloud/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
+++ b/cluster-api/providers/ibmcloud/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
@@ -8,7 +8,7 @@ import (
 // SysTypes denotes the available system types against individual zones
 // The system types against each zone can be fetched using either of the following:
 // 1. ibmcloud cli command
-//    `ibmcloud pi datacenter ls --json | jq -r '.datacenters[] | "\(.location.region),\(.capabilitiesDetails.supportedSystems.general[])"' | sort -u`
+//    `ibmcloud pi datacenter ls --json | jq -r '.datacenters[] | "\(.location.region),\(.capabilitiesDetails.supportedSystems.general[])"' | awk -F, '{if($1 in m){m[$1]=m[$1]", \""$2"\""}else{m[$1]="\"" $2 "\""}} END{for(k in m) print "\""k"\": {" m[k] "}"}' | sort`
 // 2. https://cloud.ibm.com/apidocs/power-cloud#v1-datacenters-getall (the above command uses this api underneath).
 
 type SysTypes []string
@@ -16,34 +16,34 @@ type SysTypes []string
 func GetRegion(zone string) (region string, err error) {
 	err = nil
 	switch {
-	case strings.HasPrefix(zone, "us-south"):
-		region = "us-south"
+	case strings.HasPrefix(zone, "che"):
+		region = "che"
 	case strings.HasPrefix(zone, "dal"):
 		region = "dal"
-	case strings.HasPrefix(zone, "sao"):
-		region = "sao"
-	case strings.HasPrefix(zone, "us-east"):
-		region = "us-east"
 	case strings.HasPrefix(zone, "eu-de-"):
 		region = "eu-de"
 	case strings.HasPrefix(zone, "lon"):
 		region = "lon"
+	case strings.HasPrefix(zone, "mad"):
+		region = "mad"
+	case strings.HasPrefix(zone, "mon"):
+		region = "mon"
+	case strings.HasPrefix(zone, "osa"):
+		region = "osa"
+	case strings.HasPrefix(zone, "sao"):
+		region = "sao"
 	case strings.HasPrefix(zone, "syd"):
 		region = "syd"
 	case strings.HasPrefix(zone, "tok"):
 		region = "tok"
-	case strings.HasPrefix(zone, "osa"):
-		region = "osa"
-	case strings.HasPrefix(zone, "mon"):
-		region = "mon"
-	case strings.HasPrefix(zone, "mad"):
-		region = "mad"
-	case strings.HasPrefix(zone, "wdc"):
-		region = "wdc"
 	case strings.HasPrefix(zone, "tor"):
 		region = "tor"
-	case strings.HasPrefix(zone, "che"):
-		region = "che"
+	case strings.HasPrefix(zone, "us-east"):
+		region = "us-east"
+	case strings.HasPrefix(zone, "us-south"):
+		region = "us-south"
+	case strings.HasPrefix(zone, "wdc"):
+		region = "wdc"
 	default:
 		return "", fmt.Errorf("region not found for the zone, talk to the developer to add the support into the tool: %s", zone)
 	}
@@ -61,14 +61,23 @@ type Region struct {
 
 // regions provides a mapping between Power VS and IBM Cloud VPC and IBM COS regions.
 var regions = map[string]Region{
+	"che": {
+		Description: "Chennai, India",
+		VPCRegion:   "",
+		COSRegion:   "",
+		Zones: map[string]SysTypes{
+			"che01": {"e980", "s922"},
+		},
+		VPCZones: []string{},
+	},
 	"dal": {
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
 		Zones: map[string]SysTypes{
 			"dal10": {"e1080", "e980", "s1022", "s922"},
-			"dal12": {"e980", "s922"},
-			"dal14": {"e1050", "e1080", "s1022"},
+			"dal12": {"e1080", "e1050", "e980", "s1022", "s922"},
+			"dal14": {"e1050", "e1080", "s1122", "s1022"},
 		},
 		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
@@ -77,7 +86,7 @@ var regions = map[string]Region{
 		VPCRegion:   "eu-de",
 		COSRegion:   "eu-de",
 		Zones: map[string]SysTypes{
-			"eu-de-1": {"e1080", "e1050", "e980", "s1022", "s922"},
+			"eu-de-1": {"e1080", "e1050", "e980", "s1122", "s1022", "s922"},
 			"eu-de-2": {"e980", "s1022", "s922"},
 		},
 		VPCZones: []string{"eu-de-1", "eu-de-2", "eu-de-3"},
@@ -97,8 +106,8 @@ var regions = map[string]Region{
 		VPCRegion:   "eu-es",
 		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones: map[string]SysTypes{
-			"mad02": {"e1050", "e1080", "e980", "s1022", "s922"},
-			"mad04": {"e980", "s1022"},
+			"mad02": {"e1050", "e1080", "e980", "s1122", "s1022", "s922"},
+			"mad04": {"e1050", "e1080", "e980", "s1022"},
 		},
 		VPCZones: []string{"eu-es-1", "eu-es-2", "eu-es-3"},
 	},
@@ -126,7 +135,7 @@ var regions = map[string]Region{
 		COSRegion:   "br-sao",
 		Zones: map[string]SysTypes{
 			"sao01": {"e980", "s1022", "s922"},
-			"sao04": {"e980", "s1022", "s922"},
+			"sao04": {"e1050", "e1080", "e980", "s1022", "s922"},
 		},
 		VPCZones: []string{"br-sao-1", "br-sao-2", "br-sao-3"},
 	},
@@ -172,7 +181,7 @@ var regions = map[string]Region{
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
 		Zones: map[string]SysTypes{
-			"us-south": {"e980", "s922"},
+			"us-south": {"e980", "s1022", "s922"},
 		},
 		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
@@ -181,19 +190,10 @@ var regions = map[string]Region{
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
 		Zones: map[string]SysTypes{
-			"wdc06": {"e980", "s1022", "s922"},
+			"wdc06": {"e1050", "e1080", "e980", "s1122", "s1022", "s922"},
 			"wdc07": {"e1050", "e1080", "e980", "s1022", "s922"},
 		},
 		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
-	},
-	"che": {
-		Description: "Chennai, India",
-		VPCRegion:   "",
-		COSRegion:   "",
-		Zones: map[string]SysTypes{
-			"che01": {"e980", "s922"},
-		},
-		VPCZones: []string{},
 	},
 }
 

--- a/cluster-api/providers/ibmcloud/vendor/modules.txt
+++ b/cluster-api/providers/ibmcloud/vendor/modules.txt
@@ -389,8 +389,8 @@ github.com/opentracing/opentracing-go/log
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
-# github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db
-## explicit; go 1.21
+# github.com/ppc64le-cloud/powervs-utils v0.0.0-20260320143638-bc9d769bbbfc
+## explicit; go 1.25.8
 github.com/ppc64le-cloud/powervs-utils
 # github.com/prometheus/client_golang v1.22.0
 ## explicit; go 1.22

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -1122,12 +1122,15 @@ func (c *Client) GetDatacenterSupportedSystems(ctx context.Context, region strin
 			return nil, fmt.Errorf("failed to initialize PISession in GetDatacenterSupportedSystems: %w", err)
 		}
 	}
-	params := datacenters.NewV1DatacentersGetParamsWithContext(ctx).WithDatacenterRegion(region)
-	getOk, err := c.BXCli.PISession.Power.Datacenters.V1DatacentersGet(params)
+
+	// Use the global datacenter endpoint for accurate, non-cached data (other code uses a bulk endpoint)
+	datacenterClient := instance.NewIBMPIDatacenterClient(ctx, c.BXCli.PISession, "")
+	datacenter, err := datacenterClient.Get(region)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get datacenter supported systems: %w", err)
 	}
-	return getOk.Payload.CapabilitiesDetails.SupportedSystems.General, nil
+
+	return datacenter.CapabilitiesDetails.SupportedSystems.General, nil
 }
 
 // TransitGatewayNameToID checks to see if the name is an existing transit gateway name.

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -37,6 +37,9 @@ var Regions = map[string]Region{
 			"dal12": {
 				SysTypes: []string{"s922", "e980"},
 			},
+			"dal14": {
+				SysTypes: []string{"s1022", "e1080", "s1122"},
+			},
 		},
 		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},

--- a/pkg/types/powervs/validation/machinepool_test.go
+++ b/pkg/types/powervs/validation/machinepool_test.go
@@ -14,6 +14,7 @@ func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
 		name     string
 		pool     *powervs.MachinePool
+		platform *powervs.Platform
 		expected string
 	}{
 		{
@@ -73,6 +74,7 @@ func TestValidateMachinePool(t *testing.T) {
 				SysType:   "s922",
 				MemoryGiB: 943,
 			},
+			platform: &powervs.Platform{Zone: "dal10"}, // Use a zone that supports s922
 			expected: `^test-path\.memory: Invalid value: 943: maximum memory limit for the s922 SysType is 942GiB$`,
 		},
 		{
@@ -101,6 +103,7 @@ func TestValidateMachinePool(t *testing.T) {
 				SysType:    "s922",
 				Processors: intstr.FromInt(33),
 			},
+			platform: &powervs.Platform{Zone: "dal10"}, // Use a zone that supports s922
 			expected: `^test-path\.processors: Invalid value: 33: maximum processors limit for s922 SysType is 15 cores$`,
 		},
 		{
@@ -136,6 +139,7 @@ func TestValidateMachinePool(t *testing.T) {
 			pool: &powervs.MachinePool{
 				SysType: "s922",
 			},
+			platform: &powervs.Platform{Zone: "dal10"}, // Use a zone that supports s922
 		},
 		{
 			name: "invalid sysType",
@@ -147,7 +151,11 @@ func TestValidateMachinePool(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateMachinePool(validMinimalPlatform(), tc.pool, field.NewPath("test-path")).ToAggregate()
+			platform := tc.platform
+			if platform == nil {
+				platform = validMinimalPlatform()
+			}
+			err := ValidateMachinePool(platform, tc.pool, field.NewPath("test-path")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
Backport of #10268 to `release-22`.

This PR fixes supported system type retrieval for PowerVS regions by adding
dal14 region support and enabling the s1122 system type.

### Included changes
- pkg/types/powervs: add dal14 region support with s1122
- cluster-api/providers/ibmcloud: bump powervs-utils for s1122 support
- cluster-api/providers/ibmcloud: vendor updated powervs-utils

The powervs-utils version used matches the original change merged to `main`
and represents the minimal dependency update required for this fix.

Original PR: #10268
Jira: [MULTIARCH-5824](https://redhat.atlassian.net/browse/MULTIARCH-5824)