### PR TITLE
OCPBUGS-87813: [release-4.21] fix: reset associatedVCenter in failure domain validation loop

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -160,11 +160,10 @@ func validateFailureDomains(p *vsphere.Platform, platformFldPath *field.Path, fl
 	tagUrnPattern := regexp.MustCompile(`^(urn):(vmomi):(InventoryServiceTag):([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}):([^:]+)$`)
 	allErrs := field.ErrorList{}
 	topologyFld := fldPath.Child("topology")
-	var associatedVCenter *vsphere.VCenter
-
 	zoneNames := make(map[string]string)
 
 	for index, failureDomain := range p.FailureDomains {
+		var associatedVCenter *vsphere.VCenter
 		if regionName, ok := zoneNames[failureDomain.Zone]; !ok {
 			zoneNames[failureDomain.Zone] = failureDomain.Region
 		} else if regionName == failureDomain.Region {

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -1013,3 +1013,73 @@ func installConfig() *installConfigBuilder {
 func (icb *installConfigBuilder) build() *types.InstallConfig {
 	return &icb.InstallConfig
 }
+
+func TestValidateFailureDomainStaleVCenter(t *testing.T) {
+	cases := []struct {
+		name        string
+		platform    *vsphere.Platform
+		expectError string
+	}{
+		{
+			name: "second failure domain with invalid server should report error",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains = append(p.FailureDomains, vsphere.FailureDomain{
+					Name:   "test-east-3a",
+					Region: "test-east",
+					Zone:   "test-east-3a",
+					Server: "non-existent-vcenter",
+					Topology: vsphere.Topology{
+						Datacenter:     "test-datacenter",
+						ComputeCluster: "/test-datacenter/host/test-cluster",
+						Datastore:      "/test-datacenter/datastore/test-datastore",
+						Networks:       []string{"test-portgroup"},
+						ResourcePool:   "/test-datacenter/host/test-cluster/Resources/test-resourcepool",
+						Folder:         "/test-datacenter/vm/test-folder",
+					},
+				})
+				return p
+			}(),
+			expectError: "server does not exist in vcenters",
+		},
+		{
+			name: "second failure domain with invalid server should not validate datacenter against wrong vcenter",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.FailureDomains = append(p.FailureDomains, vsphere.FailureDomain{
+					Name:   "test-east-3a",
+					Region: "test-east",
+					Zone:   "test-east-3a",
+					Server: "non-existent-vcenter",
+					Topology: vsphere.Topology{
+						Datacenter:     "wrong-datacenter",
+						ComputeCluster: "/wrong-datacenter/host/test-cluster",
+						Datastore:      "/wrong-datacenter/datastore/test-datastore",
+						Networks:       []string{"test-portgroup"},
+						Folder:         "/wrong-datacenter/vm/test-folder",
+					},
+				})
+				return p
+			}(),
+			expectError: "server does not exist in vcenters",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fldPath := field.NewPath("platform", "vsphere", "failureDomains")
+			platformPath := field.NewPath("platform", "vsphere")
+			errs := validateFailureDomains(tc.platform, platformPath, fldPath, false)
+
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e.Error(), tc.expectError) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected error containing %q but got: %v", tc.expectError, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Cherry-pick of #10559 to release-4.21.

Fixes a stale `associatedVCenter` variable in the failure domain validation loop that caused subsequent failure domains to incorrectly pass validation against the wrong vCenter, leading to confusing validation errors or silent misconfiguration.

Fixes: https://issues.redhat.com/browse/OCPBUGS-87813

/cherry-pick-from #10559

Made with [Cursor](https://cursor.com)