### PR TITLE
OCPBUGS-90537: allow agent TUI to be shown also for rhcos10 base ISO

### DIFF
--- a/data/data/agent/systemd/units/agent-interactive-console-serial@.service
+++ b/data/data/agent/systemd/units/agent-interactive-console-serial@.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Get interactive user configuration at boot on %I
-After=dev-fb0.device dev-%i.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service set-hostname.service
+After=dev-fb0.device dev-dri-card0.device dev-%i.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service set-hostname.service
 Before=serial-getty@%i.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service agent-auth-token-status.service
 Wants=agent-extract-tui.service
 ConditionPathExists=/usr/local/bin/agent-tui
 ConditionPathExists=!/dev/fb0
+ConditionPathExistsGlob=!/dev/dri/card*
 ConditionPathExists=!/etc/assisted/node0
 
 [Service]

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Get interactive user configuration at boot
-After=dev-fb0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service set-hostname.service
+After=dev-fb0.device dev-dri-card0.device network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service agent-extract-tui.service set-hostname.service
 Before=getty@tty1.service network.target network.service agent.service node-zero.service NetworkManager-wait-online.service agent-auth-token-status.service
 Wants=agent-extract-tui.service
 ConditionPathExists=/usr/local/bin/agent-tui
-ConditionPathExists=/dev/fb0
+ConditionPathExists=|/dev/fb0
+ConditionPathExistsGlob=|/dev/dri/card*
 ConditionPathExists=!/etc/assisted/node0
 
 [Service]


### PR DESCRIPTION
Required by https://github.com/openshift/appliance/pull/721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced device detection for the interactive console to support a broader range of graphics hardware configurations, improving compatibility with modern display devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->