### PR TITLE
CORS-4466: aws: expand public subnet CIDR in public-only mode

### DIFF
--- a/pkg/asset/manifests/aws/zones.go
+++ b/pkg/asset/manifests/aws/zones.go
@@ -260,12 +260,14 @@ func setSubnetsManagedVPC(in *networkInput) error {
 	}
 	in.Cluster.Spec.NetworkSpec.VPC = vpcSpec
 
+	isPublicOnly := awstypes.IsPublicOnlySubnetsEnabled()
+
 	// Base subnets count considering only private zones, leaving one free block to allow
 	// future subnet expansions in Day-2.
 	numSubnets := len(allAvailabilityZones) + 1
 
 	// Public subnets consumes one range from private CIDR block.
-	if isPublishingExternal {
+	if isPublishingExternal && !isPublicOnly {
 		numSubnets++
 	}
 
@@ -280,24 +282,33 @@ func setSubnetsManagedVPC(in *networkInput) error {
 		return fmt.Errorf("unable to generate CIDR blocks for all private subnets: %w", err)
 	}
 
-	publicCIDR := privateCIDRs[len(allAvailabilityZones)].String()
-
+	// In public-only mode, public subnets use the first N CIDRs directly;
+	// otherwise they start after the private subnet CIDRs.
 	var edgeCIDR string
-	if len(allEdgeZones) > 0 {
-		edgeCIDR = privateCIDRs[len(allAvailabilityZones)+1].String()
-	}
-
 	var publicCIDRs []*net.IPNet
-	if isPublishingExternal {
-		// The last num(zones) blocks are dedicated to the public subnets.
-		publicCIDRs, err = utilscidr.SplitIntoSubnetsIPv4(publicCIDR, len(allAvailabilityZones))
-		if err != nil {
-			return fmt.Errorf("unable to generate CIDR blocks for all public subnets: %w", err)
+	if isPublicOnly {
+		publicCIDRs = privateCIDRs[:len(allAvailabilityZones)]
+		if len(allEdgeZones) > 0 {
+			edgeCIDR = privateCIDRs[len(allAvailabilityZones)].String()
+		}
+	} else {
+		publicCIDR := privateCIDRs[len(allAvailabilityZones)].String()
+
+		if len(allEdgeZones) > 0 {
+			edgeCIDR = privateCIDRs[len(allAvailabilityZones)+1].String()
+		}
+
+		if isPublishingExternal {
+			// The last num(zones) blocks are dedicated to the public subnets.
+			publicCIDRs, err = utilscidr.SplitIntoSubnetsIPv4(publicCIDR, len(allAvailabilityZones))
+			if err != nil {
+				return fmt.Errorf("unable to generate CIDR blocks for all public subnets: %w", err)
+			}
 		}
 	}
 
 	// Create subnets from zone pools (control plane and compute) with type availability-zone.
-	if len(privateCIDRs) < len(allAvailabilityZones) {
+	if !isPublicOnly && len(privateCIDRs) < len(allAvailabilityZones) {
 		return fmt.Errorf("unable to define CIDR blocks to all zones for private subnets")
 	}
 	if isPublishingExternal && len(publicCIDRs) < len(allAvailabilityZones) {
@@ -305,7 +316,7 @@ func setSubnetsManagedVPC(in *networkInput) error {
 	}
 
 	for idxCIDR, zone := range allAvailabilityZones {
-		if !awstypes.IsPublicOnlySubnetsEnabled() {
+		if !isPublicOnly {
 			in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
 				AvailabilityZone: zone,
 				CidrBlock:        privateCIDRs[idxCIDR].String(),
@@ -335,7 +346,7 @@ func setSubnetsManagedVPC(in *networkInput) error {
 	// Slice the main CIDR (edgeCIDR) into N*zones for privates subnets,
 	// and, when publish external, duplicate to create public subnets.
 	numEdgeSubnets := len(allEdgeZones)
-	if isPublishingExternal {
+	if !isPublicOnly && isPublishingExternal {
 		numEdgeSubnets *= 2
 	}
 
@@ -347,26 +358,32 @@ func setSubnetsManagedVPC(in *networkInput) error {
 	if err != nil {
 		return fmt.Errorf("unable to generate CIDR blocks for all edge subnets: %w", err)
 	}
-	if len(edgeCIDRs) < len(allEdgeZones) {
+	if !isPublicOnly && len(edgeCIDRs) < len(allEdgeZones) {
 		return fmt.Errorf("unable to define CIDR blocks to all edge zones for private subnets")
 	}
-	if isPublishingExternal && (len(edgeCIDRs) < (len(allEdgeZones) * 2)) {
+	if !isPublicOnly && isPublishingExternal && (len(edgeCIDRs) < (len(allEdgeZones) * 2)) {
 		return fmt.Errorf("unable to define CIDR blocks to all edge zones for public subnets")
 	}
 
 	// Create subnets from zone pool with type local-zone or wavelength-zone (edge zones)
 	// Important: We do not support IPv6 networking (i.e. dualstack) for edge zones
 	for idxCIDR, zone := range allEdgeZones {
-		in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
-			AvailabilityZone: zone,
-			CidrBlock:        edgeCIDRs[idxCIDR].String(),
-			ID:               fmt.Sprintf("%s-subnet-private-%s", in.ClusterID.InfraID, zone),
-			IsPublic:         false,
-		})
-		if isPublishingExternal {
+		if !isPublicOnly {
 			in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
 				AvailabilityZone: zone,
-				CidrBlock:        edgeCIDRs[len(allEdgeZones)+idxCIDR].String(),
+				CidrBlock:        edgeCIDRs[idxCIDR].String(),
+				ID:               fmt.Sprintf("%s-subnet-private-%s", in.ClusterID.InfraID, zone),
+				IsPublic:         false,
+			})
+		}
+		if isPublishingExternal {
+			publicEdgeIdx := idxCIDR
+			if !isPublicOnly {
+				publicEdgeIdx = len(allEdgeZones) + idxCIDR
+			}
+			in.Cluster.Spec.NetworkSpec.Subnets = append(in.Cluster.Spec.NetworkSpec.Subnets, capa.SubnetSpec{
+				AvailabilityZone: zone,
+				CidrBlock:        edgeCIDRs[publicEdgeIdx].String(),
 				ID:               fmt.Sprintf("%s-subnet-public-%s", in.ClusterID.InfraID, zone),
 				IsPublic:         true,
 			})

--- a/pkg/asset/manifests/aws/zones_test.go
+++ b/pkg/asset/manifests/aws/zones_test.go
@@ -612,6 +612,353 @@ func Test_setSubnetsManagedVPC(t *testing.T) {
 	}
 }
 
+func Test_setSubnetsManagedVPC_publicOnly(t *testing.T) {
+	type args struct {
+		in *networkInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    capa.NetworkSpec
+	}{
+		{
+			name: "public-only /22 with 3 AZs yields /24 public subnets",
+			args: args{
+				in: &networkInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR("10.0.0.0/22"),
+									},
+								},
+							},
+							Platform: types.Platform{
+								AWS: &awstypes.Platform{},
+							},
+						}
+						return ic
+					}(),
+					Cluster: &capa.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "infraId",
+							Namespace: capiutils.Namespace,
+						},
+						Spec: capa.AWSClusterSpec{},
+					},
+					ZonesInRegion: []string{"a", "b", "c"},
+				},
+			},
+			want: capa.NetworkSpec{
+				VPC: capa.VPCSpec{CidrBlock: "10.0.0.0/22"},
+				Subnets: []capa.SubnetSpec{
+					{
+						ID:               "infra-id-subnet-public-a",
+						AvailabilityZone: "a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.0/24",
+					},
+					{
+						ID:               "infra-id-subnet-public-b",
+						AvailabilityZone: "b",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.0/24",
+					},
+					{
+						ID:               "infra-id-subnet-public-c",
+						AvailabilityZone: "c",
+						IsPublic:         true,
+						CidrBlock:        "10.0.2.0/24",
+					},
+				},
+			},
+		},
+		{
+			name: "public-only /22 with 3 AZs and edge zone",
+			args: args{
+				in: &networkInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR("10.0.0.0/22"),
+									},
+								},
+							},
+							Compute: []types.MachinePool{
+								{
+									Name: "edge",
+									Platform: types.MachinePoolPlatform{
+										AWS: &awstypes.MachinePool{
+											Zones: []string{"edge-a"},
+										},
+									},
+								},
+							},
+							Platform: types.Platform{
+								AWS: &awstypes.Platform{},
+							},
+						}
+						return ic
+					}(),
+					Cluster: &capa.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "infraId",
+							Namespace: capiutils.Namespace,
+						},
+						Spec: capa.AWSClusterSpec{},
+					},
+					ZonesInRegion: []string{"a", "b", "c"},
+				},
+			},
+			want: capa.NetworkSpec{
+				VPC: capa.VPCSpec{CidrBlock: "10.0.0.0/22"},
+				Subnets: []capa.SubnetSpec{
+					{
+						ID:               "infra-id-subnet-public-a",
+						AvailabilityZone: "a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.0/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-b",
+						AvailabilityZone: "b",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.128/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-c",
+						AvailabilityZone: "c",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.0/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-edge-a",
+						AvailabilityZone: "edge-a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.128/26",
+					},
+				},
+			},
+		},
+		{
+			name: "public-only /22 with 3 AZs and 2 edge zones",
+			args: args{
+				in: &networkInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR("10.0.0.0/22"),
+									},
+								},
+							},
+							Compute: []types.MachinePool{
+								{
+									Name: "edge",
+									Platform: types.MachinePoolPlatform{
+										AWS: &awstypes.MachinePool{
+											Zones: []string{"edge-a", "edge-b"},
+										},
+									},
+								},
+							},
+							Platform: types.Platform{
+								AWS: &awstypes.Platform{},
+							},
+						}
+						return ic
+					}(),
+					Cluster: &capa.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "infraId",
+							Namespace: capiutils.Namespace,
+						},
+						Spec: capa.AWSClusterSpec{},
+					},
+					ZonesInRegion: []string{"a", "b", "c"},
+				},
+			},
+			want: capa.NetworkSpec{
+				VPC: capa.VPCSpec{CidrBlock: "10.0.0.0/22"},
+				Subnets: []capa.SubnetSpec{
+					{
+						ID:               "infra-id-subnet-public-a",
+						AvailabilityZone: "a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.0/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-b",
+						AvailabilityZone: "b",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.128/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-c",
+						AvailabilityZone: "c",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.0/25",
+					},
+					{
+						ID:               "infra-id-subnet-public-edge-a",
+						AvailabilityZone: "edge-a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.128/27",
+					},
+					{
+						ID:               "infra-id-subnet-public-edge-b",
+						AvailabilityZone: "edge-b",
+						IsPublic:         true,
+						CidrBlock:        "10.0.1.160/27",
+					},
+				},
+			},
+		},
+		{
+			name: "public-only single AZ",
+			args: args{
+				in: &networkInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR("10.0.0.0/22"),
+									},
+								},
+							},
+							Platform: types.Platform{
+								AWS: &awstypes.Platform{},
+							},
+						}
+						return ic
+					}(),
+					Cluster: &capa.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "infraId",
+							Namespace: capiutils.Namespace,
+						},
+						Spec: capa.AWSClusterSpec{},
+					},
+					ZonesInRegion: []string{"a"},
+				},
+			},
+			want: capa.NetworkSpec{
+				VPC: capa.VPCSpec{CidrBlock: "10.0.0.0/22"},
+				Subnets: []capa.SubnetSpec{
+					{
+						ID:               "infra-id-subnet-public-a",
+						AvailabilityZone: "a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.0/23",
+					},
+				},
+			},
+		},
+		{
+			name: "public-only dualstack",
+			args: args{
+				in: &networkInput{
+					ClusterID: stubClusterID(),
+					InstallConfig: func() *installconfig.InstallConfig {
+						ic := stubInstallConfig()
+						ic.Config = &types.InstallConfig{
+							Publish: types.ExternalPublishingStrategy,
+							Networking: &types.Networking{
+								MachineNetwork: []types.MachineNetworkEntry{
+									{
+										CIDR: *ipnet.MustParseCIDR(stubDefaultCIDR),
+									},
+								},
+							},
+							Platform: types.Platform{
+								AWS: &awstypes.Platform{
+									IPFamily: network.DualStackIPv4Primary,
+								},
+							},
+						}
+						return ic
+					}(),
+					Cluster: &capa.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "infraId",
+							Namespace: capiutils.Namespace,
+						},
+						Spec: capa.AWSClusterSpec{},
+					},
+					ZonesInRegion: []string{"a", "b"},
+				},
+			},
+			want: capa.NetworkSpec{
+				VPC: capa.VPCSpec{
+					CidrBlock: stubDefaultCIDR,
+					IPv6:      &capa.IPv6{},
+				},
+				Subnets: []capa.SubnetSpec{
+					{
+						ID:               "infra-id-subnet-public-a",
+						AvailabilityZone: "a",
+						IsPublic:         true,
+						CidrBlock:        "10.0.0.0/18",
+						IsIPv6:           true,
+					},
+					{
+						ID:               "infra-id-subnet-public-b",
+						AvailabilityZone: "b",
+						IsPublic:         true,
+						CidrBlock:        "10.0.64.0/18",
+						IsIPv6:           true,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY", "1")
+
+			err := setSubnetsManagedVPC(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setSubnetsManagedVPC() error: %+v, wantErr %+v", err, tt.wantErr)
+			}
+			if tt.args.in == nil && (err == nil) {
+				return
+			}
+			if tt.args.in.Cluster == nil && (err == nil) {
+				return
+			}
+
+			if len(tt.args.in.Cluster.Spec.NetworkSpec.Subnets) == 0 {
+				if !tt.wantErr {
+					t.Errorf("setSubnetsManagedVPC() no subnets, wantErr: %v", tt.wantErr)
+				}
+				return
+			}
+			tt.args.in.Cluster.Spec.NetworkSpec.Subnets = tSortCapaSubnetsByID(tt.args.in.Cluster.Spec.NetworkSpec.Subnets)
+			if got := tt.args.in.Cluster.Spec.NetworkSpec; !cmp.Equal(got, tt.want) {
+				t.Errorf("setSubnetsManagedVPC() NetworkSpec diff: %v", cmp.Diff(got, tt.want))
+			}
+		})
+	}
+}
+
 func Test_setSubnetsBYOVPC(t *testing.T) {
 	type args struct {
 		in *networkInput


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subnet and CIDR allocation for public-only deployments when external publishing is enabled.
  * Tightened CIDR coverage validation and edge CIDR sizing rules to correctly reflect public-only behavior.
  * Corrected edge subnet creation and CIDR indexing for public-only networks (including appropriate handling for dual-stack).
* **Tests**
  * Added `setSubnetsManagedVPC` coverage for public-only scenarios across multiple availability-zone counts and optional edge zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->