### PR TITLE
no-jira: azure: Disable shared access key by default

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -5483,8 +5483,8 @@ spec:
                   allowSharedKeyAccess:
                     description: |-
                       AllowSharedKeyAccess specifies if shared access key should be enabled for the storage account.
-                      Default value is true.
-                      Disabling this will require a new permission "Storage Blob Data Contributor" in azure.
+                      Default value is false.
+                      Needs the permission "Storage Blob Data Contributor" in azure.
                     type: boolean
                   armEndpoint:
                     description: ARMEndpoint is the endpoint for the Azure API when

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -317,8 +317,8 @@ cluster itself may not include these tags.
 		desc: `FIELDS:
     allowSharedKeyAccess <boolean>
       AllowSharedKeyAccess specifies if shared access key should be enabled for the storage account.
-Default value is true.
-Disabling this will require a new permission "Storage Blob Data Contributor" in azure.
+Default value is false.
+Needs the permission "Storage Blob Data Contributor" in azure.
 
     armEndpoint <string>
       ARMEndpoint is the endpoint for the Azure API when installing on Azure Stack.

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -232,7 +232,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	var storageClientFactory *armstorage.ClientFactory
 	var storageAccountKeys []armstorage.AccountKey
 
-	sharedKey := true
+	sharedKey := false
 	if in.InstallConfig.Config.Azure.AllowSharedKeyAccess != nil {
 		sharedKey = *in.InstallConfig.Config.Azure.AllowSharedKeyAccess
 	}
@@ -850,7 +850,7 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		return nil, fmt.Errorf("failed to create service client: %w", err)
 	}
 
-	sharedKey := true
+	sharedKey := false
 	if in.InstallConfig.Config.Azure.AllowSharedKeyAccess != nil {
 		sharedKey = *in.InstallConfig.Config.Azure.AllowSharedKeyAccess
 	}
@@ -905,7 +905,7 @@ func (p Provider) Ignition(ctx context.Context, in clusterapi.IgnitionInput) ([]
 		}
 	}
 	if sasURL == "" && !sharedKey {
-		udc, err := serviceClient.GetUserDelegationCredential(context.Background(), info, nil)
+		udc, err := serviceClient.GetUserDelegationCredential(ctx, info, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create user delegation credentials: %w", err)
 		}

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -52,8 +52,9 @@ type Platform struct {
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
 
 	// AllowSharedKeyAccess specifies if shared access key should be enabled for the storage account.
-	// Default value is true.
-	// Disabling this will require a new permission "Storage Blob Data Contributor" in azure.
+	// Default value is false.
+	// Needs the permission "Storage Blob Data Contributor" in azure.
+	//
 	//
 	// +optional
 	AllowSharedKeyAccess *bool `json:"allowSharedKeyAccess,omitempty"`


### PR DESCRIPTION
Setting the allow shared access key to false by default for
better security practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Default for Azure storage shared key access changed from enabled to disabled.

* **Documentation**
  * Marked Azure shared key access as deprecated.
  * Clarified that enabling shared key access requires the "Storage Blob Data Contributor" permission and updated default wording.

* **Tests**
  * Updated tests/expected output to reflect the new default, deprecation, and permission wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->