### PR TITLE
[DNM] MCO-2249: Custom Pool Booting on Day 0 prototype

### DIFF
--- a/docs/design/custom-machine-pools-day0.md
+++ b/docs/design/custom-machine-pools-day0.md
@@ -1,0 +1,164 @@
+# Custom Machine Pools at Day 0 via InstallConfig
+
+## Background
+
+The `Compute` field in `InstallConfig` is already a `[]MachinePool` array, and the `Worker` asset already loops over all entries to generate MachineSets — so the plumbing is partially there. The blockers today are:
+
+1. Validation rejects any pool name that isn't `"worker"` or `"edge"` (`pkg/types/validation/installconfig.go`)
+2. No `MachineConfigPool` (MCP) manifest is generated for pools the installer doesn't know about — MCO won't manage the nodes without one at day 0
+3. Custom pool machines need a pool-specific pointer ignition stub so the MCS serves the right MachineConfigs
+
+---
+
+## Decisions
+
+| Decision | Detail |
+|---|---|
+| Custom pool naming | Any valid DNS label is allowed; no prescribed naming convention |
+| Max custom pools | **5** custom pools per install config |
+| Platform support | GCP only for the initial prototype |
+| MachineSet role | Custom pool MachineSets use the `worker` role for tags, subnets, and MAPI labels — only the user-data secret differs |
+| Worker balancing | Only auto-balance when the user has not explicitly set a worker replica count |
+
+---
+
+## Phase 1 — Allow Custom Pool Names ✅
+
+**Files changed:**
+- `pkg/types/machinepools.go`
+- `pkg/types/validation/installconfig.go`
+- `pkg/types/defaults/machinepools.go`
+
+**What was done:**
+
+1. **Reserved-name set** added to `machinepools.go`:
+   ```go
+   var ReservedMachinePoolNames = sets.New(
+       MachinePoolComputeRoleName,      // "worker"
+       MachinePoolEdgeRoleName,         // "edge"
+       MachinePoolControlPlaneRoleName, // "master"
+       MachinePoolArbiterRoleName,      // "arbiter"
+   )
+
+   func IsCustomPool(poolName string) bool {
+       return poolName != "" && !ReservedMachinePoolNames.Has(poolName)
+   }
+   ```
+
+2. **`validateCompute()`** relaxed: name must be a valid DNS label, must not collide with reserved names, GCP-only platform restriction, at most 5 custom pools.
+
+3. **Defaults**: custom pools default to **0 replicas** so users must opt in. `IsCustomPool("")` returns false so unnamed pools (test fixtures) are unaffected.
+
+---
+
+## Phase 2 — MachineConfigPool Manifest Generation ✅
+
+During bootstrap, MCO runs in bootstrap mode and generates `master` and `worker` MCPs itself. The bootstrap controller ingests installer-written manifests from `openshift/` (via `cp openshift/* /etc/mcc/bootstrap/` in `bootkube.sh`). MCO has no knowledge of custom pool names, so the installer writing the MCP into `openshift/` is the **only** path for a custom pool to be recognised during bootstrap.
+
+**Files created/modified:**
+- `pkg/asset/machines/machineconfigpool/manifest.go` — pure helper functions, no Asset interface; mirrors the `machineconfig/` package pattern
+- `pkg/asset/machines/worker.go` — calls MCP generation per custom pool
+
+**MCP structure generated** (per custom pool named `<pool-name>`):
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: <pool-name>
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker, <pool-name>]   # inherits worker configs
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/<pool-name>: ""
+```
+
+`worker` is included in `matchExpressions` so the custom pool inherits base worker MachineConfigs. MCO uses `nodeSelector` (not `machineSelector`) to assign nodes; pool placement on day 2 is driven by the node's initial MCS request to `/config/<pool-name>`.
+
+File naming: `99_openshift-machineconfig_<pool-name>-mcp.yaml`
+
+---
+
+## Phase 3 — Custom Pool Ignition and User Data Secret ✅
+
+**The pointer ignition stub must be pool-specific.** `pkg/asset/ignition/machine/node.go:pointerIgnitionConfig` embeds the role as the MCS URL path (`https://api-int.<cluster>.<domain>:22623/config/<role>`). A custom pool machine booting with `/config/worker` would receive worker MachineConfigs, not its own pool's configs.
+
+**Files created/modified:**
+- `pkg/asset/ignition/machine/custompool.go` — generates one `<pool-name>.ign` per custom pool; holds results in `FilesByPool map[string]*asset.File`
+- `pkg/asset/machines/worker.go` — generates `<pool-name>-user-data` secret per pool; stores them in `CustomPoolUserDataFiles []*asset.File`
+
+**GCP-specific implementation details:**
+
+Custom pool MachineSets use `"worker"` as the GCP role (not the pool name). This ensures:
+- Standard worker firewall tags apply (`<clusterID>-worker`)
+- Standard worker subnet is used (`<clusterID>-worker-subnet`)
+- MAPI labels are `machine-role: worker` / `machine-type: worker`
+
+Only the user-data secret differs, pointing machines at `/config/<pool-name>` on the MCS. MCO handles pool assignment from there.
+
+`pkg/asset/machines/gcp/machines.go` — `getTags` and `getNetworks` default cases now handle arbitrary roles gracefully (fall through to worker behaviour) as a safety net.
+
+`pkg/asset/manifests/mco.go` — `gcpBootImages()` previously only checked `ic.Compute[0]` for a custom `OSImage`, so a custom pool with an overridden boot image would not disable automatic boot image management. Fixed to loop all compute pools (matching the AWS/Azure pattern), so setting `OSImage` on any custom pool correctly disables MCO's automatic MachineSet boot image updates cluster-wide.
+
+**Worker replica balancing:**
+- The worker pool's replica count defaults to 3 (`pkg/types/defaults/machinepools.go`)
+- Whether the user explicitly set the worker count is determined by parsing `installConfig.File.Data` (raw YAML, pre-defaults) — if `replicas` is absent for the worker pool in the raw YAML, it was defaulted
+- If worker count was **not** explicitly set: worker replicas = `max(0, workerDefault - sum(allCustomPoolReplicas))`
+- If worker count **was** explicitly set: both counts are respected as-is
+- Example: worker unspecified, custom=2 → worker adjusted to 1
+- Example: worker=2 explicit, custom=2 → both kept, worker=2 custom=2
+- Example: worker unspecified, custom=4 → worker=0 (warn logged), custom=4
+
+**MachineSet topology note:**
+All platforms create **one MachineSet per availability zone** (or failure domain), with total replicas spread evenly (`total / numZones`, remainder distributed round-robin). The replica count on the pool is the *total* across all MachineSets for that pool, not per-MachineSet.
+
+---
+
+## Phase 4 — CAPI Path (deferred)
+
+**File:** `pkg/asset/machines/clusterapi.go`
+
+`ClusterAPIComputeInstall` gate path would need the same treatment as Phase 3. Deferred — CAPI compute is still feature-gated and not broadly enabled.
+
+---
+
+## Phase 5 — Tests and Docs (pending)
+
+1. **Validation tests** (`pkg/types/validation/installconfig_test.go`):
+   - Valid custom pool name
+   - Reserved name collision
+   - Invalid DNS label
+   - More than 5 custom pools → validation error
+   - Custom pool on non-GCP platform → error
+   - Existing `"worker"` / `"edge"` cases still pass
+
+2. **MCP generation tests** (`pkg/asset/machines/machineconfigpool/manifest_test.go`):
+   - Correct `nodeSelector` (not `machineSelector`)
+   - `matchExpressions` includes both `worker` and pool name
+
+3. **User docs** (`docs/user/`): naming rules, replica defaults, MCP inheritance
+
+---
+
+## Example InstallConfig
+
+```yaml
+compute:
+  - name: worker
+    replicas: 2
+  - name: gpu-pool
+    replicas: 3
+    platform:
+      gcp:
+        zones: [us-east4-a, us-east4-b]
+```
+
+This produces:
+- MachineSets: `cluster-worker-*` (2 total replicas), `cluster-gpu-pool-a` (2 replicas), `cluster-gpu-pool-b` (1 replica)
+- MCP `gpu-pool` inheriting worker MachineConfigs, selecting nodes with `node-role.kubernetes.io/gpu-pool: ""`
+- `gpu-pool.ign` pointer ignition pointing to `/config/gpu-pool` on the MCS
+- `gpu-pool-user-data` secret wrapping the custom ignition

--- a/pkg/asset/ignition/machine/custompool.go
+++ b/pkg/asset/ignition/machine/custompool.go
@@ -1,0 +1,89 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// CustomPool is an asset that generates pointer ignition configs for all
+// user-defined custom compute pools. Each stub points to /config/<pool-name>
+// on the MCS so that MCO serves the correct rendered MachineConfig for the pool.
+type CustomPool struct {
+	// FilesByPool maps pool name to its pointer ignition file.
+	FilesByPool map[string]*asset.File
+}
+
+var _ asset.WritableAsset = (*CustomPool)(nil)
+
+// Dependencies returns the assets required to generate the custom pool ignitions.
+func (a *CustomPool) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&installconfig.InstallConfig{},
+		&tls.RootCA{},
+	}
+}
+
+// Generate generates pointer ignition configs for every custom pool in the
+// install config. It is a no-op when no custom pools are defined.
+func (a *CustomPool) Generate(_ context.Context, dependencies asset.Parents) error {
+	installConfig := &installconfig.InstallConfig{}
+	rootCA := &tls.RootCA{}
+	dependencies.Get(installConfig, rootCA)
+
+	logrus.Debugf("[custom-pool] CustomPool ignition: scanning %d compute pool(s)", len(installConfig.Config.Compute))
+
+	a.FilesByPool = make(map[string]*asset.File)
+	for i := range installConfig.Config.Compute {
+		name := installConfig.Config.Compute[i].Name
+		if !types.IsCustomPool(name) {
+			logrus.Debugf("[custom-pool] CustomPool ignition: pool[%d] name=%q — not custom, skipping", i, name)
+			continue
+		}
+
+		logrus.Infof("[custom-pool] CustomPool ignition: generating pointer ignition for pool %q (MCS path: /config/%s)", name, name)
+		cfg := pointerIgnitionConfig(installConfig.Config, rootCA.Cert(), name)
+		data, err := ignition.Marshal(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to marshal ignition config for custom pool %q: %w", name, err)
+		}
+		filename := fmt.Sprintf("%s.ign", name)
+		logrus.Infof("[custom-pool] CustomPool ignition: wrote %q (%d bytes)", filename, len(data))
+		a.FilesByPool[name] = &asset.File{
+			Filename: filename,
+			Data:     data,
+		}
+	}
+
+	if len(a.FilesByPool) == 0 {
+		logrus.Debugf("[custom-pool] CustomPool ignition: no custom pools found, skipping ignition generation")
+	}
+	return nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *CustomPool) Name() string {
+	return "Custom Pool Ignition Config"
+}
+
+// Files returns the ignition files generated for all custom pools.
+func (a *CustomPool) Files() []*asset.File {
+	files := make([]*asset.File, 0, len(a.FilesByPool))
+	for _, f := range a.FilesByPool {
+		files = append(files, f)
+	}
+	return files
+}
+
+// Load returns false because ignition filenames depend on pool names which are
+// not known until the install config is available. Generate() is always used.
+func (a *CustomPool) Load(_ asset.FileFetcher) (bool, error) {
+	return false, nil
+}

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -244,7 +244,8 @@ func getNetworks(platform *gcp.Platform, clusterID, role string) (string, string
 	case "master":
 		return platform.Network, platform.ControlPlaneSubnet, nil
 	default:
-		return "", "", fmt.Errorf("unrecognized machine role %s", role)
+		// Custom pool: use the compute subnet, same as worker.
+		return platform.Network, platform.ComputeSubnet, nil
 	}
 }
 
@@ -255,6 +256,11 @@ func getTags(clusterID, role string) []string {
 	case "master":
 		return []string{fmt.Sprintf("%s-%s", clusterID, "control-plane"), clusterID}
 	default:
-		panic(fmt.Sprintf("unrecognized machine role %s", role))
+		// Custom pool: include the worker tag so existing worker firewall rules
+		// apply, plus a pool-specific tag for future targeted rules.
+		return []string{
+			fmt.Sprintf("%s-worker", clusterID),
+			fmt.Sprintf("%s-%s", clusterID, role),
+		}
 	}
 }

--- a/pkg/asset/machines/machineconfigpool/manifest.go
+++ b/pkg/asset/machines/machineconfigpool/manifest.go
@@ -1,0 +1,64 @@
+// Package machineconfigpool generates MachineConfigPool manifests for custom
+// compute pools. It mirrors the machineconfig/ helper package: pure functions,
+// no Asset interface.
+package machineconfigpool
+
+import (
+	"fmt"
+	"path/filepath"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/installer/pkg/asset"
+)
+
+const (
+	machineConfigPoolFileName = "99_openshift-machineconfig_%s-mcp.yaml"
+)
+
+// ForCustomPool builds a MachineConfigPool for a user-defined compute pool.
+// The pool inherits base worker MachineConfigs via machineConfigSelector and
+// MCO uses nodeSelector to assign nodes to this pool on day 2 (driven by the
+// initial MCS request to /config/<poolName>).
+func ForCustomPool(poolName string) *mcfgv1.MachineConfigPool {
+	return &mcfgv1.MachineConfigPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfigPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: poolName,
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "machineconfiguration.openshift.io/role",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", poolName},
+					},
+				},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/" + poolName: "",
+				},
+			},
+		},
+	}
+}
+
+// Manifest serialises a MachineConfigPool for the given custom pool into an
+// asset file ready to be written to the openshift/ manifest directory.
+func Manifest(poolName, directory string) (*asset.File, error) {
+	data, err := yaml.Marshal(ForCustomPool(poolName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal MachineConfigPool for pool %q: %w", poolName, err)
+	}
+	return &asset.File{
+		Filename: filepath.Join(directory, fmt.Sprintf(machineConfigPoolFileName, poolName)),
+		Data:     data,
+	}, nil
+}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/ibmcloud"
 	"github.com/openshift/installer/pkg/asset/machines/machineconfig"
+	"github.com/openshift/installer/pkg/asset/machines/machineconfigpool"
 	"github.com/openshift/installer/pkg/asset/machines/nutanix"
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/machines/ovirt"
@@ -285,12 +286,14 @@ func awsSetPreferredInstanceByEdgeZone(ctx context.Context, defaultTypes []strin
 
 // Worker generates the machinesets for `worker` machine pool.
 type Worker struct {
-	UserDataFile       *asset.File
-	MachineConfigFiles []*asset.File
-	MachineSetFiles    []*asset.File
-	MachineFiles       []*asset.File
-	IPClaimFiles       []*asset.File
-	IPAddrFiles        []*asset.File
+	UserDataFile            *asset.File
+	MachineConfigFiles      []*asset.File
+	MachineSetFiles         []*asset.File
+	MachineFiles            []*asset.File
+	IPClaimFiles            []*asset.File
+	IPAddrFiles             []*asset.File
+	CustomPoolUserDataFiles []*asset.File
+	MachineConfigPoolFiles  []*asset.File
 }
 
 // Name returns a human friendly name for the Worker Asset.
@@ -311,6 +314,7 @@ func (w *Worker) Dependencies() []asset.Asset {
 		new(rhcos.Image),
 		new(rhcos.Release),
 		&machine.Worker{},
+		&machine.CustomPool{},
 	}
 }
 
@@ -323,7 +327,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 	rhcosImage := new(rhcos.Image)
 	rhcosRelease := new(rhcos.Release)
 	wign := &machine.Worker{}
-	dependencies.Get(clusterID, installConfig, rhcosImage, rhcosRelease, wign)
+	cign := &machine.CustomPool{}
+	dependencies.Get(clusterID, installConfig, rhcosImage, rhcosRelease, wign, cign)
 
 	workerUserDataSecretName := "worker-user-data"
 
@@ -334,8 +339,68 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 	var ipAddrs []ipamv1.IPAddress
 	var err error
 	ic := installConfig.Config
+
+	// Pre-pass: sum replica counts across all custom pools for worker balancing,
+	// and determine whether the worker replica count was explicitly set by the user.
+	// We check the raw YAML (pre-defaults) because by Generate() time defaults
+	// have already filled in Replicas for every pool.
+	var customPoolReplicas int64
+	var customPoolNames []string
+	for i := range ic.Compute {
+		if types.IsCustomPool(ic.Compute[i].Name) && ic.Compute[i].Replicas != nil {
+			customPoolReplicas += *ic.Compute[i].Replicas
+			customPoolNames = append(customPoolNames, ic.Compute[i].Name)
+		}
+	}
+	if len(customPoolNames) > 0 {
+		logrus.Infof("[custom-pool] found %d custom pool(s) %v with %d total requested replicas", len(customPoolNames), customPoolNames, customPoolReplicas)
+	} else {
+		logrus.Debugf("[custom-pool] no custom pools found in compute pools, skipping custom pool logic")
+	}
+
+	workerReplicasExplicitlySet := false
+	var rawIC struct {
+		Compute []struct {
+			Name     string `json:"name"`
+			Replicas *int64 `json:"replicas"`
+		} `json:"compute"`
+	}
+	if installConfig.File != nil {
+		if err := yaml.Unmarshal(installConfig.File.Data, &rawIC); err == nil {
+			for _, p := range rawIC.Compute {
+				if p.Name == types.MachinePoolComputeRoleName && p.Replicas != nil {
+					workerReplicasExplicitlySet = true
+					break
+				}
+			}
+		}
+	}
+	logrus.Debugf("[custom-pool] worker replicas explicitly set by user: %v", workerReplicasExplicitlySet)
+
 	for _, pool := range ic.Compute {
 		pool := pool // this makes golint happy... G601: Implicit memory aliasing in for loop. (gosec)
+
+		logrus.Debugf("[custom-pool] processing compute pool %q (replicas=%v, isCustom=%v)", pool.Name, pool.Replicas, types.IsCustomPool(pool.Name))
+
+		// Apply worker balancing: reduce worker replicas by the custom pool count so
+		// that total compute remains constant. Only balance when the user has not
+		// explicitly set a worker replica count — if they did, respect both counts.
+		if pool.Name == types.MachinePoolComputeRoleName && !workerReplicasExplicitlySet && customPoolReplicas > 0 && pool.Replicas != nil {
+			adjusted := *pool.Replicas - customPoolReplicas
+			if adjusted <= 0 {
+				if adjusted < 0 {
+					logrus.Warnf("Custom pool requests %d nodes which exceeds worker pool replicas %d; worker pool will have 0 nodes", customPoolReplicas, *pool.Replicas)
+				}
+				adjusted = 0
+			}
+			logrus.Infof("[custom-pool] worker pool balancing: original=%d custom=%d adjusted-worker=%d", *pool.Replicas, customPoolReplicas, adjusted)
+			pool.Replicas = &adjusted
+		} else if pool.Name == types.MachinePoolComputeRoleName && workerReplicasExplicitlySet && customPoolReplicas > 0 {
+			logrus.Infof("[custom-pool] worker replicas explicitly set to %d; skipping balancing (custom pools total %d)", *pool.Replicas, customPoolReplicas)
+		}
+		// Custom pools inherit MachineConfigs from the worker pool via the MCP's
+		// machineConfigSelector, so we skip per-pool MC generation for them.
+		if !types.IsCustomPool(pool.Name) {
 		if pool.Hyperthreading == types.HyperthreadingDisabled {
 			ignHT, err := machineconfig.ForHyperthreadingDisabled("worker")
 			if err != nil {
@@ -447,6 +512,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 			}
 			machineConfigs = append(machineConfigs, ignIPv6)
 		}
+		} // end !types.IsCustomPool
 
 		switch ic.Platform.Name() {
 		case awstypes.Name:
@@ -664,12 +730,54 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				mpool.Zones = azs
 			}
 			pool.Platform.GCP = &mpool
-			sets, err := gcp.MachineSets(clusterID.InfraID, ic, &pool, rhcosImage.Compute, "worker", workerUserDataSecretName)
+
+			// Custom pools use the worker role so they get standard worker tags,
+			// subnets, and MAPI labels. Only the user-data secret differs, pointing
+			// machines at /config/<poolName> on the MCS instead of /config/worker.
+			gcpRole := types.MachinePoolComputeRoleName
+			gcpUserDataSecret := workerUserDataSecretName
+			if types.IsCustomPool(pool.Name) {
+				gcpUserDataSecret = pool.Name + "-user-data"
+				logrus.Infof("[custom-pool] GCP: pool %q will use user-data secret %q with role %q", pool.Name, gcpUserDataSecret, gcpRole)
+			}
+
+			logrus.Debugf("[custom-pool] GCP: generating MachineSets for pool %q (role=%q, userDataSecret=%q)", pool.Name, gcpRole, gcpUserDataSecret)
+			sets, err := gcp.MachineSets(clusterID.InfraID, ic, &pool, rhcosImage.Compute, gcpRole, gcpUserDataSecret)
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
+			logrus.Infof("[custom-pool] GCP: generated %d MachineSet(s) for pool %q", len(sets), pool.Name)
 			for _, set := range sets {
 				machineSets = append(machineSets, set)
+			}
+
+			// Generate the MCP and user-data secret for custom pools.
+			if types.IsCustomPool(pool.Name) {
+				ignFile := cign.FilesByPool[pool.Name]
+				logrus.Debugf("[custom-pool] GCP: ignition file found=%v for pool %q", ignFile != nil, pool.Name)
+				if ignFile != nil {
+					logrus.Infof("[custom-pool] GCP: generating MachineConfigPool manifest for pool %q", pool.Name)
+					mcpFile, err := machineconfigpool.Manifest(pool.Name, directory)
+					if err != nil {
+						return errors.Wrapf(err, "failed to create MachineConfigPool manifest for pool %q", pool.Name)
+					}
+					logrus.Debugf("[custom-pool] GCP: MachineConfigPool manifest written to %q", mcpFile.Filename)
+					w.MachineConfigPoolFiles = append(w.MachineConfigPoolFiles, mcpFile)
+
+					logrus.Infof("[custom-pool] GCP: generating user-data secret %q for pool %q", gcpUserDataSecret, pool.Name)
+					secretData, err := UserDataSecret(gcpUserDataSecret, ignFile.Data)
+					if err != nil {
+						return errors.Wrapf(err, "failed to create user-data secret for custom pool %q", pool.Name)
+					}
+					secretFilename := filepath.Join(directory, fmt.Sprintf("99_openshift-cluster-api_%s-user-data-secret.yaml", pool.Name))
+					logrus.Debugf("[custom-pool] GCP: user-data secret written to %q (%d bytes)", secretFilename, len(secretData))
+					w.CustomPoolUserDataFiles = append(w.CustomPoolUserDataFiles, &asset.File{
+						Filename: secretFilename,
+						Data:     secretData,
+					})
+				} else {
+					logrus.Warnf("[custom-pool] GCP: skipping MCP and user-data secret for pool %q because custom pool ignition was not generated", pool.Name)
+				}
 			}
 		case ibmcloudtypes.Name:
 			subnets := map[string]string{}
@@ -870,15 +978,17 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 
 // Files returns the files generated by the asset.
 func (w *Worker) Files() []*asset.File {
-	files := make([]*asset.File, 0, 1+len(w.MachineConfigFiles)+len(w.MachineSetFiles))
+	files := make([]*asset.File, 0, 1+len(w.MachineConfigFiles)+len(w.MachineSetFiles)+len(w.MachineConfigPoolFiles)+1)
 	if w.UserDataFile != nil {
 		files = append(files, w.UserDataFile)
 	}
+	files = append(files, w.CustomPoolUserDataFiles...)
 	files = append(files, w.MachineConfigFiles...)
 	files = append(files, w.MachineSetFiles...)
 	files = append(files, w.MachineFiles...)
 	files = append(files, w.IPClaimFiles...)
 	files = append(files, w.IPAddrFiles...)
+	files = append(files, w.MachineConfigPoolFiles...)
 	return files
 }
 

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -167,6 +167,7 @@ spec:
 						Data:     []byte("test-ignition"),
 					},
 				},
+				&machine.CustomPool{},
 			)
 			worker := &Worker{}
 			if err := worker.Generate(context.Background(), parents); err != nil {
@@ -230,6 +231,7 @@ func TestComputeIsNotModified(t *testing.T) {
 				Data:     []byte("test-ignition"),
 			},
 		},
+		&machine.CustomPool{},
 	)
 	worker := &Worker{}
 	if err := worker.Generate(context.Background(), parents); err != nil {

--- a/pkg/asset/manifests/mco.go
+++ b/pkg/asset/manifests/mco.go
@@ -77,8 +77,11 @@ func gcpBootImages(ic *types.InstallConfig) (cpImg bool, wImg bool) {
 		cpImg = true
 	}
 
-	if w := ic.Compute; len(w) > 0 && w[0].Platform.GCP != nil && w[0].Platform.GCP.OSImage != nil {
-		wImg = true
+	for _, computeMP := range ic.Compute {
+		if gcpPlatform := computeMP.Platform.GCP; gcpPlatform != nil && gcpPlatform.OSImage != nil {
+			wImg = true
+			break
+		}
 	}
 	return
 }

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -14,7 +14,7 @@ import (
 // SetMachinePoolDefaults sets the defaults for the machine pool.
 func SetMachinePoolDefaults(p *types.MachinePool, platform *types.Platform) {
 	defaultReplicaCount := int64(3)
-	if p.Name == types.MachinePoolEdgeRoleName || p.Name == types.MachinePoolArbiterRoleName {
+	if p.Name == types.MachinePoolEdgeRoleName || p.Name == types.MachinePoolArbiterRoleName || types.IsCustomPool(p.Name) {
 		defaultReplicaCount = 0
 	}
 	if p.Replicas == nil {

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -26,6 +28,21 @@ const (
 	// MachinePoolDefaultConfig name associated with the generic default configs for machine pool.
 	MachinePoolDefaultConfig = "default"
 )
+
+// ReservedMachinePoolNames contains pool names that are reserved by the installer
+// and may not be used as custom pool names.
+var ReservedMachinePoolNames = sets.New(
+	MachinePoolComputeRoleName,
+	MachinePoolEdgeRoleName,
+	MachinePoolControlPlaneRoleName,
+	MachinePoolArbiterRoleName,
+)
+
+// IsCustomPool returns true if the pool name is a user-defined custom pool,
+// i.e. non-empty and not one of the built-in reserved names.
+func IsCustomPool(poolName string) bool {
+	return poolName != "" && !ReservedMachinePoolNames.Has(poolName)
+}
 
 // HyperthreadingMode is the mode of hyperthreading for a machine.
 // +kubebuilder:validation:Enum="";Enabled;Disabled

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilsnet "k8s.io/utils/net"
 
@@ -893,6 +894,7 @@ func validateCompute(platform *types.Platform, control *types.MachinePool, pools
 	// three valid platforms for multi arch installations.
 	isMultiArchEnabled := platform.AWS != nil || platform.GCP != nil || platform.BareMetal != nil
 	poolNames := map[string]bool{}
+	customPoolCount := 0
 	for i, p := range pools {
 		poolFldPath := fldPath.Index(i)
 		switch p.Name {
@@ -900,7 +902,19 @@ func validateCompute(platform *types.Platform, control *types.MachinePool, pools
 		case types.MachinePoolEdgeRoleName:
 			allErrs = append(allErrs, validateComputeEdge(platform, p.Name, poolFldPath, poolFldPath)...)
 		default:
-			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), p.Name, []string{types.MachinePoolComputeRoleName, types.MachinePoolEdgeRoleName}))
+			// Custom pool: validate name is a legal DNS label, not a reserved name, and limit to five.
+			if errs := k8svalidation.IsDNS1123Label(p.Name); len(errs) > 0 {
+				allErrs = append(allErrs, field.Invalid(poolFldPath.Child("name"), p.Name, strings.Join(errs, "; ")))
+			} else if types.ReservedMachinePoolNames.Has(p.Name) {
+				allErrs = append(allErrs, field.Invalid(poolFldPath.Child("name"), p.Name, "pool name is reserved"))
+			} else if platform.GCP == nil {
+				allErrs = append(allErrs, field.Invalid(poolFldPath.Child("name"), p.Name, "custom compute pools are currently only supported on GCP"))
+			} else {
+				customPoolCount++
+				if customPoolCount > 5 {
+					allErrs = append(allErrs, field.TooMany(poolFldPath.Child("name"), customPoolCount, 5))
+				}
+			}
 		}
 
 		if poolNames[p.Name] {


### PR DESCRIPTION
Implementation details can be found in `docs/design/custom-machine-pools-day0.md` attached to this PR. Scrapes from a sample run below:

**InstallConfig** used:
```
(skipping the boring parts)
.....
compute:
- architecture: amd64
  hyperthreading: Enabled
  name: worker
  platform: {}
  replicas: 3
- architecture: amd64
  hyperthreading: Enabled
  name: grace-blackwell
  platform:                                                                                                                                                                           
    gcp:                           
      osImage:                            
        project: rhcos-cloud           
        name: rhcos-9-6-20251212-1-gcp-x86-64
  replicas: 1
- architecture: amd64
  hyperthreading: Enabled
  name: vera-rubin
  platform:                                                                                                                                                                           
    gcp:                           
      osImage:                            
        project: rhcos-cloud           
        name: rhcos-9-8-20260403-0-gcp-x86-64
  replicas: 1      
controlPlane:
  architecture: amd64
  hyperthreading: Enabled
  name: master
  platform: {}
  replicas: 3

```
Note that I've specified a different bootimage for each of the custom pools. Post installation, we have:
```
~/projects/openshift-installer/download 
$ oc get node -n openshift-machine-config-operator
NAME                                           STATUS   ROLES                    AGE     VERSION
djoshy-dev-104-lfrz2-grace-blackwell-a-vmll8   Ready    grace-blackwell,worker   9m26s   v1.35.3
djoshy-dev-104-lfrz2-master-0                  Ready    control-plane,master     23m     v1.35.3
djoshy-dev-104-lfrz2-master-1                  Ready    control-plane,master     25m     v1.35.3
djoshy-dev-104-lfrz2-master-2                  Ready    control-plane,master     25m     v1.35.3
djoshy-dev-104-lfrz2-vera-rubin-a-jjttg        Ready    vera-rubin,worker        9m33s   v1.35.3
djoshy-dev-104-lfrz2-worker-a-77wlc            Ready    worker                   9m41s   v1.35.3
djoshy-dev-104-lfrz2-worker-b-f2mvt            Ready    worker                   9m36s   v1.35.3
djoshy-dev-104-lfrz2-worker-c-j92jt            Ready    worker                   10m     v1.35.3

~/projects/openshift-installer/download 
$ oc get mcp -n openshift-machine-config-operator
NAME              CONFIG                                                      UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
grace-blackwell   rendered-grace-blackwell-cffc9c9465ea8a10a54e8548cd2814dd   True      False      False      1              1                   1                     0                      26m
master            rendered-master-4430ec896cff75e9184474fb035c29fd            True      False      False      3              3                   3                     0                      21m
vera-rubin        rendered-vera-rubin-cffc9c9465ea8a10a54e8548cd2814dd        True      False      False      1              1                   1                     0                      26m
worker            rendered-worker-cffc9c9465ea8a10a54e8548cd2814dd            True      False      False      3              3                   3                     0                      21m

~/projects/openshift-installer/download 
$ oc get machinesets.machine.openshift.io,machines.machine.openshift.io -n openshift-machine-api 
NAME                                                                     DESIRED   CURRENT   READY   AVAILABLE   AGE
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-grace-blackwell-a   1         1         1       1           26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-grace-blackwell-b   0         0                             26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-grace-blackwell-c   0         0                             26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-vera-rubin-a        1         1         1       1           26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-vera-rubin-b        0         0                             26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-vera-rubin-c        0         0                             26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-worker-a            1         1         1       1           26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-worker-b            1         1         1       1           26m
machineset.machine.openshift.io/djoshy-dev-104-lfrz2-worker-c            1         1         1       1           26m

NAME                                                                        PHASE     TYPE            REGION     ZONE         AGE
machine.machine.openshift.io/djoshy-dev-104-lfrz2-grace-blackwell-a-vmll8   Running   n2-standard-4   us-east4   us-east4-a   19m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-master-0                  Running   n2-standard-4   us-east4   us-east4-a   26m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-master-1                  Running   n2-standard-4   us-east4   us-east4-b   26m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-master-2                  Running   n2-standard-4   us-east4   us-east4-c   26m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-vera-rubin-a-jjttg        Running   n2-standard-4   us-east4   us-east4-a   19m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-worker-a-77wlc            Running   n2-standard-4   us-east4   us-east4-a   19m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-worker-b-f2mvt            Running   n2-standard-4   us-east4   us-east4-b   19m
machine.machine.openshift.io/djoshy-dev-104-lfrz2-worker-c-j92jt            Running   n2-standard-4   us-east4   us-east4-c   19m

```
Examining the aleph version on each node indicates they used the bootimages we have defined:
```
$ oc debug node/djoshy-dev-104-lfrz2-grace-blackwell-a-vmll8 -- chroot /host cat /sysroot/.coreos-aleph-version.json
{
     ......
    "version": "9.6.20251212-1"
}
$ oc debug node/djoshy-dev-104-lfrz2-vera-rubin-a-jjttg -- chroot /host cat /sysroot/.coreos-aleph-version.json
{
    .....
    "version": "9.8.20260403-0"
}
```
Both nodes pivoted to the rhel-9 stream after firstboot, as that is the default currently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced custom machine pools at Day 0 installation on GCP with DNS-compliant naming and a 5-pool limit per cluster.
  * Custom pools receive dedicated configuration, node selection, and ignition settings.
  * Worker replicas automatically balance when custom pools are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->