### PR TITLE
OCPBUGS-88701: Exclude bind-mounted crypto policies from rsync

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
@@ -11,7 +11,10 @@ echo "Overlaying node image content"
 # keep /usr/lib/modules from the booted deployment for kernel modules
 mount -o bind,ro "/usr/lib/modules" "${ostree_checkout}/usr/lib/modules"
 mount -o rbind,ro "${ostree_checkout}/usr" /usr
-rsync -a "${ostree_checkout}/usr/etc/" /etc
+# Exclude crypto-policies as it may be bind-mounted by fips-crypto-policy-overlay
+# during FIPS boot, causing "Device or resource busy" and "Read-only file system"
+# errors when rsync attempts to rename/symlink files under it.
+rsync -a --exclude crypto-policies "${ostree_checkout}/usr/etc/" /etc
 
 # reload the new policy
 echo "Reloading SELinux policy"


### PR DESCRIPTION
The crypto policies are bind-mounted by the FIPS/crypto-policy services which causes a failure when the rsync is done by node-image-overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FIPS boot failures that previously resulted in "Device or resource busy" and read-only filesystem errors during the node image overlay process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->