### PR TITLE
MCO-2200: Simplify CoreOS fetching code

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -106,7 +106,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 			logrus.Debugf("Using custom rootfs URL: %s", a.rootFSURL)
 		} else {
 			// Default to the URL from the RHCOS streams file
-			defaultRootFSURL, err := baseIso.getRootFSURL(ctx, a.cpuArch, agentWorkflow, clusterInfo)
+			defaultRootFSURL, err := baseIso.getRootFSURL(ctx, a.cpuArch, clusterInfo.OSImage)
 			if err != nil {
 				return err
 			}

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -37,9 +37,8 @@ func (i *BaseIso) Name() string {
 }
 
 // Fetch RootFS URL using the rhcos.json.
-func (i *BaseIso) getRootFSURL(ctx context.Context, archName string, agentWorkflow *workflow.AgentWorkflow, clusterInfo *joiner.ClusterInfo) (string, error) {
-	metal, err := rhcos.GetMetalArtifact(
-		ctx, archName, customStreamGetter(agentWorkflow, clusterInfo))
+func (i *BaseIso) getRootFSURL(ctx context.Context, archName string, agentWorkflow *workflow.AgentWorkflow, st *stream.Stream) (string, error) {
+	metal, err := rhcos.GetMetalArtifactWithStream(ctx, archName, st)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -37,7 +37,7 @@ func (i *BaseIso) Name() string {
 }
 
 // Fetch RootFS URL using the rhcos.json.
-func (i *BaseIso) getRootFSURL(ctx context.Context, archName string, agentWorkflow *workflow.AgentWorkflow, st *stream.Stream) (string, error) {
+func (i *BaseIso) getRootFSURL(ctx context.Context, archName string, st *stream.Stream) (string, error) {
 	metal, err := rhcos.GetMetalArtifactWithStream(ctx, archName, st)
 	if err != nil {
 		return "", err
@@ -72,7 +72,7 @@ func (i *BaseIso) Generate(ctx context.Context, dependencies asset.Parents) erro
 
 	baseIsoFileName, err := rhcos.NewBaseISOFetcher(
 		i.getRelease(agentManifests, registriesConf.MirrorConfig),
-		customStreamGetter(agentWorkflow, clusterInfo)).GetBaseISOFilename(ctx, agentManifests.InfraEnv.Spec.CpuArchitecture)
+		clusterInfo.OSImage).GetBaseISOFilename(ctx, agentManifests.InfraEnv.Spec.CpuArchitecture)
 
 	if err == nil {
 		logrus.Debugf("Using base ISO image %s", baseIsoFileName)
@@ -82,15 +82,6 @@ func (i *BaseIso) Generate(ctx context.Context, dependencies asset.Parents) erro
 	logrus.Debugf("Failed to download base ISO: %s", err)
 
 	return errors.Wrap(err, "failed to get base ISO image")
-}
-
-func customStreamGetter(agentWorkflow *workflow.AgentWorkflow, clusterInfo *joiner.ClusterInfo) rhcos.CoreOSBuildFetcher {
-	if agentWorkflow.Workflow == workflow.AgentWorkflowTypeAddNodes {
-		return func(ctx context.Context) (*stream.Stream, error) {
-			return clusterInfo.OSImage, nil
-		}
-	}
-	return nil
 }
 
 func (i *BaseIso) getRelease(agentManifests *manifests.AgentManifests, mirrorConfig types.MirrorConfig) rhcos.ReleasePayload {

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/stream-metadata-go/arch"
+	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -269,7 +270,7 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 	infraEnvID := infraEnvAsset.ID
 	logrus.Debug("Generated random infra-env id ", infraEnvID)
 
-	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion, customStreamGetter(agentWorkflow, clusterInfo))
+	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion, clusterInfo.OSImage)
 	if err != nil {
 		return err
 	}
@@ -745,13 +746,13 @@ func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraM
 	return nil
 }
 
-func getOSImagesInfo(ctx context.Context, cpuArch string, openshiftVersion string, streamGetter rhcos.CoreOSBuildFetcher) (*models.OsImage, error) {
+func getOSImagesInfo(ctx context.Context, cpuArch string, openshiftVersion string, st *stream.Stream) (*models.OsImage, error) {
 	osImage := &models.OsImage{
 		CPUArchitecture: &cpuArch,
 	}
 	osImage.OpenshiftVersion = &openshiftVersion
 
-	artifacts, err := rhcos.GetMetalArtifact(ctx, cpuArch, streamGetter)
+	artifacts, err := rhcos.GetMetalArtifactWithStream(ctx, cpuArch, st)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/imagebased/image/baseiso.go
+++ b/pkg/asset/imagebased/image/baseiso.go
@@ -18,16 +18,8 @@ import (
 
 // BaseIso generates the base ISO file for the image.
 type BaseIso struct {
+	st   *stream.Stream
 	File *asset.File
-
-	streamGetter CoreOSBuildFetcher
-}
-
-// CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
-type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
-
-func defaultCoreOSStreamGetter(ctx context.Context) (*stream.Stream, error) {
-	return rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
 }
 
 var _ asset.WritableAsset = (*BaseIso)(nil)
@@ -56,9 +48,6 @@ func (i *BaseIso) Generate(_ context.Context, dependencies asset.Parents) error 
 		logrus.Warn("Found override for OS Image. Please be warned, this is not advised.")
 		baseIsoFileName, err = cache.DownloadImageFile(urlOverride, cache.ImageBasedApplicationName)
 	} else {
-		if i.streamGetter == nil {
-			i.streamGetter = defaultCoreOSStreamGetter
-		}
 		architecture := types.ArchitectureAMD64
 		if ibiConfig.Config.Architecture != "" {
 			architecture = ibiConfig.Config.Architecture
@@ -118,9 +107,13 @@ func (i *BaseIso) metalArtifact(archName string) (stream.PlatformArtifacts, erro
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
-	st, err := i.streamGetter(ctx)
-	if err != nil {
-		return stream.PlatformArtifacts{}, err
+	st := i.st
+	var err error
+	if st == nil {
+		st, err = rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
+		if err != nil {
+			return stream.PlatformArtifacts{}, err
+		}
 	}
 
 	streamArch, err := st.GetArchitecture(archName)

--- a/pkg/asset/imagebased/image/baseiso_test.go
+++ b/pkg/asset/imagebased/image/baseiso_test.go
@@ -72,39 +72,37 @@ func TestBaseIso_Generate(t *testing.T) {
 			}()
 
 			baseIso := &BaseIso{
-				streamGetter: func(ctx context.Context) (*stream.Stream, error) {
-					return &stream.Stream{
-						Architectures: map[string]stream.Arch{
-							"x86_64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
-												},
-											},
-										},
-									},
-								},
-							},
-							"aarch64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s-arm64", svr.URL, ocReleaseImage),
-												},
+				st: &stream.Stream{
+					Architectures: map[string]stream.Arch{
+						"x86_64": {
+							Artifacts: map[string]stream.PlatformArtifacts{
+								"metal": {
+									Release: ocReleaseImage,
+									Formats: map[string]stream.ImageFormat{
+										"iso": {
+											Disk: &stream.Artifact{
+												Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
 											},
 										},
 									},
 								},
 							},
 						},
-					}, nil
+						"aarch64": {
+							Artifacts: map[string]stream.PlatformArtifacts{
+								"metal": {
+									Release: ocReleaseImage,
+									Formats: map[string]stream.ImageFormat{
+										"iso": {
+											Disk: &stream.Artifact{
+												Location: fmt.Sprintf("%s/%s-arm64", svr.URL, ocReleaseImage),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 			parents := asset.Parents{}

--- a/pkg/asset/rhcos/iso.go
+++ b/pkg/asset/rhcos/iso.go
@@ -22,8 +22,8 @@ import (
 
 // BaseIso generates the base ISO file for the image.
 type BaseIso struct {
-	streamGetter CoreOSBuildFetcher
-	ocRelease    ReleasePayload
+	st        *stream.Stream
+	ocRelease ReleasePayload
 }
 
 // CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
@@ -36,13 +36,10 @@ var defaultCoreOSStreamGetter = func(ctx context.Context) (*stream.Stream, error
 
 // NewBaseISOFetcher returns a struct that can be used to fetch a base ISO using
 // the default method.
-func NewBaseISOFetcher(ocRelease ReleasePayload, streamGetter CoreOSBuildFetcher) *BaseIso {
-	if streamGetter == nil {
-		streamGetter = defaultCoreOSStreamGetter
-	}
+func NewBaseISOFetcher(ocRelease ReleasePayload, st *stream.Stream) *BaseIso {
 	return &BaseIso{
-		streamGetter: streamGetter,
-		ocRelease:    ocRelease,
+		st:        st,
+		ocRelease: ocRelease,
 	}
 }
 
@@ -91,38 +88,9 @@ func GetMetalArtifactWithStream(ctx context.Context, archName string, st *stream
 	return metal, nil
 }
 
-// GetMetalArtifact returns the CoreOS artifacts for metal for a given arch
-// from a given stream.
-func GetMetalArtifact(ctx context.Context, archName string, streamGetter CoreOSBuildFetcher) (stream.PlatformArtifacts, error) {
-	if streamGetter == nil {
-		streamGetter = defaultCoreOSStreamGetter
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	// Get the ISO to use from rhcos.json
-	st, err := streamGetter(ctx)
-	if err != nil {
-		return stream.PlatformArtifacts{}, err
-	}
-
-	streamArch, err := st.GetArchitecture(archName)
-	if err != nil {
-		return stream.PlatformArtifacts{}, err
-	}
-
-	metal, ok := streamArch.Artifacts["metal"]
-	if !ok {
-		return stream.PlatformArtifacts{}, fmt.Errorf("coreOs stream data not found for 'metal' artifact")
-	}
-
-	return metal, nil
-}
-
 // Download the ISO using the URL in rhcos.json.
 func (i *BaseIso) downloadIso(ctx context.Context, archName string) (string, error) {
-	metal, err := GetMetalArtifact(ctx, archName, i.streamGetter)
+	metal, err := GetMetalArtifactWithStream(ctx, archName, i.st)
 	if err != nil {
 		return "", err
 	}
@@ -153,7 +121,7 @@ func (i *BaseIso) checkReleasePayloadBaseISOVersion(ctx context.Context, r Relea
 	}
 
 	// Get pinned version from installer
-	metal, err := GetMetalArtifact(ctx, archName, i.streamGetter)
+	metal, err := GetMetalArtifactWithStream(ctx, archName, i.st)
 	if err != nil {
 		logrus.Warnf("unable to determine base ISO version: %s", err.Error())
 		return
@@ -178,7 +146,7 @@ func (i *BaseIso) retrieveBaseIso(ctx context.Context, archName string) (string,
 		if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOExtract); err != nil {
 			return "", err
 		}
-		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName, i.streamGetter)
+		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName, func(ctx context.Context) (*stream.Stream, error) { return i.st, nil } /* TODO: temp change */)
 		if err == nil {
 			if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOVerify); err != nil {
 				return "", err

--- a/pkg/asset/rhcos/iso.go
+++ b/pkg/asset/rhcos/iso.go
@@ -26,14 +26,6 @@ type BaseIso struct {
 	ocRelease ReleasePayload
 }
 
-// CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
-type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
-
-// defaultCoreOSStreamGetter uses the pinned metadata.
-var defaultCoreOSStreamGetter = func(ctx context.Context) (*stream.Stream, error) {
-	return rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
-}
-
 // NewBaseISOFetcher returns a struct that can be used to fetch a base ISO using
 // the default method.
 func NewBaseISOFetcher(ocRelease ReleasePayload, st *stream.Stream) *BaseIso {
@@ -146,7 +138,7 @@ func (i *BaseIso) retrieveBaseIso(ctx context.Context, archName string) (string,
 		if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOExtract); err != nil {
 			return "", err
 		}
-		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName, func(ctx context.Context) (*stream.Stream, error) { return i.st, nil } /* TODO: temp change */)
+		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName, i.st)
 		if err == nil {
 			if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOVerify); err != nil {
 				return "", err

--- a/pkg/asset/rhcos/iso.go
+++ b/pkg/asset/rhcos/iso.go
@@ -64,6 +64,33 @@ func (i *BaseIso) GetBaseISOFilename(ctx context.Context, arch string) (baseIsoF
 	return
 }
 
+// GetMetalArtifactWithStream returns the CoreOS artifacts for metal for a given arch
+// from a given stream. If the stream is not present, the default one will be used.
+func GetMetalArtifactWithStream(ctx context.Context, archName string, st *stream.Stream) (stream.PlatformArtifacts, error) {
+	var err error
+
+	if st == nil {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		st, err = rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
+		if err != nil {
+			return stream.PlatformArtifacts{}, err
+		}
+	}
+
+	streamArch, err := st.GetArchitecture(archName)
+	if err != nil {
+		return stream.PlatformArtifacts{}, err
+	}
+
+	metal, ok := streamArch.Artifacts["metal"]
+	if !ok {
+		return stream.PlatformArtifacts{}, fmt.Errorf("coreOs stream data not found for 'metal' artifact")
+	}
+
+	return metal, nil
+}
+
 // GetMetalArtifact returns the CoreOS artifacts for metal for a given arch
 // from a given stream.
 func GetMetalArtifact(ctx context.Context, archName string, streamGetter CoreOSBuildFetcher) (stream.PlatformArtifacts, error) {

--- a/pkg/asset/rhcos/iso_test.go
+++ b/pkg/asset/rhcos/iso_test.go
@@ -77,25 +77,23 @@ func TestBaseIso(t *testing.T) {
 					baseIsoFileName: ocBaseIsoFilename,
 					baseIsoError:    tc.getIsoError,
 				},
-				func(ctx context.Context) (*stream.Stream, error) {
-					return &stream.Stream{
-						Architectures: map[string]stream.Arch{
-							"x86_64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
-												},
+				&stream.Stream{
+					Architectures: map[string]stream.Arch{
+						"x86_64": {
+							Artifacts: map[string]stream.PlatformArtifacts{
+								"metal": {
+									Release: ocReleaseImage,
+									Formats: map[string]stream.ImageFormat{
+										"iso": {
+											Disk: &stream.Artifact{
+												Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
 											},
 										},
 									},
 								},
 							},
 						},
-					}, nil
+					},
 				})
 			filename, err := fetcher.GetBaseISOFilename(context.Background(), "")
 

--- a/pkg/asset/rhcos/iso_test.go
+++ b/pkg/asset/rhcos/iso_test.go
@@ -113,7 +113,7 @@ type mockRelease struct {
 	baseIsoError    error
 }
 
-func (m *mockRelease) GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error) {
+func (m *mockRelease) GetBaseIso(architecture string, st *stream.Stream) (string, error) {
 	if m.baseIsoError != nil {
 		return "", m.baseIsoError
 	}

--- a/pkg/asset/rhcos/releaseextract.go
+++ b/pkg/asset/rhcos/releaseextract.go
@@ -22,6 +22,7 @@ import (
 	"github.com/thedevsaddam/retry"
 
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/rhcos/cache"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -45,7 +46,7 @@ type ExtractConfig struct {
 
 // ReleasePayload is the interface to use the oc command to the get image info.
 type ReleasePayload interface {
-	GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error)
+	GetBaseIso(architecture string, st *stream.Stream) (string, error)
 	GetBaseIsoVersion(architecture string) (string, error)
 	ExtractFile(image string, filename string, architecture string) ([]string, error)
 }
@@ -93,7 +94,7 @@ func (r *releasePayload) ExtractFile(image string, filename string, architecture
 }
 
 // Get the CoreOS ISO from the releaseImage.
-func (r *releasePayload) GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error) {
+func (r *releasePayload) GetBaseIso(architecture string, st *stream.Stream) (string, error) {
 	// Get the machine-os-images pullspec from the release and use that to get the CoreOS ISO
 	image, err := r.getImageFromRelease(machineOsImageName, architecture)
 	if err != nil {
@@ -113,7 +114,7 @@ func (r *releasePayload) GetBaseIso(architecture string, streamGetter CoreOSBuil
 	}
 	if cachedFile != "" {
 		logrus.Info("Verifying cached file")
-		valid, err := r.verifyCacheFile(image, cachedFile, architecture, streamGetter)
+		valid, err := r.verifyCacheFile(image, cachedFile, architecture, st)
 		if err != nil {
 			return "", err
 		}
@@ -265,12 +266,15 @@ func (r *releasePayload) extractFileFromImage(image, file, cacheDir string, arch
 }
 
 // Get hash from rhcos.json.
-func (r *releasePayload) getHashFromInstaller(architecture string, streamGetter CoreOSBuildFetcher) (bool, string) {
+func (r *releasePayload) getHashFromInstaller(architecture string, st *stream.Stream) (bool, string) {
 	// Get hash from metadata in the installer
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
-	st, err := streamGetter(ctx)
+	var err error
+	if st == nil {
+		st, err = rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
+	}
 	if err != nil {
 		return false, ""
 	}
@@ -298,7 +302,7 @@ func matchingHash(imageSha []byte, sha string) bool {
 }
 
 // Check if there is a different base ISO in the release payload.
-func (r *releasePayload) verifyCacheFile(image, file, architecture string, streamGetter CoreOSBuildFetcher) (bool, error) {
+func (r *releasePayload) verifyCacheFile(image, file, architecture string, st *stream.Stream) (bool, error) {
 	// Get hash of cached file
 	f, err := os.Open(file)
 	if err != nil {
@@ -313,7 +317,7 @@ func (r *releasePayload) verifyCacheFile(image, file, architecture string, strea
 	fileSha := h.Sum(nil)
 
 	// Check if the hash of cached file matches hash in rhcos.json
-	found, rhcosSha := r.getHashFromInstaller(architecture, streamGetter)
+	found, rhcosSha := r.getHashFromInstaller(architecture, st)
 	if found && matchingHash(fileSha, rhcosSha) {
 		logrus.Debug("Found matching hash in installer metadata")
 		return true, nil


### PR DESCRIPTION
This patch is meant to be a preliminary simplification to facilitate future `osImageStream` (rhel-9/rhel-10) adoption (see https://github.com/openshift/installer/pull/10481/).

Previously a `streamGetter` func was introduced mainly to support a distinction between the ABI `Install` and `AddNodes` workflow: in the latter, the stream data are directly fetched from the target cluster - and not from the embedded installer metadata as usual. Anyhow this design didn't make it easier to introduce a new field (to select the source stream), and was used only for above case. 

**Changes**
- Removed the `CoreOSBuildFetcher `function type and replaced it with a direct `*stream.Stream` pointer throughout the base ISO fetching and CoreOS metadata resolution paths                              
- When the stream is `nil` (`Install` workflow, baremetal bootstrap, unconfigured ignition), the code falls back to fetching from embedded metadata; when non-nil (`AddNodes` workflow), the provided stream from the target cluster is used directly                                                                                                                                                      
- Rename `GetMetalArtifact` to `GetMetalArtifactWithStream` to make the nil-handling behavior explicit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for artifact management and simplified dependency handling across image generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->