### PR TITLE
no-jira: tests: verify AWS instance type minimum cpu and mem requirement tests

### DIFF
--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -107,6 +107,22 @@ func TestValidate(t *testing.T) {
 			expectErr:     `^\Q[compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 2 vCPUs, compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 8192 MiB Memory]\E$`,
 		},
 		{
+			name:          "invalid control plane and compute instance types",
+			installConfig: icBuild.build(icBuild.withInstanceType("m5.xlarge", "t2.small", "t2.small")),
+			availRegions:  validAvailRegions(),
+			availZones:    validAvailZones(),
+			instanceTypes: validInstanceTypes(),
+			expectErr:     `^\Q[controlPlane.platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 4 vCPUs, controlPlane.platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 16384 MiB Memory, compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 2 vCPUs, compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 8192 MiB Memory]\E$`,
+		},
+		{
+			name:          "invalid default machine platform instance type",
+			installConfig: icBuild.build(icBuild.withInstanceType("t2.small", "", "")),
+			availRegions:  validAvailRegions(),
+			availZones:    validAvailZones(),
+			instanceTypes: validInstanceTypes(),
+			expectErr:     `^\Q[platform.aws.defaultMachinePlatform.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 4 vCPUs, platform.aws.defaultMachinePlatform.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 16384 MiB Memory, controlPlane.platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 4 vCPUs, controlPlane.platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 16384 MiB Memory, compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 2 vCPUs, compute[0].platform.aws.type: Invalid value: "t2.small": instance type does not meet minimum resource requirements of 8192 MiB Memory]\E$`,
+		},
+		{
 			name:          "invalid undefined compute instance type",
 			installConfig: icBuild.build(icBuild.withInstanceType("m5.xlarge", "m5.xlarge", "m5.dummy")),
 			availRegions:  validAvailRegions(),


### PR DESCRIPTION
OCP-36911 - [ipi-on-aws] instance types in install config should meet minimum cpu and mem requirement

Add test cases to verify validation when both control plane and compute instance types are undersized, and when the defaultMachinePlatform instance type is undersized with pool-specific types unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation test coverage for AWS infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->