### PR TITLE
OCPBUGS-60993: Enrich IBI config image proxy NoProxy with cluster networks

### DIFF
--- a/pkg/asset/imagebased/configimage/clusterconfiguration.go
+++ b/pkg/asset/imagebased/configimage/clusterconfiguration.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/thoas/go-funk"
 	k8sjson "sigs.k8s.io/json"
@@ -108,7 +109,7 @@ func (cc *ClusterConfiguration) Generate(_ context.Context, dependencies asset.P
 		Hostname:              imageBasedConfig.Config.Hostname,
 		InfraID:               clusterID.InfraID,
 		KubeadminPasswordHash: pwdHash,
-		Proxy:                 installConfig.Config.Proxy,
+		Proxy:                 enrichNoProxy(installConfig.Config.Proxy, installConfig.Config.Networking),
 		PullSecret:            installConfig.Config.PullSecret,
 		ReleaseRegistry:       imageBasedConfig.Config.ReleaseRegistry,
 		SSHKey:                installConfig.Config.SSHKey,
@@ -214,6 +215,25 @@ func (cc *ClusterConfiguration) finish() error {
 		return errors.New("missing configuration or manifest file")
 	}
 	return nil
+}
+
+// enrichNoProxy adds cluster, service, and machine networks to the NoProxy field
+// to ensure internal cluster communication bypasses the proxy.
+func enrichNoProxy(proxy *types.Proxy, networking *types.Networking) *types.Proxy {
+	if proxy == nil {
+		return nil
+	}
+	if proxy.NoProxy == "*" {
+		return proxy
+	}
+
+	set := types.BuildNoProxySet(networking, proxy.NoProxy)
+
+	return &types.Proxy{
+		HTTPProxy:  proxy.HTTPProxy,
+		HTTPSProxy: proxy.HTTPSProxy,
+		NoProxy:    strings.Join(set.List(), ","),
+	}
 }
 
 func chronyConfWithAdditionalNTPSources(sources []string) string {

--- a/pkg/asset/imagebased/configimage/clusterconfiguration_test.go
+++ b/pkg/asset/imagebased/configimage/clusterconfiguration_test.go
@@ -120,7 +120,7 @@ func TestClusterConfiguration_Generate(t *testing.T) {
 				imageBasedConfig(),
 			},
 
-			expectedConfig: clusterConfiguration().proxy(proxy()).build().Config,
+			expectedConfig: clusterConfiguration().proxy(enrichedProxy()).build().Config,
 		},
 		{
 			name: "valid configuration with additionalTrustBundle, policyAlways without proxy",
@@ -159,7 +159,7 @@ func TestClusterConfiguration_Generate(t *testing.T) {
 			},
 
 			expectedConfig: clusterConfiguration().
-				proxy(proxy()).
+				proxy(enrichedProxy()).
 				additionalTrustBundle(imagebased.AdditionalTrustBundle{
 					UserCaBundle: testCert,
 				}).
@@ -183,7 +183,7 @@ func TestClusterConfiguration_Generate(t *testing.T) {
 			},
 
 			expectedConfig: clusterConfiguration().
-				proxy(proxy()).
+				proxy(enrichedProxy()).
 				additionalTrustBundle(imagebased.AdditionalTrustBundle{
 					UserCaBundle:         testCert,
 					ProxyConfigmapBundle: testCert,
@@ -413,6 +413,16 @@ func proxy() *types.Proxy {
 		HTTPProxy:  "http://10.10.10.11:80",
 		HTTPSProxy: "http://my-lab-proxy.org:443",
 		NoProxy:    "internal.com",
+	}
+}
+
+func enrichedProxy() *types.Proxy {
+	// This is the proxy after enrichNoProxy() is applied with default test networks:
+	// MachineNetwork: 10.10.11.0/24, ClusterNetwork: 192.168.111.0/24, ServiceNetwork: 172.30.0.0/16
+	return &types.Proxy{
+		HTTPProxy:  "http://10.10.10.11:80",
+		HTTPSProxy: "http://my-lab-proxy.org:443",
+		NoProxy:    ".cluster.local,.svc,10.10.11.0/24,127.0.0.1,172.30.0.0/16,192.168.111.0/24,internal.com,localhost",
 	}
 }
 

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -43,15 +43,13 @@ func (*Proxy) Name() string {
 func (*Proxy) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.InstallConfig{},
-		&Networking{},
 	}
 }
 
 // Generate generates the Proxy config and its CRD.
 func (p *Proxy) Generate(_ context.Context, dependencies asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
-	network := &Networking{}
-	dependencies.Get(installConfig, network)
+	dependencies.Get(installConfig)
 
 	p.Config = &configv1.Proxy{
 		TypeMeta: metav1.TypeMeta{
@@ -82,7 +80,7 @@ func (p *Proxy) Generate(_ context.Context, dependencies asset.Parents) error {
 	}
 
 	if p.Config.Spec.HTTPProxy != "" || p.Config.Spec.HTTPSProxy != "" {
-		noProxy, err := createNoProxy(installConfig, network)
+		noProxy, err := createNoProxy(installConfig)
 		if err != nil {
 			return err
 		}
@@ -122,7 +120,7 @@ func (p *Proxy) Generate(_ context.Context, dependencies asset.Parents) error {
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 // https://cloud.google.com/compute/docs/storing-retrieving-metadata
-func createNoProxy(installConfig *installconfig.InstallConfig, network *Networking) (string, error) {
+func createNoProxy(installConfig *installconfig.InstallConfig) (string, error) {
 	internalAPIServer, err := url.Parse(getInternalAPIServerURL(installConfig.Config))
 	if err != nil {
 		return "", errors.New("failed parsing internal API server when creating Proxy manifest")
@@ -179,8 +177,8 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 		set.Insert(network.CIDR.String())
 	}
 
-	for _, clusterNetwork := range network.Config.Spec.ClusterNetwork {
-		set.Insert(clusterNetwork.CIDR)
+	for _, clusterNetwork := range installConfig.Config.Networking.ClusterNetwork {
+		set.Insert(clusterNetwork.CIDR.String())
 	}
 
 	for _, userValue := range strings.Split(installConfig.Config.Proxy.NoProxy, ",") {

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -121,18 +120,13 @@ func (p *Proxy) Generate(_ context.Context, dependencies asset.Parents) error {
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 // https://cloud.google.com/compute/docs/storing-retrieving-metadata
 func createNoProxy(installConfig *installconfig.InstallConfig) (string, error) {
+	set := types.BuildNoProxySet(installConfig.Config.Networking, installConfig.Config.Proxy.NoProxy)
+
 	internalAPIServer, err := url.Parse(getInternalAPIServerURL(installConfig.Config))
 	if err != nil {
 		return "", errors.New("failed parsing internal API server when creating Proxy manifest")
 	}
-
-	set := sets.NewString(
-		"127.0.0.1",
-		"localhost",
-		".svc",
-		".cluster.local",
-		internalAPIServer.Hostname(),
-	)
+	set.Insert(internalAPIServer.Hostname())
 
 	platform := installConfig.Config.Platform.Name()
 
@@ -167,24 +161,6 @@ func createNoProxy(installConfig *installconfig.InstallConfig) (string, error) {
 	// "metadata.google.internal." added due to https://bugzilla.redhat.com/show_bug.cgi?id=1754049
 	if platform == gcp.Name {
 		set.Insert("metadata", "metadata.google.internal", "metadata.google.internal.")
-	}
-
-	for _, network := range installConfig.Config.Networking.ServiceNetwork {
-		set.Insert(network.String())
-	}
-
-	for _, network := range installConfig.Config.Networking.MachineNetwork {
-		set.Insert(network.CIDR.String())
-	}
-
-	for _, clusterNetwork := range installConfig.Config.Networking.ClusterNetwork {
-		set.Insert(clusterNetwork.CIDR.String())
-	}
-
-	for _, userValue := range strings.Split(installConfig.Config.Proxy.NoProxy, ",") {
-		if userValue != "" {
-			set.Insert(userValue)
-		}
 	}
 
 	return strings.Join(set.List(), ","), nil

--- a/pkg/types/proxy.go
+++ b/pkg/types/proxy.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// BuildNoProxySet creates a set of NoProxy entries from networking configuration.
+// It includes localhost entries (.svc, .cluster.local, 127.0.0.1, localhost),
+// all network CIDRs (cluster, service, machine), and user-provided NoProxy values.
+// The caller can add platform-specific and API-server entries as needed.
+func BuildNoProxySet(networking *Networking, userNoProxy string) sets.String {
+	set := sets.NewString(
+		"127.0.0.1",
+		"localhost",
+		".svc",
+		".cluster.local",
+	)
+
+	for _, network := range networking.ServiceNetwork {
+		set.Insert(network.String())
+	}
+
+	for _, network := range networking.MachineNetwork {
+		set.Insert(network.CIDR.String())
+	}
+
+	for _, network := range networking.ClusterNetwork {
+		set.Insert(network.CIDR.String())
+	}
+
+	for _, userValue := range strings.Split(userNoProxy, ",") {
+		trimmed := strings.TrimSpace(userValue)
+		if trimmed != "" {
+			set.Insert(trimmed)
+		}
+	}
+
+	return set
+}

--- a/pkg/types/proxy_test.go
+++ b/pkg/types/proxy_test.go
@@ -1,0 +1,137 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/ipnet"
+)
+
+func TestBuildNoProxySet(t *testing.T) {
+	cases := []struct {
+		name        string
+		networking  *Networking
+		userNoProxy string
+		expected    []string
+	}{
+		{
+			name:        "empty networking and no user entries",
+			networking:  &Networking{},
+			userNoProxy: "",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local"},
+		},
+		{
+			name: "service network entries are included",
+			networking: &Networking{
+				ServiceNetwork: []ipnet.IPNet{
+					*ipnet.MustParseCIDR("172.30.0.0/16"),
+				},
+			},
+			userNoProxy: "",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "172.30.0.0/16"},
+		},
+		{
+			name: "machine network entries are included",
+			networking: &Networking{
+				MachineNetwork: []MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+				},
+			},
+			userNoProxy: "",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "10.0.0.0/16"},
+		},
+		{
+			name: "cluster network entries are included",
+			networking: &Networking{
+				ClusterNetwork: []ClusterNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")},
+				},
+			},
+			userNoProxy: "",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "10.128.0.0/14"},
+		},
+		{
+			name:        "single user no-proxy entry is included",
+			networking:  &Networking{},
+			userNoProxy: "example.com",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "example.com"},
+		},
+		{
+			name:        "multiple comma-separated user entries are included",
+			networking:  &Networking{},
+			userNoProxy: "example.com,internal.corp,192.168.1.0/24",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "example.com", "internal.corp", "192.168.1.0/24"},
+		},
+		{
+			name:        "user entries with surrounding whitespace are trimmed",
+			networking:  &Networking{},
+			userNoProxy: " example.com , internal.corp ",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "example.com", "internal.corp"},
+		},
+		{
+			name:        "empty segments in user no-proxy are ignored",
+			networking:  &Networking{},
+			userNoProxy: "example.com,,internal.corp,",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "example.com", "internal.corp"},
+		},
+		{
+			name: "all network types and user entries combined",
+			networking: &Networking{
+				ServiceNetwork: []ipnet.IPNet{
+					*ipnet.MustParseCIDR("172.30.0.0/16"),
+				},
+				MachineNetwork: []MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+				},
+				ClusterNetwork: []ClusterNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")},
+				},
+			},
+			userNoProxy: "example.com",
+			expected: []string{
+				"127.0.0.1", "localhost", ".svc", ".cluster.local",
+				"172.30.0.0/16", "10.0.0.0/16", "10.128.0.0/14", "example.com",
+			},
+		},
+		{
+			name: "duplicate user entry matching a built-in entry is deduplicated",
+			networking: &Networking{
+				ServiceNetwork: []ipnet.IPNet{
+					*ipnet.MustParseCIDR("172.30.0.0/16"),
+				},
+			},
+			userNoProxy: "172.30.0.0/16,localhost",
+			expected:    []string{"127.0.0.1", "localhost", ".svc", ".cluster.local", "172.30.0.0/16"},
+		},
+		{
+			name: "multiple entries in each network type",
+			networking: &Networking{
+				ServiceNetwork: []ipnet.IPNet{
+					*ipnet.MustParseCIDR("172.30.0.0/16"),
+					*ipnet.MustParseCIDR("fd02::/112"),
+				},
+				MachineNetwork: []MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					{CIDR: *ipnet.MustParseCIDR("fd00::/48")},
+				},
+				ClusterNetwork: []ClusterNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")},
+					{CIDR: *ipnet.MustParseCIDR("fd01::/48")},
+				},
+			},
+			userNoProxy: "",
+			expected: []string{
+				"127.0.0.1", "localhost", ".svc", ".cluster.local",
+				"172.30.0.0/16", "fd02::/112", "10.0.0.0/16", "fd00::/48", "10.128.0.0/14", "fd01::/48",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := BuildNoProxySet(tc.networking, tc.userNoProxy)
+			assert.ElementsMatch(t, tc.expected, result.List())
+		})
+	}
+}


### PR DESCRIPTION
Automatically add cluster, service, and machine network CIDRs to the proxy NoProxy field during image-based installation. This ensures internal cluster communication bypasses the proxy, preventing an additional node reboot that occurs when these networks aren't explicitly included in the install-config.yaml.

The enrichment adds:
- Essential values (localhost, 127.0.0.1, .svc, .cluster.local)
- All service network CIDRs
- All machine network CIDRs
- All cluster network (pod) CIDRs
- User-provided NoProxy values (deduplicated)

Resolves https://redhat.atlassian.net/browse/OCPBUGS-60993

/cc @omertuc 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy handling now enriches NO_PROXY to include internal API hostname, cluster/service/machine networks and common local entries so internal Kubernetes communication bypasses the proxy.
* **Bug Fixes**
  * Manifest generation now computes NO_PROXY from install configuration consistently, avoiding missing internal entries.
* **Tests**
  * Added tests validating the expanded no-proxy set, trimming/deduplication, and multi-CIDR handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->