### PR TITLE
OCPBUGS-85352: aws: fix Route 53 resource leak during cluster destroy in China regions

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -277,6 +277,9 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 		case awstypes.AwsEuscPartitionID:
 			// For AWS EU Sovereign Cloud, use "eusc-de-east-1"
 			tagRegion = awstypes.EuscDeEast1RegionID
+		case awstypes.AwsCnPartitionID:
+			// For AWS China, use "cn-northwest-1"
+			tagRegion = awstypes.CnNorthwest1RegionID
 		case awstypes.AwsUsGovPartitionID:
 			// For AWS Government Cloud, use "us-gov-west-1"
 			tagRegion = awstypes.UsGovWest1RegionID
@@ -301,6 +304,16 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	switch o.Region {
 	case awstypes.EuscDeEast1RegionID:
 	case awstypes.CnNorth1RegionID, awstypes.CnNorthwest1RegionID:
+		if o.Region != awstypes.CnNorthwest1RegionID {
+			tagClient, err := awssession.NewResourceGroupsTaggingAPIClient(ctx, awssession.EndpointOptions{
+				Region:    awstypes.CnNorthwest1RegionID,
+				Endpoints: o.endpoints,
+			}, "", resourcegroupstaggingapi.WithAPIOptions(awsmiddleware.AddUserAgentKeyValue(awssession.OpenShiftInstallerDestroyerUserAgent, version.Raw)))
+			if err != nil {
+				return nil, fmt.Errorf("failed to create resource tagging client for cn-northwest-1: %w", err)
+			}
+			tagClients = append(tagClients, tagClient)
+		}
 	case awstypes.UsIsoEast1RegionID, awstypes.UsIsoWest1RegionID, awstypes.UsIsoBEast1RegionID:
 	case awstypes.UsGovEast1RegionID, awstypes.UsGovWest1RegionID:
 		if o.Region != awstypes.UsGovWest1RegionID {


### PR DESCRIPTION
When destroying a cluster in cn-north-1, the installer was not searching `cn-northwest-1` for tagged resources. Since Route 53 is a global service within the `aws-cn` partition, hosted zones need to be discovered via the `cn-northwest-1` region regardless of which China region was used for installation. See [AWS docs](https://docs.aws.amazon.com/general/latest/gr/r53.html).

This adds cross-region tag client search for China regions (mirroring the existing GovCloud pattern) and also adds the `aws-cn` partition case to the shared hosted zone tag region resolution.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource tagging consistency during cluster destruction in AWS China regions. The system now ensures comprehensive tag discovery across both `cn-north-1` and `cn-northwest-1` regions, improving the reliability and completeness of resource cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->