### PR TITLE
MCO-2181: Fix linter error

### DIFF
--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,4 +1,4 @@
-package version
+package version //nolint:revive
 
 import (
 	"testing"


### PR DESCRIPTION
https://github.com/openshift/installer/pull/10621 was merged with a linter error overridden, leaving the job permafailing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal code quality adjustments to test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->