### PR TITLE
Add GitHub Actions workflows for presubmit checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,92 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for the openshift-splat-team installer fork.
+
+## Workflows
+
+### vendor-check.yml
+**Purpose:** Ensures the vendor directory is in sync with go.mod and go.sum
+
+**Runs on:** PRs and pushes to master/main
+
+**What it checks:**
+- Runs `go mod tidy` and `go mod vendor`
+- Verifies no changes to go.mod, go.sum, or vendor/
+
+**How to fix failures:**
+```bash
+go mod tidy
+go mod vendor
+git add go.mod go.sum vendor/
+git commit -m "Update vendor directory"
+```
+
+---
+
+### lint.yml
+**Purpose:** Runs golangci-lint to check code quality
+
+**Runs on:** PRs and pushes to master/main
+
+**What it checks:**
+- Uses `.golangci.yaml` configuration
+- Runs all configured linters
+
+**How to fix failures:**
+```bash
+golangci-lint run --config .golangci.yaml
+# Fix reported issues
+```
+
+---
+
+### format-check.yml
+**Purpose:** Verifies code is properly formatted
+
+**Runs on:** PRs and pushes to master/main
+
+**What it checks:**
+- gofmt formatting
+- goimports (warning only)
+
+**How to fix failures:**
+```bash
+gofmt -w .
+# Or use goimports for import organization too
+go install golang.org/x/tools/cmd/goimports@latest
+goimports -w .
+```
+
+---
+
+### build-test.yml
+**Purpose:** Builds the installer and runs unit tests
+
+**Runs on:** PRs and pushes to master/main
+
+**What it does:**
+- Builds openshift-install binary via `hack/build.sh`
+- Runs all unit tests with race detection
+- Uploads coverage to Codecov (if configured)
+
+**How to run locally:**
+```bash
+# Build
+./hack/build.sh
+
+# Test
+go test -v -race ./...
+```
+
+## Adding New Workflows
+
+When adding new workflows:
+1. Follow the existing naming convention
+2. Use the same trigger events (pull_request, push)
+3. Use `go-version-file: 'go.mod'` for consistent Go versions
+4. Document the workflow in this README
+5. Provide clear error messages with remediation steps
+
+## Notes
+
+These workflows supplement (not replace) the OpenShift CI presubmit tests defined in the openshift/release repository. They provide quick feedback for common issues before the full CI suite runs.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,61 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    name: Build installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build installer
+        run: ./hack/build.sh
+        env:
+          MODE: release
+
+      - name: Verify binary
+        run: |
+          ./bin/openshift-install version
+
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run tests
+        run: |
+          go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+        env:
+          CGO_ENABLED: 1
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        if: success()
+        continue-on-error: true
+        with:
+          file: ./coverage.out
+          flags: unittests

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,48 @@
+name: Format Check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  gofmt:
+    name: Check gofmt formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::The following files are not formatted with gofmt:"
+            echo "$unformatted"
+            echo ""
+            echo "Run 'gofmt -w .' to fix formatting issues."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Check goimports (if available)
+        continue-on-error: true
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          unformatted=$(goimports -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::warning::The following files need import formatting:"
+            echo "$unformatted"
+          fi
+        shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --config .golangci.yaml --timeout 10m
+          skip-cache: false
+          skip-pkg-cache: false
+          skip-build-cache: false
+
+      - name: Check lint results
+        if: failure()
+        run: |
+          echo "::error::Linting failed. Run 'golangci-lint run --config .golangci.yaml' locally to see issues."
+          exit 1

--- a/.github/workflows/vendor-check.yml
+++ b/.github/workflows/vendor-check.yml
@@ -1,0 +1,38 @@
+name: Vendor Check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  verify-vendor:
+    name: Verify vendor directory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Verify vendor dependencies
+        run: |
+          go mod tidy
+          go mod vendor
+          git diff --exit-code go.mod go.sum vendor/
+        shell: bash
+
+      - name: Check for vendor changes
+        if: failure()
+        run: |
+          echo "::error::Vendor directory is out of sync. Run 'go mod tidy && go mod vendor' and commit the changes."
+          exit 1


### PR DESCRIPTION
Add GitHub Actions workflows to provide quick feedback on common issues for the openshift-splat-team fork. These supplement the full OpenShift CI presubmit tests defined in openshift/release.

Workflows added:
- vendor-check.yml: Verify vendor/ is in sync with go.mod/go.sum
- lint.yml: Run golangci-lint with existing .golangci.yaml config
- format-check.yml: Verify gofmt formatting
- build-test.yml: Build installer and run unit tests with coverage

Each workflow includes clear error messages with remediation steps. Documented all workflows in .github/workflows/README.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining the repository's GitHub Actions workflows, including their purpose and guidance for remediation.

* **Chores**
  * Added automated CI/CD pipelines to validate code quality (linting and formatting), verify builds and unit tests, and ensure vendor dependencies remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->