### PR TITLE
OCPBUGS-85232: PowerVS: Add port 80 security group rule

### DIFF
--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -219,7 +219,7 @@ func createLoadBalancerDNSRecords(ctx context.Context, in clusterapi.InfraReadyI
 
 func findMissingSecurityGroupRules(ctx context.Context, in clusterapi.InfraReadyInput, vpcID string) (sets.Set[int64], error) {
 	foundPorts := sets.Set[int64]{}
-	wantedPorts := sets.New[int64](22, 443, 5000, 6443, 10258, 22623)
+	wantedPorts := sets.New[int64](22, 80, 443, 5000, 6443, 10258, 22623)
 
 	existingRules, err := in.InstallConfig.PowerVS.ListSecurityGroupRules(ctx, vpcID)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added TCP port 80 to the required security group rules for PowerVS VPC configurations to ensure proper HTTP connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->