### PR TITLE
no-jira: PowerVS: Remove unrequired logging

### DIFF
--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -314,7 +314,6 @@ func (p Provider) PostProvision(ctx context.Context, in clusterapi.PostProvision
 	if err != nil {
 		return fmt.Errorf("failed to get NewClient in PostProvision: %w", err)
 	}
-	logrus.Debugf("PostProvision: NewClient returns %+v", client)
 
 	// We need to set the region we will eventually query inside
 	vpcRegion = in.InstallConfig.Config.Platform.PowerVS.VPCRegion


### PR DESCRIPTION
Logging too many details makes the output cluttered. This PR reduces some unrequired logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal debug log from the PowerVS provisioning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->