### PR TITLE
OCPBUGS-87817: [release-4.19] Add omitempty to vSphere and Nutanix MachinePool slice fields

### DIFF
--- a/pkg/types/nutanix/machinepool.go
+++ b/pkg/types/nutanix/machinepool.go
@@ -61,12 +61,12 @@ type MachinePool struct {
 	// GPUs is a list of GPU devices to attach to the machine's VM.
 	// +listType=set
 	// +optional
-	GPUs []machinev1.NutanixGPU `json:"gpus"`
+	GPUs []machinev1.NutanixGPU `json:"gpus,omitempty"`
 
 	// DataDisks holds information of the data disks to attach to the Machine's VM
 	// +listType=set
 	// +optional
-	DataDisks []DataDisk `json:"dataDisks"`
+	DataDisks []DataDisk `json:"dataDisks,omitempty"`
 
 	// FailureDomains optionally configures a list of failure domain names
 	// that will be applied to the MachinePool

--- a/pkg/types/vsphere/machinepool.go
+++ b/pkg/types/vsphere/machinepool.go
@@ -30,7 +30,7 @@ type MachinePool struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=29
-	DataDisks []DataDisk `json:"dataDisks"`
+	DataDisks []DataDisk `json:"dataDisks,omitempty"`
 
 	// Zones defines available zones
 	// Zones is available in TechPreview.


### PR DESCRIPTION
## Summary
Cherry-pick of #10551 to release-4.19.

Adds `omitempty` to the `DataDisks` JSON tag on vSphere and Nutanix MachinePool structs, preventing empty slice serialization that causes unknown-field warnings when hive revendors these types and generates install-configs for older payloads.

Fixes: https://issues.redhat.com/browse/OCPBUGS-85509

/cherry-pick-from #10551

Made with [Cursor](https://cursor.com)