### PR TITLE
SPLAT-2795: Enhanced vSphere cloud config to include node network cidr information

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -386,7 +386,7 @@ NodeIPFamilies=ipv4
 		}
 		cm.Data[cloudProviderConfigDataKey] = powervsConfig
 	case vspheretypes.Name:
-		vsphereConfig, err := vspheremanifests.CloudProviderConfigYaml(clusterID.InfraID, installConfig.Config.Platform.VSphere)
+		vsphereConfig, err := vspheremanifests.CloudProviderConfigYaml(clusterID.InfraID, installConfig)
 
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -7,6 +7,8 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 	cloudconfig "github.com/openshift/library-go/pkg/cloudprovider/vsphere"
 )
@@ -22,8 +24,20 @@ func printIfNotEmpty(buf *bytes.Buffer, k, v string) {
 	}
 }
 
+// setNodes sets Nodes section in vsphere-cloud-provider config according passed VSpherePlatformNodeNetworking spec.
+func setNodes(cfg *cloudconfig.CPIConfig, nodeNetworking *configv1.VSpherePlatformNodeNetworking) {
+	cfg.Nodes.ExternalVMNetworkName = nodeNetworking.External.Network
+	cfg.Nodes.ExternalNetworkSubnetCIDR = strings.Join(nodeNetworking.External.NetworkSubnetCIDR, ",")
+	cfg.Nodes.ExcludeExternalNetworkSubnetCIDR = strings.Join(nodeNetworking.External.ExcludeNetworkSubnetCIDR, ",")
+
+	cfg.Nodes.InternalVMNetworkName = nodeNetworking.Internal.Network
+	cfg.Nodes.InternalNetworkSubnetCIDR = strings.Join(nodeNetworking.Internal.NetworkSubnetCIDR, ",")
+	cfg.Nodes.ExcludeInternalNetworkSubnetCIDR = strings.Join(nodeNetworking.Internal.ExcludeNetworkSubnetCIDR, ",")
+}
+
 // CloudProviderConfigYaml generates the yaml out of tree cloud provider config for the vSphere platform.
-func CloudProviderConfigYaml(infraID string, p *vspheretypes.Platform) (string, error) {
+func CloudProviderConfigYaml(infraID string, ic *installconfig.InstallConfig) (string, error) {
+	p := ic.Config.Platform.VSphere
 	vCenters := make(map[string]*cloudconfig.VirtualCenterConfig)
 
 	for _, vCenter := range p.VCenters {
@@ -41,20 +55,42 @@ func CloudProviderConfigYaml(infraID string, p *vspheretypes.Platform) (string, 
 		vCenters[vCenter.Server] = &vCenterConfig
 	}
 
-	cloudProviderConfig := cloudconfig.CommonConfig{
+	cloudProviderConfig := cloudconfig.CPIConfig{CommonConfig: cloudconfig.CommonConfig{
 		Global: cloudconfig.Global{
 			SecretName:      "vsphere-creds", // #nosec G101 -- this is the name of a Kubernetes secret, not a credential
 			SecretNamespace: "kube-system",
 			InsecureFlag:    true,
 		},
 		Vcenter: vCenters,
-	}
+	}}
 
 	if len(p.FailureDomains) > 1 {
 		cloudProviderConfig.Labels = &cloudconfig.Labels{
 			Zone:   vspheretypes.TagCategoryZone,
 			Region: vspheretypes.TagCategoryRegion,
 		}
+	}
+
+	// Populate the nodes section with networking information mirroring the logic
+	// in GetInfraPlatformSpec. If nodeNetworking is explicitly set in the
+	// install-config, use it directly; otherwise fall back to the machine
+	// network CIDRs (which should encompass the VIPs).
+	if p.NodeNetworking != nil {
+		setNodes(&cloudProviderConfig, p.NodeNetworking)
+	} else {
+		var cidrs []string
+		for _, machineNetwork := range ic.Config.MachineNetwork {
+			cidrs = append(cidrs, machineNetwork.CIDR.String())
+		}
+		nodeNetworking := &configv1.VSpherePlatformNodeNetworking{
+			External: configv1.VSpherePlatformNodeNetworkingSpec{
+				NetworkSubnetCIDR: cidrs,
+			},
+			Internal: configv1.VSpherePlatformNodeNetworkingSpec{
+				NetworkSubnetCIDR: cidrs,
+			},
+		}
+		setNodes(&cloudProviderConfig, nodeNetworking)
 	}
 
 	cloudProviderConfigYaml, err := yaml.Marshal(cloudProviderConfig)

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -41,16 +41,16 @@ func CloudProviderConfigYaml(infraID string, ic *installconfig.InstallConfig) (s
 	vCenters := make(map[string]*cloudconfig.VirtualCenterConfig)
 
 	for _, vCenter := range p.VCenters {
-		vCenterPort := int32(443)
-		if vCenter.Port != 0 {
-			vCenterPort = vCenter.Port
-		}
 		vCenterConfig := cloudconfig.VirtualCenterConfig{
 			VCenterIP:   vCenter.Server,
-			VCenterPort: uint(vCenterPort),
 			Datacenters: vCenter.Datacenters,
 			// We are setting this in global so lets remove from here
 			//InsecureFlag: true,
+		}
+		// Only set port if it is configured in the install-config.  infrastructure/cluster will do the same which results
+		// in the 3CMO not setting port if not configured in infrastructure/cluster.
+		if vCenter.Port != 0 {
+			vCenterConfig.VCenterPort = uint(vCenter.Port)
 		}
 		vCenters[vCenter.Server] = &vCenterConfig
 	}

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
@@ -1,11 +1,16 @@
 package vsphere
 
 import (
+	"net"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
 	vsphere "github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -34,6 +39,9 @@ region = "openshift-region"
 zone = "openshift-zone"
 `
 
+	// expectedYamlConfig is used by the basic yaml path test (feature gate
+	// enabled via inDefault, machine network 10.0.0.0/24 → nodes section
+	// populated with that CIDR).
 	expectedYamlConfig = `global:
   insecureFlag: true
   secretName: vsphere-creds
@@ -41,6 +49,52 @@ zone = "openshift-zone"
 labels:
   region: openshift-region
   zone: openshift-zone
+nodes:
+  externalNetworkSubnetCidr: 10.0.0.0/24
+  internalNetworkSubnetCidr: 10.0.0.0/24
+vcenter:
+  test-vcenter:
+    datacenters:
+    - test-datacenter
+    - test-datacenter2
+    port: 443
+    server: test-vcenter
+`
+
+	// expectedYamlConfigWithNodes is used by tests that exercise the yaml path
+	// with the VSphereMultiNetworks feature gate enabled and a machine network
+	// CIDR of 10.0.0.0/24 (the fallback path).
+	expectedYamlConfigWithNodes = `global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+labels:
+  region: openshift-region
+  zone: openshift-zone
+nodes:
+  externalNetworkSubnetCidr: 10.0.0.0/24
+  internalNetworkSubnetCidr: 10.0.0.0/24
+vcenter:
+  test-vcenter:
+    datacenters:
+    - test-datacenter
+    - test-datacenter2
+    port: 443
+    server: test-vcenter
+`
+
+	// expectedYamlConfigWithExplicitNodes is used by the test that sets
+	// NodeNetworking explicitly in the install-config.
+	expectedYamlConfigWithExplicitNodes = `global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+labels:
+  region: openshift-region
+  zone: openshift-zone
+nodes:
+  externalNetworkSubnetCidr: 192.168.10.0/24
+  internalNetworkSubnetCidr: 192.168.20.0/24
 vcenter:
   test-vcenter:
     datacenters:
@@ -112,11 +166,34 @@ func validPlatform() *vsphere.Platform {
 	}
 }
 
+// makeInstallConfig builds a minimal installconfig.InstallConfig for use in
+// tests. featureSet controls which feature gates are active.
+func makeInstallConfig(platform *vsphere.Platform, featureSet configv1.FeatureSet, machineNetworkCIDR string) *installconfig.InstallConfig {
+	_, cidr, err := net.ParseCIDR(machineNetworkCIDR)
+	if err != nil {
+		panic(err)
+	}
+	cfg := &types.InstallConfig{
+		FeatureSet: featureSet,
+		Networking: &types.Networking{
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: ipnet.IPNet{IPNet: *cidr}},
+			},
+		},
+		Platform: types.Platform{
+			VSphere: platform,
+		},
+	}
+	return installconfig.MakeAsset(cfg)
+}
+
 func TestCloudProviderConfig(t *testing.T) {
 	cases := []struct {
 		name                string
 		platform            *vsphere.Platform
 		cloudProviderFunc   func(string, *vsphere.Platform) (string, error)
+		installConfig       *installconfig.InstallConfig
+		useYaml             bool
 		expectedCloudConfig string
 	}{
 		{
@@ -143,10 +220,54 @@ func TestCloudProviderConfig(t *testing.T) {
 			}(),
 		},
 		{
+			// VSphereMultiNetworks is enabled in inDefault() so the nodes
+			// section is always populated from the machine network CIDR when
+			// nodeNetworking is not explicitly set.
 			name:                "valid out of tree yaml cloud provider config",
 			platform:            validPlatform(),
-			cloudProviderFunc:   CloudProviderConfigYaml,
+			installConfig:       makeInstallConfig(validPlatform(), "", "10.0.0.0/24"),
+			useYaml:             true,
 			expectedCloudConfig: expectedYamlConfig,
+		},
+		{
+			// TechPreviewNoUpgrade also enables VSphereMultiNetworks – same
+			// result as the default case above.
+			name:                "valid out of tree yaml cloud provider config with node networking from machine network",
+			platform:            validPlatform(),
+			installConfig:       makeInstallConfig(validPlatform(), configv1.TechPreviewNoUpgrade, "10.0.0.0/24"),
+			useYaml:             true,
+			expectedCloudConfig: expectedYamlConfigWithNodes,
+		},
+		{
+			// With VSphereMultiNetworks enabled and explicit nodeNetworking set
+			// in the install-config, the explicit values take precedence.
+			name: "valid out of tree yaml cloud provider config with explicit node networking",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.NodeNetworking = &configv1.VSpherePlatformNodeNetworking{
+					External: configv1.VSpherePlatformNodeNetworkingSpec{
+						NetworkSubnetCIDR: []string{"192.168.10.0/24"},
+					},
+					Internal: configv1.VSpherePlatformNodeNetworkingSpec{
+						NetworkSubnetCIDR: []string{"192.168.20.0/24"},
+					},
+				}
+				return p
+			}(),
+			installConfig: func() *installconfig.InstallConfig {
+				p := validPlatform()
+				p.NodeNetworking = &configv1.VSpherePlatformNodeNetworking{
+					External: configv1.VSpherePlatformNodeNetworkingSpec{
+						NetworkSubnetCIDR: []string{"192.168.10.0/24"},
+					},
+					Internal: configv1.VSpherePlatformNodeNetworkingSpec{
+						NetworkSubnetCIDR: []string{"192.168.20.0/24"},
+					},
+				}
+				return makeInstallConfig(p, configv1.TechPreviewNoUpgrade, "10.0.0.0/24")
+			}(),
+			useYaml:             true,
+			expectedCloudConfig: expectedYamlConfigWithExplicitNodes,
 		},
 	}
 
@@ -154,7 +275,11 @@ func TestCloudProviderConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cloudConfig string
 			var err error
-			cloudConfig, err = tc.cloudProviderFunc("infraID", tc.platform)
+			if tc.useYaml {
+				cloudConfig, err = CloudProviderConfigYaml("infraID", tc.installConfig)
+			} else {
+				cloudConfig, err = tc.cloudProviderFunc("infraID", tc.platform)
+			}
 			assert.NoError(t, err, "failed to create cloud provider config")
 			assert.Equal(t, tc.expectedCloudConfig, cloudConfig, "unexpected cloud provider config")
 		})

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
@@ -34,6 +34,26 @@ resourcepool-path = "/test-datacenter/host/cluster/Resources/test-resourcepool"
 
 `
 
+	// expectedIniConfigNoPort is the expected INI config when the vCenter port
+	// is not set (Port == 0). The port line and its trailing blank line must be
+	// absent from the VirtualCenter section.
+	expectedIniConfigNoPort = `[Global]
+secret-name = "vsphere-creds"
+secret-namespace = "kube-system"
+insecure-flag = "1"
+
+[VirtualCenter "test-vcenter"]
+datacenters = "test-datacenter,test-datacenter2"
+
+[Workspace]
+server = "test-vcenter"
+datacenter = "test-datacenter"
+default-datastore = "test-datastore"
+folder = "/test-datacenter/vm/test-folder"
+resourcepool-path = "/test-datacenter/host/cluster/Resources/test-resourcepool"
+
+`
+
 	expectIniLabelsSection = `[Labels]
 region = "openshift-region"
 zone = "openshift-zone"
@@ -58,6 +78,26 @@ vcenter:
     - test-datacenter
     - test-datacenter2
     port: 443
+    server: test-vcenter
+`
+
+	// expectedYamlConfigNoPort is used when the vCenter port is not set
+	// (Port == 0). The port field must be absent from the vcenter block.
+	expectedYamlConfigNoPort = `global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+labels:
+  region: openshift-region
+  zone: openshift-zone
+nodes:
+  externalNetworkSubnetCidr: 10.0.0.0/24
+  internalNetworkSubnetCidr: 10.0.0.0/24
+vcenter:
+  test-vcenter:
+    datacenters:
+    - test-datacenter
+    - test-datacenter2
     server: test-vcenter
 `
 
@@ -268,6 +308,30 @@ func TestCloudProviderConfig(t *testing.T) {
 			}(),
 			useYaml:             true,
 			expectedCloudConfig: expectedYamlConfigWithExplicitNodes,
+		},
+		{
+			// When Port is not set (zero value) the INI VirtualCenter section
+			// must not contain a port line.
+			name: "intree cloud provider config omits port when not configured",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.VCenters[0].Port = 0
+				return p
+			}(),
+			cloudProviderFunc:   CloudProviderConfigIni,
+			expectedCloudConfig: expectedIniConfigNoPort + expectIniLabelsSection,
+		},
+		{
+			// When Port is not set (zero value) the YAML vcenter block must
+			// not contain a port field.
+			name: "outtree yaml cloud provider config omits port when not configured",
+			installConfig: func() *installconfig.InstallConfig {
+				p := validPlatform()
+				p.VCenters[0].Port = 0
+				return makeInstallConfig(p, "", "10.0.0.0/24")
+			}(),
+			useYaml:             true,
+			expectedCloudConfig: expectedYamlConfigNoPort,
 		},
 	}
 

--- a/pkg/asset/manifests/vsphere/infrastructure.go
+++ b/pkg/asset/manifests/vsphere/infrastructure.go
@@ -8,7 +8,6 @@ import (
 	utilsnet "k8s.io/utils/net"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -82,25 +81,22 @@ func GetInfraPlatformSpec(ic *installconfig.InstallConfig, clusterID string) *co
 		}
 	}
 
-	if ic.Config.Enabled(features.FeatureGateVSphereMultiNetworks) {
-		logrus.Debug("Multi-networks feature gate enabled")
-		if icPlatformSpec.NodeNetworking != nil {
-			logrus.Debug("Multi-networks: node networking defined, copying to infrastructure spec")
-			icPlatformSpec.NodeNetworking.DeepCopyInto(&platformSpec.NodeNetworking)
-		} else {
-			logrus.Debug("Multi-networks: node networking not defined, deriving from machineNetwork")
-			var cidrs []string
-			for _, machineNetwork := range ic.Config.MachineNetwork {
-				cidrs = append(cidrs, machineNetwork.CIDR.String())
-			}
-
-			// if NodeNetworking is not defined, use the machine cidrs. the machine cidrs
-			// should align with the VIP and should be a safe choice for inclusion in NodeNetworking.
-			platformSpec.NodeNetworking.External.NetworkSubnetCIDR = cidrs
-			platformSpec.NodeNetworking.Internal.NetworkSubnetCIDR = cidrs
-
-			logrus.Debugf("Multi-networks appending cidrs: %v", cidrs)
+	if icPlatformSpec.NodeNetworking != nil {
+		logrus.Debug("Multi-networks: node networking defined, copying to infrastructure spec")
+		icPlatformSpec.NodeNetworking.DeepCopyInto(&platformSpec.NodeNetworking)
+	} else {
+		logrus.Debug("Multi-networks: node networking not defined, deriving from machineNetwork")
+		var cidrs []string
+		for _, machineNetwork := range ic.Config.MachineNetwork {
+			cidrs = append(cidrs, machineNetwork.CIDR.String())
 		}
+
+		// if NodeNetworking is not defined, use the machine cidrs. the machine cidrs
+		// should align with the VIP and should be a safe choice for inclusion in NodeNetworking.
+		platformSpec.NodeNetworking.External.NetworkSubnetCIDR = cidrs
+		platformSpec.NodeNetworking.Internal.NetworkSubnetCIDR = cidrs
+
+		logrus.Debugf("Multi-networks appending cidrs: %v", cidrs)
 	}
 	return &platformSpec
 }


### PR DESCRIPTION
[SPLAT-2795](https://redhat.atlassian.net/browse/SPLAT-2795)

### Changes
- Enhanced cloud config generation logic to include node network cidr information
- Removed FeatureGateVSphereMultiNetworks check since its been GA for a while now
- Modified vSphere cloud config to not set port for vCenter if not configured in install-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * vSphere multi-network support is now enabled by default.

* **Improvements**
  * Cloud provider config generation now consumes the full install configuration so node-networking and subnet details are included; explicit node settings override derived defaults and vCenter port omission is respected.

* **Tests**
  * Expanded tests to validate YAML cloud provider outputs and multiple node-networking scenarios (defaults, overrides, and port omission).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->