### PR TITLE
OCPBUGS-86471: baremetal: fix hostSelector for default stream

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	baremetalprovider "github.com/openshift/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
@@ -73,12 +74,26 @@ func provider(platform *baremetal.Platform, userDataSecret string, osImageStream
 		CustomDeploy: baremetalprovider.CustomDeploy{
 			Method: "install_coreos",
 		},
-		UserData: &corev1.SecretReference{Name: userDataSecret},
-		HostSelector: baremetalprovider.HostSelector{
-			MatchLabels: map[string]string{
-				"coreos.openshift.io/stream": string(osImageStream),
+		UserData:     &corev1.SecretReference{Name: userDataSecret},
+		HostSelector: hostSelectorForStream(osImageStream),
+	}
+	return config, nil
+}
+
+func hostSelectorForStream(stream types.OSImageStream) baremetalprovider.HostSelector {
+	var exclude []string
+	for _, s := range types.OSImageStreamValues {
+		if s != stream {
+			exclude = append(exclude, string(s))
+		}
+	}
+	return baremetalprovider.HostSelector{
+		MatchExpressions: []baremetalprovider.HostSelectorRequirement{
+			{
+				Key:      streamLabelKey,
+				Operator: selection.NotIn,
+				Values:   exclude,
 			},
 		},
 	}
-	return config, nil
 }


### PR DESCRIPTION
Use a `NotIn` MatchExpression to exclude other known streams rather than requiring an exact label match via MatchLabels. NotIn matches when the label is absent or has any value not in the exclusion set, so unlabeled BareMetalHosts (e.g. spare hosts in a CI pool) can still be claimed while hosts labeled for a different stream are rejected.

This applies to all streams, not just the compile-time default, because the cluster's effective default stream is determined at install time, not by the installer binary's DefaultOSImageStream constant. The exclusion list is computed from types.OSImageStreamValues, so new streams are automatically excluded without additional code changes..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores bare-metal host selection so hosts lacking stream labels are matched by the default stream, avoiding unintended exclusions.
  * Ensures non-default OS image streams continue to require explicit label matching, preserving intended targeting.
  * Prevents deployments from being filtered out unless hosts are manually labeled, improving discovery and provisioning reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->