### PR TITLE
Add tzdata to openstack image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -43,6 +43,7 @@ RUN yum update -y && \
     python3-netaddr \
     python3-openstackclient \
     python3-pip \
+    tzdata \
     unzip \
     util-linux && \
     yum clean all && rm -rf /var/cache/yum/* && \


### PR DESCRIPTION
When running the openstack CLI, I see the following errors:
```
Could not load 'flavor_create': [Errno 2] No such file or directory: '/usr/share/zoneinfo/zone.tab'
```

So add the tzdata rpm during the container build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environment dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->