### PR TITLE
OCPBUGS-86498: openstack: add tzdata dependency to CI image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -28,7 +28,8 @@ COPY --from=builder /go/src/github.com/openshift/installer/docs/user/openstack /
 COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-manifests.sh /go/src/github.com/openshift/installer/scripts/openstack/manifest-tests /var/lib/openshift-install/manifest-tests
 
 # Install Dependendencies for tests
-RUN yum update -y && \
+RUN yum update -y --setopt=tsflags= tzdata && \
+    yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     ansible-collection-ansible-netcommon \
     ansible-collection-community-general \


### PR DESCRIPTION
The `tzdata` dependency was recently removed from oslo-utils via [1], which now causes the openstack cli started failing because the image misses the `tzdata` package, as seen in [2].

[1] https://review.opendev.org/c/openstack/oslo.utils/+/975021
[2] https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openstack-test/262/pull-ci-openshift-openstack-test-main-test/2059170623128604672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI container image updated to install timezone data (tzdata) early in the dependency setup, ensuring consistent timezone information during CI runs and avoiding time-related discrepancies across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->