### PR TITLE
OCPBUGS-90536: openstack: Guard network resource names on `os_net_id` being defined

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -47,3 +47,4 @@
       # Port names
       os_port_api: "{{ os_net_id }}-api-port"
       os_port_ingress: "{{ os_net_id }}-ingress-port"
+    when: os_net_id is defined

--- a/upi/openstack/down-network.yaml
+++ b/upi/openstack/down-network.yaml
@@ -40,6 +40,16 @@
       cmd: "openstack port delete {{ ports.stdout_lines | join(' ') }}"
     when: ports.stdout != ""
 
+  - name: 'List FIPs'
+    ansible.builtin.command:
+      cmd: "openstack floating ip list --router {{ os_router}} -f value -c ID"
+    register: fips
+
+  - name: 'Remove the cluster FIPs'
+    ansible.builtin.command:
+      cmd: "openstack floating ip delete {{ fips.stdout_lines | join(' ') }}"
+    when: fips.stdout != ""
+
   - name: 'Remove the cluster router'
     openstack.cloud.router:
       name: "{{ os_router }}"


### PR DESCRIPTION
The `Compute network resource names` task in common.yaml uses the `os_net_id` variable, which is loaded from `netid.json`. Since commit 7b6b3f1c70 (OCPBUGS-39285), `netid.json` is loaded conditionally via `include_vars` (skipped when the file doesn't exist), but the task that consumes `os_net_id` had no corresponding guard. This causes the UPI deprovision playbook to fail with `'os_net_id' is undefined` when `netid.json` is not present in the working directory.

Add a `when: os_net_id is defined` guard, consistent with the existing `when: sym.stat.exists` guard on the `Compute resource names` task above.

Note that the deprovision playbooks (e.g. `down-network.yaml`) do use these network resource names, but they already handle missing resources gracefully - they list resources by tag first and use `state: absent` for deletion. Without `os_net_id` the names can't be computed at all, so skipping is the only safe option. More importantly, failing hard here prevents the entire deprovision run from cleaning up resources that *can* be cleaned up (servers, security groups, etc. that use `infraID` from `metadata.json` rather than `os_net_id`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network resource name generation now runs only when the required network identifier is available, reducing deployment-time errors.
  * Network teardown now identifies matching floating IPs by cluster and deletes them before removing the router and network resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->