### PR TITLE
OCPBUGS-44637: node-joiner: configure proxy CA certificate before image pulls

### DIFF
--- a/pkg/nodejoiner/addnodes.go
+++ b/pkg/nodejoiner/addnodes.go
@@ -1,10 +1,19 @@
 package nodejoiner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/configimage"
 	"github.com/openshift/installer/pkg/asset/agent/image"
@@ -18,6 +27,10 @@ const (
 	addNodesResultFile = "exit_code"
 )
 
+// systemCACertBundle is the path to the system CA bundle on RHEL/CoreOS nodes.
+// It is a variable to allow overriding in tests.
+var systemCACertBundle = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+
 // NewAddNodesCommand creates a new command for add nodes.
 func NewAddNodesCommand(directory string, kubeConfig string, generatePXE bool, generateConfigISO bool) error {
 	if generatePXE && generateConfigISO {
@@ -27,6 +40,10 @@ func NewAddNodesCommand(directory string, kubeConfig string, generatePXE bool, g
 	err := saveParams(directory, kubeConfig)
 	if err != nil {
 		return err
+	}
+
+	if err := setupProxyCACert(directory, kubeConfig); err != nil {
+		logrus.Warnf("Failed to setup proxy CA certificate: %v", err)
 	}
 
 	assets := []asset.WritableAsset{
@@ -62,6 +79,81 @@ func NewAddNodesCommand(directory string, kubeConfig string, generatePXE bool, g
 	}
 
 	return err
+}
+
+// setupProxyCACert fetches the proxy trusted CA from the cluster and configures
+// SSL_CERT_FILE so that subsequent image pulls through the proxy succeed.
+func setupProxyCACert(directory, kubeConfig string) error {
+	var config *rest.Config
+	var err error
+	if kubeConfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return fmt.Errorf("cannot build cluster config: %w", err)
+	}
+
+	configClient, err := configclient.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("cannot create config client: %w", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("cannot create kubernetes client: %w", err)
+	}
+
+	return setupProxyCACertWithClients(directory, configClient, k8sClient)
+}
+
+// setupProxyCACertWithClients contains the testable logic for setupProxyCACert.
+// The combined bundle includes the system CA certs so public registries remain trusted.
+func setupProxyCACertWithClients(directory string, configClient configclient.Interface, k8sClient kubernetes.Interface) error {
+	proxy, err := configClient.ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot get proxy config: %w", err)
+	}
+
+	if proxy.Spec.TrustedCA.Name == "" {
+		return nil
+	}
+
+	caConfigMap, err := k8sClient.CoreV1().ConfigMaps("openshift-config").Get(context.Background(), proxy.Spec.TrustedCA.Name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot get CA bundle configmap %q: %w", proxy.Spec.TrustedCA.Name, err)
+	}
+
+	proxyCACert, ok := caConfigMap.Data["ca-bundle.crt"]
+	if !ok || proxyCACert == "" {
+		return nil
+	}
+
+	// Read the system CA bundle so public registries remain trusted alongside the proxy CA.
+	systemCerts, err := os.ReadFile(systemCACertBundle)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot read system CA bundle: %w", err)
+	}
+
+	combined := systemCerts
+	if len(combined) > 0 && combined[len(combined)-1] != '\n' {
+		combined = append(combined, '\n')
+	}
+	combined = append(combined, []byte(proxyCACert)...)
+	caFile := filepath.Join(directory, "proxy-ca-bundle.crt")
+	if err := os.WriteFile(caFile, combined, 0600); err != nil {
+		return fmt.Errorf("cannot write combined CA bundle: %w", err)
+	}
+
+	logrus.Infof("Proxy CA certificate configured from cluster configmap %q", proxy.Spec.TrustedCA.Name)
+	return os.Setenv("SSL_CERT_FILE", caFile)
 }
 
 func saveParams(directory, kubeConfig string) error {

--- a/pkg/nodejoiner/addnodes_test.go
+++ b/pkg/nodejoiner/addnodes_test.go
@@ -1,0 +1,175 @@
+package nodejoiner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	faketesting "k8s.io/client-go/testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeclientconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+)
+
+const fakeProxyCACert = "-----BEGIN CERTIFICATE-----\nfake-proxy-ca-data\n-----END CERTIFICATE-----\n"
+
+func TestSetupProxyCACert(t *testing.T) {
+	testCases := []struct {
+		name            string
+		configObjects   []runtime.Object
+		kubeObjects     []runtime.Object
+		systemCAContent string
+		expectedSSLFile bool
+		expectedContent string
+		expectedError   string
+	}{
+		{
+			name:            "no proxy configured",
+			expectedSSLFile: false,
+		},
+		{
+			name: "proxy without trusted CA",
+			configObjects: []runtime.Object{
+				&configv1.Proxy{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				},
+			},
+			expectedSSLFile: false,
+		},
+		{
+			name: "proxy with trusted CA, no system bundle",
+			configObjects: []runtime.Object{
+				proxyWithTrustedCA("user-ca-bundle"),
+			},
+			kubeObjects: []runtime.Object{
+				caConfigMap("user-ca-bundle", fakeProxyCACert),
+			},
+			expectedSSLFile: true,
+			expectedContent: fakeProxyCACert,
+		},
+		{
+			name: "proxy with trusted CA, system bundle concatenated",
+			configObjects: []runtime.Object{
+				proxyWithTrustedCA("user-ca-bundle"),
+			},
+			kubeObjects: []runtime.Object{
+				caConfigMap("user-ca-bundle", fakeProxyCACert),
+			},
+			systemCAContent: "system-ca-data\n",
+			expectedSSLFile: true,
+			expectedContent: "system-ca-data\n" + fakeProxyCACert,
+		},
+		{
+			name: "proxy with trusted CA, system bundle missing trailing newline",
+			configObjects: []runtime.Object{
+				proxyWithTrustedCA("user-ca-bundle"),
+			},
+			kubeObjects: []runtime.Object{
+				caConfigMap("user-ca-bundle", fakeProxyCACert),
+			},
+			systemCAContent: "system-ca-data-no-newline",
+			expectedSSLFile: true,
+			expectedContent: "system-ca-data-no-newline\n" + fakeProxyCACert,
+		},
+		{
+			name: "proxy with trusted CA, configmap not found",
+			configObjects: []runtime.Object{
+				proxyWithTrustedCA("user-ca-bundle"),
+			},
+			expectedSSLFile: false,
+		},
+		{
+			name: "proxy with trusted CA, ca-bundle.crt key missing",
+			configObjects: []runtime.Object{
+				proxyWithTrustedCA("user-ca-bundle"),
+			},
+			kubeObjects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "user-ca-bundle", Namespace: "openshift-config"},
+					Data:       map[string]string{},
+				},
+			},
+			expectedSSLFile: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Point systemCACertBundle at a temp file so tests don't read the real system bundle.
+			fakeSystemBundle := filepath.Join(dir, "system-ca-bundle.pem")
+			original := systemCACertBundle
+			systemCACertBundle = fakeSystemBundle
+			defer func() { systemCACertBundle = original }()
+
+			if tc.systemCAContent != "" {
+				if err := os.WriteFile(fakeSystemBundle, []byte(tc.systemCAContent), 0600); !assert.NoError(t, err) {
+					return
+				}
+			}
+
+			fakeConfigClient := fakeclientconfig.NewClientset(tc.configObjects...)
+			fakeK8sClient := fake.NewClientset(tc.kubeObjects...)
+
+			// Return a proper not-found error for configmaps not in the test's kubeObjects.
+			fakeK8sClient.PrependReactor("get", "configmaps", func(action faketesting.Action) (bool, runtime.Object, error) {
+				name := action.(faketesting.GetAction).GetName()
+				for _, obj := range tc.kubeObjects {
+					if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == name {
+						return false, nil, nil // let the default handler serve it
+					}
+				}
+				return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, name)
+			})
+
+			os.Unsetenv("SSL_CERT_FILE")
+
+			err := setupProxyCACertWithClients(dir, fakeConfigClient, fakeK8sClient)
+
+			if tc.expectedError != "" {
+				assert.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			caFile := filepath.Join(dir, "proxy-ca-bundle.crt")
+			if tc.expectedSSLFile {
+				assert.Equal(t, caFile, os.Getenv("SSL_CERT_FILE"))
+				content, readErr := os.ReadFile(caFile)
+				if assert.NoError(t, readErr) {
+					assert.Equal(t, tc.expectedContent, string(content))
+				}
+			} else {
+				assert.Empty(t, os.Getenv("SSL_CERT_FILE"))
+				_, statErr := os.Stat(caFile)
+				assert.True(t, os.IsNotExist(statErr), "expected no CA bundle file to be written")
+			}
+		})
+	}
+}
+
+func proxyWithTrustedCA(configMapName string) *configv1.Proxy {
+	return &configv1.Proxy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.ProxySpec{
+			TrustedCA: configv1.ConfigMapNameReference{Name: configMapName},
+		},
+	}
+}
+
+func caConfigMap(name, cert string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "openshift-config"},
+		Data:       map[string]string{"ca-bundle.crt": cert},
+	}
+}


### PR DESCRIPTION
When a cluster proxy is configured with a self-signed certificate, the node-joiner pod fails to pull images through the proxy because the proxy CA is not trusted by the pod's TLS stack.

setupProxyCACert now runs before the asset graph. It reads proxy/cluster to check for a trusted CA bundle, fetches the named ConfigMap from openshift-config, concatenates the cert with the system CA bundle, and sets SSL_CERT_FILE so that all subsequent Go TLS connections and oc subprocess calls trust both the proxy CA and public registry CAs.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node-join now picks up cluster proxy trusted CA, merges it with the system CA bundle when present, and generates an SSL certificate bundle used by the process.
  * If no trusted CA is configured or the referenced CA data is missing, no bundle is created and behavior remains unchanged.

* **Tests**
  * Added tests covering bundle creation, concatenation behavior (including missing trailing newline), and no-op cases when proxy/CA data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->