### PR TITLE
AGENT-626: Allow UserManaged LoadBalancer on baremetal/vsphere platforms

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -6286,9 +6286,8 @@ spec:
                       Default is qemu:///system
                     type: string
                   loadBalancer:
-                    description: |-
-                      LoadBalancer defines how the load balancer used by the cluster is configured.
-                      LoadBalancer is available in TechPreview.
+                    description: LoadBalancer defines how the load balancer used by
+                      the cluster is configured.
                     properties:
                       type:
                         default: OpenShiftManagedDefault
@@ -7280,9 +7279,8 @@ spec:
                     maxItems: 2
                     type: array
                   loadBalancer:
-                    description: |-
-                      LoadBalancer defines how the load balancer used by the cluster is configured.
-                      LoadBalancer is available in TechPreview.
+                    description: LoadBalancer defines how the load balancer used by
+                      the cluster is configured.
                     properties:
                       type:
                         default: OpenShiftManagedDefault
@@ -7847,9 +7845,8 @@ spec:
                     maxItems: 2
                     type: array
                   loadBalancer:
-                    description: |-
-                      LoadBalancer defines how the load balancer used by the cluster is configured.
-                      LoadBalancer is available in TechPreview.
+                    description: LoadBalancer defines how the load balancer used by
+                      the cluster is configured.
                     properties:
                       type:
                         default: OpenShiftManagedDefault
@@ -8637,9 +8634,8 @@ spec:
                     maxItems: 2
                     type: array
                   loadBalancer:
-                    description: |-
-                      LoadBalancer defines how the load balancer used by the cluster is configured.
-                      LoadBalancer is available in TechPreview.
+                    description: LoadBalancer defines how the load balancer used by
+                      the cluster is configured.
                     properties:
                       type:
                         default: OpenShiftManagedDefault

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -538,11 +538,6 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			logrus.Warnf("%s: %s is ignored", fieldPath, vspherePlatform.DiskType)
 		}
 
-		if vspherePlatform.LoadBalancer != nil && !reflect.DeepEqual(*vspherePlatform.LoadBalancer, configv1.VSpherePlatformLoadBalancer{}) {
-			fieldPath := vsPath.Child("loadBalancer")
-			logrus.Warnf("%s: %v is ignored", fieldPath, vspherePlatform.LoadBalancer)
-		}
-
 		if len(vspherePlatform.Hosts) > 1 {
 			fieldPath := vsPath.Child("hosts")
 			logrus.Warnf("%s: %v is ignored", fieldPath, vspherePlatform.Hosts)

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -313,6 +313,11 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.BareMetal.IngressVIPs
 			agentClusterInstall.Spec.APIVIP = installConfig.Config.Platform.BareMetal.APIVIPs[0]
 			agentClusterInstall.Spec.IngressVIP = installConfig.Config.Platform.BareMetal.IngressVIPs[0]
+			if installConfig.Config.Platform.BareMetal.LoadBalancer != nil {
+				agentClusterInstall.Spec.LoadBalancer = &hiveext.LoadBalancer{
+					Type: loadBalancerType(installConfig.Config.Platform.BareMetal.LoadBalancer.Type),
+				}
+			}
 		} else if installConfig.Config.Platform.VSphere != nil {
 			vspherePlatform := vsphere.Platform{}
 			if len(installConfig.Config.Platform.VSphere.APIVIPs) > 1 {
@@ -341,6 +346,11 @@ func (a *AgentClusterInstall) Generate(_ context.Context, dependencies asset.Par
 			}
 			agentClusterInstall.Spec.APIVIPs = installConfig.Config.Platform.VSphere.APIVIPs
 			agentClusterInstall.Spec.IngressVIPs = installConfig.Config.Platform.VSphere.IngressVIPs
+			if installConfig.Config.Platform.VSphere.LoadBalancer != nil {
+				agentClusterInstall.Spec.LoadBalancer = &hiveext.LoadBalancer{
+					Type: loadBalancerType(installConfig.Config.Platform.VSphere.LoadBalancer.Type),
+				}
+			}
 		} else if installConfig.Config.Platform.Nutanix != nil {
 			icNutanixPlatformBytes, err := json.Marshal(*installConfig.Config.Platform.Nutanix)
 			if err != nil {
@@ -639,6 +649,13 @@ func (a *AgentClusterInstall) GetExternalPlatformName() string {
 		return a.Config.Spec.ExternalPlatformSpec.PlatformName
 	}
 	return ""
+}
+
+func loadBalancerType(lbType configv1.PlatformLoadBalancerType) hiveext.LoadBalancerType {
+	if lbType == configv1.LoadBalancerTypeUserManaged {
+		return hiveext.LoadBalancerTypeUserManaged
+	}
+	return hiveext.LoadBalancerTypeClusterManaged
 }
 
 func (a *AgentClusterInstall) validateDiskEncryption() field.ErrorList {

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	externaltype "github.com/openshift/installer/pkg/types/external"
+	vspheretype "github.com/openshift/installer/pkg/types/vsphere"
 )
 
 func TestAgentClusterInstall_Generate(t *testing.T) {
@@ -160,6 +161,35 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodArbiterACI := getGoodACI()
 	goodArbiterACI.Spec.ProvisionRequirements.ArbiterAgents = 1
 	goodArbiterACI.Spec.ProvisionRequirements.WorkerAgents = 0
+
+	installConfigBaremetalUserManagedLB := getValidOptionalInstallConfig()
+	installConfigBaremetalUserManagedLB.Config.Platform.BareMetal.LoadBalancer = &configv1.BareMetalPlatformLoadBalancer{
+		Type: configv1.LoadBalancerTypeUserManaged,
+	}
+
+	goodBaremetalUserManagedLBACI := getGoodACI()
+	goodBaremetalUserManagedLBACI.Spec.LoadBalancer = &hiveext.LoadBalancer{
+		Type: hiveext.LoadBalancerTypeUserManaged,
+	}
+
+	installConfigVSphereUserManagedLB := getValidOptionalInstallConfig()
+	installConfigVSphereUserManagedLB.Config.Platform = types.Platform{
+		VSphere: &vspheretype.Platform{
+			APIVIPs:     []string{"192.168.122.10"},
+			IngressVIPs: []string{"192.168.122.11"},
+			LoadBalancer: &configv1.VSpherePlatformLoadBalancer{
+				Type: configv1.LoadBalancerTypeUserManaged,
+			},
+		},
+	}
+
+	goodVSphereUserManagedLBACI := getGoodACI()
+	goodVSphereUserManagedLBACI.Spec.APIVIP = ""
+	goodVSphereUserManagedLBACI.Spec.IngressVIP = ""
+	goodVSphereUserManagedLBACI.Spec.PlatformType = hiveext.VSpherePlatformType
+	goodVSphereUserManagedLBACI.Spec.LoadBalancer = &hiveext.LoadBalancer{
+		Type: hiveext.LoadBalancerTypeUserManaged,
+	}
 
 	cases := []struct {
 		name           string
@@ -336,6 +366,26 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&agentconfig.AgentConfig{},
 			},
 			expectedConfig: goodArbiterACI,
+		},
+		{
+			name: "valid configuration baremetal user-managed load balancer",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				installConfigBaremetalUserManagedLB,
+				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
+			},
+			expectedConfig: goodBaremetalUserManagedLBACI,
+		},
+		{
+			name: "valid configuration vsphere user-managed load balancer",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeInstall},
+				installConfigVSphereUserManagedLB,
+				&agentconfig.AgentHosts{},
+				&agentconfig.AgentConfig{},
+			},
+			expectedConfig: goodVSphereUserManagedLBACI,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -247,7 +247,6 @@ type Platform struct {
 	BootstrapExternalStaticGateway string `json:"bootstrapExternalStaticGateway,omitempty"`
 
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
-	// LoadBalancer is available in TechPreview.
 	// +optional
 	LoadBalancer *configv1.BareMetalPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 

--- a/pkg/types/nutanix/platform.go
+++ b/pkg/types/nutanix/platform.go
@@ -75,7 +75,6 @@ type Platform struct {
 	SubnetUUIDs []string `json:"subnetUUIDs"`
 
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
-	// LoadBalancer is available in TechPreview.
 	// +optional
 	LoadBalancer *configv1.NutanixPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 

--- a/pkg/types/ovirt/platform.go
+++ b/pkg/types/ovirt/platform.go
@@ -70,7 +70,6 @@ type Platform struct {
 	AffinityGroups []AffinityGroup `json:"affinityGroups"`
 
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
-	// LoadBalancer is available in TechPreview.
 	// +optional
 	LoadBalancer *configv1.OvirtPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -145,7 +145,6 @@ type Platform struct {
 	NodeNetworking *configv1.VSpherePlatformNodeNetworking `json:"nodeNetworking,omitempty"`
 
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
-	// LoadBalancer is available in TechPreview.
 	// +optional
 	LoadBalancer *configv1.VSpherePlatformLoadBalancer `json:"loadBalancer,omitempty"`
 


### PR DESCRIPTION
Map the LoadBalancer type from platform install-config (baremetal,
vsphere) through to the AgentClusterInstall spec. The configv1
PlatformLoadBalancerType is converted to the hiveext
LoadBalancerType (UserManaged -> UserManaged,
OpenShiftManagedDefault -> ClusterManaged).

Remove the "is ignored" warning for LoadBalancer on the vsphere
platform, since the field is now plumbed through.

Note that in Assisted Service, the UserManaged LoadBalancer is not currently supported with Nutanix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-specific load balancer handling for agent-based BareMetal and vSphere installs with type mapping.

* **Bug Fixes**
  * Removed an inaccurate warning about load balancer being ignored for agent-based vSphere installs.

* **Documentation**
  * Removed TechPreview note and simplified load balancer field descriptions across BareMetal, Nutanix, oVirt, and vSphere CRD/docs.

* **Tests**
  * Added test cases covering user-managed load balancer scenarios for BareMetal and vSphere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->