### PR TITLE
OCPBUGS-84643: Update RHCOS-release-4.22 bootimage metadata to 10.2.20260423-0 / 9.8.20260428-0

### DIFF
--- a/data/data/coreos/coreos-rhel-10.json
+++ b/data/data/coreos/coreos-rhel-10.json
@@ -1,117 +1,117 @@
 {
   "stream": "rhcos-4.22",
   "metadata": {
-    "last-modified": "2026-04-08T16:31:45Z",
-    "generator": "plume cosa2stream b23d8cf"
+    "last-modified": "2026-04-28T22:11:51Z",
+    "generator": "plume cosa2stream 211dee6"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-aws.aarch64.vmdk.gz",
-                "sha256": "a80d57a5bbdb63000bca66497e214653b36c01a8ff6329451a1525328609d605",
-                "uncompressed-sha256": "3640de771b7db25c37496d386b333fde82c9029c4297bbc0beef30c9384bec99"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-aws.aarch64.vmdk.gz",
+                "sha256": "4e403b805d4e5cf6899b033c95653a2eb31bb327c6384f7ea1d22d2085002459",
+                "uncompressed-sha256": "2129f42e8444d41f805acd200dcb0a95d9f215c94c6054c51f6b9a56beb5ff6a"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-azure.aarch64.vhd.gz",
-                "sha256": "797b0ef113420d87f4e3a31c528baa2be2f27c3152d3daaa7089a01899ef33a9",
-                "uncompressed-sha256": "20b031a0237b96c90eceaf6b8cd523388245ab12d28022b7639cda2badb06e7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-azure.aarch64.vhd.gz",
+                "sha256": "7766833d8c5cad9970fa24406b4bd1d7e65f411530d397df4fbd8ddcd320f24f",
+                "uncompressed-sha256": "4b0dc0cc08b9f36c878fac89901c3eda5912adec022918de73ba55ec46dd0f16"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-gcp.aarch64.tar.gz",
-                "sha256": "8c81c2ddb100a21cd290870e3f62c3e57d4c08d781c6817bf0143985aac32130"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-gcp.aarch64.tar.gz",
+                "sha256": "7352b3952284d8a8c7345b14052e08cf7862481f323ad28da09eca19160e83d1"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-metal4k.aarch64.raw.gz",
-                "sha256": "a786da18e195dc45d359a04f7147f8b70edcb97a146be1419601c59727b84847",
-                "uncompressed-sha256": "9f1333aba4f943b89de83de75afcacb5e194bc67d4ec3b59e5fc5032c3b791a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-metal4k.aarch64.raw.gz",
+                "sha256": "0d24004369c4c10e9d2ad44a9c342b36ce9b6521528c5be744bba4333b9d356e",
+                "uncompressed-sha256": "1aa97472007867c02a036497f0e854676bca400534c2ea694c3727ac37365d99"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-iso.aarch64.iso",
-                "sha256": "7ea8be2989e85ad7c089144716dd6e30343185dca004871649468ecf27c46308"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-live-iso.aarch64.iso",
+                "sha256": "de5b65a716db5d144a0de5cc4e7f200413ae426602811b0807a60f2266fa2a40"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-kernel.aarch64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-live-kernel.aarch64",
                 "sha256": "365986469730ef6cd2317a3a098dd6bb3d128a24d28c028d65f3e538399eaa25"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-initramfs.aarch64.img",
-                "sha256": "f04ad979c167753e72faca1d6df4a6188023497ed1cae27d50d26d3c0530f539"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-live-initramfs.aarch64.img",
+                "sha256": "44ad24c5a3d8b7a882acd8d95a663f5c0428fbbde6a97d39141818b72508872a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-live-rootfs.aarch64.img",
-                "sha256": "0ea68f6187d4964e966531f3237619f814d58b384eec2e47645347bed9f3ad84"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-live-rootfs.aarch64.img",
+                "sha256": "c47214bab9c0c7adee3c7b9d7949709d306fa7f729a62535df405913d2c5b8f0"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-metal.aarch64.raw.gz",
-                "sha256": "94bc161ba65840d7c28704e2e03ee6ebfa8fa52b97ba032dda43f87db84f8e63",
-                "uncompressed-sha256": "2d89587937641365a1c9eb5a1701ad501b2978320e77e41ad7496170ab217c9a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-metal.aarch64.raw.gz",
+                "sha256": "727d37a878186071eb9156a69e125711a21b66f8216dd57ddf54ddb0125e44fb",
+                "uncompressed-sha256": "8b18f1270211666483ad45a0bb99c5e546ea349c3d7fe372cb513b3cacaf3bad"
               }
             }
           }
         },
         "nvidiabluefield": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "bfb": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "9972628d17ebd585edaff81aeb624c1d1dc75a9ebc9858c53da8cda4aa6e2fec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-nvidiabluefield.aarch64.bfb",
+                "sha256": "5a4f22099bb6fed627e8e0cf279285f9bf99c19b9f5d250b8d5ede6e49af8871"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-openstack.aarch64.qcow2.gz",
-                "sha256": "6d534cd2f188970920ff2b506321ce947c4520992c9608d0a7ad812a9d059c1f",
-                "uncompressed-sha256": "e241eef78bd60d6a24b2fb8d2abaad91ef94f48ee0b7ecee570f169c174bb923"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-openstack.aarch64.qcow2.gz",
+                "sha256": "5b5c507e51ee4a12602adeb75138ec25e6cc5f4e0c1539e9066d7677c46473c1",
+                "uncompressed-sha256": "b2395a2c326dbb71bfa4174ca0a381d0b769b6017f7900b6ba23364b6372d039"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-qemu.aarch64.qcow2.gz",
-                "sha256": "46289adada5d2819332fe54757f230ccb7430203b84c6d461064b412e7d9f6bd",
-                "uncompressed-sha256": "48d2d6e217032457086bfeb4b26ab17b428f276c8aa9dfb2173f691cad14c19c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/aarch64/rhcos-10.2.20260423-0-qemu.aarch64.qcow2.gz",
+                "sha256": "6fe2bfb21063a15c450ff7ad4adbb7b4a4e23e0cb6b1976a9034feca59a670aa",
+                "uncompressed-sha256": "2a124285c63b755908133aa208a8d78a11f6a866205fd68c8938ad440af2f806"
               }
             }
           }
@@ -121,229 +121,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01edee0bc30a94bb5"
+              "release": "10.2.20260423-0",
+              "image": "ami-09715861f76e6bf9c"
             },
             "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03a09cb0a80c9dfe1"
+              "release": "10.2.20260423-0",
+              "image": "ami-0289b8234470a5e18"
             },
             "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-008848ad3ce515986"
+              "release": "10.2.20260423-0",
+              "image": "ami-0cfdde3a2f98a74a5"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09fe07667320a3c7b"
+              "release": "10.2.20260423-0",
+              "image": "ami-098d3970c5039ae54"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-031c6e2d2e91d81e8"
+              "release": "10.2.20260423-0",
+              "image": "ami-06f2d069eff192b69"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d9ea1a9c9fd8993d"
+              "release": "10.2.20260423-0",
+              "image": "ami-0bb0771af90d00d4d"
             },
             "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ce5d7cd569f7ddcf"
+              "release": "10.2.20260423-0",
+              "image": "ami-03d13dd057ed2b6d4"
             },
             "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e55b9a5ee91005b3"
+              "release": "10.2.20260423-0",
+              "image": "ami-0b10a8bfe5402d844"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-022fe13ec4f6b448d"
+              "release": "10.2.20260423-0",
+              "image": "ami-03035531216c3f759"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0766cd9c6911c4d4a"
+              "release": "10.2.20260423-0",
+              "image": "ami-09bbe38e67569f00b"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0824c47c0c332a0d6"
+              "release": "10.2.20260423-0",
+              "image": "ami-0b913497781d56773"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ad64701471c4a4a8"
+              "release": "10.2.20260423-0",
+              "image": "ami-00c84451a292445d2"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08ebba59f462478cc"
+              "release": "10.2.20260423-0",
+              "image": "ami-0eb7000e6e1d82a55"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09dedbd99dbfd4e53"
+              "release": "10.2.20260423-0",
+              "image": "ami-08d8cae62f83aeb1a"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-037ddf8344ba74866"
+              "release": "10.2.20260423-0",
+              "image": "ami-05a8784d424e6d835"
             },
             "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-056d2edf0ec039382"
+              "release": "10.2.20260423-0",
+              "image": "ami-0aa2c7d49c4db8910"
             },
             "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-073af394c3ead0b10"
+              "release": "10.2.20260423-0",
+              "image": "ami-03a88dc62aa93d084"
             },
             "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09b4f847184438c31"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a793d50e3236745f"
             },
             "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05811424b806e1bfe"
+              "release": "10.2.20260423-0",
+              "image": "ami-0dc76ec2c374fbe5f"
             },
             "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08ddd9e4086c3b5da"
+              "release": "10.2.20260423-0",
+              "image": "ami-02b6157dc5d22d364"
             },
             "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05358d3d407992467"
+              "release": "10.2.20260423-0",
+              "image": "ami-061edcb611acc1929"
             },
             "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-076272842238056ec"
+              "release": "10.2.20260423-0",
+              "image": "ami-06fd8c1161091f116"
             },
             "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0fd49af85fc4b0121"
+              "release": "10.2.20260423-0",
+              "image": "ami-0d570987b63d64aec"
             },
             "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0dc571ee0a20af3bc"
+              "release": "10.2.20260423-0",
+              "image": "ami-0f19a32f2b1afdf01"
             },
             "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09ae32c4d26889a54"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c45fd8598192e3f8"
             },
             "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-077b9594541c0343f"
+              "release": "10.2.20260423-0",
+              "image": "ami-0110770b8dd42a632"
             },
             "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e35888f9497eedf6"
+              "release": "10.2.20260423-0",
+              "image": "ami-052a904ab957793b5"
             },
             "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ad422d84cfba3c5b"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a3744a775afbc252"
             },
             "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d7237e6b04d9a9e1"
+              "release": "10.2.20260423-0",
+              "image": "ami-014fed2ebdf1be642"
             },
             "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a3e0f0816d1ba247"
+              "release": "10.2.20260423-0",
+              "image": "ami-03df8340dedd38140"
             },
             "us-gov-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e1f7f148cda4206a"
+              "release": "10.2.20260423-0",
+              "image": "ami-00f811351648b0888"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-043dc05714b5fea29"
+              "release": "10.2.20260423-0",
+              "image": "ami-02a889ca76200b81d"
             },
             "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-069d992efa13b2d3a"
+              "release": "10.2.20260423-0",
+              "image": "ami-081d394481132ca26"
             },
             "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-067c61e7fb4d54a67"
+              "release": "10.2.20260423-0",
+              "image": "ami-0f99752b66ba9ef7c"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260405-0-gcp-aarch64"
+          "name": "rhcos-10-2-20260423-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "10.2.20260405-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.aarch64.vhd"
+          "release": "10.2.20260423-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260423-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-metal4k.ppc64le.raw.gz",
-                "sha256": "3db1e37f29293017c38459e0189f3d98ad62509539cd33b6ec36c52944971b59",
-                "uncompressed-sha256": "5a68828266eb29b75423b8693ecfcb70d694e441a52ab3599206f6de805e6a70"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-metal4k.ppc64le.raw.gz",
+                "sha256": "f408079ed186d19289c53bfb5a065aa28e10f4a947f4ad352f780c9238f5e5a5",
+                "uncompressed-sha256": "d475451439d4d3afe05168f5b30f52986184c51047d6731d9afe1df115a86fc5"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-iso.ppc64le.iso",
-                "sha256": "cc57a556b882fd67cb333bcbb7a4e52acd9af3e153029d8c07b2cd6266c619a8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-live-iso.ppc64le.iso",
+                "sha256": "0466071c5361a621cde42d9a11fa7d55b3c742c3ee4ddbd4dfaa38f5a1ee71e7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-kernel.ppc64le",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-live-kernel.ppc64le",
                 "sha256": "00d01662a7b9da0e27916100111fe671b79ff3fc1ab50f64e4f0559341e85b3a"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-initramfs.ppc64le.img",
-                "sha256": "643ec38650f2d40fd7960b14e7ac47b7ce0927a1e5c3b5dd8c23f88da736b49c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-live-initramfs.ppc64le.img",
+                "sha256": "f2eed9475d883cf763778ab54be53706bc8c5025a0b834c1bafe94a5ac4e67c0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-live-rootfs.ppc64le.img",
-                "sha256": "f78f178ee7c3d4971a1a764ae0ed5be78605d4bfae87b97fbd6e4a12623a4967"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-live-rootfs.ppc64le.img",
+                "sha256": "b5924442f99b43c649a23d5bffc343c1bcff7852f81a1401d5ca8f7477c50da5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-metal.ppc64le.raw.gz",
-                "sha256": "e9f85318686415d62ba0b7224349fb3b4369421abedc148104a9613ea5ceebf5",
-                "uncompressed-sha256": "23c2ea9288b23c56f676838578565dbe082b4227606521c022c36f0911993d21"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-metal.ppc64le.raw.gz",
+                "sha256": "cc17f0c32a148a8f8bb82193e613fe8d33310b45e2bc2a0dd3e093fb0c4f492a",
+                "uncompressed-sha256": "3e4f6bc4c7c1daf0d230d34dcdf619dac8e5361da7a0744dec9609e51a5daa09"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "8c1edfc4372ad8c544103c512a8fe1b856c2dfc87cbefd4100c3d46c9e849a90",
-                "uncompressed-sha256": "918dac1deee062bd20eb3af6ab8134a73f9bfdd7bd071fe9f774967126373b8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "6d58603600d00b603a259f9f895cce6d58cf2e308403685b81ebaa504e832392",
+                "uncompressed-sha256": "902abac1e651b1653720d0ed2422394658478394472c63c1cb0631d406dc6143"
               }
             }
           }
         },
         "powervs": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-powervs.ppc64le.ova.gz",
-                "sha256": "c679883122fa6d563d42198c5f0ca133996eec7c0e9592fc767e1f42e5cfa29d",
-                "uncompressed-sha256": "4ab60d42ce6023f8012183458d16aad90a868feb862a0ac0f2b8721bf61e39b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-powervs.ppc64le.ova.gz",
+                "sha256": "c1f87ad69726dd37c4a011b94a098bc41e5ca258d61cea7f8442034444a2f879",
+                "uncompressed-sha256": "dec0997f22934dfddf743a7a664104d8f0213c5a2e35b224b86418824981760f"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "f41180d5e74c0218247c5ceb91c4e5defd2d63189ba41b6387eba02a377b1ce0",
-                "uncompressed-sha256": "65b0dd052304567fbfff2aa5bc65cbca99cdd438f6fff861c41dca740b606ef2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/ppc64le/rhcos-10.2.20260423-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "4bccd4a5131b20956addaf8ddc2a4e63a13266198073ac1c03d493a91d2ff755",
+                "uncompressed-sha256": "aa3d79de6f7b0fbf2b5e25b72f8cbad53255c6dfcfda41f30ed36c6498aa2c68"
               }
             }
           }
@@ -353,64 +353,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "10.2.20260405-0",
-              "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260423-0",
+              "object": "rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260423-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +419,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "9e9d4ff1a0913e009eedf914c2fc2126c0aec6dfefc874ebcede62001093328d",
-                "uncompressed-sha256": "09805367e90b08ade16e67f5683b16c7796588d885ae7fd0893ba56c373d0c22"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "9ecd99dca70359b18c69291d6f9543415b6945c1097b734d5bb1db72a06e5fbf",
+                "uncompressed-sha256": "f188eaf8ea5446293d0ae6da341ed9d63e2682c5e2289a98c300e94454b29d71"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-kubevirt.s390x.ociarchive",
-                "sha256": "4f79d84853a69d3abab5faf450a588c1afbd0f2c54a26645761c2ce0361df8c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-kubevirt.s390x.ociarchive",
+                "sha256": "4b0e45e62564514975bdd08b49d58dc74e790cf37cc61cd166b28ff6a702194f"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-metal4k.s390x.raw.gz",
-                "sha256": "fece30e2d4a8dea9e0d3ecd6360f45fed1aee0f38ea4ca6ce554e68cdc04ddae",
-                "uncompressed-sha256": "470e5b44a0533dc6806d11888eaa39f81982968631d86d5d8d94840786b9f512"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-metal4k.s390x.raw.gz",
+                "sha256": "8e941a6d7145b924c637107813864b6cde043892db4cfbda9da5630bbe1564ce",
+                "uncompressed-sha256": "0148c560ddece52bea9cb13da835b71b49fb83a87597d1305f499d7d7473396a"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-iso.s390x.iso",
-                "sha256": "d97e25fcb0517e0dbed1cf63759b3d6fbe64df238184316e207d9b2902a38320"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-live-iso.s390x.iso",
+                "sha256": "52df13e4c9da57c0c720a9487352201d80d87012e745016187fe44c82fbc65a1"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-kernel.s390x",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-live-kernel.s390x",
                 "sha256": "692867f01e6be50813a1f00a28155e849f767668898245cd14a72178b5b2b370"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-initramfs.s390x.img",
-                "sha256": "48c35995ce47b8c68ce255f4d0043ba699c15d26f9ab04790d017f5cd00a816f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-live-initramfs.s390x.img",
+                "sha256": "cb71c66d01e1d678751450db68aec89fada0dfbd7dfb321f3d4219763aaa9b0a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-live-rootfs.s390x.img",
-                "sha256": "1c60c8d4bd13471f823cf32fd9b24f6529108e2f5334ba83483b2214e6a16839"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-live-rootfs.s390x.img",
+                "sha256": "b0cc96925526d249a6dd14e245c1d49d3daf2da8cdc020852f689004f2e231be"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-metal.s390x.raw.gz",
-                "sha256": "eaab142f77bb854538f96bd0b81e7c06fab25b3351328f31d3ecd83dc149fafa",
-                "uncompressed-sha256": "e69bdc89f9a1192a5e5a09a0861a25599200da247a919818acb36b686665ec3f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-metal.s390x.raw.gz",
+                "sha256": "258dd4dd5005ffe80595f93a5f82fad1d2899dead6038a78372db2f3dd9d05a4",
+                "uncompressed-sha256": "3b881da080f0c2dca4311556330d51eeee5d31d48f203ff6a80576f6290bd37c"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-openstack.s390x.qcow2.gz",
-                "sha256": "973c7bdf2aa8c689a7051faac86fac21956483ee7ed4cc526e0b8e922787ba07",
-                "uncompressed-sha256": "5d2a22391b6ced0b413be125dc8e910fc971a467fb208203db895f5b68cc60f2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-openstack.s390x.qcow2.gz",
+                "sha256": "d8416c02e20ab42e44a98d97a914095145566e23b90283a407bcf7fff4406daf",
+                "uncompressed-sha256": "d910ff66eb3defd0c0bc38dc35b552e99eeb5de46a6d78dda0f053a20e5d8dc5"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-qemu.s390x.qcow2.gz",
-                "sha256": "2d47d448d7e075d9148c222f81f0949f018fffb1c0ac77f1cbbb8c7719b5e6c5",
-                "uncompressed-sha256": "5bddbe9212f636422543d480c5bc4bdc14845a256390af584979cfb14003a515"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-qemu.s390x.qcow2.gz",
+                "sha256": "8339c87cb50baa03ed5e132fba79f67bad50d4af22a01c906d7527fab271e47b",
+                "uncompressed-sha256": "dcec7c0dc57d30ac897c5cbf4f47a69b6d52787360ceeb8b3301664f48bf2e47"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/s390x/rhcos-10.2.20260405-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "c709b6e7ffeef0ca18c504b0387566f030676085b405ba1df24fe8df05bfd292",
-                "uncompressed-sha256": "70805c9e62412a1a013a0fde226cbefe2703f07838f60c4dd69804d92d747b34"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "2e17c7ea1fe0f426f1e08a402e2baa0b76fc196f014de661261dc8611c49f584",
+                "uncompressed-sha256": "22701aec4dfaa692bb9a2d561e367ca899260ca5b022554badbce7a368a10d16"
               }
             }
           }
@@ -519,165 +519,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f78f955810dcae8bb94dd7d3349459d847099e6cdeb8da2ffdb37fd1c040d336"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79badc5fad21d22814d077560c10a90abd7d1896d415548281afbe3b7ea75861"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-aws.x86_64.vmdk.gz",
-                "sha256": "0e79a40deeeb833f14ab4e520e5fb576b373ca69046834b157100aa0de818872",
-                "uncompressed-sha256": "f9c0544e959bcb31cda7a3381188634db56ab04723fcf7239f72ec0c57683ee1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-aws.x86_64.vmdk.gz",
+                "sha256": "b34ba1d4ab2188752055d008dd9c74552e1bab7791b99650339856aa5254e0f8",
+                "uncompressed-sha256": "8fb87a842b902d66cc07f13fc739635eeb6f64d8925aedf7aa21d1147108d305"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-azure.x86_64.vhd.gz",
-                "sha256": "f28a0995b7d20fb7928d7b8a1752a983ea881d7b7f497c40ae5548bd17f05187",
-                "uncompressed-sha256": "55b910b5f0459add2b86863280e8c56f47d3f3097a4c145391608261b9a0a33e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-azure.x86_64.vhd.gz",
+                "sha256": "dbb6e922bd0252acf53140b4d5dc4d1c1b978b7a7d281544c042c8ff1e11cf33",
+                "uncompressed-sha256": "0e44df05042ed5e5c8fc30c47ee9848b4cabf6540c3d9ba17452f56ac28a240f"
               }
             }
           }
         },
         "azurestack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-azurestack.x86_64.vhd.gz",
-                "sha256": "987efaddd9535237c9c8a41a98d346f55c4cbaa5cd4f48fbf57aec6e6179bc13",
-                "uncompressed-sha256": "8e93444ec5b40f31089a2483d31db4a46c31696cbb65ece9e549f2201a983639"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-azurestack.x86_64.vhd.gz",
+                "sha256": "e34f9334166221437bae7a66cfb8978ad558c825444c86e283df4d77502b5b7f",
+                "uncompressed-sha256": "e3222f1944da1d02a6eca820ee18ace732ce975b62556f5e103b20d41a0017be"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-gcp.x86_64.tar.gz",
-                "sha256": "2a05fbf5872c95ac72d591868a12bd679d7f99a34a130ab661f8132cab55a783"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-gcp.x86_64.tar.gz",
+                "sha256": "9b9b15a7d515dc2ff9fad1587e256cea2a4dea87bb8e171d18756bf3534198d5"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "f9613fadca1caaacf21c5005b0c8ef20345ce3d7b36add9226ba2c5dd87354b1",
-                "uncompressed-sha256": "113ea1c5a1bfcbbecb5c8202b590f17b4a73a594543d756007f8065efb34b98d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "00be4c856e8458bbf9622a46e636c3894bc257e0d121ea03a171168c39963400",
+                "uncompressed-sha256": "4938c5f02393af20dc8298122f463e00f7311e4b39607d49b17ade23a981dda7"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-kubevirt.x86_64.ociarchive",
-                "sha256": "16372a2e36fc8a73f9f1fb6a8c0d987ef3b30a9dfd687221e3d82def2e781a48"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-kubevirt.x86_64.ociarchive",
+                "sha256": "9e18a6556f9f20a878a4b5f45204279493b1371c92961f7e1ca718b232c42c4b"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-metal4k.x86_64.raw.gz",
-                "sha256": "d98bbb3c46ed61797650785862c3c7d27bad0c729982d965cdb59fb5f666bf6e",
-                "uncompressed-sha256": "02d571be69fdd8f50ead1323ae472e543c107042cf75c917499b465fa7117982"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-metal4k.x86_64.raw.gz",
+                "sha256": "68e2ee9426cfec115fc3494b2840154a12fe5b18115073256b863bf77076f598",
+                "uncompressed-sha256": "07e57611b940306262d0b72d25e0987114d51ff9f94fe06e406a886aa146e0e3"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-iso.x86_64.iso",
-                "sha256": "bc134e07147abe5420a7e7e59d041984a0b94593787cfcc87efc52e159ad04c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-live-iso.x86_64.iso",
+                "sha256": "c5fa949c55e45513e5a1522ea4e2acd15c6c5462900978e4c7f030bcbecde685"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-kernel.x86_64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-live-kernel.x86_64",
                 "sha256": "62f6c048aef362c496f6f7cd3b0bb07d9a648fbacb212e2d1951979dcbe72f75"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-initramfs.x86_64.img",
-                "sha256": "af9ee3295284d439c99d36ea0508b8162279bef7271087375c98547ea132f05f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-live-initramfs.x86_64.img",
+                "sha256": "0bbc93340d6de9e278eb1157657e2cd625f7319e4cbe8786671b9ae19c15f0dc"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-live-rootfs.x86_64.img",
-                "sha256": "59d7394ec157b50b73b08ea373cbcee4b4897bd36dcbd31d24862f95659f355b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-live-rootfs.x86_64.img",
+                "sha256": "08b65c7b380a52673ed55feced80da3f616896136b45c6f857ac455a6f989e80"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-metal.x86_64.raw.gz",
-                "sha256": "199b3ab66e1713a816e6f7c303dce08858d6bc945e5228a2cdc8c38ec22b1d7b",
-                "uncompressed-sha256": "b3ccfed4e71dff91c67e82a19a90079f88f988f673e7f0b596bf299640b34fb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-metal.x86_64.raw.gz",
+                "sha256": "5217cb80166b87038c68e9c687a3fe3c153aa374179a389cd3287b5ad6f7cfc4",
+                "uncompressed-sha256": "0fb1465f17f529b57c4f716e8b0c7259f1ffb4c1b04d42fa9a0ea807f7b28ad5"
               }
             }
           }
         },
         "nutanix": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-nutanix.x86_64.qcow2",
-                "sha256": "30526d7a30ee239f4ccf8e763f4d98921408fca42b8cde569cc03d4f1afc16fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-nutanix.x86_64.qcow2",
+                "sha256": "b7a5f091e7d24485b035d799da78ee1f45a204dd68c511f25821bd81f3591482"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-openstack.x86_64.qcow2.gz",
-                "sha256": "baa7d50598d76c76e65342d38fd5e90e34e9874ae1f6e82c3f2ad8303747a3ca",
-                "uncompressed-sha256": "a502fba4cc14d2c057f0f37635b9269d78bce51e2f0ec4d51d2ba18f33abcd8a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-openstack.x86_64.qcow2.gz",
+                "sha256": "e44ff8d8592e6803d9c059061c8cac9525351b1236649b30b69d5a810b17f1d5",
+                "uncompressed-sha256": "7745c09e28b81be121240a5c6b555423732cb64a23a93a4de6802d3311cc24e5"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-qemu.x86_64.qcow2.gz",
-                "sha256": "644727600b591043068abb973ddbc4a9edf5c8339f57b5d9b52f2bf3c7f7933f",
-                "uncompressed-sha256": "895aa8e700b46cfbf37fdd78eacaa2265df03ee54cd17dfa1ed08a6eac052537"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-qemu.x86_64.qcow2.gz",
+                "sha256": "f63172f2be871b99a9250138715a829be55015fb70068258959efbeeadd071f2",
+                "uncompressed-sha256": "81777f4d3ac9ebd68bcbdf0732806f00881258e554e97131a965f22762bd3a9f"
               }
             }
           }
         },
         "vmware": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-vmware.x86_64.ova",
-                "sha256": "4803d8cbf8daaa10f313fbb8d9ec32a8475ff39e99f4cb4e9a0109aacab5b44d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/x86_64/rhcos-10.2.20260423-0-vmware.x86_64.ova",
+                "sha256": "7148d3c44492a953d0235fae642e4bd5af5dd5b76028c27e79affafaefd7cec9"
               }
             }
           }
@@ -687,290 +687,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a5186e691de81b43"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c5fcb48f1603a75d"
             },
             "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-095dbd24b0328d8f2"
+              "release": "10.2.20260423-0",
+              "image": "ami-0fc96ff6df881d556"
             },
             "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0120ea02d72754898"
+              "release": "10.2.20260423-0",
+              "image": "ami-0e3ddb3ec619894d5"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0119e1aa14e77f023"
+              "release": "10.2.20260423-0",
+              "image": "ami-0eec95b98eceb2bf3"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-063029f6170f5fb08"
+              "release": "10.2.20260423-0",
+              "image": "ami-094664dd5ed1a0a08"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07c023a841de3abbb"
+              "release": "10.2.20260423-0",
+              "image": "ami-036379acf2607fd49"
             },
             "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01f8e80ccf33fb439"
+              "release": "10.2.20260423-0",
+              "image": "ami-0dccda49ae5506000"
             },
             "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0182cb1899dad4230"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a9c08cad6b3ba163"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06fe46f545f4adb4e"
+              "release": "10.2.20260423-0",
+              "image": "ami-09aa0af0a78f4c720"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-05d070204653b863b"
+              "release": "10.2.20260423-0",
+              "image": "ami-0d9316e0f2740a860"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-037682477b7eee3f7"
+              "release": "10.2.20260423-0",
+              "image": "ami-0103451c810b62f42"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0c8818d4996139914"
+              "release": "10.2.20260423-0",
+              "image": "ami-03ceed3001a0882c4"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06fc5006bc10caf7d"
+              "release": "10.2.20260423-0",
+              "image": "ami-028c508d6e37e539f"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0a52ddb2fcc8fe88f"
+              "release": "10.2.20260423-0",
+              "image": "ami-0fb7d9bb97099eb62"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d19766e284c5f89f"
+              "release": "10.2.20260423-0",
+              "image": "ami-03d097e98e963bd26"
             },
             "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07d662acb724c625f"
+              "release": "10.2.20260423-0",
+              "image": "ami-009debd524cfcd0d9"
             },
             "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0724849b24d060479"
+              "release": "10.2.20260423-0",
+              "image": "ami-02dbed000bdfa6070"
             },
             "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0db356ac3398f089e"
+              "release": "10.2.20260423-0",
+              "image": "ami-0580fa3dc45013fe4"
             },
             "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0616753f8aef330d7"
+              "release": "10.2.20260423-0",
+              "image": "ami-0e802407c34e968ab"
             },
             "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-070b4ab25ead43ee0"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c31e49a4923730e5"
             },
             "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e8d492e620ed47fe"
+              "release": "10.2.20260423-0",
+              "image": "ami-0987891fb99767d67"
             },
             "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0e08f4b72e21951fd"
+              "release": "10.2.20260423-0",
+              "image": "ami-0910e36319c44239d"
             },
             "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d04bd5213ffc3375"
+              "release": "10.2.20260423-0",
+              "image": "ami-0dac6e9f50572803a"
             },
             "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-016640529413d5d07"
+              "release": "10.2.20260423-0",
+              "image": "ami-0dcabe012232be13a"
             },
             "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-08febdec5fd6a355b"
+              "release": "10.2.20260423-0",
+              "image": "ami-0f72cad79ea84a213"
             },
             "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0ebb642433bf20836"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a4e9d54aea607f4a"
             },
             "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f7dbfb82a920a17e"
+              "release": "10.2.20260423-0",
+              "image": "ami-06c6d17e3411374db"
             },
             "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-095accdf292e4bef1"
+              "release": "10.2.20260423-0",
+              "image": "ami-05c13a6759be1396c"
             },
             "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-04b3d999e39d62c5b"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c6ace7ae6dea6e9d"
             },
             "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01f66c80fbd6ec318"
+              "release": "10.2.20260423-0",
+              "image": "ami-0df81851781a7c7c7"
             },
             "us-gov-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09fae5aa44aaa25ce"
+              "release": "10.2.20260423-0",
+              "image": "ami-02337e6a90d649fc1"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-036ce6462af177ac4"
+              "release": "10.2.20260423-0",
+              "image": "ami-0bd55787ff72caf2b"
             },
             "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06bf0843dc9cefeb9"
+              "release": "10.2.20260423-0",
+              "image": "ami-0bcb1eb970938a53b"
             },
             "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07e365adf44ca432a"
+              "release": "10.2.20260423-0",
+              "image": "ami-0badc1f21372efea6"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260405-0-gcp-x86-64"
+          "name": "rhcos-10-2-20260423-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "10.2.20260405-0",
+          "release": "10.2.20260423-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:843e75c16c01218cae95c74a879934a1f3ad80a2149963510a51b1f45c712c56"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abf57c6364f41ebbe9b429f08a675c8345aeb3a6f9a25c723d34464e740957b3"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f00691d8919286c4"
+              "release": "10.2.20260423-0",
+              "image": "ami-0674ac9f1ab6d0cde"
             },
             "ap-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-02085d30468be6719"
+              "release": "10.2.20260423-0",
+              "image": "ami-074cd86b28e044b7d"
             },
             "ap-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0b96642864753f697"
+              "release": "10.2.20260423-0",
+              "image": "ami-083964e4fe043cc15"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0b5b4c2fe3e88be4c"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c8b2bfa1a2a0c747"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0be7d6848e2b14148"
+              "release": "10.2.20260423-0",
+              "image": "ami-0f1f66bdf7ad6db6f"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03fb1d841af122247"
+              "release": "10.2.20260423-0",
+              "image": "ami-0d562bbb2acfd4fa0"
             },
             "ap-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0609e9fa550a150e4"
+              "release": "10.2.20260423-0",
+              "image": "ami-0ad0463e773b3b792"
             },
             "ap-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0036e48df55f3a921"
+              "release": "10.2.20260423-0",
+              "image": "ami-0c4ae4708c6c61d36"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03f094834eda476c7"
+              "release": "10.2.20260423-0",
+              "image": "ami-0aaa7e2264d9680b1"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-00cfb331b864e5fbe"
+              "release": "10.2.20260423-0",
+              "image": "ami-080de023adfd142d0"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0042f8ac85b52471b"
+              "release": "10.2.20260423-0",
+              "image": "ami-05637b59555ba4cf3"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0824247384380ad67"
+              "release": "10.2.20260423-0",
+              "image": "ami-0eee66b27641222b6"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260405-0",
-              "image": "ami-048aacf6d224a325c"
+              "release": "10.2.20260423-0",
+              "image": "ami-0386d3d259f90fb50"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03253e81cb2e25e2e"
+              "release": "10.2.20260423-0",
+              "image": "ami-0063718fc6bb91100"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01cb1c80408928303"
+              "release": "10.2.20260423-0",
+              "image": "ami-018bef5a758bbee22"
             },
             "ca-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0589bafba30fe4c4b"
+              "release": "10.2.20260423-0",
+              "image": "ami-04ae466b54a32639f"
             },
             "ca-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0f4dc7e47df2182a4"
+              "release": "10.2.20260423-0",
+              "image": "ami-0528e0781f1323e79"
             },
             "eu-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d2f1dd6ae6c1fdbe"
+              "release": "10.2.20260423-0",
+              "image": "ami-0d1969f1bb2c99f48"
             },
             "eu-central-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-032877114a3719bda"
+              "release": "10.2.20260423-0",
+              "image": "ami-0f58e770057e8b311"
             },
             "eu-north-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-031b0c6271a807e8e"
+              "release": "10.2.20260423-0",
+              "image": "ami-0b8b57521dfb6f74a"
             },
             "eu-south-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0690f5cbf014a02d0"
+              "release": "10.2.20260423-0",
+              "image": "ami-04bc8dda25a904d92"
             },
             "eu-south-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09ae00621ff968d46"
+              "release": "10.2.20260423-0",
+              "image": "ami-0790078e1841a195a"
             },
             "eu-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-09b17993cb4bf253c"
+              "release": "10.2.20260423-0",
+              "image": "ami-0902095cbe9e7daa3"
             },
             "eu-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-02dff4f6a9f6c5ff2"
+              "release": "10.2.20260423-0",
+              "image": "ami-019f2b1fd34f3f525"
             },
             "eu-west-3": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d1d7fc52c042403b"
+              "release": "10.2.20260423-0",
+              "image": "ami-02f4fa49455fe4546"
             },
             "il-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-03bb42b35d1200c2a"
+              "release": "10.2.20260423-0",
+              "image": "ami-0677e762f4145bbf8"
             },
             "mx-central-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-06bb2a8ffc898e0ad"
+              "release": "10.2.20260423-0",
+              "image": "ami-0acdcf7fea38b55cf"
             },
             "sa-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0fe32d1a681daeb35"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a08d57193e07661e"
             },
             "us-east-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-0d7d1fceead28e9d8"
+              "release": "10.2.20260423-0",
+              "image": "ami-0b5c715069c6cc54d"
             },
             "us-east-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-01125c8cf99da2698"
+              "release": "10.2.20260423-0",
+              "image": "ami-0a1ea2270da814977"
             },
             "us-west-1": {
-              "release": "10.2.20260405-0",
-              "image": "ami-07c4334822b5d5674"
+              "release": "10.2.20260423-0",
+              "image": "ami-06cafc2f03e264887"
             },
             "us-west-2": {
-              "release": "10.2.20260405-0",
-              "image": "ami-086ae350505bf8d38"
+              "release": "10.2.20260423-0",
+              "image": "ami-00439d52cdc3beb1b"
             }
           }
         },
         "azure-disk": {
-          "release": "10.2.20260405-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.x86_64.vhd"
+          "release": "10.2.20260423-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260423-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/coreos/coreos-rhel-9.json
+++ b/data/data/coreos/coreos-rhel-9.json
@@ -1,117 +1,117 @@
 {
   "stream": "rhcos-4.21",
   "metadata": {
-    "last-modified": "2026-04-08T16:31:47Z",
-    "generator": "plume cosa2stream b23d8cf"
+    "last-modified": "2026-04-28T22:11:54Z",
+    "generator": "plume cosa2stream 211dee6"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-aws.aarch64.vmdk.gz",
-                "sha256": "f92520243568674701e13d0164b33a4c93b133ec50ede26ebd0c59c4fe8c1cec",
-                "uncompressed-sha256": "f48495aa27ffb9247f0328cd7c0854df637f4eb49a650d004a60020111375f6d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-aws.aarch64.vmdk.gz",
+                "sha256": "dd98ab14cbda2d9b92b8db6ef45b953a59a0a14eaf7e6e622a5c2c0edb34d465",
+                "uncompressed-sha256": "2561ff6dc1b1086e1988d0dad2dd6fb36c960a3872a6aa4e0695fc3a6dc00b4f"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-azure.aarch64.vhd.gz",
-                "sha256": "875e90b2b3c268b7909382f6731a15e73a70cc0ed6f7798cdb777312934a7d9c",
-                "uncompressed-sha256": "0494b3adddc84f998fc98968db7430c734935d1b6770692fb653d3e71d383b7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-azure.aarch64.vhd.gz",
+                "sha256": "1a45d327dfb99f36f624171b9d080528872d5994388a1f9549a983064311bb91",
+                "uncompressed-sha256": "6f05dcde3b73e19d01db47172b47ba0fadff1d44a9e45285164f354033ef5977"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-gcp.aarch64.tar.gz",
-                "sha256": "05d123a1d851ed32ea8179078565ed5c4a2eb0c782bf5a72b0abf39ec7c5eb4e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-gcp.aarch64.tar.gz",
+                "sha256": "b76536dfaec2914333f3d6831ca62ac1aea37ae4ac39a4d857290a5281f9682d"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-metal4k.aarch64.raw.gz",
-                "sha256": "37d7793d9f2d000e5568f751ebfe0693f2f05493513ba76927dda42d57ed261e",
-                "uncompressed-sha256": "d6021e58aa6e3dc7e94eed702af3b3193e8224af7fda7264159f22fc3ae88992"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-metal4k.aarch64.raw.gz",
+                "sha256": "4e594d55cdbcf1fc86d5d6530fa76a27f0d8545e2ba03b435c6372ad73741d86",
+                "uncompressed-sha256": "97c56ec9996d41ac4eb8375b17ce57c0be09d45001abef1f899cd7e9cb103c3b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-iso.aarch64.iso",
-                "sha256": "238ee82cc6e364d70972fffae5c20edb178ef7dfea2ece5c980b97bf13109f1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-live-iso.aarch64.iso",
+                "sha256": "f589565e72475eb0921882be560e2d581d5a1147617413b65e3fca6fe137773d"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-kernel.aarch64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-live-kernel.aarch64",
                 "sha256": "3a1ba2ce594fffa19b8b6a0ade9257093b77f96087a370b6364b95813f80ba63"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-initramfs.aarch64.img",
-                "sha256": "09052303db582c06bc725fd6dfebca109f598a79694aec934b0f9cef4135f8f6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-live-initramfs.aarch64.img",
+                "sha256": "a741e181667b42516f45599d08b1da8afb731e09ed90375674d07aede120ad2c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-live-rootfs.aarch64.img",
-                "sha256": "324c6ee893727c46201c5e91f56cb91c6c46a4733bba5ddbcafa8239827f8873"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-live-rootfs.aarch64.img",
+                "sha256": "7ebe7084383b953dc3b5778cd92adf97d805e04b72e46d7ac17998ff5bc440bd"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-metal.aarch64.raw.gz",
-                "sha256": "a2fff4fd6a9274ef86cd5504b441f44cb61f9f2396da852c71ff366e21251265",
-                "uncompressed-sha256": "6229720930e4eeaa033a5e88dba6593f1219c483f2142d59728807ac603b3c1b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-metal.aarch64.raw.gz",
+                "sha256": "457bdd53b0910805b526988b9a66f4eec34e99fbc872b3cebc2c8a132d58a082",
+                "uncompressed-sha256": "a9a04147d612f0991b6b77dc85282f9e60a6a3e266805fc5aa2a0703e5c99bb3"
               }
             }
           }
         },
         "nvidiabluefield": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "bfb": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "d45339ff7b01fb848ca4961dbc8ea2cf83ad4071e2c49d8daa76c1e22b5d12b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-nvidiabluefield.aarch64.bfb",
+                "sha256": "c670b4d4af6649ea3520c3a2c011d1f684d49de9b6cdd138f26f1121aaf77f1a"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-openstack.aarch64.qcow2.gz",
-                "sha256": "9132bed288761f6df76605bcccd2ac0c58a371ca64097e5fb876e01f3c20dfe2",
-                "uncompressed-sha256": "d6ae130c04e2347994a73a05080e857622cf9ea0ed424b01cd9181ef885cb451"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-openstack.aarch64.qcow2.gz",
+                "sha256": "fdc10c240f60e775eeb43fbfce78db2af16745d9a72226c41e48b058de9d0c3e",
+                "uncompressed-sha256": "91e0e7ef49e664c5cb88add9f30bc05e7799b5b6f472e9b4118e3b376ee81db1"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-qemu.aarch64.qcow2.gz",
-                "sha256": "95b3d98022f93934a0bf8f2e157dc4565f449f5ab8e11a69106aff2023c34300",
-                "uncompressed-sha256": "dfa03aa6084420d2d4c12e57823f93476be83adebb2292effe0df5104274d231"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/aarch64/rhcos-9.8.20260428-0-qemu.aarch64.qcow2.gz",
+                "sha256": "ab9710335a8edf31a811cf820e912c23d0f713e3c39189ae84a22eae0804997a",
+                "uncompressed-sha256": "814a8c761542c03305f47c48a5b38678b24e622ea7c687e1235c6f60b714ca06"
               }
             }
           }
@@ -121,229 +121,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f2fcde0f89e82126"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d4a956f16e671c23"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f0e6c777fb84dea1"
+              "release": "9.8.20260428-0",
+              "image": "ami-0a91ae6798de76206"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cebeb66cae0ad43b"
+              "release": "9.8.20260428-0",
+              "image": "ami-0306ba47840353a29"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f02f9df51c3b2466"
+              "release": "9.8.20260428-0",
+              "image": "ami-0e82e81523d2a6813"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ef42150f8ed8724b"
+              "release": "9.8.20260428-0",
+              "image": "ami-0e75b6e8f6244e7b3"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07cd4dbc84110b760"
+              "release": "9.8.20260428-0",
+              "image": "ami-0c4199145e348e34b"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0eebbda1924f5b27a"
+              "release": "9.8.20260428-0",
+              "image": "ami-06acdabc1e3f08755"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09beb7722571337fb"
+              "release": "9.8.20260428-0",
+              "image": "ami-00040002cb10fcbd3"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-00cbb34289088361f"
+              "release": "9.8.20260428-0",
+              "image": "ami-056f278fe53db726c"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-03b9e25a16e8e8d25"
+              "release": "9.8.20260428-0",
+              "image": "ami-069ddfaade79ad56b"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01b713db435c0cffd"
+              "release": "9.8.20260428-0",
+              "image": "ami-05a97f2993a5fa2a4"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0424bef7aff7cb9fa"
+              "release": "9.8.20260428-0",
+              "image": "ami-0882b9ae23099fdd7"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fce5133c9050abf2"
+              "release": "9.8.20260428-0",
+              "image": "ami-0a37c30f59c81e7fe"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07fd5fc0595c329c5"
+              "release": "9.8.20260428-0",
+              "image": "ami-03c1020d9eed80eca"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-073b3d2c641f0ef50"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d5ef1e13732f4997"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-074572ee3cb06afd2"
+              "release": "9.8.20260428-0",
+              "image": "ami-04f7a8da19b11d4e7"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-04a43529b09c3e688"
+              "release": "9.8.20260428-0",
+              "image": "ami-0f44606f8976e0e0f"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a1cff59535f01a5d"
+              "release": "9.8.20260428-0",
+              "image": "ami-0c9138d7e9ff13e66"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07900f4ccd36aacb6"
+              "release": "9.8.20260428-0",
+              "image": "ami-0cfbb91332506b4a0"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ff829266b0454a46"
+              "release": "9.8.20260428-0",
+              "image": "ami-082bc95b00c9b83f6"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-043e0e38e3d788fbc"
+              "release": "9.8.20260428-0",
+              "image": "ami-089aada28cb59e12a"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f773283ae135ca1e"
+              "release": "9.8.20260428-0",
+              "image": "ami-0b0c4ae4240f8da12"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-018a69310b9046c03"
+              "release": "9.8.20260428-0",
+              "image": "ami-0407aed6920311b8b"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ae39fd2e812b280a"
+              "release": "9.8.20260428-0",
+              "image": "ami-04862120943aae22d"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fb75dbad40175071"
+              "release": "9.8.20260428-0",
+              "image": "ami-0e5153e2699a229e9"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d5d839a1fae35bce"
+              "release": "9.8.20260428-0",
+              "image": "ami-085a9f00fcc5f98ad"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d36d9902213c350b"
+              "release": "9.8.20260428-0",
+              "image": "ami-07cdd672851cad2d9"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09b618abde46f25e2"
+              "release": "9.8.20260428-0",
+              "image": "ami-05c188d88252a647e"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e73a95fb409d8abd"
+              "release": "9.8.20260428-0",
+              "image": "ami-01fdfbdd638f16b5f"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0bd8dcdde4641811e"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d7a99eb592f70ada"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-062e02fb7b255a2aa"
+              "release": "9.8.20260428-0",
+              "image": "ami-00a56c3ef9ddb15b2"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-00f8b2108f37fa11c"
+              "release": "9.8.20260428-0",
+              "image": "ami-04c818e5aff7aba89"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ddc9a437d26c97ba"
+              "release": "9.8.20260428-0",
+              "image": "ami-0904ff239359d1479"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f4439b005ce8bb83"
+              "release": "9.8.20260428-0",
+              "image": "ami-038d5ba7617daac0c"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260403-0-gcp-aarch64"
+          "name": "rhcos-9-8-20260428-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.8.20260403-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.aarch64.vhd"
+          "release": "9.8.20260428-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260428-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-metal4k.ppc64le.raw.gz",
-                "sha256": "f71f7577123278cb7b49307b19f81feaf62a1541521544b558f318c2c7dcf542",
-                "uncompressed-sha256": "7789eedcfba552af13e839e71e0606b1a4a380b5519e53062d19824bcc9ebddc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-metal4k.ppc64le.raw.gz",
+                "sha256": "8b30233ee5b708ff9ba2c717d97c6a9e4828d1f55dabcbaef3498b09b0171c79",
+                "uncompressed-sha256": "e83ee7b65a45087dc7b2c7d12b672e0f6b9a9e2113f8674ec4e5aa8c0034ac25"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-iso.ppc64le.iso",
-                "sha256": "c0ec496f02a0c1fe52d8b3ca6cbc6f43fac718bbf758faf45fe668bf45ba635a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-live-iso.ppc64le.iso",
+                "sha256": "9f9909c5ab50561c998aef4205d32f23c708af413b44530941e20bdcf8d74aac"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-kernel.ppc64le",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-live-kernel.ppc64le",
                 "sha256": "0a80cc120e5493a5d198cdcd04214552c57f90adbd21899cd54e6a7f561c37d0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-initramfs.ppc64le.img",
-                "sha256": "60d272fac65b5b66787429b8aa7b8734343a91237650023cacb7203e2564b3de"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-live-initramfs.ppc64le.img",
+                "sha256": "22576a0724dcc3d81c5823faadf646e5d62d9c887caad7678d56cc76c8d265e0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-live-rootfs.ppc64le.img",
-                "sha256": "1f82ecbc4a5c4478b549277e8ddc5acb005e423f71bb044fc69e5b70be0da9c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-live-rootfs.ppc64le.img",
+                "sha256": "7a30afdaa0467e2de3392513c37e3aaa8c9ad3a96cdfa61e4e357fc12145dc7c"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-metal.ppc64le.raw.gz",
-                "sha256": "0b2d07ede4ddbb3cb3e318ebe9d8c131491485761d11c17b71bde183f68a2f30",
-                "uncompressed-sha256": "54986f20c07f0e4b7db8bfa30710f6349b802284fc38ded3d0efc089dc4ca37a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-metal.ppc64le.raw.gz",
+                "sha256": "7ba47e71dd3a8d60ba6ab2293a8b242945c9fdf07438ccb17d764967d81c4395",
+                "uncompressed-sha256": "dee33275e0f36020342fc2f056ead72b90291f4174eda0db8b5ad0b736bd41a2"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "098d862bbe8ea4bade551bbb7d0b1b39c009c51bc6e07a360fd5f21ef15a5781",
-                "uncompressed-sha256": "7088202adf16433b1fdf82f75d276b39e12559f0e80564ef26bda1558557d92f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "636d027b98e7c4a31075e822db37787ec4dc4e2b99a5c846f040c0bdd6bc0215",
+                "uncompressed-sha256": "5c4b8028f8e44f6ff192eb7eccc2907093167ceabc0eef766d979a62e6f7679d"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-powervs.ppc64le.ova.gz",
-                "sha256": "1129b85d576de1c4faede1f671009fe9b50c824a7b58a72dcde3636f26edfbfb",
-                "uncompressed-sha256": "c023130cb317959cfba262c871d3f32106830622aa406ace684ae0579314f7f0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-powervs.ppc64le.ova.gz",
+                "sha256": "982b4866315b451ec96e0ca2d30661fb17149df81086a33ce9bde6a4aa27fe2c",
+                "uncompressed-sha256": "6978911ec9d3d3bf2925da72a341cad35905ed3d2edfaf4e13b9db8c4effad23"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "428dc3a8045400c3faf0118779b861213314b7f08f671710a71fdb9555991988",
-                "uncompressed-sha256": "a0f30b5d08d05754531abc61a6500ba0929db0fda12ed4f85508b2074f9be9cb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/ppc64le/rhcos-9.8.20260428-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "55a5513c5cb90427f6547a6e9521643aa2786a6d0c13f5302e524aa83f04f789",
+                "uncompressed-sha256": "ead4387754b82b8efebf9da8c216ed69523f74786f9ac4cba46d04af17c89e11"
               }
             }
           }
@@ -353,64 +353,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.8.20260403-0",
-              "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260428-0",
+              "object": "rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260428-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +419,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "8bb71320fe3905ee74325f8ded2e509b9b4305cc6afef33303aa785a7b925326",
-                "uncompressed-sha256": "0e4e13ff0ca54b0d268ba9fd55e09c7d7f3fa922d8333eaab76cd7fd98ddfd50"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "91ec41c1224bf258ff981356225dba3d5c28d72dee73156fb47e6f630c36da42",
+                "uncompressed-sha256": "64b84d50404c233f9a5ca2585a545b0d76f2814c072aed5c32037c6d1c9aa7ae"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-kubevirt.s390x.ociarchive",
-                "sha256": "ec1986ba649cbc6005f3602c16842739b2d630f9c7ec722b866bc160b5c52c9b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-kubevirt.s390x.ociarchive",
+                "sha256": "3d8d835ef54f1d6a4d8009abe2502ccc04dca35ce517dc3d83b387413a4402d0"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-metal4k.s390x.raw.gz",
-                "sha256": "c5a9346092db8fea8d2618abaedfa66adbebb39dc53aa325fdb4d58489b09e51",
-                "uncompressed-sha256": "544719e47c0fc90b144bcfc82be518763b529a37a04d7ceabfad78e743ea439a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-metal4k.s390x.raw.gz",
+                "sha256": "4e74ff9e647da49f095eef3560ebdd1ec9c3391ff22633b2c295725182d3edc7",
+                "uncompressed-sha256": "612fe329b730992b2c3623e9d1acaaf360e979977162c99fe325b8ecdd05a738"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-iso.s390x.iso",
-                "sha256": "6417aa2f40ad6b4800bbe310ddecc70c0edb8039352bb1dd14cc03fb2942e2c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-live-iso.s390x.iso",
+                "sha256": "ba9cdf88f9e496c43c7513979b9d8c06e233105fb8cd8a4a5305803856f51b30"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-kernel.s390x",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-live-kernel.s390x",
                 "sha256": "d09356ff4b21476c37848d2762757fc7bfadb8269a9d56fc869bb30679d5beb3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-initramfs.s390x.img",
-                "sha256": "0a160c204567edbbf50a18c5e7a948be4db48e7ad57e9f6f7afa9b977031358c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-live-initramfs.s390x.img",
+                "sha256": "8a024bc729b237e65bfc7078587e69e6dd7543059e6b5582dade3932a037537b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-live-rootfs.s390x.img",
-                "sha256": "358edeed9e75dd0cce60b518c52039c18ff217396c7a55973e463d2fa2efb865"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-live-rootfs.s390x.img",
+                "sha256": "5841ac072ea031b419fd1c5dacaf35446aa82b7daff1dd209f8161a6a027db86"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-metal.s390x.raw.gz",
-                "sha256": "a9e0f963454b2c4e3bcfdae91b8010496277b16b7d80220a59fb68b9731863bf",
-                "uncompressed-sha256": "398e08f441eafaf90f5d6290cc67b89194ee4009d0c8ea0edbe02a37064b44b7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-metal.s390x.raw.gz",
+                "sha256": "19b198f68a2e0568ee4067996c8216e5281f72ec34500e98af72bf530b98eec5",
+                "uncompressed-sha256": "08baf518feba7a46d2dd51fc1de27af4c26c274fe6d2ed91834cdf2877af81a6"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-openstack.s390x.qcow2.gz",
-                "sha256": "82d18e03bed79f6f5b477f5a1358826626953c43d177ac6cb23b8285e660667d",
-                "uncompressed-sha256": "cf909c4a91bbc71ec452fa1a3530d4a5931c3bf5b48a28feabbbcbb040b3c2f7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-openstack.s390x.qcow2.gz",
+                "sha256": "e607c79c65b206194dec25651992623f6e65fc8aa7706345cb6660ea2f81d56f",
+                "uncompressed-sha256": "6caeae05befdb75b8f77f3d11f529002e1b49df0206ca7c8751e79d6ab3a3f86"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-qemu.s390x.qcow2.gz",
-                "sha256": "b49a2d3a9e5d2b3c1c38ebd226ff306089aa3ace175bdae275aa05e196894684",
-                "uncompressed-sha256": "863d63ec221171552023ee0558b9ff0282697b9c2dc9b2ed88ccf3363bf6fc86"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-qemu.s390x.qcow2.gz",
+                "sha256": "e17c0f1cc85f00fe448614749e4e0fc9c0909cbc75f96fcb5a9ed0fb3b173a50",
+                "uncompressed-sha256": "33bbb6230af80be1079e87c9829f810fc51108d2ebdcdec2f52ad4b5ff81ccdd"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/s390x/rhcos-9.8.20260403-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "ed0297535feb7300cafebe68a356c29c50a16c7d46273478a9c7d223974c6327",
-                "uncompressed-sha256": "13abc5144bab6311cad7fd34ff8c75398c8e0e9c2b8ce9211ce02a0578765e6c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/s390x/rhcos-9.8.20260428-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "0f5a0dd54d3fdfa160432401901242e445ea957e9038e563b29aab10df110341",
+                "uncompressed-sha256": "0d5666d34ec515680f36b277ad66ed571d71e553f9d3eb371689cc6ab317a24d"
               }
             }
           }
@@ -519,165 +519,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b341d5f935078919094314551b6feefba5b3d640e71cc3cc08c6e63e14cddf15"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:05c3890349865e894afb7977ec40b3a7ada3b7d92a4dece03c799e558cd126b9"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-aws.x86_64.vmdk.gz",
-                "sha256": "02a831ca684a403177d0d8fca6de5627360cbf5fe99652ee6bc228152298d2d7",
-                "uncompressed-sha256": "c4ebcb48d77c57141711b2294317cf4502f3de52ffcf4518334f20de0446f0c8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-aws.x86_64.vmdk.gz",
+                "sha256": "b45a2194d0304a174859c11a4a11371a854c8366110f26606be63832a954a7ed",
+                "uncompressed-sha256": "d88f6419a46c6a07b8bcf68c80347aacc2c4e9b3994ebccf40ce0cd20fd43466"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-azure.x86_64.vhd.gz",
-                "sha256": "10e4adcb1e1469faef4a3fde5fd80c41c697b7b9fa7c8867366e679751fe74a2",
-                "uncompressed-sha256": "068b1cbb92e6e2c49a3e6330d1d0f36271a0a8744a292806a7970936b85a6803"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-azure.x86_64.vhd.gz",
+                "sha256": "c44a53b9dff042a114abb1d54f8fac0b4aab0704c40b94d60adeecb8989f339e",
+                "uncompressed-sha256": "5b1e815e2e0603ebcf7133f114ebecd0e3dc087c09f153516949edeae6c58eb4"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-azurestack.x86_64.vhd.gz",
-                "sha256": "79afc03df966bbfac192888d02ca599e78a8f9e5e18ae7fa5d2dceed52adcf2a",
-                "uncompressed-sha256": "de3aa7fbb6f770e8ff7295b168919b46a62a67f7a1fc51b02fccd2044137f20f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-azurestack.x86_64.vhd.gz",
+                "sha256": "54a0df48a6b37560a1bf6a95b9e56677d25b0eb5a172230e3fef4ca41e97ce4e",
+                "uncompressed-sha256": "0932caac7ecc6aa63c61ab45548bb7153c606d541d1e05897fab9c72be88d1d5"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-gcp.x86_64.tar.gz",
-                "sha256": "f23211117ef449d5ac61cf22f0879a1a7036a0a2354e0d401c616c01c59e8777"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-gcp.x86_64.tar.gz",
+                "sha256": "32e8467a108a5062d886d68ddb6f17da9450fe1ba5a2e3614f8de3cb59e12f0c"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "986c0af62b00e447a4c5df9c6daf31877b8c7da6c6b0db622e47ec616faef9bc",
-                "uncompressed-sha256": "75947ae3f0d72f223ce03d3422360a51c339d4edee96e91f176bb38ee513f579"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "9c359ef5443caa07919b03a6a0fac45b80a7ab28a268279fcd9c28a26f583470",
+                "uncompressed-sha256": "5442286d99bbf9d09a442d300bce6bc586be953c90ba98fd72acc8106f37ad19"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-kubevirt.x86_64.ociarchive",
-                "sha256": "1429c5556d2f2cba57f66b8df775f093e94b297de85a7a820edce601c144b72e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-kubevirt.x86_64.ociarchive",
+                "sha256": "4c465b822022c9df1b338507211331f492dd2c4536da3cfc3c2c57b026577197"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-metal4k.x86_64.raw.gz",
-                "sha256": "6e2fc5eb4a1cfcea7400029808e10fd7618935e41914035dcecdd3b11f504f75",
-                "uncompressed-sha256": "e9f983d01eebab07fa429b6c570bbf9b9b704f6d418af8164befbfc6385dcd9d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-metal4k.x86_64.raw.gz",
+                "sha256": "a9b453bd41f04484cb6e1e913351f44b1d5737562c0bc67a6c832a5ec22c1357",
+                "uncompressed-sha256": "deb1b8a2400b537e97edc960693160314cb2143f394853b005f7cb2a5492de84"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-iso.x86_64.iso",
-                "sha256": "61528a9344940565875f7c9d1f7ee0274fa4dc56d014f5e8b8af4759545d15dd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-live-iso.x86_64.iso",
+                "sha256": "a4f0115b9de378accb6359436f1869f6d5ef07840b51125217f9681c64eba9da"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-kernel.x86_64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-live-kernel.x86_64",
                 "sha256": "702d1d7f999f5036e79c2b223f9a77089453b7677a504ed38e7182009f34338c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-initramfs.x86_64.img",
-                "sha256": "aa2c109aab062b8fab3b76293e413be3b264ee02182a79c594fd3f49968ed7af"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-live-initramfs.x86_64.img",
+                "sha256": "5e265010283087f6da6cd2425d7600b45cd591e31122e6fcfa000b553f7ea816"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-live-rootfs.x86_64.img",
-                "sha256": "a874ce2a7ee0a294a9cdcd3427b1ec19e1756c8ecd32803b4efec7a6b0d5f63f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-live-rootfs.x86_64.img",
+                "sha256": "b3174477ac7f5cafab98bb83be937a82d2ad98e0050056f32d79fbc6ee0f1db6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-metal.x86_64.raw.gz",
-                "sha256": "6bffa8c2c1b86effced25f319ec8e702bb3462b060d74e801beeab80dfb66c8a",
-                "uncompressed-sha256": "cf1585f0c1941bea5b44a0b9e1225831a37ef591d14ed29b19b7643a45048d37"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-metal.x86_64.raw.gz",
+                "sha256": "f5c00e00c47d9d8871cd4b0f13f28562be39edf8ae100d43463b38f6985e51fb",
+                "uncompressed-sha256": "c02a7683ab9e2622dec35cbec65e8b2c69703269376f145cb2e0ae403eeeea1f"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-nutanix.x86_64.qcow2",
-                "sha256": "ff84dfe5905abce5cfb7f232dd3c6e664eeb9a592f51ecb87dde34e73a03c8ad"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-nutanix.x86_64.qcow2",
+                "sha256": "bc38edf688459d44e1857f7cf7d3988ae076b528f1b05ded473ac2682bf4eb0c"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-openstack.x86_64.qcow2.gz",
-                "sha256": "d774960b396372c0ed2ea00a4d98151b1cfea9c5bcfc106d3e51566b4e9cce33",
-                "uncompressed-sha256": "4664af3a371164888f096806e4b6e887f49e74d36e01c3a3a187600143a7d6e3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-openstack.x86_64.qcow2.gz",
+                "sha256": "a0b3797b69ee4369939d33f5be7a9ae8aef1b252da592b11e5a1b3cc52f12654",
+                "uncompressed-sha256": "ea8a87452d7a1469014e3fa42f688c9dd4918d5042c387d31a51a39ee98d4886"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-qemu.x86_64.qcow2.gz",
-                "sha256": "210a19fcab5cb6bf28bb6420b667d85c64ec285d3e0916345cfe3454f635f673",
-                "uncompressed-sha256": "6da93544aafec90c9508b8640d4177b93f31454d2b193d03e27ee4f1b8437296"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-qemu.x86_64.qcow2.gz",
+                "sha256": "49de4b338b3c1464e4fad04f3954ef2c416d235b7d6f05acf1caf13c98a45c86",
+                "uncompressed-sha256": "b78a1659377cd9a916ca262609a63776865fdc11f2ea6d748f9d16e7bdd4fec9"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-vmware.x86_64.ova",
-                "sha256": "4bfb9fd5e32cc9c7359bcaa3a5c40d1349f835002b71a6f2c982c5356c7a62ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260428-0/x86_64/rhcos-9.8.20260428-0-vmware.x86_64.ova",
+                "sha256": "29dcca5f196f09104e68bdae7f7706dee6bb84e9a1de4515a04ed9b8f288ce3c"
               }
             }
           }
@@ -687,290 +687,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d24483687640c868"
+              "release": "9.8.20260428-0",
+              "image": "ami-009e48dde0d8a95d9"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0b982b69062cb9819"
+              "release": "9.8.20260428-0",
+              "image": "ami-035c5a22641db21e8"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e882d9c9e56d6fbc"
+              "release": "9.8.20260428-0",
+              "image": "ami-0ea15d423da9e8060"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-047e7046d36611ff2"
+              "release": "9.8.20260428-0",
+              "image": "ami-02dfb9b06aa449db4"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-04841d66b7208f8ca"
+              "release": "9.8.20260428-0",
+              "image": "ami-05289fed2e62239d2"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0778d8a1880c38ee4"
+              "release": "9.8.20260428-0",
+              "image": "ami-0a83b2406e0cd4ffe"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01294dabc8c0127b6"
+              "release": "9.8.20260428-0",
+              "image": "ami-03bf0f8a0b1623e1a"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07badd02ceff000f3"
+              "release": "9.8.20260428-0",
+              "image": "ami-07df2a08194591bbc"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0be438eda2558f0aa"
+              "release": "9.8.20260428-0",
+              "image": "ami-06909ede3ef4fe506"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6829d91db059d1a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0ba2bfd6fee7834dd"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-020151b078dcdc39c"
+              "release": "9.8.20260428-0",
+              "image": "ami-0520f95089879d2bb"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cc605bf74e3eadaa"
+              "release": "9.8.20260428-0",
+              "image": "ami-0c49a23180b934728"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c304d1a7e122441d"
+              "release": "9.8.20260428-0",
+              "image": "ami-0476a2dcd3864f977"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-02906f55476b5b91a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0a6de2bb8bbbd37de"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07654903d4359f7df"
+              "release": "9.8.20260428-0",
+              "image": "ami-005e68d61c8c4c7a4"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01eff3b02fbce2e99"
+              "release": "9.8.20260428-0",
+              "image": "ami-03cc759d77e1721b7"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07929cf6af39cc81b"
+              "release": "9.8.20260428-0",
+              "image": "ami-0b8ebc04152d30387"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0f88f035461228c4f"
+              "release": "9.8.20260428-0",
+              "image": "ami-0db5da1b3b5ad90dc"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6ca397c49baeabc"
+              "release": "9.8.20260428-0",
+              "image": "ami-02f385043c786a5dc"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cf034bf85e475a31"
+              "release": "9.8.20260428-0",
+              "image": "ami-074121622fd955090"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ce7a965198aeb7b2"
+              "release": "9.8.20260428-0",
+              "image": "ami-0a982a0bffd68265f"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0fce61e66c5fc156a"
+              "release": "9.8.20260428-0",
+              "image": "ami-02cd268950efc44ff"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0779f0391446c8f73"
+              "release": "9.8.20260428-0",
+              "image": "ami-0554dc0c838511ba9"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0df53a0a3146e4b8c"
+              "release": "9.8.20260428-0",
+              "image": "ami-0c7c471c86eba7051"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08f1857856d26df1b"
+              "release": "9.8.20260428-0",
+              "image": "ami-0de0236a642001155"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-077867c48f6d9f479"
+              "release": "9.8.20260428-0",
+              "image": "ami-0e05d2b09e0571754"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-031b16d06c7060827"
+              "release": "9.8.20260428-0",
+              "image": "ami-0eb455daf38e190a3"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e8e6aa6db575d1a2"
+              "release": "9.8.20260428-0",
+              "image": "ami-0aeaab6d96119add3"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06a6b025350ff1e23"
+              "release": "9.8.20260428-0",
+              "image": "ami-0fbc8be8796dc1df5"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0839b9b12d88de612"
+              "release": "9.8.20260428-0",
+              "image": "ami-0f87100a0927b4e1e"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c5b30e6119ef988a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0928a4e0527b0e52a"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d6785d6f2a17ccab"
+              "release": "9.8.20260428-0",
+              "image": "ami-09dd20307815d330d"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-068a9cb3ccfa0ef0f"
+              "release": "9.8.20260428-0",
+              "image": "ami-089c98e2d700adb1e"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-087857c3acb318eac"
+              "release": "9.8.20260428-0",
+              "image": "ami-0ca6948ea14ab6096"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260403-0-gcp-x86-64"
+          "name": "rhcos-9-8-20260428-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.8.20260403-0",
+          "release": "9.8.20260428-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:833cbd9ad76a1dfae732741380fbca39220e9b123123995cc93ba0702a497d65"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1dc8aa4ed62574ca7dc7d9674f86521c73d24d8013a5e78b69f1bc084fc669e8"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c10eabe1eaf19070"
+              "release": "9.8.20260428-0",
+              "image": "ami-0ed8a39ea6cb0bced"
             },
             "ap-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0000a100764a57637"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d6ed8e9ed3abfd74"
             },
             "ap-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d0a9b4f768e40721"
+              "release": "9.8.20260428-0",
+              "image": "ami-02608f350099dfff0"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06bccded362a4e123"
+              "release": "9.8.20260428-0",
+              "image": "ami-00916bbf9666af25d"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-074a3c1013b645e2b"
+              "release": "9.8.20260428-0",
+              "image": "ami-06fa34e58d186787c"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a973131ad159455f"
+              "release": "9.8.20260428-0",
+              "image": "ami-00cd2ff770d915123"
             },
             "ap-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01a91ed16e6fe8c42"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d869cbece4f4ee76"
             },
             "ap-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-088c4f18c1ba6d16f"
+              "release": "9.8.20260428-0",
+              "image": "ami-05afbffae68f2824f"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0aa3b2c76834dfc35"
+              "release": "9.8.20260428-0",
+              "image": "ami-0975943940461da16"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0e3287c7017d769e6"
+              "release": "9.8.20260428-0",
+              "image": "ami-0805c81540426182f"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-01a6db14a61da69d2"
+              "release": "9.8.20260428-0",
+              "image": "ami-01fb2d410a04c5386"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260403-0",
-              "image": "ami-06bfcd79e173b66fc"
+              "release": "9.8.20260428-0",
+              "image": "ami-0e7be71c1e3dfe371"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260403-0",
-              "image": "ami-05d555e5f6ca0351b"
+              "release": "9.8.20260428-0",
+              "image": "ami-05eb3e0d7f74015c8"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260403-0",
-              "image": "ami-003fa9bac974b122f"
+              "release": "9.8.20260428-0",
+              "image": "ami-091759392ea3b7b89"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0a4ae56adf95a7571"
+              "release": "9.8.20260428-0",
+              "image": "ami-0f3fc37cc22d7e58c"
             },
             "ca-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0753bb5559cfe8de7"
+              "release": "9.8.20260428-0",
+              "image": "ami-0475a7435df73b2ab"
             },
             "ca-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cdc9f4fd19c77c20"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d407c90d0b687145"
             },
             "eu-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-070d80434ccbb1fa8"
+              "release": "9.8.20260428-0",
+              "image": "ami-0bec9a5cc5b3021fa"
             },
             "eu-central-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0c9b3aaa71a563f6d"
+              "release": "9.8.20260428-0",
+              "image": "ami-067e900a8c25a2b5f"
             },
             "eu-north-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-061e33ce3cf0d8f30"
+              "release": "9.8.20260428-0",
+              "image": "ami-00350f6cb58a71aaf"
             },
             "eu-south-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-060a1299d1a87244e"
+              "release": "9.8.20260428-0",
+              "image": "ami-0aaf709cb4cb9d5fd"
             },
             "eu-south-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-09d986ef8bc88b3ce"
+              "release": "9.8.20260428-0",
+              "image": "ami-087f7c75668d65a29"
             },
             "eu-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0abacf8acd414929a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0546a6c16b91e4748"
             },
             "eu-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0d52292d89797f1dc"
+              "release": "9.8.20260428-0",
+              "image": "ami-0eed23e084bf93ab7"
             },
             "eu-west-3": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08cf1b6d46bea0b36"
+              "release": "9.8.20260428-0",
+              "image": "ami-0bdc4b506a738bc5d"
             },
             "il-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-08f660deb548ef5d3"
+              "release": "9.8.20260428-0",
+              "image": "ami-056bd18c894dfcb4b"
             },
             "mx-central-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-028dd27c939e3d1e9"
+              "release": "9.8.20260428-0",
+              "image": "ami-0d8e1b28a1c5cd0b6"
             },
             "sa-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0cbff95e01bb72566"
+              "release": "9.8.20260428-0",
+              "image": "ami-0c9437d4df37302eb"
             },
             "us-east-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-07fb473b3b815c46a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0306b3689eab84e5b"
             },
             "us-east-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0b57bb61d7bd17440"
+              "release": "9.8.20260428-0",
+              "image": "ami-04e537007186ff41f"
             },
             "us-west-1": {
-              "release": "9.8.20260403-0",
-              "image": "ami-0ab712daedccb957a"
+              "release": "9.8.20260428-0",
+              "image": "ami-0b171228665f04788"
             },
             "us-west-2": {
-              "release": "9.8.20260403-0",
-              "image": "ami-076797a55a7d516dc"
+              "release": "9.8.20260428-0",
+              "image": "ami-03164a5c0c2f4b334"
             }
           }
         },
         "azure-disk": {
-          "release": "9.8.20260403-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.x86_64.vhd"
+          "release": "9.8.20260428-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260428-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

Update data/data/coreos/coreos-rhel-10.json to 10.2.20260423-0

OCPBUGS-81187 - Multi-arch OpenShift 4.22.0-ec.4 and later vs. rpm-ostree "no signature exists"
OCPBUGS-83505 - Investigate RHCOS 9.8 initramfs size increase — risk to /boot on upgrading clusters

```
plume cosa2stream --target data/data/coreos/coreos-rhel-10.json                 \n    --distro rhcos --no-signatures --name rhel-10.2                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=10.2.20260423-0                                       \n    aarch64=10.2.20260423-0                                      \n    s390x=10.2.20260423-0                                        \n    ppc64le=10.2.20260423-0
```
                    
Update data/data/coreos/coreos-rhel-9.json to 9.8.20260428-0

OCPBUGS-81187 - Multi-arch OpenShift 4.22.0-ec.4 and later vs. rpm-ostree "no signature exists"
OCPBUGS-83505 - Investigate RHCOS 9.8 initramfs size increase — risk to /boot on upgrading clusters

```
plume cosa2stream --target data/data/coreos/coreos-rhel-9.json                 \n    --distro rhcos --no-signatures --name rhel-9.8                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=9.8.20260428-0                                       \n    aarch64=9.8.20260428-0                                      \n    s390x=9.8.20260428-0                                        \n    ppc64le=9.8.20260428-0
```
                        