### PR TITLE
OCPBUGS-86012: vsphere - fix failure domain validation skipping invalid vCenter server reference

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -165,6 +165,7 @@ func validateFailureDomains(p *vsphere.Platform, platformFldPath *field.Path, fl
 	zoneNames := make(map[string]string)
 
 	for index, failureDomain := range p.FailureDomains {
+		associatedVCenter = nil
 		if regionName, ok := zoneNames[failureDomain.Zone]; !ok {
 			zoneNames[failureDomain.Zone] = failureDomain.Region
 		} else if regionName == failureDomain.Region {

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -485,6 +485,15 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.failureDomains\.server: Invalid value: "bad-vcenter": server does not exist in vcenters`,
 		},
 		{
+			name: "Multi-zone platform wrong vCenter name in second failureDomain",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains[1].Server = "bad-vcenter"
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomains\.server: Invalid value: "bad-vcenter": server does not exist in vcenters`,
+		},
+		{
 			name: "Multi-zone platform datacenter not in vCenter datacenters list",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()


### PR DESCRIPTION
The associatedVCenter variable was declared outside the failure domain loop but never reset between iterations. When the first failure domain matched a valid vCenter, the variable stayed non-nil for subsequent iterations, causing validation to silently pass even when a later failure domain referenced a nonexistent vCenter server.

Fixes https://issues.redhat.com/browse/OCPBUGS-86012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed vSphere failure domain validation to ensure proper state isolation between domain validations. Previously, validation context from earlier failure domains could persist and affect subsequent domain validations. Now each domain is validated independently.

* **Tests**
  * Added test coverage verifying validation correctly fails when a failure domain references a non-existent vCenter server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->