### PR TITLE
OCPBUGS-77049: Update RHCOS-release-4.21 bootimage metadata to 9.6.20260520-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,106 +1,106 @@
 {
   "stream": "rhcos-4.21",
   "metadata": {
-    "last-modified": "2025-12-29T15:46:59Z",
-    "generator": "plume cosa2stream c9a1e31"
+    "last-modified": "2026-05-28T18:28:07Z",
+    "generator": "plume cosa2stream af5d9c3"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-aws.aarch64.vmdk.gz",
-                "sha256": "d150aa88b809607b6e78e27a8edecb126bd1783df23fcba3356d260fb3967e9a",
-                "uncompressed-sha256": "638c111de37cc29aa4fa4562360c361d4b66ba0a325ae3d54d104358d982f5fc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-aws.aarch64.vmdk.gz",
+                "sha256": "d5ac6bec2edcc0a3a18ddefd57cd1d23d4b9786762e674e4a888977ea4470980",
+                "uncompressed-sha256": "3774ffda30205b7efc3a024fd08cfc55ac9ecc8f9594ad651690aa4ba8749218"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-azure.aarch64.vhd.gz",
-                "sha256": "d3d9b36b1394fd22c934f61661ab57d0df23451958d5956c08f29fa8d5ff5e52",
-                "uncompressed-sha256": "a99dcafe31530afa3a54e1ebe0a2f48a2bfb2b3473663bf2c101d8253dcb8b84"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-azure.aarch64.vhd.gz",
+                "sha256": "2e485b1045de1163ce35ae87da348fd7ac9c053a1dd195154d80e801f76c51b6",
+                "uncompressed-sha256": "df4fc9b063434ef793234eb9d40110be5ac1afdc44bc32d7aef9cd8bdd27a004"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-gcp.aarch64.tar.gz",
-                "sha256": "8b1f988cb9e0aca9727a6b941340f0f943c08646bf5f7d232a5694fdbf10c01f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-gcp.aarch64.tar.gz",
+                "sha256": "31106206825d891e66b02992d283e324d3b4505458ff1ce192172c46087785c6"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-metal4k.aarch64.raw.gz",
-                "sha256": "b596cf26d221a7054e34ce7b975faf09b78a274d0e9664ecc5daedafd7025c7d",
-                "uncompressed-sha256": "ed266256b342db01a8d5bea61913d8308d02c34c829da45ec6a4e7195b40b958"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-metal4k.aarch64.raw.gz",
+                "sha256": "4ef5379b3f83c2935b89bd3202ef8b7f52f656948ca5ff78e6174f60d5018bcc",
+                "uncompressed-sha256": "c3652a4b9721b5d70fbc7aca8ba764be6f708619dafa4700762d8c09b4ae24d0"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-live-iso.aarch64.iso",
-                "sha256": "9af0739ef9b5f3efa1ef195a5bcb51e60a2e2fd03bb51f40e2c5b834eb9b9840"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-iso.aarch64.iso",
+                "sha256": "f95235fc13fe764b6a67ab7ac4fbd6072067a564916dcdc470c66726b4a5ac89"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-live-kernel.aarch64",
-                "sha256": "5fc5b78fca1fbec35b52205341fc00f5fa906121aeebef969b40ff9a40b55d33"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-kernel.aarch64",
+                "sha256": "a91a728781bc16daa2190bd4b6031c5eeef49af5fc60e6fe61dd28515f1f48f8"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-live-initramfs.aarch64.img",
-                "sha256": "c871fb5e3c3e8dd90bbcf4e6af2fa837229dd3a3347355d78f442f91ac9f46c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-initramfs.aarch64.img",
+                "sha256": "670c31edf8e1c2d93bf5c445f35ee505ce87a8c2b159a07d1cdf4d037d57830e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-live-rootfs.aarch64.img",
-                "sha256": "c33499dd6eb4778a836301a97bc54ec0d30367bf4f6fe51a86b594cda394963e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-rootfs.aarch64.img",
+                "sha256": "51b0d660affcf813b53bd873db94f3964e91c6b92ddc95b506a3fad8eb227a7a"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-metal.aarch64.raw.gz",
-                "sha256": "10a22aca3b965fee35bd5db8865da2cf2c3ca8191af1142b075d5cb02f372063",
-                "uncompressed-sha256": "895ebf1697a71ffe57a3e0b73f5dce90c47dd3b61b83a21f1159e257847ec683"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-metal.aarch64.raw.gz",
+                "sha256": "4e0ef2e3cf869dffd534b12d0ed67ec0c521811900a1bc3a34e55ffb9a25cbfa",
+                "uncompressed-sha256": "4d61303d52c5c4683ef6b0876e7668c308fe858489f5db70ae6d8b2cd96d74f7"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-openstack.aarch64.qcow2.gz",
-                "sha256": "437efc4ffe52d6c2db91e3dcd03f1d4996f5c2194f88deb9c57358a7fb645b81",
-                "uncompressed-sha256": "ad4d9c8132dc47cde09a2229bde5c52798351e0e4900ed03c31c120e6741f422"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-openstack.aarch64.qcow2.gz",
+                "sha256": "6e10f3a8d669e2fa02eeb0fdab4dee53ed157f22d52ddbf14f015cd39c6b5b37",
+                "uncompressed-sha256": "6566b040f14c89c06e12e6ea08f51d7ef2f8f4fd5e54e04f8fbf4bbde246a342"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/aarch64/rhcos-9.6.20251212-1-qemu.aarch64.qcow2.gz",
-                "sha256": "b7e4e0ce260f322b96c01e6b4d3b1f00c6647498f67f0bb3071759ac167792fa",
-                "uncompressed-sha256": "1a39793a4ada8dff634af4e70b251296924d56bb4f106ae02ba761c055bf10e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-qemu.aarch64.qcow2.gz",
+                "sha256": "91d018291203e72d0a29aa58a4ec4c944f908fc64666cb34c15f453634b3482f",
+                "uncompressed-sha256": "71b1e3fe17260a1ee8a9cac9ac6941e4dd51a02610dc88f385c48dc46255c84e"
               }
             }
           }
@@ -110,237 +110,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0265ec024c31e7603"
+              "release": "9.6.20260520-0",
+              "image": "ami-0d61f2c1b27d06a5e"
             },
             "ap-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-01d0891e1fa7c28fe"
+              "release": "9.6.20260520-0",
+              "image": "ami-089ce2f9fd0160eed"
             },
             "ap-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0de88496066d7428e"
+              "release": "9.6.20260520-0",
+              "image": "ami-08245280328443a81"
             },
             "ap-northeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0d7c8859dc8f2ac02"
+              "release": "9.6.20260520-0",
+              "image": "ami-0711c9c3a6f1c9456"
             },
             "ap-northeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00377959ff7cf0ed6"
+              "release": "9.6.20260520-0",
+              "image": "ami-05442fa917a851745"
             },
             "ap-northeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-095386042a7673286"
+              "release": "9.6.20260520-0",
+              "image": "ami-06b1959f0c1123129"
             },
             "ap-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09f0f012b2c626f59"
+              "release": "9.6.20260520-0",
+              "image": "ami-0646f372940f1385d"
             },
             "ap-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-01c8221c9a56e0c74"
+              "release": "9.6.20260520-0",
+              "image": "ami-0abb3883c77105ae9"
             },
             "ap-southeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0c27520bfa297e78a"
+              "release": "9.6.20260520-0",
+              "image": "ami-03e9e076d8c965bbb"
             },
             "ap-southeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0af72833671d615f1"
+              "release": "9.6.20260520-0",
+              "image": "ami-0433fc9a0f0e93610"
             },
             "ap-southeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-085607af8f322e956"
+              "release": "9.6.20260520-0",
+              "image": "ami-08a02768cd3890eff"
             },
             "ap-southeast-4": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03d8bfd58de713367"
+              "release": "9.6.20260520-0",
+              "image": "ami-0072359ad9cdc53bd"
             },
             "ap-southeast-5": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0f6479fb82d8108d1"
+              "release": "9.6.20260520-0",
+              "image": "ami-06650e9d43dfa508c"
             },
             "ap-southeast-6": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a6a284e74f2e9afd"
+              "release": "9.6.20260520-0",
+              "image": "ami-0d17f3468c70c7601"
             },
             "ap-southeast-7": {
-              "release": "9.6.20251212-1",
-              "image": "ami-054eb3c4286f4dbca"
+              "release": "9.6.20260520-0",
+              "image": "ami-0c7b82d118063048c"
             },
             "ca-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-032e08fde31f0a6cc"
+              "release": "9.6.20260520-0",
+              "image": "ami-07f4b006a3ee17258"
             },
             "ca-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-07d83e72beff3eb6c"
+              "release": "9.6.20260520-0",
+              "image": "ami-04d6d9c8beda63813"
             },
             "eu-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a62c879da82e8f99"
+              "release": "9.6.20260520-0",
+              "image": "ami-0f2a4d3e2a95e5ea8"
             },
             "eu-central-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09c91e670678ce2c1"
+              "release": "9.6.20260520-0",
+              "image": "ami-09d94afe83d21f6cb"
             },
             "eu-north-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0e896b8e4e7de42be"
+              "release": "9.6.20260520-0",
+              "image": "ami-092e45482b1eb9602"
             },
             "eu-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-01718000bd7650956"
+              "release": "9.6.20260520-0",
+              "image": "ami-0ab12b62d54edf1fd"
             },
             "eu-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-02c48b6c8488542b2"
+              "release": "9.6.20260520-0",
+              "image": "ami-0deb02ff16cb956c9"
             },
             "eu-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-06ea845fe728a8891"
+              "release": "9.6.20260520-0",
+              "image": "ami-0ebc3bffc0ef5b733"
             },
             "eu-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0e6c67a8674179e1b"
+              "release": "9.6.20260520-0",
+              "image": "ami-07258c815b9f7461d"
             },
             "eu-west-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0c4cb83cc7e4ec057"
+              "release": "9.6.20260520-0",
+              "image": "ami-0577d7b1f657656e5"
             },
             "il-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00a88a6e634ac6676"
-            },
-            "me-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09aff5ac8bd25e9b8"
-            },
-            "me-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-043e9d5894e68426d"
+              "release": "9.6.20260520-0",
+              "image": "ami-06e2bdb6dad0411de"
             },
             "mx-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00c0f1b2fc7ab92d4"
+              "release": "9.6.20260520-0",
+              "image": "ami-0d3ebb657d5820262"
             },
             "sa-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0af3988f6b0fbee7f"
+              "release": "9.6.20260520-0",
+              "image": "ami-01d251ce232f14619"
             },
             "us-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-02ffd1d5ed7351ceb"
+              "release": "9.6.20260520-0",
+              "image": "ami-0240d1810ac82bbe3"
             },
             "us-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0d08ccc7bcf77433d"
+              "release": "9.6.20260520-0",
+              "image": "ami-0727757daa31e67c2"
             },
             "us-gov-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b183fafd7eeae965"
+              "release": "9.6.20260520-0",
+              "image": "ami-0eda8aa9aa1d84883"
             },
             "us-gov-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0411a4dd8cbf726db"
+              "release": "9.6.20260520-0",
+              "image": "ami-079436bad139f2aee"
             },
             "us-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-06149aec55f3e1d6c"
+              "release": "9.6.20260520-0",
+              "image": "ami-077212aa77fab4847"
             },
             "us-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0c2bafedf2fc1dfc3"
+              "release": "9.6.20260520-0",
+              "image": "ami-04c3da7d0017748d1"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20251212-1-gcp-aarch64"
+          "name": "rhcos-9-6-20260520-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20251212-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20251212-1-azure.aarch64.vhd"
+          "release": "9.6.20260520-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260520-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-metal4k.ppc64le.raw.gz",
-                "sha256": "c2a5e0e4aa17b46c14c57ad38700163e8e87a5daf9e4047419e08f5cd3d4f470",
-                "uncompressed-sha256": "cd085e3c529c3f7dfdfafec2b06be745667281ece7769330dbd2a40674343d20"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-metal4k.ppc64le.raw.gz",
+                "sha256": "4de2d3a3e9933ea487c2be46c73c0838eceb89cd3eaf6d4f8ef45b7cdd1bed7e",
+                "uncompressed-sha256": "31736ff532132f693e9f6f536150c6e11128d62d07ec7bfef8ba8fc06c79cad1"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-live-iso.ppc64le.iso",
-                "sha256": "c4f3052e2cd446753df5b1338f0303c154853351b38ce3a0da3b7579c98c2540"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-iso.ppc64le.iso",
+                "sha256": "9dacfc2437f00120455f8b0fc04faa005855efcb4b57115942d0184dee8ae911"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-live-kernel.ppc64le",
-                "sha256": "9b2cdb006323bd9d1a36499a49b0d350277f9e490272faed910e360e26218ef1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-kernel.ppc64le",
+                "sha256": "2b5c68b988227c68df0229f29e7367db96796abe2eb7dcd8acb7e6765d63319c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-live-initramfs.ppc64le.img",
-                "sha256": "82274d8bbf2fb5c9cbdd380a1c24fdf5f6c7b0b91c5f71a15da53dae17b368a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-initramfs.ppc64le.img",
+                "sha256": "261b67f2f5ddfea2e9c1b31e06d08c06beb6a2ee14ec4611b432b2d079998678"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-live-rootfs.ppc64le.img",
-                "sha256": "176daf0f25e4789ca73a7e50a7d6d0b4fc41322a5cbb84318c01da672f4f64d8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-rootfs.ppc64le.img",
+                "sha256": "f97b349245f2e22154d6c640a58966577efb90c727bbb9da46c11daa92b37cac"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-metal.ppc64le.raw.gz",
-                "sha256": "aa2e3009ae5e3c136e477c8c036574f440caf20dd4bdeccfbdafe55fffca5267",
-                "uncompressed-sha256": "3803488ab9dd7ccdbc84a23422a1ed6ce1cca840f56d114390c2401004bd6385"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-metal.ppc64le.raw.gz",
+                "sha256": "8480dfe445b1c161441e9f85931ae7c71407e88c22fa9e76f52b247bb80ff001",
+                "uncompressed-sha256": "185065ec94b9406c79cfc877c7634dd717cd01d402cc3a1ed3ebb64b47006c8e"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-openstack.ppc64le.qcow2.gz",
-                "sha256": "8850043eee3c2a3282cda6f85e434bd65f4541864d44bbf48b36fcfb86ed0ee0",
-                "uncompressed-sha256": "11c0acafa5dd3629bc2637c0b138f832bfafac7e875c82eddb46f8e61341d048"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "395ac291fd1edbd2df7bc07a6b22b31cfe159175eafeeb123fa4f851788d107c",
+                "uncompressed-sha256": "e1b139338b97fd27534df16522f86e2fba043f46817f88f292075bed36fc0150"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-powervs.ppc64le.ova.gz",
-                "sha256": "149d2065d6a13d3f5dc9220bce11137d365363a83943c252be3a1d4317bbd7af",
-                "uncompressed-sha256": "7ce94d4e4c71780f3418ce249d6c5f59e858cf223ba09654cb32a50fa29d3d09"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-powervs.ppc64le.ova.gz",
+                "sha256": "d9755b7f565316b211d3d424ce5123835bcf641d17faa0f4c2f05f63611c25ad",
+                "uncompressed-sha256": "52637ea364c433358b40f93c259e14d10ba5e4e65e61b094ad26ab9cc4108796"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/ppc64le/rhcos-9.6.20251212-1-qemu.ppc64le.qcow2.gz",
-                "sha256": "e0a46bb7d24050f59d5d11f0644a4fca51d931b3a5994ca83b579d2caff29a3a",
-                "uncompressed-sha256": "d42590613c83184b9901464d75f2201330d1fd6cd4caa38cbc9861372302f880"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "247383070819071ea6c811f325c1665742aa2deb573f95f44a960edc6d84155f",
+                "uncompressed-sha256": "5817d6df25ee0365f0fd832f086f48146b13447c067825f2df7ecd12cbe66274"
               }
             }
           }
@@ -350,64 +342,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.6.20251212-1",
-              "object": "rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260520-0",
+              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20251212-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -416,99 +408,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-ibmcloud.s390x.qcow2.gz",
-                "sha256": "ac417edbc3b5ff43ffdb37d306984a3d94bf913be7b70c65393326dc31470069",
-                "uncompressed-sha256": "8e33db3fbde9ada0c64a14d5033b83c86b96874687d4aa640191248c0528d93c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "08b5548a5eb730e3c083128fec64febd5f1f12f4faaad1a014bc7e57b28b4ced",
+                "uncompressed-sha256": "e5feda27a305c86348ca7a461a5a1bf95bd430a586e1373d1eb37d615a56fb9b"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-kubevirt.s390x.ociarchive",
-                "sha256": "d3781c613f06fe9367d63bac798c5d270fab09dbcd164007188658babbf911d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-kubevirt.s390x.ociarchive",
+                "sha256": "43104a64980b9755b78226603a031d86623a6152469d0278dc2d119a64aa616a"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-metal4k.s390x.raw.gz",
-                "sha256": "4c00bfb21c732cb7c9d83e864df73ede484eadcb75947f14e4b1eb4399bed6c3",
-                "uncompressed-sha256": "d469fe393514796036afa6498d1186c5cd0c2cc1227da60b96afd076afcd4ae4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-metal4k.s390x.raw.gz",
+                "sha256": "ada2954beab8c70acd2d05f2413cbb9f9df9f94fdc8ab41e5ce5f21e341d66cf",
+                "uncompressed-sha256": "433ede93d19ef8dbbe0e1c2202274d35df11dd2c532498cfa3f267b0b15ac346"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-live-iso.s390x.iso",
-                "sha256": "e55d031fae630891e51d0607de65fe42b28e1e40f6e9b100ebe5e882b70b80e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-iso.s390x.iso",
+                "sha256": "10933a001012f33dc8ffd8b984c5b2f4ffd6e5cdf51855000142343309f4a704"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-live-kernel.s390x",
-                "sha256": "b60709e9d032a4568fd560df077ba69e43ff3d30074d54b640820bb11893fb42"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-kernel.s390x",
+                "sha256": "3d311df1dcfeb64f4430423b922649fa231c70df163a5ea91500bf38562fae46"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-live-initramfs.s390x.img",
-                "sha256": "a83d6a42fa7269fd2ba1f97766f76b2b7b690a20b23c0f3c06770119839de688"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-initramfs.s390x.img",
+                "sha256": "772095b610c84af7d838ed9cca17160bf8dec80d6bab50d1757c641f3221bb38"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-live-rootfs.s390x.img",
-                "sha256": "eb89b6ad8e4b5501db02a11cf5f20c102993b84eacf9fb8536c140ec3f9c35e7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-rootfs.s390x.img",
+                "sha256": "87a072b7dc0f0f5f883049ca9d632b0907d02ce0f7a8067d3462a7a051c66421"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-metal.s390x.raw.gz",
-                "sha256": "82a46911490d4bdde013831441d7474c2f52213c2510209f81f5a0b635ab637f",
-                "uncompressed-sha256": "a4b5c08951dfe38ec99f9f3a08787843870c7326a29f90d429ef3aa81f5d9b64"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-metal.s390x.raw.gz",
+                "sha256": "a68f6c64ab39db04b06f308feb40553c1e39ba6b543677db45b2ebf35a7f7a43",
+                "uncompressed-sha256": "04c0e00d080ef4f6eb52dec4b55e0f5c6b84049a65c34d70800214c39cf35d3f"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-openstack.s390x.qcow2.gz",
-                "sha256": "777f0b1ee651fc2974ba8a97568c6ae3b1208586d793f8251ce9f7ffacf57a13",
-                "uncompressed-sha256": "9fb14e1801ce63c606083e31737f3e84df5e26543534612a5ba46d884a93c80b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-openstack.s390x.qcow2.gz",
+                "sha256": "97252b4594d57aac6ffbb5a884650fe39ba6f25dd96ea97936c84f7440e2e30c",
+                "uncompressed-sha256": "1de76be5d171c7eb0e599b2871a5f2dec10a33d913086d6f5e699a952291e6c5"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-qemu.s390x.qcow2.gz",
-                "sha256": "690d30a65aec0775f650592dd52f8fb148f8211bf8e2d1c99d74132c5a7f120c",
-                "uncompressed-sha256": "76a5a618278c97fd30867084054f83b70e6fed8ebe82e070404232ee691c2817"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-qemu.s390x.qcow2.gz",
+                "sha256": "507fdecaa79f149a68f1a44a7e795951766125a9151c4eb46adad19749100de1",
+                "uncompressed-sha256": "ef0feea3f868ae966aea98850cab67f2ce333a921a96a2a9970fbe3dfbd6e86e"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/s390x/rhcos-9.6.20251212-1-qemu-secex.s390x.qcow2.gz",
-                "sha256": "d9bcad749e7b41a7422b0e45d9396f5237831f72dbe92949c790d944b793a038",
-                "uncompressed-sha256": "bc46f29e07e759a7c272954d8a960ced2a49cd6d14032f680f257a92c2912272"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "06e7a623896d3c2d5a6698b423936e8b2003003ed7f9ae4be27c0c60325edd25",
+                "uncompressed-sha256": "f6dcdd36cc0b5101f64755fe2fa977e02efd2e19a8849dc8c7b64ea7b97ddf3d"
               }
             }
           }
@@ -516,165 +508,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ebdc076a5ee8e556d2d0edd300d3a502d23d94f177491cef4152625bcdbf510c"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9e498a892022c5bec60dacedea1af9f081690a02941197932eceb06415f5ed3b"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-aws.x86_64.vmdk.gz",
-                "sha256": "8fe2cd3e071f9fcb60676f5f8b494afd06aadbc83e72d002368d26b53cc676cf",
-                "uncompressed-sha256": "7c5ed3a69772a11aed439ea75de0c4d7c896d840874a4b2382c9bd6db1d30baf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-aws.x86_64.vmdk.gz",
+                "sha256": "b9a87e6b9f6dafda3a34671dc7954f86deda98297a4e7c943d0a80dd2414d2d9",
+                "uncompressed-sha256": "99705ff3ecff21a97bdc528005291a2534b3baf5c2d796c81e477eeb3c7650b3"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-azure.x86_64.vhd.gz",
-                "sha256": "d487d0b41e318d12abb24ab0f766afe8ae22fabfc3661aca15e6877129a6690f",
-                "uncompressed-sha256": "a261d7d41dee98c14427e95c5063111bce552f915756767857e96642d6e27599"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-azure.x86_64.vhd.gz",
+                "sha256": "eeb4ea96d672a67818162345b015e6df54e124302b36084281ca1696006b3ce2",
+                "uncompressed-sha256": "3f12ef0d3f7e78abf63c9d8e1ab3e301e2b93bd0b9ece763bac4cd9369429821"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-azurestack.x86_64.vhd.gz",
-                "sha256": "9b7fb159fc4d9a22f2af207373c5f30c775d5192ea20f248c881fc87b8f96d38",
-                "uncompressed-sha256": "85fe7f2e32da86da7ee45771cfc5c8ecce87c7fc83b56771f1f501b0efba1a26"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-azurestack.x86_64.vhd.gz",
+                "sha256": "f2f2d165646de37f0ada28ecda9e79cf90d331660664d7d65d4ee1a80f1ba490",
+                "uncompressed-sha256": "02706cfb2c3ac1c5e6a16e74f7b819de8e14ab1aa78044afa1c85bd74fa2e1da"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-gcp.x86_64.tar.gz",
-                "sha256": "9a42d4ab390b43378c85994a718d5ce405e1b33db3b8cf8a35fd528444e95571"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-gcp.x86_64.tar.gz",
+                "sha256": "cf5cfba6d3000bc99c02593807477e4e5203cfc94333947b8c1bf4b559c35ef9"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "354086f3cfad45023d72d1534a619e7e4dc971f1adc2445cf2de7f73074a91cf",
-                "uncompressed-sha256": "3d200aea9d86496306ad588fb75e5e6d21a30c1b946f9a5d261ad7e199b31c12"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "acbf76fa75ee975035324c67c861a72ee47ce6b2e17d33238562b312375a1ffd",
+                "uncompressed-sha256": "eac100794dc01cce73f14926f9be94330c5086454a43e8eeab11584650a18898"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-kubevirt.x86_64.ociarchive",
-                "sha256": "412c4f1390c3aa27aa3964e09838a92850d67ea57293e80ff997da7c0d1b90cd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-kubevirt.x86_64.ociarchive",
+                "sha256": "3dc2b67366aaadb7bae087df8f0aaf73ce466ef3206c31dd96b66ba997abafe6"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-metal4k.x86_64.raw.gz",
-                "sha256": "7abdd2707dd9fd93762298a84238ba609aadd4bc763735eaf9e99575aa02b527",
-                "uncompressed-sha256": "a92d2a9f552a97128b2d6fff0b1b2b0416fd63c7610bcf936e8d2df41b1d65e8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-metal4k.x86_64.raw.gz",
+                "sha256": "5671a8b409b1202abdc44e3d2c6f98340b72f7e1b16a52ad760e4d4ad69d8f7a",
+                "uncompressed-sha256": "778e3461b9ec563a402a159201b864f8442a578af3452cd8796149b2b1d9abdf"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-live-iso.x86_64.iso",
-                "sha256": "4b75ef7dc939f03bc0a3c383a1e3bc72ba99c8f174fffa50e28ed78e812ecb42"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-iso.x86_64.iso",
+                "sha256": "84d091a663eb4c192f0f4655ab501de43b570004b1650f6fbbd79f237310b581"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-live-kernel.x86_64",
-                "sha256": "084524c444f0782d7e1d2ed6398d7ef25f90bacda31939051a64337d4ba60e4f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-kernel.x86_64",
+                "sha256": "0e90dbd4f468fd31e8cbcd1a1c67948b86547693ee229eb5851d96b5338df93c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-live-initramfs.x86_64.img",
-                "sha256": "ee6d3bbff80fd2247a262fbea9ca1a586723c6286b2f486a8d4225ceb671c555"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-initramfs.x86_64.img",
+                "sha256": "2fc4b72cc57ce5662a0fa87306eafe0f9faa18b7b204dc54fec9e5e5411b682b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-live-rootfs.x86_64.img",
-                "sha256": "b14ce41483b704a6fd7d612c4d0fb3b292aa91414ed3f1b5a7912d3f511e94aa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-rootfs.x86_64.img",
+                "sha256": "a8ccc17ce859fe81df6334a3ea6d5410a7449609a8d69c126dd585170d4a3602"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-metal.x86_64.raw.gz",
-                "sha256": "7d198168ebd5393afecadbd9da887b391a9b9519a67e2b777bdfb259da0f8464",
-                "uncompressed-sha256": "4ac6471ffce70f267afae26389a4d611b371595d7aff0c12aa499300228e0c93"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-metal.x86_64.raw.gz",
+                "sha256": "22ff26326df25a1fe45e515c7eda4c6d604bd9f4c58202aaf2e892c649b5d0b8",
+                "uncompressed-sha256": "bda67eae9b820a14227176e5ca6cfb910370042063fe55a2bdf954f3b972ff53"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-nutanix.x86_64.qcow2",
-                "sha256": "faee3d3d53cc4fb022fc5d43d775d8291fab2af69114716aa3349302c82a919a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-nutanix.x86_64.qcow2",
+                "sha256": "6f493408f35399cf47e44fa1464fcaee2f767df9191c8af00a4b8fe759b4ddbc"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-openstack.x86_64.qcow2.gz",
-                "sha256": "8836c77b4cde31cef3c5e10e4d97e75dab1b1eba5e441ee72eb466dd221e3c83",
-                "uncompressed-sha256": "3b936203c1c7a15841a0a0d96de9a80a53dcfdf03faf1b979948196fbdb8b31c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-openstack.x86_64.qcow2.gz",
+                "sha256": "c80ebe3ace21a7ab59286c57545e3f7cfa9082f3114610fbb80c51769f2ac471",
+                "uncompressed-sha256": "ee11fc8e6a0a2c795907f5ee7bd7b8889f12474bf0cf8e98f8904f7ddcc1f2b0"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-qemu.x86_64.qcow2.gz",
-                "sha256": "1264ea9e448614ae89544a05921aae4abbf0d8b9178d05702f23c23f7147eb2d",
-                "uncompressed-sha256": "d4dd3d3739e8693b10896dbf265e38d17ef7e095a5d5c3f8010b4e30c58a0eed"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-qemu.x86_64.qcow2.gz",
+                "sha256": "1e13019dfad15a8813995a9df4a0f5370648e1b81f1432536e50ba55b745db89",
+                "uncompressed-sha256": "c736887ce8d73b0562776ba4796b087a3230ebfd603d3a06b3be1de113451b26"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-vmware.x86_64.ova",
-                "sha256": "f1c37de7e80fb03cc168596a7c33c26bd8d36c15bdbf544c51283a074d26ba05"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-vmware.x86_64.ova",
+                "sha256": "3756ba40964e93779640ca7d20abbe981498eec94c410e6cbfcc6ddcd051728a"
               }
             }
           }
@@ -684,306 +676,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a3b22174319ad66e"
+              "release": "9.6.20260520-0",
+              "image": "ami-069ec25f081cb5cff"
             },
             "ap-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09cde51703738523d"
+              "release": "9.6.20260520-0",
+              "image": "ami-06a2691ae27fe2f37"
             },
             "ap-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-05478426f756db81c"
+              "release": "9.6.20260520-0",
+              "image": "ami-0568f3afd49332306"
             },
             "ap-northeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0d6f0c1a044b6848f"
+              "release": "9.6.20260520-0",
+              "image": "ami-00785c74b02b6f722"
             },
             "ap-northeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0d19d79e52ad365c8"
+              "release": "9.6.20260520-0",
+              "image": "ami-00c6e17c9645be69f"
             },
             "ap-northeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a0391de700b812ae"
+              "release": "9.6.20260520-0",
+              "image": "ami-06039543d5c8d5f3e"
             },
             "ap-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-097ffb6f644b7bad1"
+              "release": "9.6.20260520-0",
+              "image": "ami-07c85cc08d4bc0d98"
             },
             "ap-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-08f1c0c6caafcf2c5"
+              "release": "9.6.20260520-0",
+              "image": "ami-04035ca91d49e6735"
             },
             "ap-southeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09b223a7c699ecde8"
+              "release": "9.6.20260520-0",
+              "image": "ami-04a762864127fd5ac"
             },
             "ap-southeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a44bb6d4903a93a1"
+              "release": "9.6.20260520-0",
+              "image": "ami-086d4cabcd06ba59a"
             },
             "ap-southeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-01469b817e364700f"
+              "release": "9.6.20260520-0",
+              "image": "ami-0ff0fd0ccdb0d31c2"
             },
             "ap-southeast-4": {
-              "release": "9.6.20251212-1",
-              "image": "ami-086cc002b6d450301"
+              "release": "9.6.20260520-0",
+              "image": "ami-0059f9be0ccdfd4f1"
             },
             "ap-southeast-5": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b5b9be3ea6fc17de"
+              "release": "9.6.20260520-0",
+              "image": "ami-0f8a95d604562562b"
             },
             "ap-southeast-6": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03a6ddee59246ab62"
+              "release": "9.6.20260520-0",
+              "image": "ami-045092ba047642020"
             },
             "ap-southeast-7": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03ce4d4bb4f67e777"
+              "release": "9.6.20260520-0",
+              "image": "ami-00ffe3c651aa7f1b7"
             },
             "ca-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b23054e68ef5ec3b"
+              "release": "9.6.20260520-0",
+              "image": "ami-0c554f16216af806b"
             },
             "ca-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0541a60892c677593"
+              "release": "9.6.20260520-0",
+              "image": "ami-08bc06f8a5f8564aa"
             },
             "eu-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-006a33223c87af648"
+              "release": "9.6.20260520-0",
+              "image": "ami-0b31eb834d5676043"
             },
             "eu-central-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-05ddf59e283155ea1"
+              "release": "9.6.20260520-0",
+              "image": "ami-067c8ed2801cc0693"
             },
             "eu-north-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-054f384036093db98"
+              "release": "9.6.20260520-0",
+              "image": "ami-0f8259fb88cd731a9"
             },
             "eu-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a1cc6a65238669f3"
+              "release": "9.6.20260520-0",
+              "image": "ami-0dd4df7a128ebdc01"
             },
             "eu-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0fe02b801fea5edf6"
+              "release": "9.6.20260520-0",
+              "image": "ami-02c3b1b12be3a773e"
             },
             "eu-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0632ffa330e30aea1"
+              "release": "9.6.20260520-0",
+              "image": "ami-09bd7a48295c3e52f"
             },
             "eu-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-05829d8d5c031e4a8"
+              "release": "9.6.20260520-0",
+              "image": "ami-00bb16f1535810e64"
             },
             "eu-west-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00be64f508df27900"
+              "release": "9.6.20260520-0",
+              "image": "ami-0788b88cffa35a98e"
             },
             "il-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0eeea15b1c070e051"
-            },
-            "me-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-090084b481adf23e9"
-            },
-            "me-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0569abe19529c8b10"
+              "release": "9.6.20260520-0",
+              "image": "ami-0fedec19a27a5eb0d"
             },
             "mx-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-05ab0cf33b0e946a7"
+              "release": "9.6.20260520-0",
+              "image": "ami-0a24006031e26190a"
             },
             "sa-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-04dd4c56b43a23fb5"
+              "release": "9.6.20260520-0",
+              "image": "ami-0d4e81477fe9a1073"
             },
             "us-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-04018496b0a1da2d2"
+              "release": "9.6.20260520-0",
+              "image": "ami-02807a245a41410eb"
             },
             "us-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b264801b0e00009c"
+              "release": "9.6.20260520-0",
+              "image": "ami-0904e5e509c505775"
             },
             "us-gov-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-042feba6717887157"
+              "release": "9.6.20260520-0",
+              "image": "ami-09150a1378faa930d"
             },
             "us-gov-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b05862564ac8353d"
+              "release": "9.6.20260520-0",
+              "image": "ami-06512f09d894326a7"
             },
             "us-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-08f548f5be577ce2d"
+              "release": "9.6.20260520-0",
+              "image": "ami-03728955b9e5f218b"
             },
             "us-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-04941543f3e575579"
+              "release": "9.6.20260520-0",
+              "image": "ami-0f518858c9c61520f"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20251212-1-gcp-x86-64"
+          "name": "rhcos-9-6-20260520-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.6.20251212-1",
+          "release": "9.6.20260520-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ce03dfda698bc982bbb5e8e4d8510f6609ac33a4bba13593329c69d16e6eb84"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aa9f0af3dd0180af3693021a8ac58134cfa73727d99c1f339265430ec2786b46"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-046265b58e108ce9d"
+              "release": "9.6.20260520-0",
+              "image": "ami-04d2a975eee689fc4"
             },
             "ap-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-061a848a463ac34cc"
+              "release": "9.6.20260520-0",
+              "image": "ami-09727182661090fd9"
             },
             "ap-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-015f20039cd6a920b"
+              "release": "9.6.20260520-0",
+              "image": "ami-023a55d2f06f1480a"
             },
             "ap-northeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-06f1790ede94f05bb"
+              "release": "9.6.20260520-0",
+              "image": "ami-05627624911920688"
             },
             "ap-northeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-074b751c8fd1b4352"
+              "release": "9.6.20260520-0",
+              "image": "ami-054138b8f6ecd7385"
             },
             "ap-northeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-07bb8c4c6000bdd53"
+              "release": "9.6.20260520-0",
+              "image": "ami-020fa1a0a37df5029"
             },
             "ap-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-052259adcd061bc9a"
+              "release": "9.6.20260520-0",
+              "image": "ami-01b0fc3eb9511e5ac"
             },
             "ap-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-08d2b6bcaca241f2c"
+              "release": "9.6.20260520-0",
+              "image": "ami-05f8e4731d31e606b"
             },
             "ap-southeast-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-044d4ceda29b3ae61"
+              "release": "9.6.20260520-0",
+              "image": "ami-068e9f19d41e3fa46"
             },
             "ap-southeast-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0aed5d16198d8f0c3"
+              "release": "9.6.20260520-0",
+              "image": "ami-0181476ce34b94faa"
             },
             "ap-southeast-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0185042d2323ab5b2"
+              "release": "9.6.20260520-0",
+              "image": "ami-0df1c20285cd7bde8"
             },
             "ap-southeast-4": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00e46647409373ccd"
+              "release": "9.6.20260520-0",
+              "image": "ami-09299807162fad231"
             },
             "ap-southeast-5": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09c783ffb0c11a817"
+              "release": "9.6.20260520-0",
+              "image": "ami-013b8fd48c1c1aaaa"
             },
             "ap-southeast-6": {
-              "release": "9.6.20251212-1",
-              "image": "ami-00122d5ac8e61a920"
+              "release": "9.6.20260520-0",
+              "image": "ami-0ff7ca07d83e23777"
             },
             "ap-southeast-7": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b33e5fa839bd9402"
+              "release": "9.6.20260520-0",
+              "image": "ami-0ab2ff1808712829f"
             },
             "ca-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0e57b7ffe1095cbef"
+              "release": "9.6.20260520-0",
+              "image": "ami-02648dab71c926ccf"
             },
             "ca-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0b23e452c6ef61561"
+              "release": "9.6.20260520-0",
+              "image": "ami-0e9a86f69876d1fa0"
             },
             "eu-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0df3e903f8cbb14b0"
+              "release": "9.6.20260520-0",
+              "image": "ami-00825db7899983a0c"
             },
             "eu-central-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-020580d0094aad79b"
+              "release": "9.6.20260520-0",
+              "image": "ami-0e59a9d88cd401e85"
             },
             "eu-north-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0dac5438f83a2fd80"
+              "release": "9.6.20260520-0",
+              "image": "ami-09a1f839c6a739ed0"
             },
             "eu-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03c7ddb1e5314f138"
+              "release": "9.6.20260520-0",
+              "image": "ami-0fcbfc54371e9351a"
             },
             "eu-south-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a7587d3b80d854a7"
+              "release": "9.6.20260520-0",
+              "image": "ami-0dde4bfa70ab40729"
             },
             "eu-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0a43c04558792823c"
+              "release": "9.6.20260520-0",
+              "image": "ami-0464b57c2ed725feb"
             },
             "eu-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-09fe84b542894b7b8"
+              "release": "9.6.20260520-0",
+              "image": "ami-03602d58bf40955e9"
             },
             "eu-west-3": {
-              "release": "9.6.20251212-1",
-              "image": "ami-01804615464b3fa7f"
+              "release": "9.6.20260520-0",
+              "image": "ami-085ba4472d53e106d"
             },
             "il-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0049bd4c2c9f9eb6b"
-            },
-            "me-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-02571eee09fd2067f"
-            },
-            "me-south-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-05e2f026089764e17"
+              "release": "9.6.20260520-0",
+              "image": "ami-01b3fb973a85b1455"
             },
             "mx-central-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03aed17ea188e9d92"
+              "release": "9.6.20260520-0",
+              "image": "ami-0c61cc9e0ab985c98"
             },
             "sa-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-03ad8dfd00457b6aa"
+              "release": "9.6.20260520-0",
+              "image": "ami-02399b36bfc535980"
             },
             "us-east-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-099271017e446edb7"
+              "release": "9.6.20260520-0",
+              "image": "ami-04d43de815332996a"
             },
             "us-east-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0fdb80a75b921b371"
+              "release": "9.6.20260520-0",
+              "image": "ami-06492635911977bb0"
             },
             "us-west-1": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0e4e8493548b09b54"
+              "release": "9.6.20260520-0",
+              "image": "ami-00ba9aed278b41571"
             },
             "us-west-2": {
-              "release": "9.6.20251212-1",
-              "image": "ami-0f99194701f0b95c9"
+              "release": "9.6.20260520-0",
+              "image": "ami-015f9eac1e40f6935"
             }
           }
         },
         "azure-disk": {
-          "release": "9.6.20251212-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20251212-1-azure.x86_64.vhd"
+          "release": "9.6.20260520-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260520-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

Update data/data/coreos/rhcos.json to 9.6.20260520-0

OCPBUGS-77787 - [4.21] bootimage needs a coreos update to support GNR-D hardware
OCPBUGS-77048 - [4.21] RHCOS SNO does not boot after install; wrong device uuid in GRUB
OCPBUGS-69682 - [4.21] Kernel panic when using vrf and srv6 instrumented with FRR in RHCOS

```
plume cosa2stream --target data/data/coreos/rhcos.json                 \n    --distro rhcos --no-signatures --name rhel-9.6                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=9.6.20260520-0                                       \n    aarch64=9.6.20260520-0                                      \n    s390x=9.6.20260520-0                                        \n    ppc64le=9.6.20260520-0
```
                    