### PR TITLE
OCPBUGS-78093: AWS userProvisioned DNS: Obtain Load Balancer IPs from DNS names

### DIFF
--- a/pkg/infrastructure/aws/clusterapi/ignition.go
+++ b/pkg/infrastructure/aws/clusterapi/ignition.go
@@ -3,15 +3,14 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	"net"
+	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -20,6 +19,41 @@ import (
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/network"
 )
+
+// getIPsFromDNSName resolves a DNS name to IP addresses with exponential backoff retry.
+// It returns a slice of IP address strings or an error if all retries fail.
+func getIPsFromDNSName(ctx context.Context, dnsName, lbType string) ([]string, error) {
+	resolver := &net.Resolver{}
+	var ips []net.IP
+	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    5,
+	}, func(ctx context.Context) (bool, error) {
+		var err error
+		ips, err = resolver.LookupIP(ctx, "ip", dnsName)
+		if err != nil {
+			logrus.Debugf("AWS: DNS lookup for %s DNS name %q failed, retrying: %v", lbType, dnsName, err)
+			return false, nil
+		}
+		if len(ips) == 0 {
+			logrus.Debugf("AWS: DNS lookup for %s DNS name %q returned no IPs, retrying", lbType, dnsName)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup IP for %s DNS name %q after retries: %w", lbType, dnsName, err)
+	}
+
+	var ipAddresses []string
+	for _, ip := range ips {
+		ipAddresses = append(ipAddresses, ip.String())
+	}
+	logrus.Debugf("AWS: Resolved %s DNS name %q to IPs: %v", lbType, dnsName, ipAddresses)
+	return ipAddresses, nil
+}
 
 func editIgnitionForCustomDNS(ctx context.Context, in clusterapi.IgnitionInput) (*clusterapi.IgnitionOutput, error) {
 	if in.InstallConfig.Config.AWS.UserProvisionedDNS != dns.UserProvisionedDNSEnabled {
@@ -38,53 +72,35 @@ func editIgnitionForCustomDNS(ctx context.Context, in clusterapi.IgnitionInput) 
 		return nil, fmt.Errorf("failed to get AWSCluster: %w", err)
 	}
 
-	// There is no direct access to load balancer IP addresses, so the security groups
-	// are used here to find the network interfaces that correspond to the load balancers.
-	securityGroupIDs := make([]string, 0, len(awsCluster.Status.Network.SecurityGroups))
-	for _, securityGroup := range awsCluster.Status.Network.SecurityGroups {
-		securityGroupIDs = append(securityGroupIDs, securityGroup.ID)
-	}
-	nicInput := ec2.DescribeNetworkInterfacesInput{
-		Filters: []ec2types.Filter{
-			{
-				Name:   aws.String("group-id"),
-				Values: securityGroupIDs,
-			},
-		},
-	}
+	var publicIPAddresses, privateIPAddresses []string
 
-	platformAWS := in.InstallConfig.Config.AWS
-	client, err := awsconfig.NewEC2Client(ctx, awsconfig.EndpointOptions{
-		Region:    platformAWS.Region,
-		Endpoints: platformAWS.ServiceEndpoints,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ec2 client: %w", err)
-	}
-
-	nicOutput, err := client.DescribeNetworkInterfaces(ctx, &nicInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to describe network interfaces: %w", err)
-	}
-
-	// The only network interfaces existing at this stage are those from the load balancers.
-	// If this stage is executed after control plane nodes are provisioned, there may be
-	// other network interfaces available.
-	publicIPAddresses := []string{}
-	privateIPAddresses := []string{}
-	for _, nic := range nicOutput.NetworkInterfaces {
-		if nic.Association != nil && nic.Association.PublicIp != nil {
-			logrus.Debugf("found public IP address %s associated with %s", *nic.Association.PublicIp, *nic.Description)
-			publicIPAddresses = append(publicIPAddresses, *nic.Association.PublicIp)
-		} else if nic.PrivateIpAddress != nil {
-			logrus.Debugf("found private IP address %s associated with %s", *nic.PrivateIpAddress, *nic.Description)
-			privateIPAddresses = append(privateIPAddresses, *nic.PrivateIpAddress)
+	// Get private LB IP addresses from APIServerELB DNS name
+	if dnsName := awsCluster.Status.Network.APIServerELB.DNSName; dnsName != "" {
+		ips, err := getIPsFromDNSName(ctx, dnsName, fmt.Sprintf("APIServerELB (scheme: %s)", awsCluster.Status.Network.APIServerELB.Scheme))
+		if err != nil {
+			return nil, err
 		}
+		privateIPAddresses = ips
+	} else {
+		return nil, fmt.Errorf("internal API load balancer not found")
 	}
-	if !in.InstallConfig.Config.PublicAPI() {
+
+	if in.InstallConfig.Config.PublicAPI() {
+		// Get public LB IP addresses from SecondaryAPIServerELB DNS name
+		if dnsName := awsCluster.Status.Network.SecondaryAPIServerELB.DNSName; dnsName != "" {
+			ips, err := getIPsFromDNSName(ctx, dnsName, fmt.Sprintf("SecondaryAPIServerELB (scheme: %s)", awsCluster.Status.Network.SecondaryAPIServerELB.Scheme))
+			if err != nil {
+				return nil, err
+			}
+			publicIPAddresses = ips
+		} else {
+			return nil, fmt.Errorf("public API load balancer not found")
+		}
+	} else {
 		// For private cluster installs, the API LB IP is the same as the API-Int LB IP
 		publicIPAddresses = privateIPAddresses
 	}
+
 	logrus.Debugf("AWS: Editing Ignition files to start in-cluster DNS when UserProvisionedDNS is enabled")
 	return clusterapi.EditIgnitionForCustomDNS(in, awstypes.Name, publicIPAddresses, privateIPAddresses)
 }

--- a/pkg/infrastructure/aws/clusterapi/ignition.go
+++ b/pkg/infrastructure/aws/clusterapi/ignition.go
@@ -29,7 +29,7 @@ func getIPsFromDNSName(ctx context.Context, dnsName, lbType string) ([]string, e
 		Duration: 1 * time.Second,
 		Factor:   2.0,
 		Jitter:   0.1,
-		Steps:    5,
+		Steps:    10, // ~15 minutes total timeout with exponential backoff
 	}, func(ctx context.Context) (bool, error) {
 		var err error
 		ips, err = resolver.LookupIP(ctx, "ip", dnsName)


### PR DESCRIPTION
This change obtains the API and API-Int LoadBalancer IP addresses by looking up the IP address of the DNSName of APIServerELB (public LB) and SecondaryAPIServerELB (private LB).

The original implementation used security group to find the network interfaces that correspond to the load balancers. This approach did not work in AWS Top Secret regions.

The updated implementations uses the AWSCluster's NetworkStatus field to obtain the DNS Names of the API and API Int Load Balancers and performs a Lookup to obtain their IP addresses. This works for all regions and Load Balancer types like CLB and NLB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Load balancer IP discovery now uses DNS resolution with retry/backoff instead of inspecting cloud network interfaces.
  * Adds explicit error handling and logging for missing or failed DNS lookups.
  * Public API installs obtain public IPs from the secondary endpoint; private installs reuse private addresses as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->