### PR TITLE
OCPBUGS-85509: Add omitempty to vSphere and Nutanix MachinePool slice fields

### DIFF
--- a/pkg/types/nutanix/machinepool.go
+++ b/pkg/types/nutanix/machinepool.go
@@ -61,12 +61,12 @@ type MachinePool struct {
 	// GPUs is a list of GPU devices to attach to the machine's VM.
 	// +listType=set
 	// +optional
-	GPUs []machinev1.NutanixGPU `json:"gpus"`
+	GPUs []machinev1.NutanixGPU `json:"gpus,omitempty"`
 
 	// DataDisks holds information of the data disks to attach to the Machine's VM
 	// +listType=set
 	// +optional
-	DataDisks []DataDisk `json:"dataDisks"`
+	DataDisks []DataDisk `json:"dataDisks,omitempty"`
 
 	// FailureDomains optionally configures a list of failure domain names
 	// that will be applied to the MachinePool

--- a/pkg/types/vsphere/machinepool.go
+++ b/pkg/types/vsphere/machinepool.go
@@ -30,7 +30,7 @@ type MachinePool struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=29
-	DataDisks []DataDisk `json:"dataDisks"`
+	DataDisks []DataDisk `json:"dataDisks,omitempty"`
 
 	// Zones defines available zones
 	// Zones is available in TechPreview.


### PR DESCRIPTION
## Summary

- Add `omitempty` to optional slice fields (`DataDisks`, `GPUs`) in vSphere and Nutanix `MachinePool` types that were missing it
- Aligns with Azure's `DataDisks` which already carries `omitempty`

## Problem

When automation tools (Hive, assisted-service) vendor newer installer types and marshal an `InstallConfig` targeting an older cluster version (e.g., 4.18), the empty `DataDisks` slice is serialized as `dataDisks: null`. The older installer binary does not recognize this field, and `UnmarshalStrict` emits:

```
failed to parse first occurrence of unknown field: failed to unmarshal install-config.yaml:
error unmarshaling JSON: while decoding JSON: json: unknown field "dataDisks"
```

The install succeeds (the installer falls back to non-strict unmarshal when `OPENSHIFT_INSTALL_INVOKER` is set), but the warning creates customer-facing noise.

## Fix

Add `omitempty` to 3 fields across 2 files:

| File | Field | Before | After |
|------|-------|--------|-------|
| `pkg/types/vsphere/machinepool.go` | `DataDisks` | `json:"dataDisks"` | `json:"dataDisks,omitempty"` |
| `pkg/types/nutanix/machinepool.go` | `DataDisks` | `json:"dataDisks"` | `json:"dataDisks,omitempty"` |
| `pkg/types/nutanix/machinepool.go` | `GPUs` | `json:"gpus"` | `json:"gpus,omitempty"` |

This is safe because:
- All fields are already annotated `+optional`
- All consumers use `len() > 0` guards before accessing elements
- An omitted JSON field unmarshals to a nil slice (`len() == 0`), identical to the current empty-slice behavior
- The `MachinePool.Set()` methods guard with `len(required.DataDisks) > 0`

## Test plan

- Verify existing installer unit tests pass (`go test ./pkg/types/vsphere/... ./pkg/types/nutanix/...`)
- Verify marshaling a `MachinePool` with no `DataDisks` no longer emits the `dataDisks` key
- Verify marshaling a `MachinePool` with explicit `DataDisks` still includes them

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * **Nutanix**: DataDisks field is now properly marked as optional in machine pool configurations, allowing users to omit this field when not required.
  * **vSphere**: DataDisks field is now properly marked as optional in machine pool configurations, enabling more concise and flexible configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->