### PR TITLE
fix: OCPBUGS-86073: validate duplicate failureDomain names and topology (Nutanix, vSphere)

### DIFF
--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -103,9 +105,26 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 		if err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("failureDomain", "name"), fmt.Errorf("fail to compile the pattern %q: %w", pattern, err)))
 		} else {
-			for _, fd := range p.FailureDomains {
+			fdNames := make(map[string]int)
+			fdTopologies := make(map[string]string)
+
+			for idx, fd := range p.FailureDomains {
 				if !rexp.MatchString(fd.Name) {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain name should match the pattern %q.", pattern)))
+				}
+
+				if prevIdx, exists := fdNames[fd.Name]; exists {
+					allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
+				} else {
+					fdNames[fd.Name] = idx
+				}
+
+				topoKey := nutanixFailureDomainTopologyKey(fd)
+				if prevName, exists := fdTopologies[topoKey]; exists {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomains").Index(idx), fd.Name,
+						fmt.Sprintf("failure domain %q has identical topology (same prismElement and subnets) as %q; this provides no additional fault tolerance", fd.Name, prevName)))
+				} else {
+					fdTopologies[topoKey] = fd.Name
 				}
 
 				if fd.PrismElement.UUID == "" {
@@ -151,6 +170,15 @@ func validateLoadBalancer(lbType configv1.PlatformLoadBalancerType) bool {
 	default:
 		return false
 	}
+}
+
+// nutanixFailureDomainTopologyKey builds a comparable key from the infrastructure-defining
+// fields of a failure domain: Prism Element UUID and sorted subnet UUIDs.
+func nutanixFailureDomainTopologyKey(fd nutanix.FailureDomain) string {
+	subnets := make([]string, len(fd.SubnetUUIDs))
+	copy(subnets, fd.SubnetUUIDs)
+	sort.Strings(subnets)
+	return fmt.Sprintf("pe=%s;subnets=%s", fd.PrismElement.UUID, strings.Join(subnets, ","))
 }
 
 // validateSubnets validates the input subnetUUIDs meet the configuration requirements.

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -390,6 +390,65 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.failureDomain\.dataSourceImages: Required value: failureDomain "fd-1": both the dataSourceImage's uuid and name are empty, you need to configure one\.$`,
 		},
 		{
+			name: "failureDomain with duplicate name",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1"},
+					},
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]\.name: Duplicate value: "failure domain name \\"fd-1\\" is already used by failureDomains\[0\]"`,
+		},
+		{
+			name: "failureDomain with duplicate topology same prismElement and subnet",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]: Invalid value: "fd-2": failure domain "fd-2" has identical topology \(same prismElement and subnets\) as "fd-1"; this provides no additional fault tolerance`,
+		},
+		{
+			name: "valid failureDomain with different prismElements",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+				}
+				return p
+			}(),
+		},
+		{
 			name: "valid failureDomain",
 			platform: func() *nutanix.Platform {
 				p := validPlatform()

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -163,12 +164,21 @@ func validateFailureDomains(p *vsphere.Platform, platformFldPath *field.Path, fl
 	var associatedVCenter *vsphere.VCenter
 
 	zoneNames := make(map[string]string)
+	fdTopologies := make(map[string]string)
 
 	for index, failureDomain := range p.FailureDomains {
 		if regionName, ok := zoneNames[failureDomain.Zone]; !ok {
 			zoneNames[failureDomain.Zone] = failureDomain.Region
 		} else if regionName == failureDomain.Region {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("zone"), failureDomain.Zone, fmt.Sprintf("cannot be used more than once for the failure domain region %q", failureDomain.Region)))
+		}
+
+		topoKey := vsphereFailureDomainTopologyKey(failureDomain)
+		if prevName, exists := fdTopologies[topoKey]; exists {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), failureDomain.Name,
+				fmt.Sprintf("failure domain %q has identical topology (same server, datacenter, computeCluster, datastore, networks, resourcePool) as %q; this provides no additional fault tolerance", failureDomain.Name, prevName)))
+		} else {
+			fdTopologies[topoKey] = failureDomain.Name
 		}
 
 		if failureDomain.ZoneType == "" && failureDomain.RegionType == "" {
@@ -338,6 +348,22 @@ func validateFailureDomains(p *vsphere.Platform, platformFldPath *field.Path, fl
 	}
 
 	return allErrs
+}
+
+// vsphereFailureDomainTopologyKey builds a comparable key from the infrastructure-defining
+// fields of a failure domain topology: server, datacenter, compute cluster, datastore,
+// networks, and resource pool.
+func vsphereFailureDomainTopologyKey(fd vsphere.FailureDomain) string {
+	networks := make([]string, len(fd.Topology.Networks))
+	copy(networks, fd.Topology.Networks)
+	sort.Strings(networks)
+	return fmt.Sprintf("server=%s;dc=%s;cluster=%s;ds=%s;nets=%s;rp=%s",
+		fd.Server,
+		fd.Topology.Datacenter,
+		fd.Topology.ComputeCluster,
+		fd.Topology.Datastore,
+		strings.Join(networks, ","),
+		fd.Topology.ResourcePool)
 }
 
 // validateDiskType checks that the specified diskType is valid.

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -378,7 +378,7 @@ func TestValidatePlatform(t *testing.T) {
 
 				for i := range p.FailureDomains {
 					p.FailureDomains[i].Topology.ComputeCluster = "/test-datacenter/host/HostClusterFolder/test-cluster"
-					p.FailureDomains[i].Topology.ResourcePool = "/test-datacenter/host/HostClusterFolder/test-cluster/Resources/test-resourcepool"
+					p.FailureDomains[i].Topology.ResourcePool = fmt.Sprintf("/test-datacenter/host/HostClusterFolder/test-cluster/Resources/test-resourcepool-%d", i)
 					p.FailureDomains[i].Topology.Datastore = "/test-datacenter/datastore/StorageFolder/test-datastore"
 					p.FailureDomains[i].Topology.Folder = "/test-datacenter/vm/VMFolder/test-folder"
 				}
@@ -551,6 +551,16 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			expectedError: `test-path\.failureDomains\.name\[1\]: Duplicate value: "test-east-1a"`,
+		},
+		{
+			name: "Multi-zone platform failureDomain duplicate topology",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains[1].Topology = p.FailureDomains[0].Topology
+				p.FailureDomains[1].Server = p.FailureDomains[0].Server
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]: Invalid value: "test-east-2a": failure domain "test-east-2a" has identical topology .* as "test-east-1a"; this provides no additional fault tolerance`,
 		},
 		{
 			name: "Multi-zone platform failureDomain zone missing tag category",


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-86073](https://redhat.atlassian.net/browse/OCPBUGS-86073)

The installer does not detect when multiple failure domains point to the same underlying infrastructure. This gives users a false sense of zone-level fault tolerance when none exists.

Three gaps were identified and fixed:

- **Nutanix: duplicate failure domain names accepted** — Two failure domains can have the exact same name. vSphere already had this check; Nutanix did not.
- **Nutanix: duplicate topology accepted** — Two failure domains with different names can point to the same Prism Element UUID and subnet UUIDs.
- **vSphere: duplicate topology accepted** — Two failure domains with different names/zones can have identical topology (same server, datacenter, computeCluster, datastore, networks, resourcePool).

This is especially impactful on Nutanix where failure domains are optional and entirely manual (copy-paste YAML is the only configuration method).

## Changes

- `pkg/types/nutanix/validation/platform.go`: Added duplicate name check and duplicate topology check (comparing Prism Element UUID + subnet UUIDs) across failure domains.
- `pkg/types/vsphere/validation/platform.go`: Added duplicate topology check (comparing server, datacenter, computeCluster, datastore, networks, resourcePool) across failure domains.
- Both platform test files updated with new test cases.

## Manual Test Results (4.22 RC3 custom binary)

**Test 1 — vSphere: duplicate topology, different names:**
```
$ ./openshift-install-v17-test create manifests
ERROR failed to fetch Master Machines: failed to load asset "Install Config":
  failed to create install config: invalid "install-config.yaml" file:
  [platform.vsphere.failureDomains.zone: Invalid value: "generated-zone":
   cannot be used more than once for the failure domain region "generated-region",
   platform.vsphere.failureDomains[1]: Invalid value: "fd-1": failure domain "fd-1"
   has identical topology (same server, datacenter, computeCluster, datastore,
   networks, resourcePool) as "generated-failure-domain"; this provides no
   additional fault tolerance]
```

**Test 2 — vSphere: duplicate topology + duplicate name:**
```
$ ./openshift-install-v17-test create manifests
ERROR failed to fetch Master Machines: failed to load asset "Install Config":
  failed to create install config: invalid "install-config.yaml" file:
  [platform.vsphere.failureDomains.zone: Invalid value: "generated-zone":
   cannot be used more than once for the failure domain region "generated-region",
   platform.vsphere.failureDomains[1]: Invalid value: "generated-failure-domain":
   failure domain "generated-failure-domain" has identical topology (same server,
   datacenter, computeCluster, datastore, networks, resourcePool) as
   "generated-failure-domain"; this provides no additional fault tolerance,
   platform.vsphere.failureDomains.name[1]: Duplicate value: "generated-failure-domain"]
```

**Test 3 — Nutanix: duplicate topology (same PE + subnet):**
```
$ ./openshift-install-v17-test create manifests
ERROR failed to fetch Master Machines: failed to load asset "Install Config":
  failed to create install config: invalid "install-config.yaml" file:
  platform.nutanix.failureDomains[1]: Invalid value: "fd-2": failure domain "fd-2"
  has identical topology (same prismElement and subnets) as "fd-1"; this provides
  no additional fault tolerance
```

## Test Plan

- [x] Unit tests added for Nutanix duplicate name detection
- [x] Unit tests added for Nutanix duplicate topology detection
- [x] Unit test added for vSphere duplicate topology detection
- [x] All existing Nutanix validation tests pass
- [x] All existing vSphere validation tests pass
- [x] Manual testing with custom binary on vSphere (duplicate topology — different names)
- [x] Manual testing with custom binary on vSphere (duplicate topology + duplicate name)
- [x] Manual testing with custom binary on Nutanix (duplicate topology — same PE and subnet)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced platform validation to detect and reject duplicate failure domain names across Nutanix and vSphere implementations.
  * Added topology-based validation to prevent multiple failure domains with identical configurations, ensuring proper fault tolerance.

* **Tests**
  * Expanded validation test coverage with scenarios for duplicate failure domains and topology-identical configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->