### PR TITLE
NO-ISSUE: Use types.OSImageStreamValues for validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1812,13 +1812,12 @@ func validateOSImageStream(config *types.InstallConfig) field.ErrorList {
 		return errs
 	}
 
-	supportedValues := []string{string(types.OSImageStreamRHCOS9), string(types.OSImageStreamRHCOS10)}
-	if !slices.Contains(supportedValues, string(config.OSImageStream)) {
+	if !slices.Contains(types.OSImageStreamValues, config.OSImageStream) {
 		errs = append(errs,
 			field.NotSupported(
 				field.NewPath("osImageStream"),
 				config.OSImageStream,
-				supportedValues))
+				types.OSImageStreamValues))
 	}
 	return errs
 }


### PR DESCRIPTION
Avoid having to update the list of valid streams in multiple places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated OS image stream configuration validation to check against the complete set of supported values, ensuring more comprehensive validation and clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->