### PR TITLE
OCPBUGS-88562: Use yum install vs yum update tzdata

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -27,9 +27,14 @@ COPY --from=builder /go/src/github.com/openshift/installer/upi/openstack /var/li
 COPY --from=builder /go/src/github.com/openshift/installer/docs/user/openstack /var/lib/openshift-install/docs
 COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-manifests.sh /go/src/github.com/openshift/installer/scripts/openstack/manifest-tests /var/lib/openshift-install/manifest-tests
 
+# Check if /usr/share/zoneinfo has been previously deleted
+RUN if [ ! -f /usr/share/zoneinfo/zone.tab ]; then \
+      yum reinstall -y --setopt=tsflags= tzdata; \
+      yum clean all; rm -rf /var/cache/yum/*; \
+    fi
+
 # Install Dependendencies for tests
-RUN yum update -y --setopt=tsflags= tzdata && \
-    yum update -y && \
+RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     ansible-collection-ansible-netcommon \
     ansible-collection-community-general \


### PR DESCRIPTION
The package tzdata is currently installed, but the /usr/share/zoneinfo directory has been deleted.

Therefore, `yum reinstall tzdata` will recreate /usr/share/zoneinfo and allow the openstack CLI to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Chores**
  * Improved CI image setup for timezone data by conditionally installing `tzdata` only when timezone files are missing.
  * Ensures timezone data directory contents are present after setup.
  * Reworked the CI dependency/install sequence to start with a clean system update before installing remaining packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->