### PR TITLE
OCPBUGS-77834: Update RHCOS-release-4.20 bootimage metadata to 9.6.20260512-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,106 +1,106 @@
 {
   "stream": "rhcos-4.20",
   "metadata": {
-    "last-modified": "2026-03-04T15:09:24Z",
-    "generator": "plume cosa2stream 6c82fcc"
+    "last-modified": "2026-05-28T19:06:06Z",
+    "generator": "plume cosa2stream af5d9c3"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-aws.aarch64.vmdk.gz",
-                "sha256": "769577717dcb21ec61c2ac81804a94fff699c1595556b01863978420023b7658",
-                "uncompressed-sha256": "1d5fcd2ddaf658b19ea90f8d7c7d0793785a3153b5074424feca18a50d1fb21c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-aws.aarch64.vmdk.gz",
+                "sha256": "25c36b20dab0b6877bae8b113bf3d874916603dcc598bc6c7a3bc511a466410c",
+                "uncompressed-sha256": "cef1e35cd57c3b5bfde17922bbbc3ce19589ccde47c93ebe6bd673042358ed5d"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-azure.aarch64.vhd.gz",
-                "sha256": "bb449eaf52e76e8b74288923b71b980254a2f03aebdbf43bac5790f114b30d01",
-                "uncompressed-sha256": "9eb378777b0fb643768fb9a5c7ff9dd2dc8b204a4c519c74768c181c7d630add"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-azure.aarch64.vhd.gz",
+                "sha256": "2d16d9a08fbe3ecfd9b6bcda89be2c5950f761afadd7fd706217fdb37c8f04c5",
+                "uncompressed-sha256": "b36ed652e27c147c22a2aefcfe1cce09878b789d8cd43fdd450d70d395d98162"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-gcp.aarch64.tar.gz",
-                "sha256": "adc3eed0541da6ba0269019813ab30b3eb92c316ab550c124e5f4dbb530243b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-gcp.aarch64.tar.gz",
+                "sha256": "c283be50f018a81293b31e04d9125ac1a87fc94b5fd2d8719ae5cd1eff4af22f"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-metal4k.aarch64.raw.gz",
-                "sha256": "3f04014d68747b9a0274b2a5634d2c40b9be928740ad73456da3eb7c33252330",
-                "uncompressed-sha256": "f62254fcf3710f6f4b21c9dc77a8bc078ac57423697727ee29af178341aead41"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-metal4k.aarch64.raw.gz",
+                "sha256": "427380a955ecb52306e659511276e254ef90711505ff1278b1dfafa4de71af30",
+                "uncompressed-sha256": "9495acfc84bca5e888b97edaed22f49946cc750307b843d7875f539d0ef94122"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-live-iso.aarch64.iso",
-                "sha256": "eb72c22cdbd88e84dd7a203d7b0853c64896cc734e0c1ead3a1effb27363ed7e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-live-iso.aarch64.iso",
+                "sha256": "62176c2bb4807109b7ab5e7be0c096e53ddbbebd77e19a74becc4f21ed7bd8f5"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-live-kernel.aarch64",
-                "sha256": "e83078bdc8719bf8e5203601e4abda73c44fc4de2ddabdb22c9b7fe76985299f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-live-kernel.aarch64",
+                "sha256": "cfffbb19dbc9c023be365b47beb3f499d6062e3fc8c2973e5f2254bf901ae008"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-live-initramfs.aarch64.img",
-                "sha256": "5755048d3e78026d84005388a650715483c3e74280536c68ea3bd07b04d5c57f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-live-initramfs.aarch64.img",
+                "sha256": "9527fc41b4f29c8142bb079a2900a65effd82257661804d1fa4a74be86b23d4d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-live-rootfs.aarch64.img",
-                "sha256": "d52db346d1cf18bb1481110611a38d63a4374dd71baee904d0cf1694bd7be3e5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-live-rootfs.aarch64.img",
+                "sha256": "4be8e9e71e794de7af1affc5928fb528c3c381839a789ddb70177bfb19d4f4cc"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-metal.aarch64.raw.gz",
-                "sha256": "c7cd43207d9ef68e36bfddc9a31b32c66a8d30405df4eba91f75b2e20d97be93",
-                "uncompressed-sha256": "cf6557e8fda8c165bdb67b925ac8615b22b1a34be4fc7333d5dbdc8463339c82"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-metal.aarch64.raw.gz",
+                "sha256": "9c43109d025c55323645d5e6fa3291bbbbd648605cb65775fe380b80a0cf88e9",
+                "uncompressed-sha256": "4bd1afd4d0ae295a5ed17b6dcc2c8fd8245509304c57db4f46c2253edede5ffb"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-openstack.aarch64.qcow2.gz",
-                "sha256": "55af23a355d5fbe08b7450cab35a0babbe8f0b532ed82adb5f792e4a74d5b995",
-                "uncompressed-sha256": "5775af90d2d632baa5ccafbfb73f128f3279010898d77d95f3660fcec21e47b9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-openstack.aarch64.qcow2.gz",
+                "sha256": "0a12632b87484054150eb024b4528f5e076ffd8e1038db2aef76f0f01912ec45",
+                "uncompressed-sha256": "cceda7b517d37a5536b6ef8dc76216a4e9fb0ba3bbb61c5cc94def57266cb96f"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/aarch64/rhcos-9.6.20260217-1-qemu.aarch64.qcow2.gz",
-                "sha256": "c60cd090e738333a0a946992398573ad49a8db6fc226576ed0602dec8b70a85a",
-                "uncompressed-sha256": "ffc2f0ccd1ee5b893f48a7c30c537ef2c6d2680b5904cd8d58730f9cf947defe"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/aarch64/rhcos-9.6.20260512-0-qemu.aarch64.qcow2.gz",
+                "sha256": "05f08d09728de6c175fce65de6ee5acd51603bd53abcc9fb447a2770903cd4c7",
+                "uncompressed-sha256": "94177ccbf9f8b48e5848e1575af1211f5c1b6947c100c48ced0fe7410bd53c21"
               }
             }
           }
@@ -110,237 +110,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0536d0824c43b377d"
+              "release": "9.6.20260512-0",
+              "image": "ami-01982e4a39c3bdf9c"
             },
             "ap-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-000342c5112bddf68"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a71ee632d6578096"
             },
             "ap-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0135df22e19eefd46"
+              "release": "9.6.20260512-0",
+              "image": "ami-059e02df3148ec9a6"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-073d6c9cb6ba2e80b"
+              "release": "9.6.20260512-0",
+              "image": "ami-0e9323d842cbd1aa7"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f043300ad145b5e8"
+              "release": "9.6.20260512-0",
+              "image": "ami-0bff59d145b8c8daf"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-04b1e01f266ed1d0a"
+              "release": "9.6.20260512-0",
+              "image": "ami-0930ddf63161e28ef"
             },
             "ap-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b2ea1b7e98ce2924"
+              "release": "9.6.20260512-0",
+              "image": "ami-0715d60230998dd6f"
             },
             "ap-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-078f70526e8482eef"
+              "release": "9.6.20260512-0",
+              "image": "ami-08f247f5f9e17ad4d"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-04a9cc35d5d212aff"
+              "release": "9.6.20260512-0",
+              "image": "ami-0764b20825c6badc5"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0e4d99749233db0ce"
+              "release": "9.6.20260512-0",
+              "image": "ami-06ba06fc99564b306"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b2c070ed37c6c773"
+              "release": "9.6.20260512-0",
+              "image": "ami-00146633a6747c9bb"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b147be7fe543d60b"
+              "release": "9.6.20260512-0",
+              "image": "ami-03231f177ac6b0f6e"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0758d0bb6ba551dda"
+              "release": "9.6.20260512-0",
+              "image": "ami-0f9d01760c1809e35"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b9be34d2235d970d"
+              "release": "9.6.20260512-0",
+              "image": "ami-06d28923bb8fe576a"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260217-1",
-              "image": "ami-05315c2fddf8693cd"
+              "release": "9.6.20260512-0",
+              "image": "ami-0abc3f64e0ed5ed33"
             },
             "ca-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f8fc587bdad77687"
+              "release": "9.6.20260512-0",
+              "image": "ami-07b808b41596ae914"
             },
             "ca-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-03c13ed77386363ee"
+              "release": "9.6.20260512-0",
+              "image": "ami-036dc9986b1975b86"
             },
             "eu-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-01a43bf9927a93b3a"
+              "release": "9.6.20260512-0",
+              "image": "ami-082834c5320977344"
             },
             "eu-central-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a7866ea5f8b6b4f5"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a4fdc01449699e1f"
             },
             "eu-north-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0beb76bb7824a0d5e"
+              "release": "9.6.20260512-0",
+              "image": "ami-061b695c9a2326b56"
             },
             "eu-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-084bc745a2438f746"
+              "release": "9.6.20260512-0",
+              "image": "ami-060956f3d1f4069ef"
             },
             "eu-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-002ed50c65288eb81"
+              "release": "9.6.20260512-0",
+              "image": "ami-0585a33ce2ed2fad3"
             },
             "eu-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0cdfd198102367d3f"
+              "release": "9.6.20260512-0",
+              "image": "ami-071d5413f30e86610"
             },
             "eu-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0af949d860d437407"
+              "release": "9.6.20260512-0",
+              "image": "ami-0e4872ac0efbb41fc"
             },
             "eu-west-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a869063701e9fec1"
+              "release": "9.6.20260512-0",
+              "image": "ami-01991b743996904c6"
             },
             "il-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a04d894ab736f382"
-            },
-            "me-central-1": {
-              "release": "9.6.20260112-0",
-              "image": "ami-0d48a47b22126286b"
-            },
-            "me-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f632c3b57e5ac5d1"
+              "release": "9.6.20260512-0",
+              "image": "ami-0972676b55fa61cbc"
             },
             "mx-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-02a63e9fc5e3b6a7b"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a54af1fc75b52649"
             },
             "sa-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-069bf63f12cabf768"
+              "release": "9.6.20260512-0",
+              "image": "ami-0675e0553a10ee14e"
             },
             "us-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0305a169f602a17ce"
+              "release": "9.6.20260512-0",
+              "image": "ami-055e163630b75f2fb"
             },
             "us-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b09416406227ac63"
+              "release": "9.6.20260512-0",
+              "image": "ami-0b04f3ae3f12b9849"
             },
             "us-gov-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-02ea44877ce9b2bdd"
+              "release": "9.6.20260512-0",
+              "image": "ami-0743456645364c7f3"
             },
             "us-gov-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0d8e9bcb9f25384c0"
+              "release": "9.6.20260512-0",
+              "image": "ami-0897b8887f05a6583"
             },
             "us-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b167bfc32a9a510c"
+              "release": "9.6.20260512-0",
+              "image": "ami-03d204b32880c8efd"
             },
             "us-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0ec286172087497ea"
+              "release": "9.6.20260512-0",
+              "image": "ami-009dd42cf1731d937"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20260217-1-gcp-aarch64"
+          "name": "rhcos-9-6-20260512-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20260217-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260217-1-azure.aarch64.vhd"
+          "release": "9.6.20260512-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260512-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-metal4k.ppc64le.raw.gz",
-                "sha256": "2804a8e882d04080c1f1eda89ed1f7dfb4619f2da58688797534dcb305a4d526",
-                "uncompressed-sha256": "6995273a321aa6646a13fab85795f837267f9d2aa10767b255de3e99c59f02e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-metal4k.ppc64le.raw.gz",
+                "sha256": "89cb9b03e8e628a246e38bec34877c90cd5a89bc5ed9d627f5137678520b96ff",
+                "uncompressed-sha256": "b83f9b0f242db524b7a1e68e193e8330c407c6b03c14069512ed0e676aa593f7"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-live-iso.ppc64le.iso",
-                "sha256": "f74bd433a005af37990001f281218fd0852de9c976f3458b8e3b48af5af358c0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-live-iso.ppc64le.iso",
+                "sha256": "22eddcdd2c1949b74a8b6800eb60cb00db99fe06f3d23c35579d78169495632d"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-live-kernel.ppc64le",
-                "sha256": "8367b82ae1ec95797251025618c7a806db051a068e44ff3a482873ab48f7de9e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-live-kernel.ppc64le",
+                "sha256": "20eff7f07b8a5c10e4a09beb75714d2ee92f49854b03294dcfb51d606b6b58cb"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-live-initramfs.ppc64le.img",
-                "sha256": "af460a95a7e510534d5ed9ea20778022f387dfeba262149b4c947187ecd63e09"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-live-initramfs.ppc64le.img",
+                "sha256": "c8834d1f8de4ad2f77d55d354834190fb66e6829d55ccee00117ffce0bd5658e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-live-rootfs.ppc64le.img",
-                "sha256": "b74eca8fbbc88b809b08564da27f2e56d9cd3b22780e4064006b07a6cb696c4e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-live-rootfs.ppc64le.img",
+                "sha256": "4f9422e05a23c90e1cc286e6359d15a177f5c80c3062fd30529d3fdea632d7ba"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-metal.ppc64le.raw.gz",
-                "sha256": "df59fcefa877c6af3f9b60a4197301f1a82076a2850928c6c49bffee793340f8",
-                "uncompressed-sha256": "0b7ee4eb101721a7d044d3786086b525b0195b8b0364499e3d2ce543a51859b6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-metal.ppc64le.raw.gz",
+                "sha256": "b91b554a0a1e8ec6a66dbf1844adafcfbc2b77ea5b592490a6064c2c356d7050",
+                "uncompressed-sha256": "958680d9c1c5599337588319d227da095f037af5ee423e7bec732b2eca324c8b"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-openstack.ppc64le.qcow2.gz",
-                "sha256": "fa935723832de2b98b6e60b9452d64e2cad4f4a045160c9e756fd50150fe7e97",
-                "uncompressed-sha256": "4691f412546d2c3bacfdb06c19f908da3094b9b4a15d167853d8cb085f40033a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "e143496465f3436d1fb6ae3f4bb833d508a7a632205e7f8bed3a85e3cb457332",
+                "uncompressed-sha256": "ed5aeb222d402d83cc08cccf202e794fbe16165e99e643f7593abb43b09b4d9c"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-powervs.ppc64le.ova.gz",
-                "sha256": "f320093f1e049fd10b7304eb84986a3987f8f78135a11ba86fee911a9b141733",
-                "uncompressed-sha256": "abc8de0555a3a84e33615d52d9389e4496280b956bd21662af90e5648e9d95ef"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-powervs.ppc64le.ova.gz",
+                "sha256": "4e9474f94cc57e6721d2027b96441a33f07063ce17bc40e1aaa454e33f244cfb",
+                "uncompressed-sha256": "dcaf18e2a57f9b3c718a773cd04f06e43561c69b9409e3ac4d6f3811305b9d65"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/ppc64le/rhcos-9.6.20260217-1-qemu.ppc64le.qcow2.gz",
-                "sha256": "52b0439626dd9d8d33e97b09973105eab985b42dd35c491ab24d646fd8246fb4",
-                "uncompressed-sha256": "1abfc064be30e8192a87390936950d8421820db3e9aaba421ef11abbb6978678"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/ppc64le/rhcos-9.6.20260512-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "5600978249f7422972f43a71c340f2b72b5f776aa8e00ac5ba48c68448f78daa",
+                "uncompressed-sha256": "fca1dc5da3e2efa2cfff73cb96fb6df7b09a60b75fd89787f4a1415220e148ed"
               }
             }
           }
@@ -350,64 +342,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.6.20260217-1",
-              "object": "rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260512-0",
+              "object": "rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20260217-1-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20260512-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -416,99 +408,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-ibmcloud.s390x.qcow2.gz",
-                "sha256": "cab45137bc2aff9733b02df9f6c84d14874c69c1070f7edcd69b6e2ed58d3801",
-                "uncompressed-sha256": "74412d3c7c68233b0fa3477be57451670f370e29df444553a13e603ce26f78ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "059044f14f0fefcf34323d4e7be8088462756c9c21651aa8a9f7681db10f9f6b",
+                "uncompressed-sha256": "00586a3ecd9b1f5b5b4662b05c0478cfae97b74fbff10cc8bb415a1ae83ed6a4"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-kubevirt.s390x.ociarchive",
-                "sha256": "eccac2e29eccdf318824518c41306edfeb0e4fdf127a4904bc07d9c72523fe1b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-kubevirt.s390x.ociarchive",
+                "sha256": "6ed4a2f74f4a2bd8a2bded50f11fd00f25ced5b838a5f36bb7987906ca4c0a6f"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-metal4k.s390x.raw.gz",
-                "sha256": "0effb1e592e0e4df62b30759dbad75634eb0808e3a41f42051f8a7e1a6b84431",
-                "uncompressed-sha256": "0d19738541e8c40cdb6587526b93fdc3fc90033cc0f062b59c1391d165670e52"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-metal4k.s390x.raw.gz",
+                "sha256": "8545c96bd1d8be26c533977cd76478f4a192a7bdfa627de286e95540da04d1ee",
+                "uncompressed-sha256": "07b29f3a9e3b1653b82fa3f1a256a57bb0278aa0ba5421371e38054591c8a566"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-live-iso.s390x.iso",
-                "sha256": "c6db81b28eee8567353f9ea2c46c800ee9f2b752e6be2f236ed152fdd14616b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-live-iso.s390x.iso",
+                "sha256": "e585a776273cc2f03b10a86633d9bbf723e7a5f3c08b8e6dadd42bd1e2c86fe3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-live-kernel.s390x",
-                "sha256": "c1982f893e95133d17f4e5890e2c70b6db99bb0911ff1874ab6175bc966e9bdf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-live-kernel.s390x",
+                "sha256": "dbccb938d356eb7efdc97eea50526c7ee7f06bedf4d64570e88f279ae8020fc0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-live-initramfs.s390x.img",
-                "sha256": "d9e6540613436a3fb09858ea4cc60d57294195d41bbf9a63e52e443dea87f356"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-live-initramfs.s390x.img",
+                "sha256": "625b4cdfcd14aad33bb57ca18769951a230b7668f9a59f16fc00ec874ec1b661"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-live-rootfs.s390x.img",
-                "sha256": "314d1742899f63a4b49a3eccb25e6144d2475f9cc3afcb6112991cedf33d2313"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-live-rootfs.s390x.img",
+                "sha256": "9297c120f9fb63be1a9f1fe46e10163e8b74b1b511ecb239b80de53d451c8162"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-metal.s390x.raw.gz",
-                "sha256": "da21639a94e19539aa5fab8ccb84d39a6e103076705a9e1537b9fa802ea495db",
-                "uncompressed-sha256": "a699295c122e347350d505f0afcf64c0e6824afefda921c1eedac28bfe898af0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-metal.s390x.raw.gz",
+                "sha256": "5d668ad2bf13bed334b08ac68215d25d5f4a7e32d868a597c8a782835d0cb19b",
+                "uncompressed-sha256": "9f8aea1f80a958032e81efadf32ddcba641e93850d8a4f42c84bccb4a4f14445"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-openstack.s390x.qcow2.gz",
-                "sha256": "09ecbb282db85a0e33800345aceaebbdbc934b362f0d098108676832316128aa",
-                "uncompressed-sha256": "ff96f9ad817c184765a4923f40d80aae37c75d0c12216658c0442d655ba89076"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-openstack.s390x.qcow2.gz",
+                "sha256": "dbfc883383ab996cc32608313ce4c7e246c2562ff84f02d8306777fe2d4f50e5",
+                "uncompressed-sha256": "c5fb1203c4b3ba4d751aadffbdf4a38f49a04a5f3c6e61a8e85a89982802d85e"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-qemu.s390x.qcow2.gz",
-                "sha256": "8cee5655df5faa92dc718e653ff438f0b50e98e717080ff824d4f97e30230052",
-                "uncompressed-sha256": "1a53d52d311e4f4d729ada03456a7027233048eb1cc85087bdcc1f660481bf51"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-qemu.s390x.qcow2.gz",
+                "sha256": "7e931f6db43e7b42590e4bc2a1d3a26def16017b1aa9139b329cad1d22157865",
+                "uncompressed-sha256": "24bb9aa476d8724ac4c0a97fdc1964c4615b42b172f13786150986c59bf1a19d"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/s390x/rhcos-9.6.20260217-1-qemu-secex.s390x.qcow2.gz",
-                "sha256": "e7c3b03cdf467505e8db1e315a007cf49312ea5fc59169b25eb46105512eab1e",
-                "uncompressed-sha256": "07f84e463820fb63b3174bcf182149f444f9ad55b76e017147ffea232acca82d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/s390x/rhcos-9.6.20260512-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "51f34157aa932661bbd48f02bbc24767d961f1f5ffdeeed1e8b87ecbbb87e367",
+                "uncompressed-sha256": "38ffdc75913b22bd804997f6e4adbc080362908ff28bb58ac84c8f938dcce98b"
               }
             }
           }
@@ -516,165 +508,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e6ee2013a0042fd64912db4c960c94cfa439f01e8beaf4aeff96e26fe9057699"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:35f7677f5e84f0ab1128145d6e87d7e6d7361c3acdd0ca69030406cd053a3613"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-aws.x86_64.vmdk.gz",
-                "sha256": "cef15eccd33dbc670ae816deec956e34307c56376625cd17443631a324cdd9e4",
-                "uncompressed-sha256": "5640d3ac8480a5b14048c6f93e9dd98a2d8aee59b6c6901767c32eb92fb4a9a7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-aws.x86_64.vmdk.gz",
+                "sha256": "e376e4567ba459bda4e3a18a47a62e239e6d3ec0f1fcbcfc2d5ecb4a6cbb8f1d",
+                "uncompressed-sha256": "b227bf75c1e688af63b9834a5b7403446ebd826adbde98b54f649a089919dfe3"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-azure.x86_64.vhd.gz",
-                "sha256": "cc41cb24d40b821ab21a1943018193dbed6b4cf2ee5c02ec767f1b50e37332e9",
-                "uncompressed-sha256": "14046168c6eb348e15edcd96859c5835783d15dcece220fbb81bf6159f13138d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-azure.x86_64.vhd.gz",
+                "sha256": "8720b2ba4dd768cea18c2444259228aef1659bf05dbf74685d5b7958794b274b",
+                "uncompressed-sha256": "643f3c1c6a24b5ea3676719756ee14fa84ee19e519e5e34fbb6d6ac5d0d15794"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-azurestack.x86_64.vhd.gz",
-                "sha256": "cd16cb1c8f6b910823c24eec94407abffbec448549907f1b67bee7f347f7b179",
-                "uncompressed-sha256": "2618e5c2517bfd1c0021db15e3c582ec11600b92cedcd3dc7acda0f0edd513c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-azurestack.x86_64.vhd.gz",
+                "sha256": "62fd2681f9e01279cf1a703a77799e72c26845862eb3e8f4e5358abb554f1832",
+                "uncompressed-sha256": "e8027051bf1abf83bd1905f7406280a11e74d085594bae4a75142cce1ed626fc"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-gcp.x86_64.tar.gz",
-                "sha256": "482ecf8c75ee353023449da31bb0293482048efd6a3edcfc0e48763bd9bae71c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-gcp.x86_64.tar.gz",
+                "sha256": "e1febc8dc4a2fe6cfa96c2c164106764bdb4fcec01975c88b3153394dd165f0a"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "d3a1f18829aa56e073c80cf276b087ecc4cfa5ea2173cc91edca7298be239342",
-                "uncompressed-sha256": "ab8b5925283b343647a2eebfe363a368591e6549ee22f829b324a537080323a1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "da3b8e7699a21dd9a2b925fa08f3e8a93ac714a835ecf0d946d47d94d4800e0d",
+                "uncompressed-sha256": "ca1d37c38b5fab71859ec69cec58be988753cfcf2e8a969ace5d9910b2f37b25"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-kubevirt.x86_64.ociarchive",
-                "sha256": "4581b508e5c652d75498473de7b80d0fa96738a52d7c9b7948f318dd20801026"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-kubevirt.x86_64.ociarchive",
+                "sha256": "45f97378f5fedfb0552757b586cad32564f472627bc50458dbf45f0bf74ccfa0"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-metal4k.x86_64.raw.gz",
-                "sha256": "07003c3d1c6c71b9584b6ce79b86645c1bad4a214a8e0e674cdae2a10186023b",
-                "uncompressed-sha256": "b8f710af3fb387ba544d0f7b0b48b4f192810783b3470fbe675c16daad1049e5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-metal4k.x86_64.raw.gz",
+                "sha256": "77c67f7218c156fab9b10c556ff86111d1270fa0f7c9b6ef0a63987ed960d236",
+                "uncompressed-sha256": "002f564905eb8b92f8dd4026394f9d394b205050a523d34171f733a0b4bda539"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-live-iso.x86_64.iso",
-                "sha256": "a400ff19d2b8aedacc4c60a4ec24538ed1eb6b50c2ee2f5a98f5448d313a90ca"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-live-iso.x86_64.iso",
+                "sha256": "76b0f37f10b643b3a5ea315efd7f5e915cb59616f547f92665d94752992c34f7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-live-kernel.x86_64",
-                "sha256": "51d6dba5b889b7c91a13694c2cc5301b318c0995f58dcc06ef8a2ba984acc5ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-live-kernel.x86_64",
+                "sha256": "a5abb6fb5c05508eb556f6bf54647f7d3fbfd305d8ad1ab0e0e735f2933d74eb"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-live-initramfs.x86_64.img",
-                "sha256": "771cc6318c2acf9428c40dc34edd7b5c5b526615bb3527c384aa3c38a3178470"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-live-initramfs.x86_64.img",
+                "sha256": "985097b172a5a437759e9ab016665b97f28595cb6d68bcfd55374e92839d3714"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-live-rootfs.x86_64.img",
-                "sha256": "b4bc064b764f9c947d9776eacd52de92c7f7871e63f175aec916ae81af08466e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-live-rootfs.x86_64.img",
+                "sha256": "10dd00239832943161829d871b28effbdf13977d8409b448f90ec32308360732"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-metal.x86_64.raw.gz",
-                "sha256": "7a756ab6bbba8833f13b88a17d0af302631b132796c9371e78d9c086d415098e",
-                "uncompressed-sha256": "71a2ec9a506cc4d0703352f279918e1f463f26504366e6d994ec31de8b4fd22c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-metal.x86_64.raw.gz",
+                "sha256": "3099fd62ead1fcb075f60813289543135e290e7e653cc719e43248bc10dc55ac",
+                "uncompressed-sha256": "b8089c8d205a270e1a5a5a291a451e2bdb372800d1c6305c2f1550da131fd599"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-nutanix.x86_64.qcow2",
-                "sha256": "9dc0622cd87709672f49ac6872c74031e69154e85b0e260a8e866e796fb23d4a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-nutanix.x86_64.qcow2",
+                "sha256": "60e12a8fc01c7ddbe433c0314603bdc9ee30f7665d72ce53ae8438e382b3734a"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-openstack.x86_64.qcow2.gz",
-                "sha256": "635972d97eea9f339a729de3599c347a55973a19bd2cc54acc24fec1f6109908",
-                "uncompressed-sha256": "31ef7c8d9e7003682f4f4b1e19b4f8afd81524f877135e8543b1263a2b941501"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-openstack.x86_64.qcow2.gz",
+                "sha256": "62050fa709c29de336de12315f57d89d24992a036a08d3a0c064f097575c87d4",
+                "uncompressed-sha256": "606cd68ef156b03fa3d114c1d488f5376cbc9ca0391563dabd66e16cd9001a3e"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-qemu.x86_64.qcow2.gz",
-                "sha256": "1cb50352750fdd58242b0c1d4f609879a36cb536185f27e185f5c020718727d0",
-                "uncompressed-sha256": "739c3c8e6442adca9011d4a83f53df1abbcb234becf50fad15f9939f18d11bdb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-qemu.x86_64.qcow2.gz",
+                "sha256": "86851bdfe2870d80692529adbc2c70bd5568352c4ce8cc4efb136a1297bddd31",
+                "uncompressed-sha256": "3913a2280d19b4279d88724b2fc411201f0e0fea05c647407b55f86a27a3c674"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260217-1/x86_64/rhcos-9.6.20260217-1-vmware.x86_64.ova",
-                "sha256": "bb0a8f98e3c92e8d543f1e3a6fa013f1393bdb4b7d502fdb41e226dfd7d8a6f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260512-0/x86_64/rhcos-9.6.20260512-0-vmware.x86_64.ova",
+                "sha256": "74c58e31ad052c92846835b25a0c03f979dc0ed0818c3fb46395be642e8b1568"
               }
             }
           }
@@ -684,306 +676,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-03a73b9caf983d755"
+              "release": "9.6.20260512-0",
+              "image": "ami-06ff81937edd3d8a1"
             },
             "ap-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-08722b5ad1b171da7"
+              "release": "9.6.20260512-0",
+              "image": "ami-070b700950ee24048"
             },
             "ap-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0069df2d1a4a27459"
+              "release": "9.6.20260512-0",
+              "image": "ami-07c96000a90b80f9e"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-076651ce9dde9c263"
+              "release": "9.6.20260512-0",
+              "image": "ami-0c3f9aeb5e0eb35a6"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0c48c65f578368449"
+              "release": "9.6.20260512-0",
+              "image": "ami-057c084a77d9f6569"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-01c5068babb32d9b2"
+              "release": "9.6.20260512-0",
+              "image": "ami-0cb8b7cc270bba765"
             },
             "ap-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0ae12bcb5bcaddcc7"
+              "release": "9.6.20260512-0",
+              "image": "ami-0d54cae5427eb2e33"
             },
             "ap-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-055d0f3ea4c45c91c"
+              "release": "9.6.20260512-0",
+              "image": "ami-0d9de3957d530798f"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-048402f0c181077a5"
+              "release": "9.6.20260512-0",
+              "image": "ami-0564e429a677ce58a"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-089cf2e44a2b8ae58"
+              "release": "9.6.20260512-0",
+              "image": "ami-0daf12525c34bbacd"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-069df33ee927e1bfb"
+              "release": "9.6.20260512-0",
+              "image": "ami-00ed7036ab3b95870"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0ab82ae2ddd7415f3"
+              "release": "9.6.20260512-0",
+              "image": "ami-0316f66da9eddf972"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0078086bf9e9b462d"
+              "release": "9.6.20260512-0",
+              "image": "ami-0084b011d0cb28d97"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f242bc9e3d4cf104"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a19dd0c72c4c0e08"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0831e0f5094c280d8"
+              "release": "9.6.20260512-0",
+              "image": "ami-0ee406b33bd0ee687"
             },
             "ca-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0172652ecf50f0b04"
+              "release": "9.6.20260512-0",
+              "image": "ami-0ca112947ced24692"
             },
             "ca-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-019f6a028193d06ae"
+              "release": "9.6.20260512-0",
+              "image": "ami-084a19b31af28f857"
             },
             "eu-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-09f57b39f5b80dd6d"
+              "release": "9.6.20260512-0",
+              "image": "ami-052f3db53b4a66637"
             },
             "eu-central-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0d5a9d2a414c6cf1c"
+              "release": "9.6.20260512-0",
+              "image": "ami-0cfa9ca88883fedf2"
             },
             "eu-north-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0abf8de92084d7f0a"
+              "release": "9.6.20260512-0",
+              "image": "ami-0abad2c971d02bebf"
             },
             "eu-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-01deef6bf93dbac53"
+              "release": "9.6.20260512-0",
+              "image": "ami-0f8e1456e093c2396"
             },
             "eu-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f69423fe4d4ba9de"
+              "release": "9.6.20260512-0",
+              "image": "ami-0746d5b966e1c82e5"
             },
             "eu-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-030e56dccfda9ecc4"
+              "release": "9.6.20260512-0",
+              "image": "ami-0c259facf6c975ec3"
             },
             "eu-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-06ace9dd6a22866a1"
+              "release": "9.6.20260512-0",
+              "image": "ami-077cd89ae23e1377f"
             },
             "eu-west-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b3fb6db7d1ac3b26"
+              "release": "9.6.20260512-0",
+              "image": "ami-0ed9850e8200f5189"
             },
             "il-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a392f4b1a455fa9d"
-            },
-            "me-central-1": {
-              "release": "9.6.20260112-0",
-              "image": "ami-0262e74400e67e377"
-            },
-            "me-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-05e4b10f053646f0a"
+              "release": "9.6.20260512-0",
+              "image": "ami-089f9bd74faa920f3"
             },
             "mx-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-03de8ab9ab5adc337"
+              "release": "9.6.20260512-0",
+              "image": "ami-0bf897d2701416794"
             },
             "sa-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-05613baf881000f4f"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a5676af5da406f50"
             },
             "us-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-081de8a3a5826a7d1"
+              "release": "9.6.20260512-0",
+              "image": "ami-015c3d8cbbc8f493d"
             },
             "us-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-021a620474c1cd2fe"
+              "release": "9.6.20260512-0",
+              "image": "ami-0551cfffb0c3f0e45"
             },
             "us-gov-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0bfd005b37b740046"
+              "release": "9.6.20260512-0",
+              "image": "ami-0da9fa90b3bf2f2ab"
             },
             "us-gov-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-06f6886b07c8a865e"
+              "release": "9.6.20260512-0",
+              "image": "ami-0bc39bd42dfb77bfd"
             },
             "us-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0d2dfbc8081c4cf49"
+              "release": "9.6.20260512-0",
+              "image": "ami-0de2cdf95304d16f3"
             },
             "us-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0c7c6b8489d0dd1c4"
+              "release": "9.6.20260512-0",
+              "image": "ami-062aef6e21270ac69"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20260217-1-gcp-x86-64"
+          "name": "rhcos-9-6-20260512-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.6.20260217-1",
+          "release": "9.6.20260512-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:154c14897fa1ebc55011c7944f1bfcd0a2bbf5f16e2499d38a0508d15dbbc9c0"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2e18e44e92dcde4565229af504f0c2a7eeda4fd4799b9d83d55567b6134429db"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-019a3e4a4b8e856a9"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a08b3c0ec83322fb"
             },
             "ap-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0c905b6d56a9b19dd"
+              "release": "9.6.20260512-0",
+              "image": "ami-057ceae9d786775d6"
             },
             "ap-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a32c5eb46efbf00e"
+              "release": "9.6.20260512-0",
+              "image": "ami-0d1021fd40ac8222e"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0b7e83332b0cdcd7e"
+              "release": "9.6.20260512-0",
+              "image": "ami-0fa80d356c323288c"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-050318718af0f5a8f"
+              "release": "9.6.20260512-0",
+              "image": "ami-01b36bce589971e23"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-055301e48a3f74da2"
+              "release": "9.6.20260512-0",
+              "image": "ami-0b5a53a967968b1e9"
             },
             "ap-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-03a4024d8e3511dff"
+              "release": "9.6.20260512-0",
+              "image": "ami-0b13146d81e54baac"
             },
             "ap-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-04d4794df74945f7c"
+              "release": "9.6.20260512-0",
+              "image": "ami-0c3d18d140a7d21ac"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-05b76e0a91eda2cd1"
+              "release": "9.6.20260512-0",
+              "image": "ami-0656567e8b6a172d5"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0a88acb35339a052c"
+              "release": "9.6.20260512-0",
+              "image": "ami-0534239ffa62b910c"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0fd150d8904e97bde"
+              "release": "9.6.20260512-0",
+              "image": "ami-0f70a80435f95369f"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0ef213576c8b4505d"
+              "release": "9.6.20260512-0",
+              "image": "ami-0f32f2c2dc7bd442e"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260217-1",
-              "image": "ami-04a778986bdb7939e"
+              "release": "9.6.20260512-0",
+              "image": "ami-028ab7a0837656f5f"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260217-1",
-              "image": "ami-014549668437cd365"
+              "release": "9.6.20260512-0",
+              "image": "ami-02c2a404871144c25"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260217-1",
-              "image": "ami-073d44bf4e441ea86"
+              "release": "9.6.20260512-0",
+              "image": "ami-0f78698c377b198dd"
             },
             "ca-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0f2ef6e1b4fc962e3"
+              "release": "9.6.20260512-0",
+              "image": "ami-0fb9513e96a103d58"
             },
             "ca-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-02137e274185b1e84"
+              "release": "9.6.20260512-0",
+              "image": "ami-0cc0aea1d41105edf"
             },
             "eu-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-038a0ac7be335fe7e"
+              "release": "9.6.20260512-0",
+              "image": "ami-0a4dbff981dc2352b"
             },
             "eu-central-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0e1a11968ec7595e4"
+              "release": "9.6.20260512-0",
+              "image": "ami-032f29ae3a0a33937"
             },
             "eu-north-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-07dd04d9f1888350d"
+              "release": "9.6.20260512-0",
+              "image": "ami-0b48a70250fb10c32"
             },
             "eu-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-043dfe965ee2bc7f3"
+              "release": "9.6.20260512-0",
+              "image": "ami-05997e85332e8cf06"
             },
             "eu-south-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-046ffcc3ac07ef306"
+              "release": "9.6.20260512-0",
+              "image": "ami-02ef9f12725e6d8e4"
             },
             "eu-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-098910c9bd4bb5e27"
+              "release": "9.6.20260512-0",
+              "image": "ami-0da80bee0eed76a3a"
             },
             "eu-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-00c5d924490d5b534"
+              "release": "9.6.20260512-0",
+              "image": "ami-0bdfd789a04cb005c"
             },
             "eu-west-3": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0005b2b99a4f5faee"
+              "release": "9.6.20260512-0",
+              "image": "ami-056d4024a31b94091"
             },
             "il-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0de82af6d0ca3faf5"
-            },
-            "me-central-1": {
-              "release": "9.6.20260112-0",
-              "image": "ami-03335cd0583f09a92"
-            },
-            "me-south-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-06988cdc661755ed4"
+              "release": "9.6.20260512-0",
+              "image": "ami-04b6388d5e3406e16"
             },
             "mx-central-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-06321bba3af7dc2a9"
+              "release": "9.6.20260512-0",
+              "image": "ami-0c01bef7210e974f4"
             },
             "sa-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-01e38058e3fc50a28"
+              "release": "9.6.20260512-0",
+              "image": "ami-05029c18f08239466"
             },
             "us-east-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-04f6d5fde1e53b94c"
+              "release": "9.6.20260512-0",
+              "image": "ami-08cf24dbaf4dfeca6"
             },
             "us-east-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-02e03fda4de7ea68b"
+              "release": "9.6.20260512-0",
+              "image": "ami-05a77b71409a40ea3"
             },
             "us-west-1": {
-              "release": "9.6.20260217-1",
-              "image": "ami-0076da74b040d8a3f"
+              "release": "9.6.20260512-0",
+              "image": "ami-041644667c6e08142"
             },
             "us-west-2": {
-              "release": "9.6.20260217-1",
-              "image": "ami-07b78179411af8bb8"
+              "release": "9.6.20260512-0",
+              "image": "ami-08dfa7a2b8809c54e"
             }
           }
         },
         "azure-disk": {
-          "release": "9.6.20260217-1",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260217-1-azure.x86_64.vhd"
+          "release": "9.6.20260512-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260512-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

Update data/data/coreos/rhcos.json to 9.6.20260512-0

OCPBUGS-75012 - RHCOS SNO does not boot after install; wrong device uuid in GRUB
OCPBUGS-86680 - [4.20] Kernel panic when using vrf and srv6 instrumented with FRR in RHCOS

```
plume cosa2stream --target data/data/coreos/rhcos.json                 \n    --distro rhcos --no-signatures --name rhel-9.6                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=9.6.20260512-0                                       \n    aarch64=9.6.20260512-0                                      \n    s390x=9.6.20260512-0                                        \n    ppc64le=9.6.20260512-0
```
                    