### PR TITLE
no-jira: add rochacbruno to owners file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,7 @@ aliases:
     - patrickdillon
     - pawanpinjarkar
     - rna-afk
+    - rochacbruno
     - rwsu
     - sadasu
     - tthvo
@@ -87,9 +88,11 @@ aliases:
   gcp-approvers:
     - patrickdillon
     - barbacbd
+    - rochacbruno
   gcp-reviewers:
     - patrickdillon
     - barbacbd
+    - rochacbruno
   azure-approvers:
     - jhixson74
     - rna-afk


### PR DESCRIPTION
This PR will add Bruno as the repo-wide and gcp approver :D Welcome Bruno!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new member to the installer-team alias to broaden installer responsibilities.
  * Added the same member to both GCP approvers and GCP reviewers aliases to expand GCP review coverage.
  * Updated ownership metadata to reflect these changes and improve review/approval routing for installer and GCP-related areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->