### PR TITLE
CORS-4404: pkg/quota: GCP, allow unauthenticated

### DIFF
--- a/pkg/quota/gcp/gcp.go
+++ b/pkg/quota/gcp/gcp.go
@@ -124,7 +124,7 @@ func IsUnauthorized(err error) bool {
 	}
 
 	if grpcCode := status.Code(errors.Cause(err)); grpcCode != codes.OK {
-		return grpcCode == codes.PermissionDenied
+		return grpcCode == codes.PermissionDenied || grpcCode == codes.Unauthenticated
 	}
 	return false
 }


### PR DESCRIPTION
Quota check failures should be non-fatal. This commit gracefully catches an unauthenticated error and allows that to bypass the quota check. This scenario is encountered by users who authenticate the installer with GCP Application Default Credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error detection to properly identify and handle additional types of authentication-related failures, enhancing system reliability and error handling accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->