### PR TITLE
OCPBUGS-90534: openstack: Increase bootstrap timeout

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/vsphere"
 	baremetalutils "github.com/openshift/installer/pkg/utils/baremetal"
 )
@@ -416,8 +417,8 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config) *cluster
 
 	timeout := 45 * time.Minute
 
-	// Wait longer for baremetal, VSphere due to length of time it takes to boot
-	if platformName == baremetal.Name || platformName == vsphere.Name {
+	// Wait longer for baremetal, vSphere, and OpenStack due to length of time it takes to boot
+	if platformName == baremetal.Name || platformName == openstack.Name || platformName == vsphere.Name {
 		timeout = 60 * time.Minute
 	}
 	// For AWS, only increase timeout when UserProvisionedDNS is enabled

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/dns"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 // getWaitOptionsFromInstallConfig constructs WaitOptions from an InstallConfig.
@@ -26,7 +27,7 @@ func getWaitOptionsFromInstallConfig(ic *types.InstallConfig) command.WaitOption
 	}
 	if ic != nil {
 		switch ic.Platform.Name() {
-		case baremetal.Name:
+		case baremetal.Name, openstack.Name:
 			options.ExtendTimeoutForBaremetal = true
 		case aws.Name:
 			if ic.AWS != nil &&

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/dns"
 	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 // getWaitOptionsFromInstallConfig constructs WaitOptions from an InstallConfig.
@@ -27,7 +28,7 @@ func getWaitOptionsFromInstallConfig(ic *types.InstallConfig) command.WaitOption
 	}
 	if ic != nil {
 		switch ic.Platform.Name() {
-		case baremetal.Name, openstack.Name:
+		case baremetal.Name, openstack.Name, vsphere.Name:
 			options.ExtendTimeoutForBaremetal = true
 		case aws.Name:
 			if ic.AWS != nil &&


### PR DESCRIPTION
We frequently see build timeouts in CI. Many of these issues are due to slow infra, but if we are seeing these issues then it is likely customers see the same issues. Increase the timeout for OpenStack like we have already done for VMWare and baremetal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bootstrap timeout handling for OpenStack platform installations. OpenStack deployments now receive extended wait durations during bootstrap, consistent with baremetal and vSphere platforms, improving installation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->