### PR TITLE
OCPBUGS-88303: pkg/types/gcp: apply defaultMachinePlatform values

### DIFF
--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -64,6 +64,10 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform *types.Platform, fgat
 		}
 		azuredefaults.Apply(platform.Azure.DefaultMachinePlatform, p.Platform.Azure)
 	case gcp.Name:
+		if p.Platform.GCP == nil && platform.GCP.DefaultMachinePlatform != nil {
+			p.Platform.GCP = &gcp.MachinePool{}
+		}
+		gcpdefaults.Apply(platform.GCP.DefaultMachinePlatform, p.Platform.GCP)
 		gcpdefaults.SetMachinePoolDefaults(platform, p.Platform.GCP)
 	default:
 	}

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -7,6 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 func defaultMachinePoolWithReplicaCount(name string, replicaCount int) *types.MachinePool {
@@ -201,6 +202,90 @@ func TestSetMachinePoolDefaultsWithFeatureGates(t *testing.T) {
 			}
 			SetMachinePoolDefaults(tc.pool, tc.platform, config.EnabledFeatureGates())
 			assert.Equal(t, tc.expectedManagement, tc.pool.Management, "unexpected management API")
+		})
+	}
+}
+
+func TestSetMachinePoolDefaultsGCPDefaultMachinePlatform(t *testing.T) {
+	cases := []struct {
+		name     string
+		pool     *types.MachinePool
+		platform *types.Platform
+		expected *gcp.MachinePool
+	}{
+		{
+			name: "diskType from defaultMachinePlatform applied to empty pool",
+			pool: &types.MachinePool{Name: "worker"},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-ssd",
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-ssd",
+				},
+			},
+		},
+		{
+			name: "pool diskType takes precedence over defaultMachinePlatform",
+			pool: &types.MachinePool{
+				Name: "worker",
+				Platform: types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-balanced",
+						},
+					},
+				},
+			},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						OSDisk: gcp.OSDisk{
+							DiskType: "pd-ssd",
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-balanced",
+				},
+			},
+		},
+		{
+			name: "multiple fields from defaultMachinePlatform",
+			pool: &types.MachinePool{Name: "master"},
+			platform: &types.Platform{
+				GCP: &gcp.Platform{
+					DefaultMachinePlatform: &gcp.MachinePool{
+						InstanceType: "n2-standard-4",
+						OSDisk: gcp.OSDisk{
+							DiskType:   "pd-ssd",
+							DiskSizeGB: 256,
+						},
+					},
+				},
+			},
+			expected: &gcp.MachinePool{
+				InstanceType: "n2-standard-4",
+				OSDisk: gcp.OSDisk{
+					DiskType:   "pd-ssd",
+					DiskSizeGB: 256,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &types.InstallConfig{}
+			SetMachinePoolDefaults(tc.pool, tc.platform, config.EnabledFeatureGates())
+			assert.Equal(t, tc.expected, tc.pool.Platform.GCP)
 		})
 	}
 }

--- a/pkg/types/gcp/defaults/machinepool.go
+++ b/pkg/types/gcp/defaults/machinepool.go
@@ -5,6 +5,14 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
+// Apply sets values from the default machine platform to the machinepool.
+func Apply(defaultMachinePlatform, machinePool *gcp.MachinePool) {
+	tempMP := &gcp.MachinePool{}
+	tempMP.Set(defaultMachinePlatform)
+	tempMP.Set(machinePool)
+	machinePool.Set(tempMP)
+}
+
 // SetMachinePoolDefaults sets the defaults for the platform.
 func SetMachinePoolDefaults(platform *types.Platform, pool *gcp.MachinePool) {
 	if pool == nil {


### PR DESCRIPTION
Prior to this commit, if osDisk.diskType is specified in defaultMachinePlatform it does not end up being applied to nodes. This commit resolves the issue by applying the defaultMachinePlatform to the standard machine pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure GCP machine pool platform is initialized so default GCP machine platform values are correctly applied and explicit pool settings take precedence.

* **Tests**
  * Added tests validating GCP machine pool defaulting behavior, including precedence and copying of multiple default fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->