### PR TITLE
OCPBUGS-89645: Revert: Ensure ssh keys strict permissions after bootstrap pivot

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
@@ -20,10 +20,5 @@ rsync -a --exclude crypto-policies "${ostree_checkout}/usr/etc/" /etc
 echo "Reloading SELinux policy"
 semodule -R
 
-# Fix SSH host key permissions after rsync. The node image may ship keys
-# with 0640 permissions, but OpenSSH 9.8+ (RHEL 10) requires 0600 and
-# will refuse to start if private keys are group-readable.
-chmod 0600 /etc/ssh/ssh_host_*_key 2>/dev/null || true
-
 # handle upgrade of sshd between RHEL 9.6 and 9.8
 systemctl --no-block try-restart sshd.service


### PR DESCRIPTION
Reverts openshift/installer#10631 in favor of https://github.com/openshift/appliance/pull/720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Streamlined SSH service handling during RHEL 9.6 to 9.8 system upgrades by simplifying the configuration reload sequence and removing unnecessary intermediate steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->