### PR TITLE
no-jira: images: bump UPI image dependencies to 4.22

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,8 +3,8 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 # We copy from the -artifacts images because they are statically linked
-FROM registry.ci.openshift.org/ocp/4.17:installer-kube-apiserver-artifacts AS kas-artifacts
-FROM registry.ci.openshift.org/ocp/4.17:installer-etcd-artifacts AS etcd-artifacts
+FROM registry.ci.openshift.org/ocp/4.22:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.22:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -19,13 +19,13 @@ RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
 	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.17:cli as cli
+FROM registry.ci.openshift.org/ocp/4.22:cli as cli
 FROM quay.io/ocp-splat/govc:v0.30.7 as govc
 FROM quay.io/ocp-splat/pwsh:latest as pwsh
 FROM quay.io/multi-arch/yq:3.3.0 as yq3
 FROM quay.io/multi-arch/yq:4.30.5 as yq4
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -61,7 +61,6 @@ RUN yum update -y && \
       openssl \      
       python3-pip \
       python3-pyyaml \
-      bind-utils \
       util-linux \
       xz \
       qemu-img && \


### PR DESCRIPTION
Bump source image dependencies to 4.22. This is particularly important for the oc cli as the latest 4.22 version contains a bug fix for filtering tech preview manifests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI testing environment updated to use OpenShift 4.22 base images and artifacts (replacing 4.17).
  * Runtime and build-stage images switched to the newer OpenShift 4.22 lineage.
  * No changes to build steps, installed tools, or copied artifacts; behavior of CI jobs remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->