### PR TITLE
OCPEDGE-2254: add openshift-install tnf-validate-fencing command

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -60,6 +60,7 @@ func installerMain() {
 		newAgentCmd(ctx),
 		newListFeaturesCmd(),
 		newImageBasedCmd(ctx),
+		newTNFCmd(ctx),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -60,7 +60,7 @@ func installerMain() {
 		newAgentCmd(ctx),
 		newListFeaturesCmd(),
 		newImageBasedCmd(ctx),
-		newTNFCmd(ctx),
+		newTNFValidateFencingCmd(ctx),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"path/filepath"
 
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	"github.com/openshift/installer/pkg/fencing"
 	"github.com/openshift/installer/pkg/metrics/timer"

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift/installer/cmd/openshift-install/command"
+	"github.com/openshift/installer/pkg/fencing"
+	"github.com/openshift/installer/pkg/metrics/timer"
+)
+
+var tnfValidateOpts struct {
+	sshKeys []string
+}
+
+func newTNFCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tnf",
+		Short: "Commands for Two Node with Fencing clusters",
+		Long: `Utilities for managing and validating Two Node with Fencing clusters.
+
+These commands require a deployed two node cluster with fencing and SSH access
+to both control plane nodes.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newTNFValidateFencingCmd(ctx))
+	return cmd
+}
+
+func newTNFValidateFencingCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate-fencing",
+		Short: "Validate fencing configuration and fence both nodes sequentially",
+		Long: `Validate fencing on a Two Node with Fencing cluster.
+
+This command connects to both control plane nodes via SSH, runs pre-flight
+checks (STONITH, Pacemaker, etcd), then fences each node sequentially and
+verifies recovery. This is a DISRUPTIVE operation — nodes will be power-cycled.
+
+Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			timer.StartTimer(timer.TotalTimeElapsed)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
+			defer cleanup()
+
+			kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
+			config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			if err != nil {
+				logrus.Fatalf("Failed to load kubeconfig from %s: %v", kubeconfigPath, err)
+			}
+
+			kubeClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				logrus.Fatalf("Failed to create Kubernetes client: %v", err)
+			}
+
+			cfgClient, err := configclient.NewForConfig(config)
+			if err != nil {
+				logrus.Fatalf("Failed to create config client: %v", err)
+			}
+
+			if err := fencing.Run(ctx, fencing.Config{
+				KubeClient:   kubeClient,
+				ConfigClient: cfgClient,
+				SSHUser:      "core",
+				SSHKeys:      tnfValidateOpts.sshKeys,
+			}); err != nil {
+				logrus.Fatalf("Fencing validation failed: %v", err)
+			}
+
+			timer.StopTimer(timer.TotalTimeElapsed)
+			timer.LogSummary()
+		},
+	}
+	cmd.PersistentFlags().StringArrayVar(&tnfValidateOpts.sshKeys, "key", nil,
+		"Path to SSH private keys for node access. If not provided, SSH agent or default keys are used.")
+	return cmd
+}

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -2,20 +2,23 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/cmd/openshift-install/command"
 	"github.com/openshift/installer/pkg/fencing"
 	"github.com/openshift/installer/pkg/metrics/timer"
 )
 
-var tnfValidateOpts struct {
+var tnfOpts struct {
 	sshKeys []string
 }
 
@@ -35,6 +38,28 @@ to both control plane nodes.`,
 	return cmd
 }
 
+func loadTNFClients(ctx context.Context) (kubernetes.Interface, error) {
+	kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfgClient, err := configclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	infra, err := cfgClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
+		return nil, fmt.Errorf("this command requires a Two Node with Fencing (DualReplica) cluster, found %q", infra.Status.ControlPlaneTopology)
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
 func newTNFValidateFencingCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate-fencing",
@@ -52,27 +77,15 @@ Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.
 			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
-			config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			kubeClient, err := loadTNFClients(ctx)
 			if err != nil {
-				logrus.Fatalf("Failed to load kubeconfig from %s: %v", kubeconfigPath, err)
-			}
-
-			kubeClient, err := kubernetes.NewForConfig(config)
-			if err != nil {
-				logrus.Fatalf("Failed to create Kubernetes client: %v", err)
-			}
-
-			cfgClient, err := configclient.NewForConfig(config)
-			if err != nil {
-				logrus.Fatalf("Failed to create config client: %v", err)
+				logrus.Fatalf("Failed to initialize: %v", err)
 			}
 
 			if err := fencing.Run(ctx, fencing.Config{
-				KubeClient:   kubeClient,
-				ConfigClient: cfgClient,
-				SSHUser:      "core",
-				SSHKeys:      tnfValidateOpts.sshKeys,
+				KubeClient: kubeClient,
+				SSHUser:    "core",
+				SSHKeys:    tnfOpts.sshKeys,
 			}); err != nil {
 				logrus.Fatalf("Fencing validation failed: %v", err)
 			}
@@ -81,7 +94,7 @@ Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.
 			timer.LogSummary()
 		},
 	}
-	cmd.PersistentFlags().StringArrayVar(&tnfValidateOpts.sshKeys, "key", nil,
+	cmd.PersistentFlags().StringArrayVar(&tnfOpts.sshKeys, "key", nil,
 		"Path to SSH private keys for node access. If not provided, SSH agent or default keys are used.")
 	return cmd
 }

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"path/filepath"
 
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -18,28 +17,36 @@ import (
 	"github.com/openshift/installer/pkg/metrics/timer"
 )
 
-var tnfOpts struct {
-	sshKeys    []string
-	restConfig *rest.Config
+var tnfValidateOpts struct {
+	sshKeys []string
 }
 
-func newTNFCmd(ctx context.Context) *cobra.Command {
+func newTNFValidateFencingCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tnf",
-		Short: "Commands for Two Node with Fencing clusters",
-		Long: `Utilities for managing and validating Two Node with Fencing clusters.
+		Use:   "tnf-validate-fencing",
+		Short: "Validate fencing by power-cycling both nodes sequentially (DISRUPTIVE)",
+		Long: `Validate fencing on a Two Node with Fencing cluster.
 
-These commands require a deployed two node cluster with fencing and SSH access
-to both control plane nodes.`,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+This command connects to both control plane nodes via SSH, runs pre-flight
+checks (STONITH, Pacemaker, etcd), then fences each node sequentially and
+verifies recovery.
+
+WARNING: This is a DISRUPTIVE operation — nodes will be forcibly powered off
+via STONITH and must recover automatically.
+
+Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
 			runRootCmd(cmd, args)
+			timer.StartTimer(timer.TotalTimeElapsed)
+			cleanup := command.SetupFileHook(command.RootOpts.Dir)
+			defer cleanup()
 
 			kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
 			config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 			if err != nil {
 				logrus.Fatalf("Failed to load kubeconfig from %s: %v", kubeconfigPath, err)
 			}
-			tnfOpts.restConfig = config
 
 			cfgClient, err := configclient.NewForConfig(config)
 			if err != nil {
@@ -52,33 +59,8 @@ to both control plane nodes.`,
 			if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
 				logrus.Fatalf("This command requires a Two Node with Fencing (DualReplica) cluster, found %q", infra.Status.ControlPlaneTopology)
 			}
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
-	cmd.AddCommand(newTNFValidateFencingCmd(ctx))
-	return cmd
-}
 
-func newTNFValidateFencingCmd(ctx context.Context) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "validate-fencing",
-		Short: "Validate fencing configuration and fence both nodes sequentially",
-		Long: `Validate fencing on a Two Node with Fencing cluster.
-
-This command connects to both control plane nodes via SSH, runs pre-flight
-checks (STONITH, Pacemaker, etcd), then fences each node sequentially and
-verifies recovery. This is a DISRUPTIVE operation — nodes will be power-cycled.
-
-Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.`,
-		Args: cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
-			timer.StartTimer(timer.TotalTimeElapsed)
-			cleanup := command.SetupFileHook(command.RootOpts.Dir)
-			defer cleanup()
-
-			kubeClient, err := kubernetes.NewForConfig(tnfOpts.restConfig)
+			kubeClient, err := kubernetes.NewForConfig(config)
 			if err != nil {
 				logrus.Fatalf("Failed to create Kubernetes client: %v", err)
 			}
@@ -86,7 +68,7 @@ Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.
 			if err := fencing.Run(ctx, fencing.Config{
 				KubeClient: kubeClient,
 				SSHUser:    "core",
-				SSHKeys:    tnfOpts.sshKeys,
+				SSHKeys:    tnfValidateOpts.sshKeys,
 			}); err != nil {
 				logrus.Fatalf("Fencing validation failed: %v", err)
 			}
@@ -95,7 +77,7 @@ Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.
 			timer.LogSummary()
 		},
 	}
-	cmd.PersistentFlags().StringArrayVar(&tnfOpts.sshKeys, "key", nil,
+	cmd.PersistentFlags().StringArrayVar(&tnfValidateOpts.sshKeys, "key", nil,
 		"Path to SSH private keys for node access. If not provided, SSH agent or default keys are used.")
 	return cmd
 }

--- a/cmd/openshift-install/tnf.go
+++ b/cmd/openshift-install/tnf.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -19,7 +19,8 @@ import (
 )
 
 var tnfOpts struct {
-	sshKeys []string
+	sshKeys    []string
+	restConfig *rest.Config
 }
 
 func newTNFCmd(ctx context.Context) *cobra.Command {
@@ -30,34 +31,34 @@ func newTNFCmd(ctx context.Context) *cobra.Command {
 
 These commands require a deployed two node cluster with fencing and SSH access
 to both control plane nodes.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			runRootCmd(cmd, args)
+
+			kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
+			config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			if err != nil {
+				logrus.Fatalf("Failed to load kubeconfig from %s: %v", kubeconfigPath, err)
+			}
+			tnfOpts.restConfig = config
+
+			cfgClient, err := configclient.NewForConfig(config)
+			if err != nil {
+				logrus.Fatalf("Failed to create config client: %v", err)
+			}
+			infra, err := cfgClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				logrus.Fatalf("Failed to read Infrastructure CR: %v", err)
+			}
+			if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
+				logrus.Fatalf("This command requires a Two Node with Fencing (DualReplica) cluster, found %q", infra.Status.ControlPlaneTopology)
+			}
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
 	cmd.AddCommand(newTNFValidateFencingCmd(ctx))
 	return cmd
-}
-
-func loadTNFClients(ctx context.Context) (kubernetes.Interface, error) {
-	kubeconfigPath := filepath.Join(command.RootOpts.Dir, "auth", "kubeconfig")
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	cfgClient, err := configclient.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	infra, err := cfgClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
-		return nil, fmt.Errorf("this command requires a Two Node with Fencing (DualReplica) cluster, found %q", infra.Status.ControlPlaneTopology)
-	}
-
-	return kubernetes.NewForConfig(config)
 }
 
 func newTNFValidateFencingCmd(ctx context.Context) *cobra.Command {
@@ -77,9 +78,9 @@ Requires SSH access to both nodes as user "core" and a cluster-admin kubeconfig.
 			cleanup := command.SetupFileHook(command.RootOpts.Dir)
 			defer cleanup()
 
-			kubeClient, err := loadTNFClients(ctx)
+			kubeClient, err := kubernetes.NewForConfig(tnfOpts.restConfig)
 			if err != nil {
-				logrus.Fatalf("Failed to initialize: %v", err)
+				logrus.Fatalf("Failed to create Kubernetes client: %v", err)
 			}
 
 			if err := fencing.Run(ctx, fencing.Config{

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/gather/ssh"
 )
 

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -260,11 +260,13 @@ func checkDaemons(client *gossh.Client) error {
 		return fmt.Errorf("checking daemon status: %w", err)
 	}
 
-	missing := parseDaemonStatus(out)
+	missing, found := parseDaemonStatus(out)
 	if len(missing) > 0 {
 		return fmt.Errorf("daemons not active/running: %s", strings.Join(missing, ", "))
 	}
-	logrus.Info("All daemons (corosync, pacemaker, pcsd) are active")
+	if found {
+		logrus.Info("All daemons (corosync, pacemaker, pcsd) are active")
+	}
 	return nil
 }
 
@@ -449,9 +451,8 @@ func nodeInOnlineList(node NodeInfo, online []string) bool {
 	return false
 }
 
-func parseDaemonStatus(output string) []string {
+func parseDaemonStatus(output string) (missing []string, found bool) {
 	inSection := false
-	var missing []string
 	for _, line := range strings.Split(output, "\n") {
 		if strings.Contains(line, "Daemon Status:") {
 			inSection = true
@@ -470,7 +471,7 @@ func parseDaemonStatus(output string) []string {
 	if !inSection {
 		logrus.Warn("Could not find Daemon Status section in pcs output — skipping daemon check")
 	}
-	return missing
+	return missing, inSection
 }
 
 type etcdHealthEntry struct {

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -19,8 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
-	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/installer/pkg/gather/ssh"
 )
 
@@ -49,10 +47,9 @@ type NodeInfo struct {
 
 // Config holds all inputs needed by the fencing validator.
 type Config struct {
-	KubeClient   kubernetes.Interface
-	ConfigClient configclient.Interface
-	SSHUser      string
-	SSHKeys      []string
+	KubeClient kubernetes.Interface
+	SSHUser    string
+	SSHKeys    []string
 }
 
 // Run executes the full fencing validation sequence.
@@ -60,10 +57,6 @@ func Run(ctx context.Context, cfg Config) error {
 	nodes, err := discoverNodes(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("node discovery failed: %w", err)
-	}
-
-	if err := verifyTopology(ctx, cfg); err != nil {
-		return err
 	}
 
 	logrus.Infof("Connecting to %s (%s)", nodes[0].Name, nodes[0].IP)
@@ -189,17 +182,6 @@ func nodeInternalIP(node *corev1.Node) string {
 	return ""
 }
 
-func verifyTopology(ctx context.Context, cfg Config) error {
-	infra, err := cfg.ConfigClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("reading Infrastructure CR: %w", err)
-	}
-	if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
-		return fmt.Errorf("fencing validation requires DualReplica topology, found %q", infra.Status.ControlPlaneTopology)
-	}
-	return nil
-}
-
 // --- SSH helpers ---
 
 func sshConnect(cfg Config, ip string) (*gossh.Client, error) {
@@ -313,7 +295,7 @@ func checkEtcdHealth(client *gossh.Client, nodes []NodeInfo) error {
 // --- Fencing ---
 
 func fenceNode(client *gossh.Client, pcmkName string) error {
-	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, shellQuote(pcmkName))
+	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, pcmkName)
 	_, err := sshRun(client, cmd)
 	return err
 }
@@ -324,12 +306,14 @@ func waitNotReady(ctx context.Context, kube kubernetes.Interface, nodeName strin
 	pollCtx, cancel := context.WithTimeout(ctx, notReadyTimeout)
 	defer cancel()
 	start := time.Now()
+	lastLog := start
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		if !isNodeReady(ctx, kube, nodeName) {
 			return true, nil
 		}
-		if time.Since(start) > time.Minute {
+		if time.Since(lastLog) > time.Minute {
 			logrus.Debugf("Still waiting for %s to become NotReady (%s elapsed)", nodeName, time.Since(start).Round(time.Second))
+			lastLog = time.Now()
 		}
 		return false, nil
 	})
@@ -339,12 +323,14 @@ func waitReady(ctx context.Context, kube kubernetes.Interface, nodeName string) 
 	pollCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 	defer cancel()
 	start := time.Now()
+	lastLog := start
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		if isNodeReady(ctx, kube, nodeName) {
 			return true, nil
 		}
-		if time.Since(start) > time.Minute {
+		if time.Since(lastLog) > time.Minute {
 			logrus.Debugf("Still waiting for %s to become Ready (%s elapsed)", nodeName, time.Since(start).Round(time.Second))
+			lastLog = time.Now()
 		}
 		return false, nil
 	})

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -308,7 +309,11 @@ func waitNotReady(ctx context.Context, kube kubernetes.Interface, nodeName strin
 	start := time.Now()
 	lastLog := start
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
-		if !isNodeReady(ctx, kube, nodeName) {
+		ready, err := isNodeReady(ctx, kube, nodeName)
+		if err != nil {
+			return false, nil
+		}
+		if !ready {
 			return true, nil
 		}
 		if time.Since(lastLog) > time.Minute {
@@ -325,7 +330,11 @@ func waitReady(ctx context.Context, kube kubernetes.Interface, nodeName string) 
 	start := time.Now()
 	lastLog := start
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
-		if isNodeReady(ctx, kube, nodeName) {
+		ready, err := isNodeReady(ctx, kube, nodeName)
+		if err != nil {
+			return false, nil
+		}
+		if ready {
 			return true, nil
 		}
 		if time.Since(lastLog) > time.Minute {
@@ -336,17 +345,17 @@ func waitReady(ctx context.Context, kube kubernetes.Interface, nodeName string) 
 	})
 }
 
-func isNodeReady(ctx context.Context, kube kubernetes.Interface, nodeName string) bool {
+func isNodeReady(ctx context.Context, kube kubernetes.Interface, nodeName string) (bool, error) {
 	node, err := kube.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {
-			return c.Status == corev1.ConditionTrue
+			return c.Status == corev1.ConditionTrue, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func pollPacemakerOnline(ctx context.Context, client *gossh.Client, nodes []NodeInfo) error {
@@ -486,21 +495,28 @@ func parseEtcdMembers(output, ipA, ipB string) error {
 	}
 
 	foundA, foundB := false, false
+	voters := 0
 	for _, m := range list.Members {
 		if m.IsLearner {
 			continue
 		}
+		voters++
 		for _, u := range m.ClientURLs {
-			if strings.Contains(u, ipA) {
+			parsed, err := url.Parse(u)
+			if err != nil {
+				continue
+			}
+			host := parsed.Hostname()
+			if host == ipA {
 				foundA = true
 			}
-			if strings.Contains(u, ipB) {
+			if host == ipB {
 				foundB = true
 			}
 		}
 	}
-	if !foundA || !foundB {
-		return fmt.Errorf("etcd does not have 2 voting members (found A=%v, B=%v)", foundA, foundB)
+	if voters != 2 || !foundA || !foundB {
+		return fmt.Errorf("etcd does not have exactly 2 voting members (voters=%d, foundA=%v, foundB=%v)", voters, foundA, foundB)
 	}
 	return nil
 }

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -298,6 +298,10 @@ func checkEtcdHealth(client *gossh.Client, nodes []NodeInfo) error {
 func fenceNode(client *gossh.Client, pcmkName string) error {
 	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, pcmkName)
 	_, err := sshRun(client, cmd)
+	if err != nil && strings.Contains(err.Error(), "exit status 124") {
+		return fmt.Errorf("fencing %s timed out after %ds — check BMC connectivity and fence agent config: %w",
+			pcmkName, fenceTimeout, err)
+	}
 	return err
 }
 
@@ -311,6 +315,7 @@ func waitNotReady(ctx context.Context, kube kubernetes.Interface, nodeName strin
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		ready, err := isNodeReady(ctx, kube, nodeName)
 		if err != nil {
+			logrus.Debugf("Error checking %s readiness: %v", nodeName, err)
 			return false, nil
 		}
 		if !ready {
@@ -332,6 +337,7 @@ func waitReady(ctx context.Context, kube kubernetes.Interface, nodeName string) 
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		ready, err := isNodeReady(ctx, kube, nodeName)
 		if err != nil {
+			logrus.Debugf("Error checking %s readiness: %v", nodeName, err)
 			return false, nil
 		}
 		if ready {
@@ -364,6 +370,7 @@ func pollPacemakerOnline(ctx context.Context, client *gossh.Client, nodes []Node
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		out, err := sshRun(client, "pcs status nodes || crm_mon -1")
 		if err != nil {
+			logrus.Debugf("Error checking pacemaker status: %v", err)
 			return false, nil
 		}
 		online := parsePacemakerOnline(out)
@@ -384,6 +391,7 @@ func pollEtcdHealth(ctx context.Context, client *gossh.Client, nodes []NodeInfo)
 		healthCmd := fmt.Sprintf("podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json endpoint health --endpoints=%s'", endpoints)
 		out, err := sshRun(client, healthCmd)
 		if err != nil {
+			logrus.Debugf("Error checking etcd health: %v", err)
 			return false, nil
 		}
 		if parseEtcdHealth(out) != nil {
@@ -393,6 +401,7 @@ func pollEtcdHealth(ctx context.Context, client *gossh.Client, nodes []NodeInfo)
 		memberCmd := "podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json member list'"
 		out, err = sshRun(client, memberCmd)
 		if err != nil {
+			logrus.Debugf("Error checking etcd members: %v", err)
 			return false, nil
 		}
 		if parseEtcdMembers(out, nodes[0].IP, nodes[1].IP) != nil {
@@ -458,6 +467,9 @@ func parseDaemonStatus(output string) []string {
 			}
 		}
 	}
+	if !inSection {
+		logrus.Warn("Could not find Daemon Status section in pcs output — skipping daemon check")
+	}
 	return missing
 }
 
@@ -470,6 +482,9 @@ func parseEtcdHealth(output string) error {
 	var entries []etcdHealthEntry
 	if err := json.Unmarshal([]byte(output), &entries); err != nil {
 		return fmt.Errorf("failed to parse etcd health output: %w", err)
+	}
+	if len(entries) < 2 {
+		return fmt.Errorf("expected health for 2 endpoints, got %d", len(entries))
 	}
 	for _, e := range entries {
 		if !e.Health {

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -236,12 +236,12 @@ func runPreFlight(client *gossh.Client, nodes []NodeInfo) error {
 }
 
 func checkStonith(client *gossh.Client) error {
-	out, err := sshRun(client, "(pcs stonith config || pcs stonith status || pcs stonith show) 2>&1")
-	if err != nil || strings.TrimSpace(out) == "" {
+	out, _ := sshRun(client, "pcs stonith config || pcs stonith status || pcs stonith show")
+	if strings.TrimSpace(out) == "" {
 		return fmt.Errorf("no STONITH devices configured")
 	}
 
-	prop, err := sshRun(client, "pcs property config stonith-enabled 2>&1 || pcs property list stonith-enabled 2>&1 || pcs property show --all stonith-enabled 2>&1")
+	prop, err := sshRun(client, "pcs property config stonith-enabled || pcs property list stonith-enabled || pcs property show --all stonith-enabled")
 	if err != nil {
 		return fmt.Errorf("could not read stonith-enabled property: %w", err)
 	}
@@ -253,7 +253,7 @@ func checkStonith(client *gossh.Client) error {
 }
 
 func checkPacemakerOnline(client *gossh.Client, nodes []NodeInfo) error {
-	out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+	out, err := sshRun(client, "pcs status nodes || crm_mon -1")
 	if err != nil {
 		return fmt.Errorf("checking pacemaker status: %w", err)
 	}
@@ -269,7 +269,7 @@ func checkPacemakerOnline(client *gossh.Client, nodes []NodeInfo) error {
 }
 
 func checkDaemons(client *gossh.Client) error {
-	out, err := sshRun(client, "pcs status --full 2>/dev/null || pcs status 2>/dev/null")
+	out, err := sshRun(client, "pcs status --full || pcs status")
 	if err != nil {
 		return fmt.Errorf("checking daemon status: %w", err)
 	}
@@ -364,7 +364,7 @@ func pollPacemakerOnline(ctx context.Context, client *gossh.Client, nodes []Node
 	pollCtx, cancel := context.WithTimeout(ctx, pcmkTimeout)
 	defer cancel()
 	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
-		out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+		out, err := sshRun(client, "pcs status nodes || crm_mon -1")
 		if err != nil {
 			return false, nil
 		}
@@ -517,7 +517,7 @@ func parseEtcdMembers(output, ipA, ipB string) error {
 }
 
 func resolvePacemakerNames(client *gossh.Client, nodes []NodeInfo) error {
-	out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+	out, err := sshRun(client, "pcs status nodes || crm_mon -1")
 	if err != nil {
 		return fmt.Errorf("resolving pacemaker node names: %w", err)
 	}

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -236,7 +236,10 @@ func runPreFlight(client *gossh.Client, nodes []NodeInfo) error {
 }
 
 func checkStonith(client *gossh.Client) error {
-	out, _ := sshRun(client, "pcs stonith config || pcs stonith status || pcs stonith show")
+	out, err := sshRun(client, "pcs stonith config || pcs stonith status || pcs stonith show")
+	if err != nil && strings.TrimSpace(out) == "" {
+		return fmt.Errorf("no STONITH devices configured: %w", err)
+	}
 	if strings.TrimSpace(out) == "" {
 		return fmt.Errorf("no STONITH devices configured")
 	}

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ const (
 
 var (
 	stonithEnabledRe = regexp.MustCompile(`(?i)stonith-enabled\s*[:=]\s*true`)
-	daemonActiveRe   = regexp.MustCompile(`(?i)active.*running|enabled`)
+	daemonActiveRe   = regexp.MustCompile(`(?i)active.*(running|enabled)`)
 )
 
 // NodeInfo holds resolved information about a cluster node.

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -310,7 +310,7 @@ func checkEtcdHealth(client *gossh.Client, nodes []NodeInfo) error {
 // --- Fencing ---
 
 func fenceNode(client *gossh.Client, pcmkName string) error {
-	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, pcmkName)
+	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, shellQuote(pcmkName))
 	_, err := sshRun(client, cmd)
 	return err
 }

--- a/pkg/fencing/validate.go
+++ b/pkg/fencing/validate.go
@@ -1,0 +1,554 @@
+// Package fencing validates fencing on DualReplica (Two Node with Fencing) clusters
+// by fencing both nodes sequentially and verifying recovery.
+package fencing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	gossh "golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/installer/pkg/gather/ssh"
+)
+
+const (
+	sshPort          = "22"
+	pollInterval     = 5 * time.Second
+	notReadyTimeout  = 20 * time.Minute
+	readyTimeout     = 10 * time.Minute
+	pcmkTimeout      = 10 * time.Minute
+	etcdTimeout      = 10 * time.Minute
+	fenceTimeout     = 600 // seconds, passed to timeout(1)
+	fenceWarnSeconds = 60
+)
+
+var (
+	stonithEnabledRe = regexp.MustCompile(`(?i)stonith-enabled\s*[:=]\s*true`)
+	daemonActiveRe   = regexp.MustCompile(`(?i)active.*running|enabled`)
+)
+
+// NodeInfo holds resolved information about a cluster node.
+type NodeInfo struct {
+	Name          string
+	PacemakerName string
+	IP            string
+}
+
+// Config holds all inputs needed by the fencing validator.
+type Config struct {
+	KubeClient   kubernetes.Interface
+	ConfigClient configclient.Interface
+	SSHUser      string
+	SSHKeys      []string
+}
+
+// Run executes the full fencing validation sequence.
+func Run(ctx context.Context, cfg Config) error {
+	nodes, err := discoverNodes(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("node discovery failed: %w", err)
+	}
+
+	if err := verifyTopology(ctx, cfg); err != nil {
+		return err
+	}
+
+	logrus.Infof("Connecting to %s (%s)", nodes[0].Name, nodes[0].IP)
+	clientA, err := sshConnect(cfg, nodes[0].IP)
+	if err != nil {
+		return fmt.Errorf("SSH to %s failed: %w", nodes[0].Name, err)
+	}
+	defer clientA.Close()
+
+	if err := resolvePacemakerNames(clientA, nodes[:]); err != nil {
+		return err
+	}
+
+	logrus.Info("Running pre-flight checks")
+	if err := runPreFlight(clientA, nodes[:]); err != nil {
+		return fmt.Errorf("pre-flight check failed: %w", err)
+	}
+	logrus.Info("Pre-flight checks passed")
+
+	// Fence node B from node A
+	if err := fenceAndRecover(ctx, cfg, clientA, nodes[:], 1); err != nil {
+		return err
+	}
+
+	// Fence node A from node B — need new SSH connection to B
+	logrus.Infof("Connecting to %s (%s)", nodes[1].Name, nodes[1].IP)
+	clientB, err := sshConnect(cfg, nodes[1].IP)
+	if err != nil {
+		return fmt.Errorf("SSH to %s failed: %w", nodes[1].Name, err)
+	}
+	defer clientB.Close()
+
+	if err := fenceAndRecover(ctx, cfg, clientB, nodes[:], 0); err != nil {
+		return err
+	}
+
+	logrus.Info("Fencing validation passed")
+	return nil
+}
+
+func fenceAndRecover(ctx context.Context, cfg Config, survivorClient *gossh.Client, nodes []NodeInfo, targetIdx int) error {
+	target := nodes[targetIdx]
+	survivor := nodes[1-targetIdx]
+
+	logrus.Infof("Fencing %s (pacemaker: %s) from %s", target.Name, target.PacemakerName, survivor.Name)
+	fenceStart := time.Now()
+
+	if err := fenceNode(survivorClient, target.PacemakerName); err != nil {
+		return fmt.Errorf("failed to fence %s: %w", target.Name, err)
+	}
+
+	logrus.Infof("Waiting for %s to become NotReady", target.Name)
+	if err := waitNotReady(ctx, cfg.KubeClient, target.Name); err != nil {
+		return fmt.Errorf("%s did not become NotReady: %w", target.Name, err)
+	}
+
+	fenceDuration := time.Since(fenceStart)
+	if fenceDuration.Seconds() > fenceWarnSeconds {
+		logrus.Warnf("Fencing %s took %s to power off (threshold is %ds). BMC may be performing graceful shutdown instead of power-off. Check BMC configuration.",
+			target.Name, fenceDuration.Round(time.Second), fenceWarnSeconds)
+	} else {
+		logrus.Infof("Node %s powered off in %s", target.Name, fenceDuration.Round(time.Second))
+	}
+
+	logrus.Infof("Waiting for %s to become Ready", target.Name)
+	if err := waitReady(ctx, cfg.KubeClient, target.Name); err != nil {
+		return fmt.Errorf("%s did not become Ready: %w", target.Name, err)
+	}
+
+	logrus.Infof("Waiting for %s to rejoin Pacemaker", target.Name)
+	if err := pollPacemakerOnline(ctx, survivorClient, nodes); err != nil {
+		return fmt.Errorf("%s did not rejoin Pacemaker: %w", target.Name, err)
+	}
+
+	logrus.Info("Waiting for etcd quorum")
+	if err := pollEtcdHealth(ctx, survivorClient, nodes); err != nil {
+		return fmt.Errorf("etcd quorum not restored after fencing %s: %w", target.Name, err)
+	}
+
+	if err := checkDaemons(survivorClient); err != nil {
+		return fmt.Errorf("daemon check failed after fencing %s: %w", target.Name, err)
+	}
+
+	logrus.Infof("Fencing %s: full recovery completed in %s", target.Name, time.Since(fenceStart).Round(time.Second))
+	return nil
+}
+
+// --- Node discovery ---
+
+func discoverNodes(ctx context.Context, cfg Config) ([2]NodeInfo, error) {
+	nodeList, err := cfg.KubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/master=",
+	})
+	if err != nil {
+		return [2]NodeInfo{}, fmt.Errorf("listing control-plane nodes: %w", err)
+	}
+
+	var nodes []NodeInfo
+	for i := range nodeList.Items {
+		n := &nodeList.Items[i]
+		ip := nodeInternalIP(n)
+		if ip == "" {
+			return [2]NodeInfo{}, fmt.Errorf("node %s has no InternalIP", n.Name)
+		}
+		nodes = append(nodes, NodeInfo{Name: n.Name, IP: ip})
+	}
+
+	if len(nodes) != 2 {
+		return [2]NodeInfo{}, fmt.Errorf("expected 2 control-plane nodes, found %d", len(nodes))
+	}
+
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
+	logrus.Infof("Discovered nodes: %s (%s), %s (%s)", nodes[0].Name, nodes[0].IP, nodes[1].Name, nodes[1].IP)
+	return [2]NodeInfo{nodes[0], nodes[1]}, nil
+}
+
+func nodeInternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
+}
+
+func verifyTopology(ctx context.Context, cfg Config) error {
+	infra, err := cfg.ConfigClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("reading Infrastructure CR: %w", err)
+	}
+	if infra.Status.ControlPlaneTopology != configv1.DualReplicaTopologyMode {
+		return fmt.Errorf("fencing validation requires DualReplica topology, found %q", infra.Status.ControlPlaneTopology)
+	}
+	return nil
+}
+
+// --- SSH helpers ---
+
+func sshConnect(cfg Config, ip string) (*gossh.Client, error) {
+	addr := net.JoinHostPort(ip, sshPort)
+	return ssh.NewClient(cfg.SSHUser, addr, cfg.SSHKeys)
+}
+
+func sshRun(client *gossh.Client, cmd string) (string, error) {
+	wrapped := fmt.Sprintf("sudo bash -lc %s", shellQuote(cmd))
+	stdout, stderr, err := ssh.RunOutput(client, wrapped)
+	if err != nil {
+		return stdout, fmt.Errorf("command failed: %s\nstderr: %s: %w", cmd, stderr, err)
+	}
+	return stdout, nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// --- Pre-flight checks ---
+
+func runPreFlight(client *gossh.Client, nodes []NodeInfo) error {
+	if err := checkStonith(client); err != nil {
+		return err
+	}
+	if err := checkPacemakerOnline(client, nodes); err != nil {
+		return err
+	}
+	if err := checkDaemons(client); err != nil {
+		return err
+	}
+	return checkEtcdHealth(client, nodes)
+}
+
+func checkStonith(client *gossh.Client) error {
+	out, err := sshRun(client, "(pcs stonith config || pcs stonith status || pcs stonith show) 2>&1")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return fmt.Errorf("no STONITH devices configured")
+	}
+
+	prop, err := sshRun(client, "pcs property config stonith-enabled 2>&1 || pcs property list stonith-enabled 2>&1 || pcs property show --all stonith-enabled 2>&1")
+	if err != nil {
+		return fmt.Errorf("could not read stonith-enabled property: %w", err)
+	}
+	if !parseStonithEnabled(prop) {
+		return fmt.Errorf("stonith-enabled is not set to true")
+	}
+	logrus.Info("STONITH is configured and enabled")
+	return nil
+}
+
+func checkPacemakerOnline(client *gossh.Client, nodes []NodeInfo) error {
+	out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+	if err != nil {
+		return fmt.Errorf("checking pacemaker status: %w", err)
+	}
+
+	online := parsePacemakerOnline(out)
+	for _, n := range nodes {
+		if !nodeInOnlineList(n, online) {
+			return fmt.Errorf("node %s is not online in Pacemaker", n.Name)
+		}
+	}
+	logrus.Info("Both nodes are online in Pacemaker")
+	return nil
+}
+
+func checkDaemons(client *gossh.Client) error {
+	out, err := sshRun(client, "pcs status --full 2>/dev/null || pcs status 2>/dev/null")
+	if err != nil {
+		return fmt.Errorf("checking daemon status: %w", err)
+	}
+
+	missing := parseDaemonStatus(out)
+	if len(missing) > 0 {
+		return fmt.Errorf("daemons not active/running: %s", strings.Join(missing, ", "))
+	}
+	logrus.Info("All daemons (corosync, pacemaker, pcsd) are active")
+	return nil
+}
+
+func checkEtcdHealth(client *gossh.Client, nodes []NodeInfo) error {
+	endpoints := formatEtcdURL(nodes[0].IP) + "," + formatEtcdURL(nodes[1].IP)
+
+	healthCmd := fmt.Sprintf("podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json endpoint health --endpoints=%s'", endpoints)
+	out, err := sshRun(client, healthCmd)
+	if err != nil {
+		return fmt.Errorf("etcd endpoint health check failed: %w", err)
+	}
+	if err := parseEtcdHealth(out); err != nil {
+		return err
+	}
+
+	memberCmd := "podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json member list'"
+	out, err = sshRun(client, memberCmd)
+	if err != nil {
+		return fmt.Errorf("etcd member list failed: %w", err)
+	}
+	if err := parseEtcdMembers(out, nodes[0].IP, nodes[1].IP); err != nil {
+		return err
+	}
+
+	logrus.Info("etcd has 2 healthy voter members")
+	return nil
+}
+
+// --- Fencing ---
+
+func fenceNode(client *gossh.Client, pcmkName string) error {
+	cmd := fmt.Sprintf("timeout %d pcs stonith fence %s", fenceTimeout, pcmkName)
+	_, err := sshRun(client, cmd)
+	return err
+}
+
+// --- Polling ---
+
+func waitNotReady(ctx context.Context, kube kubernetes.Interface, nodeName string) error {
+	pollCtx, cancel := context.WithTimeout(ctx, notReadyTimeout)
+	defer cancel()
+	start := time.Now()
+	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		if !isNodeReady(ctx, kube, nodeName) {
+			return true, nil
+		}
+		if time.Since(start) > time.Minute {
+			logrus.Debugf("Still waiting for %s to become NotReady (%s elapsed)", nodeName, time.Since(start).Round(time.Second))
+		}
+		return false, nil
+	})
+}
+
+func waitReady(ctx context.Context, kube kubernetes.Interface, nodeName string) error {
+	pollCtx, cancel := context.WithTimeout(ctx, readyTimeout)
+	defer cancel()
+	start := time.Now()
+	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		if isNodeReady(ctx, kube, nodeName) {
+			return true, nil
+		}
+		if time.Since(start) > time.Minute {
+			logrus.Debugf("Still waiting for %s to become Ready (%s elapsed)", nodeName, time.Since(start).Round(time.Second))
+		}
+		return false, nil
+	})
+}
+
+func isNodeReady(ctx context.Context, kube kubernetes.Interface, nodeName string) bool {
+	node, err := kube.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func pollPacemakerOnline(ctx context.Context, client *gossh.Client, nodes []NodeInfo) error {
+	pollCtx, cancel := context.WithTimeout(ctx, pcmkTimeout)
+	defer cancel()
+	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+		if err != nil {
+			return false, nil
+		}
+		online := parsePacemakerOnline(out)
+		for _, n := range nodes {
+			if !nodeInOnlineList(n, online) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+func pollEtcdHealth(ctx context.Context, client *gossh.Client, nodes []NodeInfo) error {
+	endpoints := formatEtcdURL(nodes[0].IP) + "," + formatEtcdURL(nodes[1].IP)
+	pollCtx, cancel := context.WithTimeout(ctx, etcdTimeout)
+	defer cancel()
+	return wait.PollUntilContextCancel(pollCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		healthCmd := fmt.Sprintf("podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json endpoint health --endpoints=%s'", endpoints)
+		out, err := sshRun(client, healthCmd)
+		if err != nil {
+			return false, nil
+		}
+		if parseEtcdHealth(out) != nil {
+			return false, nil
+		}
+
+		memberCmd := "podman exec etcd sh -lc 'ETCDCTL_API=3 etcdctl -w json member list'"
+		out, err = sshRun(client, memberCmd)
+		if err != nil {
+			return false, nil
+		}
+		if parseEtcdMembers(out, nodes[0].IP, nodes[1].IP) != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// --- Parsing ---
+
+func parseStonithEnabled(output string) bool {
+	return stonithEnabledRe.MatchString(output)
+}
+
+func parsePacemakerOnline(output string) []string {
+	var names []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "Online:") {
+			continue
+		}
+		rest := strings.TrimPrefix(trimmed, "Online:")
+		rest = strings.NewReplacer("[", "", "]", "").Replace(rest)
+		for _, name := range strings.Fields(rest) {
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+		break
+	}
+	return names
+}
+
+func nodeInOnlineList(node NodeInfo, online []string) bool {
+	short := strings.SplitN(node.Name, ".", 2)[0]
+	pcmkShort := strings.SplitN(node.PacemakerName, ".", 2)[0]
+	for _, name := range online {
+		nameShort := strings.SplitN(name, ".", 2)[0]
+		if name == node.Name || name == node.PacemakerName ||
+			nameShort == short || nameShort == pcmkShort {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDaemonStatus(output string) []string {
+	inSection := false
+	var missing []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "Daemon Status:") {
+			inSection = true
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		lower := strings.ToLower(strings.TrimSpace(line))
+		for _, svc := range []string{"corosync", "pacemaker", "pcsd"} {
+			if strings.HasPrefix(lower, svc+":") && !daemonActiveRe.MatchString(line) {
+				missing = append(missing, svc)
+			}
+		}
+	}
+	return missing
+}
+
+type etcdHealthEntry struct {
+	Health bool   `json:"health"`
+	Error  string `json:"error,omitempty"`
+}
+
+func parseEtcdHealth(output string) error {
+	var entries []etcdHealthEntry
+	if err := json.Unmarshal([]byte(output), &entries); err != nil {
+		return fmt.Errorf("failed to parse etcd health output: %w", err)
+	}
+	for _, e := range entries {
+		if !e.Health {
+			return fmt.Errorf("unhealthy etcd endpoint: %s", e.Error)
+		}
+	}
+	return nil
+}
+
+type etcdMemberList struct {
+	Members []etcdMember `json:"members"`
+}
+
+type etcdMember struct {
+	IsLearner  bool     `json:"isLearner"`
+	ClientURLs []string `json:"clientURLs"`
+}
+
+func parseEtcdMembers(output, ipA, ipB string) error {
+	var list etcdMemberList
+	if err := json.Unmarshal([]byte(output), &list); err != nil {
+		return fmt.Errorf("failed to parse etcd member list: %w", err)
+	}
+
+	foundA, foundB := false, false
+	for _, m := range list.Members {
+		if m.IsLearner {
+			continue
+		}
+		for _, u := range m.ClientURLs {
+			if strings.Contains(u, ipA) {
+				foundA = true
+			}
+			if strings.Contains(u, ipB) {
+				foundB = true
+			}
+		}
+	}
+	if !foundA || !foundB {
+		return fmt.Errorf("etcd does not have 2 voting members (found A=%v, B=%v)", foundA, foundB)
+	}
+	return nil
+}
+
+func resolvePacemakerNames(client *gossh.Client, nodes []NodeInfo) error {
+	out, err := sshRun(client, "pcs status nodes 2>/dev/null || crm_mon -1 2>/dev/null")
+	if err != nil {
+		return fmt.Errorf("resolving pacemaker node names: %w", err)
+	}
+
+	online := parsePacemakerOnline(out)
+	if len(online) < 2 {
+		return fmt.Errorf("expected at least 2 pacemaker nodes online, found %d", len(online))
+	}
+
+	for i := range nodes {
+		short := strings.SplitN(nodes[i].Name, ".", 2)[0]
+		for _, pname := range online {
+			pshort := strings.SplitN(pname, ".", 2)[0]
+			if pname == nodes[i].Name || pshort == short {
+				nodes[i].PacemakerName = pname
+				break
+			}
+		}
+		if nodes[i].PacemakerName == "" {
+			return fmt.Errorf("could not resolve pacemaker name for node %s", nodes[i].Name)
+		}
+	}
+
+	logrus.Infof("Pacemaker names: %s → %s, %s → %s",
+		nodes[0].Name, nodes[0].PacemakerName, nodes[1].Name, nodes[1].PacemakerName)
+	return nil
+}
+
+func formatEtcdURL(ip string) string {
+	if strings.Contains(ip, ":") {
+		return fmt.Sprintf("https://[%s]:2379", ip)
+	}
+	return fmt.Sprintf("https://%s:2379", ip)
+}

--- a/pkg/fencing/validate_test.go
+++ b/pkg/fencing/validate_test.go
@@ -199,6 +199,16 @@ func TestParseEtcdHealth(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "empty array",
+			input:   `[]`,
+			wantErr: true,
+		},
+		{
+			name:    "single endpoint",
+			input:   `[{"health":true}]`,
+			wantErr: true,
+		},
+		{
 			name:    "invalid json",
 			input:   `not json`,
 			wantErr: true,
@@ -264,6 +274,48 @@ func TestParseEtcdMembers(t *testing.T) {
 			err := parseEtcdMembers(tc.input, tc.ipA, tc.ipB)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("parseEtcdMembers() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "simple string",
+			input:  "pcs status nodes",
+			expect: "'pcs status nodes'",
+		},
+		{
+			name:   "string with single quotes",
+			input:  "echo 'hello'",
+			expect: "'echo '\"'\"'hello'\"'\"''",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			expect: "''",
+		},
+		{
+			name:   "subshell syntax",
+			input:  "$(whoami)",
+			expect: "'$(whoami)'",
+		},
+		{
+			name:   "semicolon and pipe",
+			input:  "cmd1; cmd2 | cmd3",
+			expect: "'cmd1; cmd2 | cmd3'",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellQuote(tc.input)
+			if got != tc.expect {
+				t.Errorf("shellQuote(%q) = %q, want %q", tc.input, got, tc.expect)
 			}
 		})
 	}

--- a/pkg/fencing/validate_test.go
+++ b/pkg/fencing/validate_test.go
@@ -228,7 +228,8 @@ func TestParseEtcdMembers(t *testing.T) {
 				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]},
 				{"isLearner":false,"clientURLs":["https://10.0.0.2:2379"]}
 			]}`,
-			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			ipA:     "10.0.0.1",
+			ipB:     "10.0.0.2",
 			wantErr: false,
 		},
 		{
@@ -237,7 +238,8 @@ func TestParseEtcdMembers(t *testing.T) {
 				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]},
 				{"isLearner":true,"clientURLs":["https://10.0.0.2:2379"]}
 			]}`,
-			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			ipA:     "10.0.0.1",
+			ipB:     "10.0.0.2",
 			wantErr: true,
 		},
 		{
@@ -245,13 +247,15 @@ func TestParseEtcdMembers(t *testing.T) {
 			input: `{"members":[
 				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]}
 			]}`,
-			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			ipA:     "10.0.0.1",
+			ipB:     "10.0.0.2",
 			wantErr: true,
 		},
 		{
 			name:    "invalid json",
 			input:   `bad`,
-			ipA:     "10.0.0.1", ipB: "10.0.0.2",
+			ipA:     "10.0.0.1",
+			ipB:     "10.0.0.2",
 			wantErr: true,
 		},
 	}
@@ -267,14 +271,23 @@ func TestParseEtcdMembers(t *testing.T) {
 
 func TestFormatEtcdURL(t *testing.T) {
 	tests := []struct {
+		name   string
 		ip     string
 		expect string
 	}{
-		{"10.0.0.1", "https://10.0.0.1:2379"},
-		{"fd00::1", "https://[fd00::1]:2379"},
+		{
+			name:   "IPv4 address",
+			ip:     "10.0.0.1",
+			expect: "https://10.0.0.1:2379",
+		},
+		{
+			name:   "IPv6 address",
+			ip:     "fd00::1",
+			expect: "https://[fd00::1]:2379",
+		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.ip, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			got := formatEtcdURL(tc.ip)
 			if got != tc.expect {
 				t.Errorf("formatEtcdURL(%q) = %q, want %q", tc.ip, got, tc.expect)

--- a/pkg/fencing/validate_test.go
+++ b/pkg/fencing/validate_test.go
@@ -1,0 +1,284 @@
+package fencing
+
+import (
+	"testing"
+)
+
+func TestParseStonithEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{
+			name:   "enabled with colon",
+			input:  " stonith-enabled: true\n",
+			expect: true,
+		},
+		{
+			name:   "enabled with equals",
+			input:  "stonith-enabled=true\n",
+			expect: true,
+		},
+		{
+			name:   "disabled",
+			input:  " stonith-enabled: false\n",
+			expect: false,
+		},
+		{
+			name:   "mixed case",
+			input:  " Stonith-Enabled: True\n",
+			expect: true,
+		},
+		{
+			name:   "empty",
+			input:  "",
+			expect: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseStonithEnabled(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseStonithEnabled(%q) = %v, want %v", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestParsePacemakerOnline(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{
+		{
+			name:   "two nodes with brackets",
+			input:  "Online: [ node-a node-b ]\nStandby:\n",
+			expect: []string{"node-a", "node-b"},
+		},
+		{
+			name:   "two nodes without brackets",
+			input:  "Online: node-a node-b\n",
+			expect: []string{"node-a", "node-b"},
+		},
+		{
+			name:   "one node",
+			input:  "Online: [ node-a ]\n",
+			expect: []string{"node-a"},
+		},
+		{
+			name:   "indented",
+			input:  "  Online: [ master-0.example.com master-1.example.com ]\n",
+			expect: []string{"master-0.example.com", "master-1.example.com"},
+		},
+		{
+			name:   "no online line",
+			input:  "Standby: node-a\n",
+			expect: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePacemakerOnline(tc.input)
+			if len(got) != len(tc.expect) {
+				t.Fatalf("parsePacemakerOnline() = %v, want %v", got, tc.expect)
+			}
+			for i := range got {
+				if got[i] != tc.expect[i] {
+					t.Errorf("parsePacemakerOnline()[%d] = %q, want %q", i, got[i], tc.expect[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNodeInOnlineList(t *testing.T) {
+	node := NodeInfo{Name: "master-0.example.com", PacemakerName: "master-0"}
+	tests := []struct {
+		name   string
+		online []string
+		expect bool
+	}{
+		{
+			name:   "exact K8s name match",
+			online: []string{"master-0.example.com", "master-1.example.com"},
+			expect: true,
+		},
+		{
+			name:   "exact pacemaker name match",
+			online: []string{"master-0", "master-1"},
+			expect: true,
+		},
+		{
+			name:   "short hostname match",
+			online: []string{"master-0.other.domain", "master-1.other.domain"},
+			expect: true,
+		},
+		{
+			name:   "no match",
+			online: []string{"worker-0", "worker-1"},
+			expect: false,
+		},
+		{
+			name:   "empty list",
+			online: nil,
+			expect: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nodeInOnlineList(node, tc.online)
+			if got != tc.expect {
+				t.Errorf("nodeInOnlineList() = %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestParseDaemonStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		missing []string
+	}{
+		{
+			name: "all active",
+			input: `Full List of Resources:
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
+`,
+			missing: nil,
+		},
+		{
+			name: "pacemaker inactive",
+			input: `Daemon Status:
+  corosync: active/running
+  pacemaker: inactive/disabled
+  pcsd: active/running
+`,
+			missing: []string{"pacemaker"},
+		},
+		{
+			name:    "no daemon section",
+			input:   "some other output\n",
+			missing: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDaemonStatus(tc.input)
+			if len(got) != len(tc.missing) {
+				t.Fatalf("parseDaemonStatus() = %v, want %v", got, tc.missing)
+			}
+			for i := range got {
+				if got[i] != tc.missing[i] {
+					t.Errorf("parseDaemonStatus()[%d] = %q, want %q", i, got[i], tc.missing[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseEtcdHealth(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "both healthy",
+			input:   `[{"health":true,"took":"10ms"},{"health":true,"took":"12ms"}]`,
+			wantErr: false,
+		},
+		{
+			name:    "one unhealthy",
+			input:   `[{"health":true},{"health":false,"error":"context deadline exceeded"}]`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseEtcdHealth(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseEtcdHealth() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseEtcdMembers(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		ipA     string
+		ipB     string
+		wantErr bool
+	}{
+		{
+			name: "two voters",
+			input: `{"members":[
+				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]},
+				{"isLearner":false,"clientURLs":["https://10.0.0.2:2379"]}
+			]}`,
+			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			wantErr: false,
+		},
+		{
+			name: "one learner",
+			input: `{"members":[
+				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]},
+				{"isLearner":true,"clientURLs":["https://10.0.0.2:2379"]}
+			]}`,
+			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			wantErr: true,
+		},
+		{
+			name: "missing node B",
+			input: `{"members":[
+				{"isLearner":false,"clientURLs":["https://10.0.0.1:2379"]}
+			]}`,
+			ipA: "10.0.0.1", ipB: "10.0.0.2",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			input:   `bad`,
+			ipA:     "10.0.0.1", ipB: "10.0.0.2",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseEtcdMembers(tc.input, tc.ipA, tc.ipB)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseEtcdMembers() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFormatEtcdURL(t *testing.T) {
+	tests := []struct {
+		ip     string
+		expect string
+	}{
+		{"10.0.0.1", "https://10.0.0.1:2379"},
+		{"fd00::1", "https://[fd00::1]:2379"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.ip, func(t *testing.T) {
+			got := formatEtcdURL(tc.ip)
+			if got != tc.expect {
+				t.Errorf("formatEtcdURL(%q) = %q, want %q", tc.ip, got, tc.expect)
+			}
+		})
+	}
+}

--- a/pkg/fencing/validate_test.go
+++ b/pkg/fencing/validate_test.go
@@ -169,7 +169,7 @@ Daemon Status:
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseDaemonStatus(tc.input)
+			got, _ := parseDaemonStatus(tc.input)
 			if len(got) != len(tc.missing) {
 				t.Fatalf("parseDaemonStatus() = %v, want %v", got, tc.missing)
 			}

--- a/pkg/gather/ssh/ssh.go
+++ b/pkg/gather/ssh/ssh.go
@@ -68,6 +68,25 @@ func Run(client *ssh.Client, command string) error {
 	return sess.Run(command)
 }
 
+// RunOutput executes a command via SSH and returns the captured stdout and stderr.
+// Unlike Run, which pipes output to the logger, RunOutput captures it for programmatic use.
+func RunOutput(client *ssh.Client, command string) (string, string, error) {
+	sess, err := client.NewSession()
+	if err != nil {
+		return "", "", err
+	}
+	defer sess.Close()
+	if err := agent.RequestAgentForwarding(sess); err != nil {
+		return "", "", errors.Wrap(err, "failed to setup request agent forwarding")
+	}
+
+	var stdout, stderr strings.Builder
+	sess.Stdout = &stdout
+	sess.Stderr = &stderr
+	err = sess.Run(command)
+	return stdout.String(), stderr.String(), err
+}
+
 // PullFileTo downloads the file from remote server using SSH connection and writes to localPath.
 func PullFileTo(client *ssh.Client, remotePath, localPath string) error {
 	sc, err := sftp.NewClient(client)

--- a/pkg/gather/ssh/ssh.go
+++ b/pkg/gather/ssh/ssh.go
@@ -77,7 +77,7 @@ func RunOutput(client *ssh.Client, command string) (string, string, error) {
 	}
 	defer sess.Close()
 	if err := agent.RequestAgentForwarding(sess); err != nil {
-		return "", "", errors.Wrap(err, "failed to setup request agent forwarding")
+		logrus.Debugf("agent forwarding unavailable: %v", err)
 	}
 
 	var stdout, stderr strings.Builder


### PR DESCRIPTION
## Summary

Adds `openshift-install tnf-validate-fencing` — a command to validate fencing on Two Node with Fencing (DualReplica) clusters by power-cycling both nodes sequentially via STONITH and verifying full recovery.

## Background

Two Node with Fencing clusters use Pacemaker with STONITH to fence failed nodes and recover etcd automatically. While BMC credentials are validated during installation by the TNF fencing job, this does not confirm that an actual fence operation works end-to-end — the BMC could be misconfigured to perform a graceful shutdown instead of a hard power-off, the recovery sequence could fail, or etcd quorum restoration could stall.

This command fills that gap. It runs after the cluster is fully operational, performs a real fence-and-recover cycle on both nodes, and reports exactly what broke if something fails. It is intentionally decoupled from the install flow because it requires the full TNF stack (Pacemaker, STONITH, podman-etcd) to be operational, and because it is disruptive — it should only run when the user explicitly chooses to power-cycle their nodes.

## Usage

```sh
# From the install directory
openshift-install tnf-validate-fencing

# With explicit directory and SSH key
openshift-install tnf-validate-fencing --dir /path/to/install-dir --key ~/.ssh/id_rsa
```

## What it does

**Pre-flight checks** (via SSH to a control plane node):
- STONITH devices configured and enabled
- Both nodes online in Pacemaker
- corosync, pacemaker, pcsd daemons active
- etcd has 2 healthy voter members

**Disruptive validation** (for each node):
- Fences the node from its peer via `pcs stonith fence`
- Waits for the node to go NotReady, then recover to Ready
- Verifies Pacemaker rejoins and etcd quorum is restored
- Warns if fencing takes >60s (possible BMC graceful shutdown)

## Prerequisites

- Deployed DualReplica cluster (rejects non-DualReplica with clear error)
- SSH access to both nodes as `core` user
- Cluster-admin kubeconfig at `<dir>/auth/kubeconfig`

## Files

| File | Change |
|------|--------|
| `pkg/fencing/validate.go` | New — validation logic, SSH checks, parsing, orchestration |
| `pkg/fencing/validate_test.go` | New — unit tests for all parsing functions (31 tests) |
| `cmd/openshift-install/tnf.go` | New — cobra command `tnf-validate-fencing` |
| `cmd/openshift-install/main.go` | Register `newTNFValidateFencingCmd()` |
| `pkg/gather/ssh/ssh.go` | Add `RunOutput()` for capturing SSH command output |

[OCPEDGE-2254](https://redhat.atlassian.net/browse/OCPEDGE-2254)