### PR TITLE
CORS-4423: GCP: Use WithCredentialsJSON when Possible

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -720,7 +720,11 @@ func (c *Client) GetNamespacedTagValue(ctx context.Context, tagNamespacedName st
 }
 
 func (c *Client) getKeyManagementClient(ctx context.Context) (*kms.KeyManagementClient, error) {
-	kmsClient, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(c.ssn.Credentials))
+	opts, err := CredentialOptions(c.ssn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credential options: %w", err)
+	}
+	kmsClient, err := kms.NewKeyManagementClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kms key management client: %w", err)
 	}

--- a/pkg/asset/installconfig/gcp/services.go
+++ b/pkg/asset/installconfig/gcp/services.go
@@ -59,17 +59,34 @@ func CreateEndpointOption(endpointName string, service ServiceNameGCP) option.Cl
 	return option.WithEndpoint(endpoint)
 }
 
+// CredentialOptions returns the client options for authenticating with GCP,
+// including universe domain support for Google Cloud Dedicated.
+// When credential JSON is available, it is passed via WithCredentialsJSON so
+// the client library can use self-signed JWTs for non-default universe
+// domains (where the OAuth2 token endpoint is unavailable). Falls back to
+// WithCredentials for metadata-based credentials that have no JSON.
+func CredentialOptions(ssn *Session) ([]option.ClientOption, error) {
+	ud, err := ssn.Credentials.GetUniverseDomain()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get universe domain: %w", err)
+	}
+	var opts []option.ClientOption
+	if len(ssn.Credentials.JSON) > 0 {
+		opts = append(opts, option.WithCredentialsJSON(ssn.Credentials.JSON))
+	} else {
+		opts = append(opts, option.WithCredentials(ssn.Credentials))
+	}
+	opts = append(opts, option.WithUniverseDomain(ud))
+	return opts, nil
+}
+
 // getOptions creates the options for use during service creation.
 func getOptions(ctx context.Context) ([]option.ClientOption, error) {
 	ssn, err := GetSession(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
 	}
-
-	options := []option.ClientOption{
-		option.WithCredentials(ssn.Credentials),
-	}
-	return options, nil
+	return CredentialOptions(ssn)
 }
 
 // GetComputeService creates the compute service. The service is created with credentials and any service

--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -311,6 +311,17 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 			logrus.Infof("setting %q to %s for capg infrastructure controller", gAppCredEnvVar, v)
 		}
 
+		// Google Cloud Dedicated support: detect universe domain from
+		// credentials and pass it to the CAPG controller via env var.
+		ud, err := session.Credentials.GetUniverseDomain()
+		if err != nil {
+			return fmt.Errorf("failed to get universe domain from gcp credentials: %w", err)
+		}
+		if ud != "googleapis.com" {
+			capgEnvVars["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = ud
+			logrus.Infof("setting GOOGLE_CLOUD_UNIVERSE_DOMAIN to %q for capg infrastructure controller", ud)
+		}
+
 		controllers = append(controllers,
 			c.getInfrastructureController(
 				&GCP,

--- a/pkg/quota/gcp/gcp.go
+++ b/pkg/quota/gcp/gcp.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -35,7 +36,10 @@ func Load(ctx context.Context, project string, endpoint *gcptypes.PSCEndpoint, s
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create services svc")
 	}
-	metricsOptions := []option.ClientOption{option.WithCredentials(ssn.Credentials)}
+	metricsOptions, err := gcpconfig.CredentialOptions(ssn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credential options: %w", err)
+	}
 	metricsSvc, err := monitoring.NewMetricClient(ctx, metricsOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create metrics svc")


### PR DESCRIPTION
Prior to this commit, using a GCP Service Account with a Key failed in scenarios where an alternate UNIVERSE_DOMAIN is needed. This updates the GCP auth to use `option.WithCredentialsJSON`, determine the universe domain and set it. Using `option.WithCredentialsJSON` is necessary because it uses a different authentication flow utilizing a self-signed JWT rather than oauth2. See more details in the commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved GCP authentication for Key Management and Cloud Monitoring by automatically selecting the appropriate credential method, including JSON-based service account support.
  * Ensures the correct universe domain is used when configured.
* **Bug Fixes**
  * Added clearer, earlier error handling when credential options cannot be prepared, reducing confusing runtime failures.
* **Chores**
  * Updated Google Cloud and related Go dependencies to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->