### PR TITLE
OCPBUGS-89645: Ensure ssh keys strict permissions after bootstrap pivot

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
@@ -20,5 +20,10 @@ rsync -a --exclude crypto-policies "${ostree_checkout}/usr/etc/" /etc
 echo "Reloading SELinux policy"
 semodule -R
 
+# Fix SSH host key permissions after rsync. The node image may ship keys
+# with 0640 permissions, but OpenSSH 9.8+ (RHEL 10) requires 0600 and
+# will refuse to start if private keys are group-readable.
+chmod 0600 /etc/ssh/ssh_host_*_key 2>/dev/null || true
+
 # handle upgrade of sshd between RHEL 9.6 and 9.8
 systemctl --no-block try-restart sshd.service


### PR DESCRIPTION
After pivoting to RHCOS 10.2 bootstrap, sshd requires 0600 permissions but RHEL 9 sshd has more permissive 0640. This results in the sshd.service exiting with message:
`Permissions 0640 for '/etc/ssh/ssh_host_ed25519_key' are too open.`

Set the permissions after rsync to ensure strict permissions are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH host key permissions are now automatically configured during system initialization to ensure proper security settings and compatibility with current system requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->