### PR TITLE
OCPBUGS-91640: Warn about ignored install-config fields in ABI

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -581,6 +581,14 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		}
 	}
 
+	if installConfig.Networking != nil &&
+		installConfig.Networking.OVNKubernetesConfig != nil &&
+		installConfig.Networking.OVNKubernetesConfig.IPv4 != nil &&
+		installConfig.Networking.OVNKubernetesConfig.IPv4.InternalJoinSubnet != nil {
+		fieldPath := field.NewPath("networking", "ovnKubernetesConfig", "ipv4", "internalJoinSubnet")
+		logrus.Warnf("%s: %s is ignored", fieldPath, installConfig.Networking.OVNKubernetesConfig.IPv4.InternalJoinSubnet)
+	}
+
 	// "External" is the default set from generic install config code
 	if installConfig.Publish != "External" {
 		fieldPath := field.NewPath("publish")

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -461,6 +461,11 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			fieldPath := computePath.Child("platform")
 			logrus.Warnf("%s is ignored", fieldPath)
 		}
+
+		if len(compute.DiskSetup) > 0 {
+			fieldPath := computePath.Child("diskSetup")
+			logrus.Warnf("%s is ignored", fieldPath)
+		}
 	}
 
 	if installConfig.ControlPlane.Hyperthreading != "Enabled" {
@@ -470,6 +475,11 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 
 	if installConfig.ControlPlane.Platform != (types.MachinePoolPlatform{}) {
 		fieldPath := field.NewPath("controlPlane", "platform")
+		logrus.Warnf("%s is ignored", fieldPath)
+	}
+
+	if len(installConfig.ControlPlane.DiskSetup) > 0 {
+		fieldPath := field.NewPath("controlPlane", "diskSetup")
 		logrus.Warnf("%s is ignored", fieldPath)
 	}
 


### PR DESCRIPTION
`diskSetup` and `networking.ovnKubernetesConfig` were added to the install-config after the agent-based installation method was created, without being plumbed through or generating a warning that its value would be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation warnings for agent install configuration. Users will now receive log warnings when unsupported configuration fields are specified, including disk setup options and internal networking parameters, providing better feedback on configuration usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->