### PR TITLE
tls: backdate certificate NotBefore by 24 hours to tolerate clock skew

### DIFF
--- a/pkg/asset/imagebased/configimage/ingressoperatorsigner.go
+++ b/pkg/asset/imagebased/configimage/ingressoperatorsigner.go
@@ -112,7 +112,7 @@ func selfSignedCertificate(cfg *tls.CertCfg, key *rsa.PrivateKey) (*x509.Certifi
 		IsCA:                  cfg.IsCA,
 		KeyUsage:              cfg.KeyUsages,
 		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             time.Now(),
+		NotBefore:             time.Now().Add(-24 * time.Hour),
 		SerialNumber:          serial,
 		Subject:               cfg.Subject,
 	}

--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -64,7 +64,7 @@ func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate
 		IsCA:                  cfg.IsCA,
 		KeyUsage:              cfg.KeyUsages,
 		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             time.Now(),
+		NotBefore:             time.Now().Add(-24 * time.Hour),
 		SerialNumber:          serial,
 		Subject:               cfg.Subject,
 	}


### PR DESCRIPTION
## Problem

When a VM's hardware clock (RTC) stores local time but the OS has no configuration telling it so, Linux reads the hwclock assuming UTC. The resulting system clock is offset behind true UTC by the host's timezone difference—up to several hours—until NTP corrects it.

The certificate's `NotBefore` is a correct UTC timestamp, but from the VM's skewed perspective it appears to be in the future, so TLS handshakes fail during bootstrap with **"certificate not yet valid"**.

## Change

Set `NotBefore` to `time.Now() - 24h` in the two places where self-signed certificates are created:

- `pkg/asset/tls/tls.go` — `SelfSignedCertificate`
- `pkg/asset/imagebased/configimage/ingressoperatorsigner.go` — `selfSignedCertificate`

`NotAfter` is left unchanged, so the validity window simply shifts: it starts 24 hours earlier and ends at the originally intended expiry time. This tolerates a VM clock up to 24 hours behind true UTC.

`SignedCertificate` already inherits `NotBefore` from its signing CA (`caCert.NotBefore`), so certificates in that path pick up the change automatically with no additional modifications needed.

## Testing

- `go build ./pkg/asset/tls/... ./pkg/asset/imagebased/configimage/...` passes cleanly.