### PR TITLE
MCO-2200: refactored node-joiner to use embedded rhcos data

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -106,7 +106,7 @@ func (a *AgentImage) Generate(ctx context.Context, dependencies asset.Parents) e
 			logrus.Debugf("Using custom rootfs URL: %s", a.rootFSURL)
 		} else {
 			// Default to the URL from the RHCOS streams file
-			defaultRootFSURL, err := baseIso.getRootFSURL(ctx, a.cpuArch, agentWorkflow, clusterInfo)
+			defaultRootFSURL, err := baseIso.getRootFSURL(ctx, a.cpuArch)
 			if err != nil {
 				return err
 			}

--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -37,9 +36,8 @@ func (i *BaseIso) Name() string {
 }
 
 // Fetch RootFS URL using the rhcos.json.
-func (i *BaseIso) getRootFSURL(ctx context.Context, archName string, agentWorkflow *workflow.AgentWorkflow, clusterInfo *joiner.ClusterInfo) (string, error) {
-	metal, err := rhcos.GetMetalArtifact(
-		ctx, archName, customStreamGetter(agentWorkflow, clusterInfo))
+func (i *BaseIso) getRootFSURL(ctx context.Context, archName string) (string, error) {
+	metal, err := rhcos.GetMetalArtifact(ctx, archName)
 	if err != nil {
 		return "", err
 	}
@@ -72,8 +70,7 @@ func (i *BaseIso) Generate(ctx context.Context, dependencies asset.Parents) erro
 	dependencies.Get(agentManifests, registriesConf, agentWorkflow, clusterInfo)
 
 	baseIsoFileName, err := rhcos.NewBaseISOFetcher(
-		i.getRelease(agentManifests, registriesConf.MirrorConfig),
-		customStreamGetter(agentWorkflow, clusterInfo)).GetBaseISOFilename(ctx, agentManifests.InfraEnv.Spec.CpuArchitecture)
+		i.getRelease(agentManifests, registriesConf.MirrorConfig)).GetBaseISOFilename(ctx, agentManifests.InfraEnv.Spec.CpuArchitecture)
 
 	if err == nil {
 		logrus.Debugf("Using base ISO image %s", baseIsoFileName)
@@ -83,15 +80,6 @@ func (i *BaseIso) Generate(ctx context.Context, dependencies asset.Parents) erro
 	logrus.Debugf("Failed to download base ISO: %s", err)
 
 	return errors.Wrap(err, "failed to get base ISO image")
-}
-
-func customStreamGetter(agentWorkflow *workflow.AgentWorkflow, clusterInfo *joiner.ClusterInfo) rhcos.CoreOSBuildFetcher {
-	if agentWorkflow.Workflow == workflow.AgentWorkflowTypeAddNodes {
-		return func(ctx context.Context) (*stream.Stream, error) {
-			return clusterInfo.OSImage, nil
-		}
-	}
-	return nil
 }
 
 func (i *BaseIso) getRelease(agentManifests *manifests.AgentManifests, mirrorConfig types.MirrorConfig) rhcos.ReleasePayload {

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -269,7 +269,7 @@ func (a *Ignition) Generate(ctx context.Context, dependencies asset.Parents) err
 	infraEnvID := infraEnvAsset.ID
 	logrus.Debug("Generated random infra-env id ", infraEnvID)
 
-	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion, customStreamGetter(agentWorkflow, clusterInfo))
+	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion)
 	if err != nil {
 		return err
 	}
@@ -745,13 +745,13 @@ func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraM
 	return nil
 }
 
-func getOSImagesInfo(ctx context.Context, cpuArch string, openshiftVersion string, streamGetter rhcos.CoreOSBuildFetcher) (*models.OsImage, error) {
+func getOSImagesInfo(ctx context.Context, cpuArch string, openshiftVersion string) (*models.OsImage, error) {
 	osImage := &models.OsImage{
 		CPUArchitecture: &cpuArch,
 	}
 	osImage.OpenshiftVersion = &openshiftVersion
 
-	artifacts, err := rhcos.GetMetalArtifact(ctx, cpuArch, streamGetter)
+	artifacts, err := rhcos.GetMetalArtifact(ctx, cpuArch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/agent/image/unconfigured_ignition.go
+++ b/pkg/asset/agent/image/unconfigured_ignition.go
@@ -155,7 +155,7 @@ func (a *UnconfiguredIgnition) Generate(ctx context.Context, dependencies asset.
 	if err != nil {
 		return err
 	}
-	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion, nil)
+	osImage, err := getOSImagesInfo(ctx, archName, openshiftVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/coreos/stream-metadata-go/arch"
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -70,8 +68,6 @@ type ClusterInfo struct {
 	DeprecatedImageContentSources []types.ImageContentSource
 	PlatformType                  hiveext.PlatformType
 	SSHKey                        string
-	OSImage                       *stream.Stream
-	OSImageLocation               string
 	IgnitionEndpointWorker        *models.IgnitionEndpoint
 	FIPS                          bool
 	Nodes                         *corev1.NodeList
@@ -121,7 +117,6 @@ func (ci *ClusterInfo) Generate(ctx context.Context, dependencies asset.Parents)
 		ci.retrieveArchitecture,
 		ci.retrieveImageDigestMirrorSets,
 		ci.retrieveImageContentSourcePolicies,
-		ci.retrieveOsImage,
 		ci.retrieveIgnitionEndpointWorker,
 		ci.retrievePlatformType,
 		ci.retrieveAPIDNSName,
@@ -475,43 +470,6 @@ func (ci *ClusterInfo) retrieveImageContentSourcePolicies() error {
 	return nil
 }
 
-func (ci *ClusterInfo) retrieveOsImage() error {
-	clusterConfig, err := ci.Client.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.Background(), "coreos-bootimages", metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	data, ok := clusterConfig.Data["stream"]
-	if !ok {
-		return fmt.Errorf("cannot find stream data")
-	}
-
-	var st stream.Stream
-	if err := json.Unmarshal([]byte(data), &st); err != nil {
-		return fmt.Errorf("failed to parse CoreOS stream metadata: %w", err)
-	}
-	ci.OSImage = &st
-
-	clusterArch := arch.RpmArch(ci.Architecture)
-	streamArch, err := st.GetArchitecture(clusterArch)
-	if err != nil {
-		return err
-	}
-	metal, ok := streamArch.Artifacts["metal"]
-	if !ok {
-		return fmt.Errorf("stream data not found for 'metal' artifact")
-	}
-	format, ok := metal.Formats["iso"]
-	if !ok {
-		return fmt.Errorf("no ISO found to download for %s", clusterArch)
-	}
-	ci.OSImageLocation = format.Disk.Location
-
-	return nil
-}
-
 // This method retrieves, if present, the secured ignition endpoint - along with its ca certificate.
 // These information will be used to configure subsequently the imported Assisted Service cluster,
 // so that the secure port (22623) could be used by the nodes to fetch the worker ignition.
@@ -679,7 +637,6 @@ func (ci *ClusterInfo) reportResult(ctx context.Context) error {
 	results := map[string]string{
 		"Version":      ci.Version,
 		"ReleaseImage": ci.ReleaseImage,
-		"OSImage":      ci.OSImageLocation,
 		"PlatformType": string(ci.PlatformType),
 		"Architecture": ci.Architecture,
 	}

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -2,13 +2,11 @@ package joiner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	ignutil "github.com/coreos/ignition/v2/config/util"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +83,6 @@ func TestClusterInfo_Generate(t *testing.T) {
 			overrideExpectedClusterInfo: func(clusterInfo ClusterInfo) ClusterInfo {
 				t.Helper()
 				clusterInfo.Architecture = "arm64"
-				clusterInfo.OSImageLocation = "http://my-coreosimage-url/416.94.202402130130-1"
 				return clusterInfo
 			},
 		},
@@ -358,51 +355,6 @@ passwd:
 	}
 }
 
-func buildStreamData() *stream.Stream {
-	return &stream.Stream{
-		Architectures: map[string]stream.Arch{
-			"x86_64": {
-				Artifacts: map[string]stream.PlatformArtifacts{
-					"metal": {
-						Release: "416.94.202402130130-0",
-						Formats: map[string]stream.ImageFormat{
-							"iso": {
-								Disk: &stream.Artifact{
-									Location: "http://my-coreosimage-url/416.94.202402130130-0",
-								},
-							},
-						},
-					},
-				},
-			},
-			"aarch64": {
-				Artifacts: map[string]stream.PlatformArtifacts{
-					"metal": {
-						Release: "416.94.202402130130-0",
-						Formats: map[string]stream.ImageFormat{
-							"iso": {
-								Disk: &stream.Artifact{
-									Location: "http://my-coreosimage-url/416.94.202402130130-1",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func makeCoreOsBootImages(t *testing.T, st *stream.Stream) string {
-	t.Helper()
-	data, err := json.Marshal(st)
-	if err != nil {
-		t.Error(err)
-	}
-
-	return string(data)
-}
-
 func makeInstallConfig(t *testing.T) string {
 	t.Helper()
 	ic := &types.InstallConfig{
@@ -470,15 +422,6 @@ func defaultObjects() func(t *testing.T) ([]runtime.Object, []runtime.Object, []
 				},
 				Data: map[string]string{
 					"install-config": makeInstallConfig(t),
-				},
-			},
-			&corev1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "coreos-bootimages",
-					Namespace: "openshift-machine-config-operator",
-				},
-				Data: map[string]string{
-					"stream": makeCoreOsBootImages(t, buildStreamData()),
 				},
 			},
 			&corev1.Secret{
@@ -591,9 +534,7 @@ func defaultExpectedClusterInfo() ClusterInfo {
 				},
 			},
 		},
-		PlatformType:    v1beta1.BareMetalPlatformType,
-		OSImage:         buildStreamData(),
-		OSImageLocation: "http://my-coreosimage-url/416.94.202402130130-0",
+		PlatformType: v1beta1.BareMetalPlatformType,
 		IgnitionEndpointWorker: &models.IgnitionEndpoint{
 			URL:           ptr.To("https://192.168.111.5:22623/config/worker"),
 			CaCertificate: ptr.To("LS0tL_FakeCertificate_LS0tCg=="),
@@ -618,8 +559,6 @@ func verifyClusterInfo(t *testing.T, expectedClusterInfo, clusterInfo ClusterInf
 	assert.Equal(t, expectedClusterInfo.DeprecatedImageContentSources, clusterInfo.DeprecatedImageContentSources)
 	assert.Equal(t, expectedClusterInfo.PlatformType, clusterInfo.PlatformType)
 	assert.Equal(t, expectedClusterInfo.SSHKey, clusterInfo.SSHKey)
-	assert.Equal(t, expectedClusterInfo.OSImageLocation, clusterInfo.OSImageLocation)
-	assert.Equal(t, expectedClusterInfo.OSImage, clusterInfo.OSImage)
 	assert.Equal(t, expectedClusterInfo.IgnitionEndpointWorker, clusterInfo.IgnitionEndpointWorker)
 	assert.Equal(t, expectedClusterInfo.FIPS, clusterInfo.FIPS)
 	assert.Equal(t, expectedClusterInfo.ChronyConf, clusterInfo.ChronyConf)

--- a/pkg/asset/imagebased/image/baseiso.go
+++ b/pkg/asset/imagebased/image/baseiso.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/coreos/stream-metadata-go/arch"
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/rhcos"
+	assetrhcos "github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/rhcos/cache"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -19,15 +17,6 @@ import (
 // BaseIso generates the base ISO file for the image.
 type BaseIso struct {
 	File *asset.File
-
-	streamGetter CoreOSBuildFetcher
-}
-
-// CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
-type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
-
-func defaultCoreOSStreamGetter(ctx context.Context) (*stream.Stream, error) {
-	return rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
 }
 
 var _ asset.WritableAsset = (*BaseIso)(nil)
@@ -45,7 +34,7 @@ func (i *BaseIso) Dependencies() []asset.Asset {
 }
 
 // Generate generates the base ISO.
-func (i *BaseIso) Generate(_ context.Context, dependencies asset.Parents) error {
+func (i *BaseIso) Generate(ctx context.Context, dependencies asset.Parents) error {
 	ibiConfig := &ImageBasedInstallationConfig{}
 	dependencies.Get(ibiConfig)
 
@@ -56,15 +45,12 @@ func (i *BaseIso) Generate(_ context.Context, dependencies asset.Parents) error 
 		logrus.Warn("Found override for OS Image. Please be warned, this is not advised.")
 		baseIsoFileName, err = cache.DownloadImageFile(urlOverride, cache.ImageBasedApplicationName)
 	} else {
-		if i.streamGetter == nil {
-			i.streamGetter = defaultCoreOSStreamGetter
-		}
 		architecture := types.ArchitectureAMD64
 		if ibiConfig.Config.Architecture != "" {
 			architecture = ibiConfig.Config.Architecture
 		}
 		logrus.Debugf("Using %s as the architecture for the iso", architecture)
-		baseIsoFileName, err = i.downloadBaseIso(arch.RpmArch(architecture))
+		baseIsoFileName, err = i.downloadBaseIso(ctx, arch.RpmArch(architecture))
 	}
 
 	if err == nil {
@@ -93,15 +79,15 @@ func (i *BaseIso) Load(f asset.FileFetcher) (bool, error) {
 }
 
 // Download the RHCOS base ISO via rhcos.json.
-func (i *BaseIso) downloadBaseIso(archName string) (string, error) {
-	metal, err := i.metalArtifact(archName)
+func (i *BaseIso) downloadBaseIso(ctx context.Context, archName string) (string, error) {
+	metal, err := assetrhcos.GetMetalArtifact(ctx, archName)
 	if err != nil {
 		return "", err
 	}
 
 	format, ok := metal.Formats["iso"]
 	if !ok {
-		return "", fmt.Errorf("no ISO found to download for %s: %w", archName, err)
+		return "", fmt.Errorf("no ISO found to download for %s", archName)
 	}
 
 	url := format.Disk.Location
@@ -112,26 +98,4 @@ func (i *BaseIso) downloadBaseIso(archName string) (string, error) {
 	}
 
 	return cachedImage, nil
-}
-
-func (i *BaseIso) metalArtifact(archName string) (stream.PlatformArtifacts, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
-	defer cancel()
-
-	st, err := i.streamGetter(ctx)
-	if err != nil {
-		return stream.PlatformArtifacts{}, err
-	}
-
-	streamArch, err := st.GetArchitecture(archName)
-	if err != nil {
-		return stream.PlatformArtifacts{}, err
-	}
-
-	metal, ok := streamArch.Artifacts["metal"]
-	if !ok {
-		return stream.PlatformArtifacts{}, fmt.Errorf("coreOs stream data not found for 'metal' artifact")
-	}
-
-	return metal, nil
 }

--- a/pkg/asset/imagebased/image/baseiso_test.go
+++ b/pkg/asset/imagebased/image/baseiso_test.go
@@ -9,35 +9,21 @@ import (
 	"os"
 	"testing"
 
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/types"
 )
 
 func TestBaseIso_Generate(t *testing.T) {
-	ocReleaseImage := "417.94.202407011030-0"
-
 	cases := []struct {
 		name                       string
 		envVarOsImageOverrideValue string
 		expectedBaseIsoFilename    string
-		architecture               string
 	}{
 		{
 			name:                       "os image override",
 			envVarOsImageOverrideValue: "openshift-4.18",
 			expectedBaseIsoFilename:    "openshift-4.18",
-		},
-		{
-			name:                    "default",
-			expectedBaseIsoFilename: ocReleaseImage,
-		},
-		{
-			name:                    "arm64 architecture",
-			expectedBaseIsoFilename: fmt.Sprintf("%s-arm64", ocReleaseImage),
-			architecture:            types.ArchitectureARM64,
 		},
 	}
 	for _, tc := range cases {
@@ -71,47 +57,10 @@ func TestBaseIso_Generate(t *testing.T) {
 				assert.NoError(t, err)
 			}()
 
-			baseIso := &BaseIso{
-				streamGetter: func(ctx context.Context) (*stream.Stream, error) {
-					return &stream.Stream{
-						Architectures: map[string]stream.Arch{
-							"x86_64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
-												},
-											},
-										},
-									},
-								},
-							},
-							"aarch64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s-arm64", svr.URL, ocReleaseImage),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}, nil
-				},
-			}
+			baseIso := &BaseIso{}
 			parents := asset.Parents{}
 			parents.Add(&ImageBasedInstallationConfig{
-				Config: ibiConfig().
-					architecture(tc.architecture).
-					build(),
+				Config: ibiConfig().build(),
 			})
 			err = baseIso.Generate(context.TODO(), parents)
 

--- a/pkg/asset/rhcos/iso.go
+++ b/pkg/asset/rhcos/iso.go
@@ -22,27 +22,14 @@ import (
 
 // BaseIso generates the base ISO file for the image.
 type BaseIso struct {
-	streamGetter CoreOSBuildFetcher
-	ocRelease    ReleasePayload
-}
-
-// CoreOSBuildFetcher will be to used to switch the source of the coreos metadata.
-type CoreOSBuildFetcher func(ctx context.Context) (*stream.Stream, error)
-
-// defaultCoreOSStreamGetter uses the pinned metadata.
-var defaultCoreOSStreamGetter = func(ctx context.Context) (*stream.Stream, error) {
-	return rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
+	ocRelease ReleasePayload
 }
 
 // NewBaseISOFetcher returns a struct that can be used to fetch a base ISO using
 // the default method.
-func NewBaseISOFetcher(ocRelease ReleasePayload, streamGetter CoreOSBuildFetcher) *BaseIso {
-	if streamGetter == nil {
-		streamGetter = defaultCoreOSStreamGetter
-	}
+func NewBaseISOFetcher(ocRelease ReleasePayload) *BaseIso {
 	return &BaseIso{
-		streamGetter: streamGetter,
-		ocRelease:    ocRelease,
+		ocRelease: ocRelease,
 	}
 }
 
@@ -64,18 +51,13 @@ func (i *BaseIso) GetBaseISOFilename(ctx context.Context, arch string) (baseIsoF
 	return
 }
 
-// GetMetalArtifact returns the CoreOS artifacts for metal for a given arch
-// from a given stream.
-func GetMetalArtifact(ctx context.Context, archName string, streamGetter CoreOSBuildFetcher) (stream.PlatformArtifacts, error) {
-	if streamGetter == nil {
-		streamGetter = defaultCoreOSStreamGetter
-	}
-
+// GetMetalArtifact returns the CoreOS metal artifacts for a given arch
+// using the embedded stream metadata.
+func GetMetalArtifact(ctx context.Context, archName string) (stream.PlatformArtifacts, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// Get the ISO to use from rhcos.json
-	st, err := streamGetter(ctx)
+	st, err := rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
 	if err != nil {
 		return stream.PlatformArtifacts{}, err
 	}
@@ -95,7 +77,7 @@ func GetMetalArtifact(ctx context.Context, archName string, streamGetter CoreOSB
 
 // Download the ISO using the URL in rhcos.json.
 func (i *BaseIso) downloadIso(ctx context.Context, archName string) (string, error) {
-	metal, err := GetMetalArtifact(ctx, archName, i.streamGetter)
+	metal, err := GetMetalArtifact(ctx, archName)
 	if err != nil {
 		return "", err
 	}
@@ -126,7 +108,7 @@ func (i *BaseIso) checkReleasePayloadBaseISOVersion(ctx context.Context, r Relea
 	}
 
 	// Get pinned version from installer
-	metal, err := GetMetalArtifact(ctx, archName, i.streamGetter)
+	metal, err := GetMetalArtifact(ctx, archName)
 	if err != nil {
 		logrus.Warnf("unable to determine base ISO version: %s", err.Error())
 		return
@@ -151,7 +133,7 @@ func (i *BaseIso) retrieveBaseIso(ctx context.Context, archName string) (string,
 		if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOExtract); err != nil {
 			return "", err
 		}
-		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName, i.streamGetter)
+		baseIsoFileName, err := i.ocRelease.GetBaseIso(archName)
 		if err == nil {
 			if err := workflowreport.GetReport(ctx).SubStage(workflow.StageFetchBaseISOVerify); err != nil {
 				return "", err

--- a/pkg/asset/rhcos/iso_test.go
+++ b/pkg/asset/rhcos/iso_test.go
@@ -7,10 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"testing"
 
-	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,11 +31,6 @@ func TestBaseIso(t *testing.T) {
 		{
 			name:                    "default",
 			expectedBaseIsoFilename: ocBaseIsoFilename,
-		},
-		{
-			name:                    "direct download if oc is not available",
-			getIsoError:             &exec.Error{},
-			expectedBaseIsoFilename: ocReleaseImage,
 		},
 	}
 	for _, tc := range cases {
@@ -76,26 +69,6 @@ func TestBaseIso(t *testing.T) {
 					isoBaseVersion:  ocReleaseImage,
 					baseIsoFileName: ocBaseIsoFilename,
 					baseIsoError:    tc.getIsoError,
-				},
-				func(ctx context.Context) (*stream.Stream, error) {
-					return &stream.Stream{
-						Architectures: map[string]stream.Arch{
-							"x86_64": {
-								Artifacts: map[string]stream.PlatformArtifacts{
-									"metal": {
-										Release: ocReleaseImage,
-										Formats: map[string]stream.ImageFormat{
-											"iso": {
-												Disk: &stream.Artifact{
-													Location: fmt.Sprintf("%s/%s", svr.URL, ocReleaseImage),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}, nil
 				})
 			filename, err := fetcher.GetBaseISOFilename(context.Background(), "")
 
@@ -115,7 +88,7 @@ type mockRelease struct {
 	baseIsoError    error
 }
 
-func (m *mockRelease) GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error) {
+func (m *mockRelease) GetBaseIso(architecture string) (string, error) {
 	if m.baseIsoError != nil {
 		return "", m.baseIsoError
 	}

--- a/pkg/asset/rhcos/releaseextract.go
+++ b/pkg/asset/rhcos/releaseextract.go
@@ -22,6 +22,7 @@ import (
 	"github.com/thedevsaddam/retry"
 
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/rhcos/cache"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -45,7 +46,7 @@ type ExtractConfig struct {
 
 // ReleasePayload is the interface to use the oc command to the get image info.
 type ReleasePayload interface {
-	GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error)
+	GetBaseIso(architecture string) (string, error)
 	GetBaseIsoVersion(architecture string) (string, error)
 	ExtractFile(image string, filename string, architecture string) ([]string, error)
 }
@@ -93,7 +94,7 @@ func (r *releasePayload) ExtractFile(image string, filename string, architecture
 }
 
 // Get the CoreOS ISO from the releaseImage.
-func (r *releasePayload) GetBaseIso(architecture string, streamGetter CoreOSBuildFetcher) (string, error) {
+func (r *releasePayload) GetBaseIso(architecture string) (string, error) {
 	// Get the machine-os-images pullspec from the release and use that to get the CoreOS ISO
 	image, err := r.getImageFromRelease(machineOsImageName, architecture)
 	if err != nil {
@@ -113,7 +114,7 @@ func (r *releasePayload) GetBaseIso(architecture string, streamGetter CoreOSBuil
 	}
 	if cachedFile != "" {
 		logrus.Info("Verifying cached file")
-		valid, err := r.verifyCacheFile(image, cachedFile, architecture, streamGetter)
+		valid, err := r.verifyCacheFile(image, cachedFile, architecture)
 		if err != nil {
 			return "", err
 		}
@@ -265,12 +266,11 @@ func (r *releasePayload) extractFileFromImage(image, file, cacheDir string, arch
 }
 
 // Get hash from rhcos.json.
-func (r *releasePayload) getHashFromInstaller(architecture string, streamGetter CoreOSBuildFetcher) (bool, string) {
-	// Get hash from metadata in the installer
+func (r *releasePayload) getHashFromInstaller(architecture string) (bool, string) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
-	st, err := streamGetter(ctx)
+	st, err := rhcos.FetchCoreOSBuild(ctx, rhcos.DefaultOSImageStream)
 	if err != nil {
 		return false, ""
 	}
@@ -298,7 +298,7 @@ func matchingHash(imageSha []byte, sha string) bool {
 }
 
 // Check if there is a different base ISO in the release payload.
-func (r *releasePayload) verifyCacheFile(image, file, architecture string, streamGetter CoreOSBuildFetcher) (bool, error) {
+func (r *releasePayload) verifyCacheFile(image, file, architecture string) (bool, error) {
 	// Get hash of cached file
 	f, err := os.Open(file)
 	if err != nil {
@@ -313,7 +313,7 @@ func (r *releasePayload) verifyCacheFile(image, file, architecture string, strea
 	fileSha := h.Sum(nil)
 
 	// Check if the hash of cached file matches hash in rhcos.json
-	found, rhcosSha := r.getHashFromInstaller(architecture, streamGetter)
+	found, rhcosSha := r.getHashFromInstaller(architecture)
 	if found && matchingHash(fileSha, rhcosSha) {
 		logrus.Debug("Found matching hash in installer metadata")
 		return true, nil

--- a/pkg/infrastructure/baremetal/bootstrap.go
+++ b/pkg/infrastructure/baremetal/bootstrap.go
@@ -177,8 +177,7 @@ func getLiveISO(config baremetalConfig, arch string) (string, error) {
 			config.ReleaseImagePullSpec,
 			config.PullSecret,
 			config.MirrorConfig,
-		),
-		nil)
+		))
 	return fetcher.GetBaseISOFilename(context.Background(), arch)
 }
 

--- a/pkg/nodejoiner/.claude/skills/nodejoiner-command/SKILL.md
+++ b/pkg/nodejoiner/.claude/skills/nodejoiner-command/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: nodejoiner-command
+description: Describes the acceptance criteria, BDD tests and specific implementation details when developing a new feature (or fixing an issue) related to the node-joiner command.
+user-invocable: false
+---
+
+# Implementation details
+The nodejoiner is a internal command (not meant to be used directly by the user) wrapped by the `oc adm nodeimage` command, to allow the user adding a new node to an existing target cluster by building an ISO. The command reuses most of the code of the Agent-based Installer, but since it follows a slightly different workflow
+some differences have been implemented in the code (through the usage of the `workflow.AgentWorkflowTypeAddNodes` enum value).
+
+The most important asset is the `joiner.ClusterInfo`, as it contains the logic to inspect the current target cluster and to extract the input configuration required by
+the ABI assets to generate the add node ISO. So usually the target cluster is considered the authoritative source of truth for the configuration.
+
+# Testing
+
+- To run just the unit tests, you must use `hack/go-test.sh`
+- To run the specific node-joiner integration test, you must use only `hack/go-integration-test-nodejoiner.sh`
+- **Integration test prerequisites**:
+  - `oc` must be installed and in `$PATH`. Install with:
+    `curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz && mkdir -p ~/.local/bin && tar -xzf /tmp/oc.tar.gz -C ~/.local/bin oc kubectl && rm /tmp/oc.tar.gz`
+  - Override `GOPATH` to a writable location (the default `/tmp/claude/go` is not writable in containers):
+    `PATH=$HOME/.local/bin:$PATH GOPATH=$HOME/go hack/go-integration-test-nodejoiner.sh`
+
+# Useful references
+- https://github.com/openshift/enhancements/blob/master/enhancements/oc/day2-add-nodes.md. This the official `oc` enhancement proposal to 
+  add a new `oc adm nodeimage` command for letting the user easily add a new node by building an ISO. The `oc` command is a thin wrapper of the `node-joiner` command.
+- https://github.com/openshift/oc/tree/main/pkg/cli/admin/nodeimage. The code repository for the `oc adm nodeimage` commands.
+
+# Supporting files
+- `acceptance/coreos-bootimages-data.md`: how to fetch the coreos bootimages data required for building the ISO.

--- a/pkg/nodejoiner/.claude/skills/nodejoiner-command/acceptance/coreos-bootimages-data.md
+++ b/pkg/nodejoiner/.claude/skills/nodejoiner-command/acceptance/coreos-bootimages-data.md
@@ -1,0 +1,7 @@
+# CoreOS bootimages data
+
+## Scenario: use embedded metadata
+
+Given an existing target cluster,
+When building a new ISO using the node-joiner command
+Then the node-joiner command must use the embedded stream data to fetch the base RHCOS ISO (when required)


### PR DESCRIPTION
(Followup from the discussions in https://github.com/openshift/installer/pull/10534)

This patch simplifies the node-joiner code, so that now it retrieves the bootimages data from the embedded streams (instead of fetching them from the `coreos-bootimages` ConfigMap in the target cluster).
As previously discussed, the advantages of this new approach are:
*  Simpler code (no difference between the various ABI workflows for retrieving the data)
* Will make it simpler adopt the `osImageStream` adoption for selecting the current steam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated OS/ISO artifact retrieval into a single metal-artifact lookup and simplified base-ISO fetching across image generation paths.
  * Removed per-cluster OS image inspection and related fields from the join workflow.

* **Tests**
  * Simplified unit tests by removing reliance on embedded stream metadata and related fixtures.

* **Documentation**
  * Added node-joiner command guidance and an acceptance scenario for embedded RHCOS metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->