### PR TITLE
CORS-4349: hack/build: Trim v1 prefix from git tag for BUILD_VERSION

### DIFF
--- a/hack/build-node-joiner.sh
+++ b/hack/build-node-joiner.sh
@@ -17,7 +17,7 @@ export CGO_ENABLED=0
 MODE="${MODE:-release}"
 
 GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
-GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"
+GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty | sed 's/^v\?1\.//')}"
 DEFAULT_ARCH="${DEFAULT_ARCH:-amd64}"
 GOFLAGS="${GOFLAGS:--mod=vendor}"
 GCFLAGS=""

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -25,7 +25,7 @@ make -C cluster-api all
 copy_cluster_api_to_mirror
 
 GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
-GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"
+GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty | sed 's/^v\?1\.//')}"
 DEFAULT_ARCH="${DEFAULT_ARCH:-amd64}"
 GOFLAGS="${GOFLAGS:--mod=vendor}"
 GCFLAGS=""


### PR DESCRIPTION
This commit takes a git tag and converts it to an openshift version. Per go module guidelines, our tags need to start with v1.y.z. By convention we are populating these with openshift versions v1.x.y.

For example, v1.4.22-ec5 is an unreleased version of 4.22.

We need this change in order to distinguish between 5.0 and 4.23 which are being built from the same branch. BUILD_VERSION can be used to determine, well, build version; but that is not populated in CI. Our build script falls back to git tags, so this change helps translate to the openshift version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build script version tag normalization to ensure consistent and predictable versioning during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->