### PR TITLE
Bug 86133: validate duplicate Nutanix failureDomain names and topology

### DIFF
--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -113,33 +113,33 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain name should match the pattern %q.", pattern)))
 				}
 
-			if prevIdx, exists := fdNames[fd.Name]; exists {
-				allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
-			} else {
-				fdNames[fd.Name] = idx
-			}
-
-			if fd.PrismElement.UUID == "" {
-				allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "prismElement", "uuid"), "failureDomain prismElement uuid cannot be empty"))
-			}
-
-			// validate subnets configuration
-			if errs := validateSubnets(fldPath.Child("failureDomain", "subnetUUIDs"), fd.SubnetUUIDs); len(errs) > 0 {
-				allErrs = append(allErrs, errs...)
-			}
-
-			// Only check for duplicate topology after basic required-field validation,
-			// so users see actionable "required field" errors instead of misleading
-			// "identical topology" when fields are simply empty.
-			if fd.PrismElement.UUID != "" && len(fd.SubnetUUIDs) > 0 {
-				topoKey := nutanixFailureDomainTopologyKey(fd)
-				if prevName, exists := fdTopologies[topoKey]; exists {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomains").Index(idx), fd.Name,
-						fmt.Sprintf("failure domain %q has identical topology (same prismElement and subnets) as %q; this provides no additional fault tolerance", fd.Name, prevName)))
+				if prevIdx, exists := fdNames[fd.Name]; exists {
+					allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
 				} else {
-					fdTopologies[topoKey] = fd.Name
+					fdNames[fd.Name] = idx
 				}
-			}
+
+				if fd.PrismElement.UUID == "" {
+					allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "prismElement", "uuid"), "failureDomain prismElement uuid cannot be empty"))
+				}
+
+				// validate subnets configuration
+				if errs := validateSubnets(fldPath.Child("failureDomain", "subnetUUIDs"), fd.SubnetUUIDs); len(errs) > 0 {
+					allErrs = append(allErrs, errs...)
+				}
+
+				// Only check for duplicate topology after basic required-field validation,
+				// so users see actionable "required field" errors instead of misleading
+				// "identical topology" when fields are simply empty.
+				if fd.PrismElement.UUID != "" && len(fd.SubnetUUIDs) > 0 {
+					topoKey := nutanixFailureDomainTopologyKey(fd)
+					if prevName, exists := fdTopologies[topoKey]; exists {
+						allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomains").Index(idx), fd.Name,
+							fmt.Sprintf("failure domain %q has identical topology (same prismElement and subnets) as %q; this provides no additional fault tolerance", fd.Name, prevName)))
+					} else {
+						fdTopologies[topoKey] = fd.Name
+					}
+				}
 
 				for _, sc := range fd.StorageContainers {
 					if sc.ReferenceName == "" {

--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -113,12 +113,25 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain name should match the pattern %q.", pattern)))
 				}
 
-				if prevIdx, exists := fdNames[fd.Name]; exists {
-					allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
-				} else {
-					fdNames[fd.Name] = idx
-				}
+			if prevIdx, exists := fdNames[fd.Name]; exists {
+				allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
+			} else {
+				fdNames[fd.Name] = idx
+			}
 
+			if fd.PrismElement.UUID == "" {
+				allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "prismElement", "uuid"), "failureDomain prismElement uuid cannot be empty"))
+			}
+
+			// validate subnets configuration
+			if errs := validateSubnets(fldPath.Child("failureDomain", "subnetUUIDs"), fd.SubnetUUIDs); len(errs) > 0 {
+				allErrs = append(allErrs, errs...)
+			}
+
+			// Only check for duplicate topology after basic required-field validation,
+			// so users see actionable "required field" errors instead of misleading
+			// "identical topology" when fields are simply empty.
+			if fd.PrismElement.UUID != "" && len(fd.SubnetUUIDs) > 0 {
 				topoKey := nutanixFailureDomainTopologyKey(fd)
 				if prevName, exists := fdTopologies[topoKey]; exists {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomains").Index(idx), fd.Name,
@@ -126,15 +139,7 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 				} else {
 					fdTopologies[topoKey] = fd.Name
 				}
-
-				if fd.PrismElement.UUID == "" {
-					allErrs = append(allErrs, field.Required(fldPath.Child("failureDomain", "prismElement", "uuid"), "failureDomain prismElement uuid cannot be empty"))
-				}
-
-				// validate subnets configuration
-				if errs := validateSubnets(fldPath.Child("failureDomain", "subnetUUIDs"), fd.SubnetUUIDs); len(errs) > 0 {
-					allErrs = append(allErrs, errs...)
-				}
+			}
 
 				for _, sc := range fd.StorageContainers {
 					if sc.ReferenceName == "" {
@@ -178,7 +183,7 @@ func nutanixFailureDomainTopologyKey(fd nutanix.FailureDomain) string {
 	subnets := make([]string, len(fd.SubnetUUIDs))
 	copy(subnets, fd.SubnetUUIDs)
 	sort.Strings(subnets)
-	return fmt.Sprintf("pe=%s;subnets=%s", fd.PrismElement.UUID, strings.Join(subnets, ","))
+	return fmt.Sprintf("pe=%s;subnets=%s", fd.PrismElement.UUID, strings.Join(subnets, "\x00"))
 }
 
 // validateSubnets validates the input subnetUUIDs meet the configuration requirements.

--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -103,9 +105,26 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 		if err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("failureDomain", "name"), fmt.Errorf("fail to compile the pattern %q: %w", pattern, err)))
 		} else {
-			for _, fd := range p.FailureDomains {
+			fdNames := make(map[string]int)
+			fdTopologies := make(map[string]string)
+
+			for idx, fd := range p.FailureDomains {
 				if !rexp.MatchString(fd.Name) {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain name should match the pattern %q.", pattern)))
+				}
+
+				if prevIdx, exists := fdNames[fd.Name]; exists {
+					allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomains").Index(idx).Child("name"), fmt.Sprintf("failure domain name %q is already used by failureDomains[%d]", fd.Name, prevIdx)))
+				} else {
+					fdNames[fd.Name] = idx
+				}
+
+				topoKey := nutanixFailureDomainTopologyKey(fd)
+				if prevName, exists := fdTopologies[topoKey]; exists {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomains").Index(idx), fd.Name,
+						fmt.Sprintf("failure domain %q has identical topology (same prismElement and subnets) as %q; this provides no additional fault tolerance", fd.Name, prevName)))
+				} else {
+					fdTopologies[topoKey] = fd.Name
 				}
 
 				if fd.PrismElement.UUID == "" {
@@ -151,6 +170,15 @@ func validateLoadBalancer(lbType configv1.PlatformLoadBalancerType) bool {
 	default:
 		return false
 	}
+}
+
+// nutanixFailureDomainTopologyKey builds a comparable key from the infrastructure-defining
+// fields of a failure domain: Prism Element UUID and sorted subnet UUIDs.
+func nutanixFailureDomainTopologyKey(fd nutanix.FailureDomain) string {
+	subnets := make([]string, len(fd.SubnetUUIDs))
+	copy(subnets, fd.SubnetUUIDs)
+	sort.Strings(subnets)
+	return fmt.Sprintf("pe=%s;subnets=%s", fd.PrismElement.UUID, strings.Join(subnets, ","))
 }
 
 // validateSubnets validates the input subnetUUIDs meet the configuration requirements.

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -469,6 +469,26 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 		},
 		{
+			name: "failureDomain duplicate topology with same subnets in different order",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"subnet-a", "subnet-b"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"subnet-b", "subnet-a"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]: Invalid value: "fd-2": failure domain "fd-2" has identical topology \(same prismElement and subnets\) as "fd-1"; this provides no additional fault tolerance`,
+		},
+		{
 			name: "valid failureDomain with multiple subnets for multi-NIC",
 			platform: func() *nutanix.Platform {
 				p := validPlatform()

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -410,6 +410,65 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 		},
 		{
+			name: "failureDomain with duplicate name",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1"},
+					},
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]\.name: Duplicate value: "failure domain name \\"fd-1\\" is already used by failureDomains\[0\]"`,
+		},
+		{
+			name: "failureDomain with duplicate topology same prismElement and subnet",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `test-path\.failureDomains\[1\]: Invalid value: "fd-2": failure domain "fd-2" has identical topology \(same prismElement and subnets\) as "fd-1"; this provides no additional fault tolerance`,
+		},
+		{
+			name: "valid failureDomain with different prismElements",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+				}
+				return p
+			}(),
+		},
+		{
 			name: "valid failureDomain with multiple subnets for multi-NIC",
 			platform: func() *nutanix.Platform {
 				p := validPlatform()


### PR DESCRIPTION
## Summary

Adds two missing validation checks for Nutanix failure domains:

- **Duplicate name detection:** Rejects configurations where two failure domains share the same name. This was previously unvalidated for Nutanix (vSphere already had this check).
- **Duplicate topology detection:** Rejects failure domains that have identical Prism Element UUID and subnet UUIDs. Copy-pasted failure domains that differ only in name provide no additional fault tolerance and can cause subtle scheduling issues.

Split from #10561 per reviewer feedback — this PR contains the Nutanix portion only.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-86133

## Manual Test Results

Tested with a custom-built `openshift-install` binary. When two Nutanix failure domains share the same name or identical topology, the installer now correctly rejects:

**Duplicate name:**
```
ERROR failed to load asset "Install Config": invalid "install-config.yaml" file:
  platform.nutanix.failureDomains[1].name: Duplicate value:
    "failure domain name \"fd-pe1\" is already used by failureDomains[0]"
```

**Duplicate topology:**
```
ERROR failed to load asset "Install Config": invalid "install-config.yaml" file:
  platform.nutanix.failureDomains[1]: Invalid value: "fd-pe1-copy":
    failure domain "fd-pe1-copy" has identical topology (same prismElement and subnets)
    as "fd-pe1"; this provides no additional fault tolerance
```

## Test Plan

- [x] Unit tests pass: `go test ./pkg/types/nutanix/validation/`
- [x] New test cases: `failureDomain with duplicate name`, `failureDomain with duplicate topology same prismElement and subnet`, `valid failureDomain with different prismElements`
- [x] Manual testing with custom binary

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nutanix platform failure-domain validation to catch duplicate failure-domain names and detect identical topology configurations (same Prism Element and same set of subnets), treating subnet lists as order-independent.

* **Tests**
  * Added table-driven tests verifying duplicate-name detection, identical-topology rejection, and subnet-order-independence in topology comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->