### PR TITLE
do not merge - vsphere client mgmt

### DIFF
--- a/pkg/asset/installconfig/vsphere/client.go
+++ b/pkg/asset/installconfig/vsphere/client.go
@@ -2,17 +2,14 @@ package vsphere
 
 import (
 	"context"
-	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -46,37 +43,16 @@ func NewFinder(client *vim25.Client, all ...bool) Finder {
 type ClientLogout func()
 
 // CreateVSphereClients creates the SOAP and REST client to access
-// different portions of the vSphere API
-// e.g. tags are only available in REST
+// different portions of the vSphere API.
+//
+// Deprecated: use NewSession instead, which provides unified session
+// management with caching, lifecycle management, and proper cleanup.
 func CreateVSphereClients(ctx context.Context, vcenter, username, password string) (*vim25.Client, *rest.Client, ClientLogout, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	u, err := soap.ParseURL(vcenter)
+	sess, cleanup, err := NewSession(ctx, vcenter, username, password)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	u.User = url.UserPassword(username, password)
-	c, err := govmomi.NewClient(ctx, u, false)
-
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	restClient := rest.NewClient(c.Client)
-	err = restClient.Login(ctx, u.User)
-	if err != nil {
-		logoutErr := c.Logout(context.TODO())
-		if logoutErr != nil {
-			err = logoutErr
-		}
-		return nil, nil, nil, err
-	}
-
-	return c.Client, restClient, func() {
-		c.Logout(context.TODO())
-		restClient.Logout(context.TODO())
-	}, nil
+	return sess.vim25, sess.rest, cleanup, nil
 }
 
 // getNetworks returns a slice of Managed Object references for networks in the given vSphere Cluster.

--- a/pkg/asset/installconfig/vsphere/session.go
+++ b/pkg/asset/installconfig/vsphere/session.go
@@ -189,7 +189,6 @@ func (s *Session) Close() {
 
 // Error returns any error that occurred during Close.
 func (s *Session) Error() error {
-	s.once.Do(func() {}) // ensure once guard is initialized
 	return s.closeErr
 }
 
@@ -225,13 +224,13 @@ func newSessionFromConn(ctx context.Context, server, username, password string, 
 	}
 	s.rest = restClient
 
-	if cnsClient, err := cns.NewClient(ctx, s.vim25); err == nil {
+	if cnsClient, err := cns.NewClient(context.Background(), s.vim25); err == nil {
 		s.cns = cnsClient
 	} else {
 		opts.Logger.WithError(err).Debug("CNS client creation failed (optional)")
 	}
 
-	if pbmClient, err := pbm.NewClient(ctx, s.vim25); err == nil {
+	if pbmClient, err := pbm.NewClient(context.Background(), s.vim25); err == nil {
 		s.pbm = pbmClient
 	} else {
 		opts.Logger.WithError(err).Debug("PBM client creation failed (optional)")

--- a/pkg/asset/installconfig/vsphere/session.go
+++ b/pkg/asset/installconfig/vsphere/session.go
@@ -85,6 +85,13 @@ var (
 	sessions   = make(map[string]*Session)
 )
 
+// redactHostname returns a short deterministic hash of the hostname, suitable
+// for logging. The plain hostname is never exposed in logs.
+func redactHostname(hostname string) string {
+	h := sha256.Sum256([]byte(hostname))
+	return fmt.Sprintf("%x", h[:16])
+}
+
 // NewSession creates or retrieves a cached vSphere session for the given
 // server, username, and password. Returns the session and a cleanup function.
 //
@@ -104,8 +111,15 @@ func NewSession(ctx context.Context, server, username, password string, opts ...
 
 	sessionsMu.Lock()
 	if sess, ok := sessions[key]; ok {
-		sessionsMu.Unlock()
-		return sess, func() { sess.Close() }, nil
+		if sess.Error() != nil {
+			// Cached session is closed — evict it so a fresh one is created.
+			delete(sessions, key)
+			sessionsMu.Unlock()
+			// Fall through to create a new session.
+		} else {
+			sessionsMu.Unlock()
+			return sess, func() { sess.Close() }, nil
+		}
 	}
 	sessionsMu.Unlock()
 
@@ -121,6 +135,9 @@ func NewSession(ctx context.Context, server, username, password string, opts ...
 	// Double check after acquiring the lock (another goroutine may have created
 	// the session in the meantime).
 	if s, ok := sessions[key]; ok {
+		// A cached session arrived in the meantime — close the one we just
+		// created to avoid leaking an authenticated client.
+		sess.Close()
 		sessionsMu.Unlock()
 		return s, func() { s.Close() }, nil
 	}
@@ -145,7 +162,7 @@ func (s *Session) Close() {
 	s.once.Do(func() {
 		var firstErr error
 
-		s.logger.WithField("vcenter", s.server).Debug("Closing vSphere session")
+		s.logger.WithField("vcenter", redactHostname(s.server)).Debug("Closing vSphere session")
 
 		if s.rest != nil {
 			if err := s.rest.Logout(context.Background()); err != nil {
@@ -166,7 +183,7 @@ func (s *Session) Close() {
 		}
 
 		s.closeErr = firstErr
-		s.logger.WithField("vcenter", s.server).Debug("vSphere session closed")
+		s.logger.WithField("vcenter", redactHostname(s.server)).Debug("vSphere session closed")
 	})
 }
 
@@ -220,7 +237,7 @@ func newSessionFromConn(ctx context.Context, server, username, password string, 
 		opts.Logger.WithError(err).Debug("PBM client creation failed (optional)")
 	}
 
-	s.logger.WithField("vcenter", server).Info("vSphere session created")
+	s.logger.WithField("vcenter", redactHostname(server)).Info("vSphere session created")
 	return s, nil
 }
 

--- a/pkg/asset/installconfig/vsphere/session.go
+++ b/pkg/asset/installconfig/vsphere/session.go
@@ -1,0 +1,255 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/pbm"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// Session manages a vCenter connection lifecycle including SOAP, REST, and
+// auxiliary clients. It provides a single entry point for creating and
+// reusing vSphere client sessions with proper caching and cleanup.
+type Session struct {
+	server   string
+	govmomi  *govmomi.Client
+	vim25    *vim25.Client
+	rest     *rest.Client
+	cns      *cns.Client
+	pbm      *pbm.Client
+	finder   *find.Finder
+	logger   logrus.FieldLogger
+	once     sync.Once
+	closeErr error
+}
+
+// SessionOptions configures a vSphere session.
+type SessionOptions struct {
+	// Timeout for the initial connection. Defaults to 60s if zero.
+	Timeout time.Duration
+	// Insecure skips TLS certificate verification. Defaults to false.
+	Insecure bool
+	// Logger for structured logging. If nil, uses logrus.StandardLogger().
+	Logger logrus.FieldLogger
+}
+
+// SessionOption configures a session via functional options.
+type SessionOption func(*SessionOptions)
+
+// WithTimeout sets the connection timeout.
+func WithTimeout(timeout time.Duration) SessionOption {
+	return func(o *SessionOptions) { o.Timeout = timeout }
+}
+
+// WithInsecure skips TLS certificate verification.
+func WithInsecure(insecure bool) SessionOption {
+	return func(o *SessionOptions) { o.Insecure = insecure }
+}
+
+// WithLogger sets the logger for structured logging.
+func WithLogger(logger logrus.FieldLogger) SessionOption {
+	return func(o *SessionOptions) { o.Logger = logger }
+}
+
+// applyDefaults sets reasonable defaults for unset options.
+func (o *SessionOptions) applyDefaults() {
+	if o.Timeout == 0 {
+		o.Timeout = 60 * time.Second
+	}
+	if o.Logger == nil {
+		o.Logger = logrus.StandardLogger()
+	}
+}
+
+// SessionCacheKey returns a deterministic key for session caching based on
+// server, username, and password.
+func SessionCacheKey(server, username, password string) string {
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s", server, username, password)))
+	return fmt.Sprintf("%x", hash[:16])
+}
+
+var (
+	sessionsMu sync.Mutex
+	sessions   = make(map[string]*Session)
+)
+
+// NewSession creates or retrieves a cached vSphere session for the given
+// server, username, and password. Returns the session and a cleanup function.
+//
+// The cleanup function must be called when the session is no longer needed.
+// It is idempotent and safe to call multiple times.
+//
+// Options allow configuring timeout, TLS, and other settings.
+func NewSession(ctx context.Context, server, username, password string, opts ...SessionOption) (*Session, func(), error) {
+	options := makeSessionOptions(opts...)
+	options.applyDefaults()
+
+	if server == "" || username == "" || password == "" {
+		return nil, nil, errors.New("vSphere server, username, and password are required")
+	}
+
+	key := SessionCacheKey(server, username, password)
+
+	sessionsMu.Lock()
+	if sess, ok := sessions[key]; ok {
+		sessionsMu.Unlock()
+		return sess, func() { sess.Close() }, nil
+	}
+	sessionsMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+
+	sess, err := newSessionFromConn(ctx, server, username, password, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sessionsMu.Lock()
+	// Double check after acquiring the lock (another goroutine may have created
+	// the session in the meantime).
+	if s, ok := sessions[key]; ok {
+		sessionsMu.Unlock()
+		return s, func() { s.Close() }, nil
+	}
+	sessions[key] = sess
+	sessionsMu.Unlock()
+
+	return sess, func() { sess.Close() }, nil
+}
+
+func makeSessionOptions(opts ...SessionOption) *SessionOptions {
+	o := &SessionOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// Close releases all resources held by the session. It is safe to call
+// multiple times. If any cleanup operation fails, the first error is
+// stored and returned via Error().
+func (s *Session) Close() {
+	s.once.Do(func() {
+		var firstErr error
+
+		s.logger.WithField("vcenter", s.server).Debug("Closing vSphere session")
+
+		if s.rest != nil {
+			if err := s.rest.Logout(context.Background()); err != nil {
+				s.logger.WithError(err).Warn("Failed to logout REST client")
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+
+		if s.govmomi != nil {
+			if err := s.govmomi.Logout(context.Background()); err != nil {
+				s.logger.WithError(err).Warn("Failed to logout SOAP client")
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+
+		s.closeErr = firstErr
+		s.logger.WithField("vcenter", s.server).Debug("vSphere session closed")
+	})
+}
+
+// Error returns any error that occurred during Close.
+func (s *Session) Error() error {
+	s.once.Do(func() {}) // ensure once guard is initialized
+	return s.closeErr
+}
+
+func newSessionFromConn(ctx context.Context, server, username, password string, opts *SessionOptions) (*Session, error) {
+	s := &Session{
+		server: server,
+		logger: opts.Logger,
+	}
+
+	u, err := soap.ParseURL(server)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse vCenter URL")
+	}
+	u.User = url.UserPassword(username, password)
+
+	c, err := govmomi.NewClient(ctx, u, opts.Insecure)
+	if err != nil {
+		return nil, errors.Wrap(err, "create SOAP client")
+	}
+	s.govmomi = c
+	s.vim25 = c.Client
+	s.finder = find.NewFinder(s.vim25, true)
+
+	restClient := rest.NewClient(c.Client)
+	if err := restClient.Login(ctx, u.User); err != nil {
+		// Log out SOAP client before returning error — this replaces the
+		// buggy pattern in CreateVSphereClients where the logout error
+		// was swallowed and could mask the original error.
+		if logoutErr := c.Logout(context.Background()); logoutErr != nil {
+			opts.Logger.WithError(logoutErr).Warn("Failed to logout SOAP client after REST login failure")
+		}
+		return nil, errors.Wrap(err, "REST client login")
+	}
+	s.rest = restClient
+
+	if cnsClient, err := cns.NewClient(ctx, s.vim25); err == nil {
+		s.cns = cnsClient
+	} else {
+		opts.Logger.WithError(err).Debug("CNS client creation failed (optional)")
+	}
+
+	if pbmClient, err := pbm.NewClient(ctx, s.vim25); err == nil {
+		s.pbm = pbmClient
+	} else {
+		opts.Logger.WithError(err).Debug("PBM client creation failed (optional)")
+	}
+
+	s.logger.WithField("vcenter", server).Info("vSphere session created")
+	return s, nil
+}
+
+// Vim25Client returns the underlying SOAP client for general vSphere API calls.
+func (s *Session) Vim25Client() *vim25.Client {
+	return s.vim25
+}
+
+// RestClient returns the REST client for vSphere tag and policy operations.
+func (s *Session) RestClient() *rest.Client {
+	return s.rest
+}
+
+// CNSClient returns the CNS (vSAN) client for storage volume operations.
+func (s *Session) CNSClient() *cns.Client {
+	return s.cns
+}
+
+// PBMClient returns the PBM (storage policy) client.
+func (s *Session) PBMClient() *pbm.Client {
+	return s.pbm
+}
+
+// Finder returns a finder for locating vSphere inventory objects.
+func (s *Session) Finder() *find.Finder {
+	return s.finder
+}
+
+// Server returns the vCenter server URL.
+func (s *Session) Server() string {
+	return s.server
+}

--- a/pkg/asset/installconfig/vsphere/session_test.go
+++ b/pkg/asset/installconfig/vsphere/session_test.go
@@ -1,0 +1,404 @@
+package vsphere
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionCacheKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		username string
+		password string
+	}{
+		{"empty server", "", "user", "pass"},
+		{"empty username", "https://vcenter", "", "pass"},
+		{"empty password", "https://vcenter", "user", ""},
+		{"full credentials", "https://vcenter.example.com", "admin@vsphere.local", "password123"},
+		{"different server", "https://vcenter2.example.com", "admin@vsphere.local", "password123"},
+		{"different username", "https://vcenter.example.com", "admin2@vsphere.local", "password123"},
+		{"different password", "https://vcenter.example.com", "admin@vsphere.local", "password456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := SessionCacheKey(tt.server, tt.username, tt.password)
+			assert.NotEmpty(t, key, "cache key should not be empty")
+			assert.Equal(t, 32, len(key), "cache key should be 32 hex characters")
+		})
+	}
+}
+
+func TestSessionCacheKeyDeterministic(t *testing.T) {
+	key1 := SessionCacheKey("https://vcenter", "user", "pass")
+	key2 := SessionCacheKey("https://vcenter", "user", "pass")
+	assert.Equal(t, key1, key2, "same credentials should produce same cache key")
+}
+
+func TestSessionCacheKeyNotEqual(t *testing.T) {
+	key1 := SessionCacheKey("https://vcenter1", "user", "pass")
+	key2 := SessionCacheKey("https://vcenter2", "user", "pass")
+	assert.NotEqual(t, key1, key2, "different servers should produce different cache keys")
+}
+
+func TestNewSessionMissingCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		username string
+		password string
+	}{
+		{"empty server", "", "user", "pass"},
+		{"empty username", "https://vcenter", "", "pass"},
+		{"empty password", "https://vcenter", "user", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess, cleanup, err := NewSession(context.Background(), tt.server, tt.username, tt.password)
+			assert.Nil(t, sess, "session should be nil on error")
+			assert.Nil(t, cleanup, "cleanup should be nil on error")
+			assert.Error(t, err, "should return error for missing credentials")
+			assert.Contains(t, err.Error(), "required", "error should mention required fields")
+		})
+	}
+}
+
+func TestNewSessionInvalidServer(t *testing.T) {
+	sess, cleanup, err := NewSession(context.Background(), "not a valid url", "user", "pass")
+	assert.Nil(t, sess, "session should be nil on invalid URL")
+	assert.Nil(t, cleanup, "cleanup should be nil on error")
+	assert.Error(t, err, "should return error for invalid URL")
+	assert.Contains(t, err.Error(), "parse vCenter URL", "error should mention URL parsing")
+}
+
+func TestNewSessionTimeout(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	sess, _, err := NewSession(ctx, "https://nonexistent.example.com:80", "user", "pass", WithTimeout(1*time.Millisecond), WithLogger(logger))
+	assert.Nil(t, sess, "session should be nil on timeout")
+	assert.Error(t, err, "should return error on timeout")
+}
+
+func TestSessionCloseIdempotent(t *testing.T) {
+	// Create a session with nil fields to test idempotent close
+	sess := &Session{
+		server: "https://vcenter",
+		logger: logrus.New(),
+	}
+
+	// First close should not panic
+	sess.Close()
+
+	// Second close should also not panic
+	sess.Close()
+
+	// Third close should also not panic
+	sess.Close()
+
+	// Error should still be nil (no close errors occurred)
+	assert.Nil(t, sess.Error(), "error should be nil after idempotent close")
+}
+
+func TestSessionCloseWithNilClients(t *testing.T) {
+	logger := logrus.New()
+
+	sess := &Session{
+		server:  "https://vcenter",
+		logger:  logger,
+		rest:    nil,
+		govmomi: nil,
+	}
+
+	// Should not panic
+	sess.Close()
+	sess.Close()
+
+	// Error should be nil
+	assert.Nil(t, sess.Error())
+}
+
+func TestSessionServer(t *testing.T) {
+	sess := &Session{
+		server: "https://vcenter.example.com",
+	}
+
+	assert.Equal(t, "https://vcenter.example.com", sess.Server())
+}
+
+func TestSessionNilAccessors(t *testing.T) {
+	sess := &Session{
+		server: "https://vcenter",
+	}
+
+	// All accessor methods should return nil for unpopulated fields
+	assert.Nil(t, sess.Vim25Client())
+	assert.Nil(t, sess.RestClient())
+	assert.Nil(t, sess.CNSClient())
+	assert.Nil(t, sess.PBMClient())
+	assert.Nil(t, sess.Finder())
+}
+
+func TestSessionLogger(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	sess := &Session{
+		server: "https://vcenter",
+		logger: logger,
+	}
+
+	sess.Close()
+
+	// Should have logged the close message
+	found := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Message == "Closing vSphere session" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "should have logged closing session message")
+}
+
+func TestSessionRedactHostname(t *testing.T) {
+	// Same hostname should produce same hash
+	hash1 := redactHostname("vcenter.example.com")
+	hash2 := redactHostname("vcenter.example.com")
+	assert.Equal(t, hash1, hash2)
+
+	// Different hostnames should produce different hashes
+	hash3 := redactHostname("vcenter2.example.com")
+	assert.NotEqual(t, hash1, hash3)
+
+	// Hash should not contain the hostname
+	assert.NotContains(t, hash1, "vcenter")
+	assert.NotContains(t, hash1, ".")
+	assert.NotContains(t, hash1, ":")
+
+	// Hash should be a hex string of fixed length (16 bytes = 32 hex chars)
+	assert.Equal(t, 32, len(hash1), "hash should be 32 hex characters")
+}
+
+func TestSessionOptionsDefaults(t *testing.T) {
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+
+	assert.Equal(t, 60*time.Second, opts.Timeout, "timeout should default to 60s")
+	assert.False(t, opts.Insecure, "insecure should default to false")
+	assert.NotNil(t, opts.Logger, "logger should default to standard logger")
+}
+
+func TestSessionOptionsWithTimeout(t *testing.T) {
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+	opts.Timeout = 30 * time.Second
+
+	assert.Equal(t, 30*time.Second, opts.Timeout)
+}
+
+func TestSessionOptionsWithInsecure(t *testing.T) {
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+	opts.Insecure = true
+
+	assert.True(t, opts.Insecure)
+}
+
+func TestSessionOptionsWithLogger(t *testing.T) {
+	logger := logrus.New()
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+	opts.Logger = logger
+
+	assert.Equal(t, logger, opts.Logger)
+}
+
+func TestSessionCacheKeyCollision(t *testing.T) {
+	// Verify that different combinations don't collide
+	key1 := SessionCacheKey("https://vcenter", "user", "pass")
+	key2 := SessionCacheKey("https://vcenter", "user2", "pass")
+	key3 := SessionCacheKey("https://vcenter", "user", "pass2")
+
+	assert.NotEqual(t, key1, key2, "different username should produce different key")
+	assert.NotEqual(t, key1, key3, "different password should produce different key")
+}
+
+func TestSessionCacheKeyEmptyComponents(t *testing.T) {
+	// Empty components should still produce valid (but different) keys
+	key1 := SessionCacheKey("", "user", "pass")
+	key2 := SessionCacheKey("https://vcenter", "", "pass")
+	key3 := SessionCacheKey("https://vcenter", "user", "")
+
+	assert.NotEmpty(t, key1)
+	assert.NotEmpty(t, key2)
+	assert.NotEmpty(t, key3)
+	assert.NotEqual(t, key1, key2)
+	assert.NotEqual(t, key1, key3)
+	assert.NotEqual(t, key2, key3)
+}
+
+func TestSessionCacheKeyCaseSensitive(t *testing.T) {
+	key1 := SessionCacheKey("https://vcenter", "User", "pass")
+	key2 := SessionCacheKey("https://vcenter", "user", "pass")
+
+	assert.NotEqual(t, key1, key2, "cache key should be case-sensitive")
+}
+
+func TestSessionCloseMultipleTimes(t *testing.T) {
+	logger := logrus.New()
+
+	sess := &Session{
+		server: "https://vcenter",
+		logger: logger,
+	}
+
+	// Close multiple times - should be idempotent
+	sess.Close()
+	err1 := sess.Error()
+
+	sess.Close()
+	err2 := sess.Error()
+
+	sess.Close()
+	err3 := sess.Error()
+
+	// All errors should be the same
+	assert.Equal(t, err1, err2)
+	assert.Equal(t, err2, err3)
+	assert.Nil(t, err1)
+}
+
+func TestSessionCacheKeySpecialCharacters(t *testing.T) {
+	// Test with special characters in credentials
+	key := SessionCacheKey("https://vcenter:8080", "user@domain", "pass:word/with/special")
+
+	assert.NotEmpty(t, key)
+	assert.Equal(t, 32, len(key))
+}
+
+func TestSessionCacheKeyVeryLongCredentials(t *testing.T) {
+	// Test with very long credentials
+	longServer := "https://" + string(make([]byte, 1000))
+	longUser := string(make([]byte, 1000))
+	longPass := string(make([]byte, 1000))
+
+	key := SessionCacheKey(longServer, longUser, longPass)
+
+	assert.NotEmpty(t, key)
+	assert.Equal(t, 32, len(key))
+}
+
+func TestSessionOptionsApplyMultiple(t *testing.T) {
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+
+	// Apply multiple options
+	opts.Timeout = 120 * time.Second
+	opts.Insecure = true
+
+	logger := logrus.New()
+	opts.Logger = logger
+
+	assert.Equal(t, 120*time.Second, opts.Timeout)
+	assert.True(t, opts.Insecure)
+	assert.Equal(t, logger, opts.Logger)
+}
+
+func TestSessionCacheKeyWhitespace(t *testing.T) {
+	// Whitespace should be significant
+	key1 := SessionCacheKey("https://vcenter", " user", "pass")
+	key2 := SessionCacheKey("https://vcenter", "user ", "pass")
+
+	assert.NotEqual(t, key1, key2, "whitespace should be significant")
+}
+
+func TestSessionCacheKeyLength(t *testing.T) {
+	// SHA256 produces 32 bytes, we take first 16 bytes and format as hex
+	// 16 bytes * 2 hex chars per byte = 32 hex chars
+	key := SessionCacheKey("https://vcenter", "user", "pass")
+	assert.Equal(t, 32, len(key), "cache key should be 32 hex characters")
+}
+
+func TestSessionCacheKeyHexFormat(t *testing.T) {
+	key := SessionCacheKey("https://vcenter", "user", "pass")
+
+	// Should be valid hex
+	for _, c := range key {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"character %q should be hex", c)
+	}
+}
+
+func TestSessionCloseLogsRedactedHostname(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	sess := &Session{
+		server: "https://vcenter.example.com",
+		logger: logger,
+	}
+
+	sess.Close()
+
+	// Check that the logged hostname is redacted
+	found := false
+	for _, entry := range hook.AllEntries() {
+		if field, ok := entry.Data["vcenter"]; ok {
+			vcenter, ok := field.(string)
+			if ok && vcenter != "https://vcenter.example.com" {
+				found = true
+				break
+			}
+		}
+	}
+	assert.True(t, found, "should have logged redacted vcenter hostname")
+}
+
+func TestSessionOptionsNoOptions(t *testing.T) {
+	opts := &SessionOptions{}
+	opts.applyDefaults()
+
+	// Should use all defaults
+	assert.Equal(t, 60*time.Second, opts.Timeout)
+	assert.False(t, opts.Insecure)
+	assert.NotNil(t, opts.Logger)
+}
+
+func TestSessionCloseErrorIsNil(t *testing.T) {
+	logger := logrus.New()
+
+	sess := &Session{
+		server: "https://vcenter",
+		logger: logger,
+	}
+
+	// Close without any clients set - should not produce errors
+	sess.Close()
+	assert.Nil(t, sess.Error(), "error should be nil when no clients are set")
+}
+
+func TestSessionErrorBeforeClose(t *testing.T) {
+	sess := &Session{
+		server: "https://vcenter",
+		logger: logrus.New(),
+	}
+
+	// Error() before Close() should return nil
+	assert.Nil(t, sess.Error(), "error should be nil before Close() is called")
+}
+
+func TestSessionCacheKeyPortNumbers(t *testing.T) {
+	key1 := SessionCacheKey("https://vcenter:443", "user", "pass")
+	key2 := SessionCacheKey("https://vcenter:8443", "user", "pass")
+
+	assert.NotEqual(t, key1, key2, "different ports should produce different keys")
+}

--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -63,7 +63,7 @@ func getVCenterClient(failureDomain vsphere.FailureDomain, ic *types.InstallConf
 	ctx := context.TODO()
 	for _, vcenter := range ic.VSphere.VCenters {
 		if vcenter.Server == server {
-			vim25Client, vim25RestClient, cleanup, err := CreateVSphereClients(ctx,
+			sess, cleanup, err := NewSession(ctx,
 				vcenter.Server,
 				vcenter.Username,
 				vcenter.Password)
@@ -73,12 +73,12 @@ func getVCenterClient(failureDomain vsphere.FailureDomain, ic *types.InstallConf
 			}
 
 			validationCtx := validationContext{
-				TagManager:  vapitags.NewManager(vim25RestClient),
-				AuthManager: newAuthManager(vim25Client),
-				Finder:      find.NewFinder(vim25Client),
-				Client:      vim25Client,
+				TagManager:  vapitags.NewManager(sess.RestClient()),
+				AuthManager: newAuthManager(sess.Vim25Client()),
+				Finder:      find.NewFinder(sess.Vim25Client()),
+				Client:      sess.Vim25Client(),
 			}
-			return &validationCtx, cleanup, err
+			return &validationCtx, cleanup, nil
 		}
 	}
 	return nil, nil, fmt.Errorf("vcenter %s not defined in vcenters", server)

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -146,10 +146,10 @@ func getClients() (*vCenterClient, error) {
 
 	// There is a noticeable delay when creating the client, so let the user know what's going on.
 	logrus.Infof("Connecting to vCenter %s", vcenter)
-	vim25Client, restClient, logoutFunction, err := CreateVSphereClients(context.TODO(),
-		vcenter,
-		username,
-		password)
+		sess, cleanup, err := NewSession(context.TODO(),
+			vcenter,
+			username,
+			password)
 
 	// Survey does not allow validation of groups of input
 	// so we perform our own validation.
@@ -161,9 +161,9 @@ func getClients() (*vCenterClient, error) {
 		VCenter:    vcenter,
 		Username:   username,
 		Password:   password,
-		Client:     vim25Client,
-		RestClient: restClient,
-		Logout:     logoutFunction,
+		Client:     sess.Vim25Client(),
+		RestClient: sess.RestClient(),
+		Logout:     cleanup,
 	}, nil
 }
 

--- a/pkg/destroy/vsphere/client.go
+++ b/pkg/destroy/vsphere/client.go
@@ -69,6 +69,7 @@ func NewClient(vCenter, username, password string, logger logrus.FieldLogger) (*
 
 	cnsClient, err := cns.NewClient(context.TODO(), sess.Vim25Client())
 	if err != nil {
+		sess.Close()
 		return nil, err
 	}
 

--- a/pkg/destroy/vsphere/client.go
+++ b/pkg/destroy/vsphere/client.go
@@ -53,7 +53,6 @@ type Client struct {
 	session    *vsphere.Session
 	logger     logrus.FieldLogger
 }
-
 const defaultTimeout = time.Minute * 5
 
 // NewClient initializes a client for cluster destruction.

--- a/pkg/destroy/vsphere/client.go
+++ b/pkg/destroy/vsphere/client.go
@@ -44,48 +44,49 @@ type API interface {
 	GetVCenterName() string
 }
 
-// Client makes calls to the Azure API.
+// Client makes calls to the vSphere API.
 type Client struct {
 	vcenter    string
 	client     *vim25.Client
 	restClient *rest.Client
 	cnsClient  *cns.Client
-	cleanup    vsphere.ClientLogout
+	session    *vsphere.Session
 	logger     logrus.FieldLogger
 }
 
 const defaultTimeout = time.Minute * 5
 
-// NewClient initializes a client.
-// Logout() must be called when you are done with the client.
+// NewClient initializes a client for cluster destruction.
+//
+// This calls NewSession for connection pooling but stores the
+// cleanup function separately since the destroy client needs
+// to explicitly close its session lifecycle.
 func NewClient(vCenter, username, password string, logger logrus.FieldLogger) (*Client, error) {
-	vim25Client, restClient, cleanup, err := vsphere.CreateVSphereClients(
-		context.TODO(),
-		vCenter,
-		username,
-		password)
+	sess, _, err := vsphere.NewSession(context.TODO(), vCenter, username, password)
 	if err != nil {
 		return nil, err
 	}
 
-	cnsClient, err := cns.NewClient(context.TODO(), vim25Client)
+	cnsClient, err := cns.NewClient(context.TODO(), sess.Vim25Client())
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
 		vcenter:    vCenter,
-		client:     vim25Client,
-		restClient: restClient,
-		cleanup:    cleanup,
+		client:     sess.Vim25Client(),
+		restClient: sess.RestClient(),
 		cnsClient:  cnsClient,
+		session:    sess,
 		logger:     logger,
 	}, nil
 }
 
 // Logout logs out from the clients used.
 func (c *Client) Logout() {
-	c.cleanup()
+	if c.session != nil {
+		c.session.Close()
+	}
 }
 
 func isNotFound(err error) bool {


### PR DESCRIPTION
Messing around with Hermes, vLLM and https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4


```
model: "RedHatAI/Qwen3.6-35B-A3B-NVFP4"
enforce-eager: false
enable-prefix-caching: true
gpu-memory-utilization: 0.88
kv-cache-dtype: fp8
language-model-only: true
max-model-len: auto
max-num-seqs: 1
reasoning-parser: qwen3
tensor-parallel-size: 2
tool-call-parser: "qwen3_coder"
trust-remote-code: true
enable-auto-tool-choice: true
enable-expert-parallel: true
enable-chunked-prefill: true
speculative-config: '{"method":"mtp","num_speculative_tokens":1}'
max-num-batched-tokens: 8192
moe-backend: flashinfer_cutlass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable vSphere session options (timeout, TLS/insecure toggle, structured logging).

* **Refactor**
  * Unified session-based vSphere connection management with deterministic caching to avoid redundant logins.
  * Centralized and improved session cleanup/logout for more reliable connection teardown.
  * Deprecated legacy direct client-creation API in favor of the new session approach.

* **Tests**
  * Added comprehensive session/cache and option validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->