### PR TITLE
MULTIARCH-6014: PowerVS: Use PowerVS Stock Catalogue Images

### DIFF
--- a/pkg/asset/machines/powervs/images.go
+++ b/pkg/asset/machines/powervs/images.go
@@ -1,0 +1,22 @@
+package powervs
+
+import "github.com/openshift/installer/pkg/types"
+
+const (
+	// OSImageNameRHCOS9 is the catalog image name for RHEL CoreOS 9.
+	OSImageNameRHCOS9 = "RHEL-CoreOS-9"
+
+	// OSImageNameRHCOS10 is the catalog image name for RHEL CoreOS 10.
+	OSImageNameRHCOS10 = "RHEL-CoreOS-10"
+)
+
+// OSImageNameFromStream returns the PowerVS catalog image name that corresponds
+// to the given osImageStream value from the install-config.
+// types.OSImageStreamRHCOS10 ("rhel-10") maps to RHEL-CoreOS-10;
+// anything else (including empty) defaults to RHEL-CoreOS-9.
+func OSImageNameFromStream(stream types.OSImageStream) string {
+	if stream == types.OSImageStreamRHCOS10 {
+		return OSImageNameRHCOS10
+	}
+	return OSImageNameRHCOS9
+}

--- a/pkg/asset/machines/powervs/machinesets.go
+++ b/pkg/asset/machines/powervs/machinesets.go
@@ -25,7 +25,9 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	platform := config.Platform.PowerVS
 	mpool := pool.Platform.PowerVS
 	var network string
-	image := fmt.Sprintf("rhcos-%s", clusterID)
+
+	// Resolve the catalog image name from osImageStream (defaults to RHEL-CoreOS-9).
+	image := OSImageNameFromStream(config.OSImageStream)
 
 	total := int32(0)
 	if pool.Replicas != nil {

--- a/pkg/asset/machines/powervs/powervsmachines.go
+++ b/pkg/asset/machines/powervs/powervsmachines.go
@@ -29,18 +29,17 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 		total = *pool.Replicas
 	}
 
+	// Resolve the catalog image name from osImageStream (defaults to RHEL-CoreOS-9).
+	image := OSImageNameFromStream(ic.OSImageStream)
+
 	var (
 		result         []*asset.RuntimeFile
-		image          string
 		service        capibm.IBMPowerVSResourceReference
 		name           string
 		powerVSMachine *capibm.IBMPowerVSMachine
 		dataSecret     string
 		machine        *capi.Machine
 	)
-
-	// Note: This will be created later
-	image = fmt.Sprintf("rhcos-%s", clusterID)
 
 	if ic.PowerVS.ServiceInstanceGUID == "" {
 		serviceName := fmt.Sprintf("%s-power-iaas", clusterID)
@@ -112,13 +111,11 @@ func GenerateMachine(ic *types.InstallConfig, service capibm.IBMPowerVSResourceR
 			ServiceInstanceID: ic.PowerVS.ServiceInstanceGUID,
 			ServiceInstance:   &service,
 			SSHKey:            "",
-			ImageRef: &v1.LocalObjectReference{
-				Name: image,
-			},
-			SystemType:    mpool.SysType,
-			ProcessorType: capibm.PowerVSProcessorType(mpool.ProcType),
-			Processors:    mpool.Processors,
-			MemoryGiB:     mpool.MemoryGiB,
+			Image:             &capibm.IBMPowerVSResourceReference{Name: &image},
+			SystemType:        mpool.SysType,
+			ProcessorType:     capibm.PowerVSProcessorType(mpool.ProcType),
+			Processors:        mpool.Processors,
+			MemoryGiB:         mpool.MemoryGiB,
 		},
 	}
 	utils.SetMachineOSStreamLabels(machine, ic)

--- a/pkg/asset/manifests/clusterapi/cluster.go
+++ b/pkg/asset/manifests/clusterapi/cluster.go
@@ -128,8 +128,7 @@ func (c *Cluster) Generate(_ context.Context, dependencies asset.Parents) error 
 		}
 	case powervstypes.Name:
 		var err error
-		osImage := strings.SplitN(rhcosImage.ControlPlane, "/", 2)
-		out, err = powervs.GenerateClusterAssets(installConfig, clusterID, osImage[0], osImage[1])
+		out, err = powervs.GenerateClusterAssets(installConfig, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed to generate PowerVS manifests %w", err)
 		}

--- a/pkg/asset/manifests/powervs/cluster.go
+++ b/pkg/asset/manifests/powervs/cluster.go
@@ -15,13 +15,14 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
+	machinespowervs "github.com/openshift/installer/pkg/asset/machines/powervs"
 	"github.com/openshift/installer/pkg/asset/manifests/capiutils"
 	"github.com/openshift/installer/pkg/types"
 	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 )
 
 // GenerateClusterAssets generates the manifests for the cluster-api.
-func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID, bucket string, object string) (*capiutils.GenerateClusterAssetsOutput, error) {
+func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID *installconfig.ClusterID) (*capiutils.GenerateClusterAssetsOutput, error) {
 	var (
 		manifests          []*asset.RuntimeFile
 		network            string
@@ -32,7 +33,6 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		vpcRegion          string
 		cosName            string
 		cosRegion          string
-		imageName          string
 		bucketName         string
 		transitGatewayName string
 		client             *powervsconfig.Client
@@ -40,11 +40,10 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		transitGateway     *capibm.TransitGateway
 		err                error
 		powerVSCluster     *capibm.IBMPowerVSCluster
-		powerVSImage       *capibm.IBMPowerVSImage
 	)
 
 	defer func() {
-		logrus.Debugf("GenerateClusterAssets: installConfig = %+v, clusterID = %v, bucket = %v, object = %v", installConfig, *clusterID, bucket, object)
+		logrus.Debugf("GenerateClusterAssets: installConfig = %+v, clusterID = %v", installConfig, *clusterID)
 		logrus.Debugf("GenerateClusterAssets: ic.ObjectMeta = %+v", installConfig.Config.ObjectMeta.Name)
 		logrus.Debugf("GenerateClusterAssets: installConfig.Config.PowerVS = %+v", *installConfig.Config.PowerVS)
 		logrus.Debugf("GenerateClusterAssets: installConfig.Config.Platform.PowerVS.VPC = %v", installConfig.Config.Platform.PowerVS.VPC)
@@ -54,7 +53,6 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		logrus.Debugf("GenerateClusterAssets: transitGatewayName = %v", transitGatewayName)
 		logrus.Debugf("GenerateClusterAssets: cosName = %v", cosName)
 		logrus.Debugf("GenerateClusterAssets: cosRegion = %v", cosRegion)
-		logrus.Debugf("GenerateClusterAssets: imageName = %v", imageName)
 		logrus.Debugf("GenerateClusterAssets: bucketName = %v", bucketName)
 		logrus.Debugf("GenerateClusterAssets: powerVSCluster.Spec.ControlPlaneEndpoint.Host = %v", powerVSCluster.Spec.ControlPlaneEndpoint.Host)
 	}()
@@ -163,8 +161,6 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 	if cosRegion, err = powervstypes.COSRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
 		return nil, fmt.Errorf("unable to derive cosRegion from region: %s %w", installConfig.Config.PowerVS.Region, err)
 	}
-
-	imageName = fmt.Sprintf("rhcos-%s", clusterID.InfraID)
 
 	bucketName = fmt.Sprintf("%s-bootstrap-ign", clusterID.InfraID)
 
@@ -280,33 +276,7 @@ func GenerateClusterAssets(installConfig *installconfig.InstallConfig, clusterID
 		File:   asset.File{Filename: "02_powervs-cluster.yaml"},
 	})
 
-	if vpcRegion != cosRegion {
-		logrus.Debugf("GenerateClusterAssets: vpcRegion(%s) is different than cosRegion(%s), cosRegion. Overriding bucket name", vpcRegion, cosRegion)
-		bucket = fmt.Sprintf("rhcos-powervs-images-%s", cosRegion)
-	}
-
-	powerVSImage = &capibm.IBMPowerVSImage{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: capibm.GroupVersion.String(),
-			Kind:       "IBMPowerVSImage",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      imageName,
-			Namespace: capiutils.Namespace,
-		},
-		Spec: capibm.IBMPowerVSImageSpec{
-			ClusterName:     clusterID.InfraID,
-			ServiceInstance: &service,
-			Bucket:          &bucket,
-			Object:          &object,
-			Region:          &cosRegion,
-		},
-	}
-
-	manifests = append(manifests, &asset.RuntimeFile{
-		Object: powerVSImage,
-		File:   asset.File{Filename: "03_powervs-image.yaml"},
-	})
+	logrus.Infof("Using PowerVS catalog image: %s", machinespowervs.OSImageNameFromStream(installConfig.Config.OSImageStream))
 
 	return &capiutils.GenerateClusterAssetsOutput{
 		Manifests: manifests,

--- a/pkg/infrastructure/powervs/clusterapi/powervs.go
+++ b/pkg/infrastructure/powervs/clusterapi/powervs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
@@ -100,7 +101,8 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 	}
 	logrus.Debugf("InfraReady: powerVSCluster.Status.VPC.ID = %s", *powerVSCluster.Status.VPC.ID)
 
-	// Get the image from the provider
+	// Get the image from the provider when an IBMPowerVSImage resource was created.
+	// Existing workspace images skip manifest creation, so a missing resource is expected.
 	key = crclient.ObjectKey{
 		Name:      fmt.Sprintf("rhcos-%s", in.InfraID),
 		Namespace: capiutils.Namespace,
@@ -108,9 +110,13 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 	logrus.Debugf("InfraReady: image key = %+v", key)
 	powerVSImage := &capibm.IBMPowerVSImage{}
 	if err = in.Client.Get(ctx, key, powerVSImage); err != nil {
-		return fmt.Errorf("failed to get PowerVS image in InfraReady: %w", err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get PowerVS image in InfraReady: %w", err)
+		}
+		logrus.Debugf("InfraReady: image resource %q not found, assuming existing workspace image is being used", key.Name)
+	} else {
+		logrus.Debugf("InfraReady: image = %+v", powerVSImage)
 	}
-	logrus.Debugf("InfraReady: image = %+v", powerVSImage)
 
 	// We need to set the region we will eventually query inside
 	vpcRegion := in.InstallConfig.Config.Platform.PowerVS.VPCRegion


### PR DESCRIPTION
If a stock catalogue OS image is available in the Workspace, use it. If not, fall back to importing the image from public COS.

Why this change:
Importing images from COS is time consuming and introduces a failure mode that can be avoided by using an existing stock catalogue image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PowerVS machine provisioning now dynamically selects the RHCOS boot image from the workspace (based on configured zone and service instance).
* **Bug Fixes / Reliability**
  * If no active workspace image is found, or the lookup fails, the system falls back to the existing `rhcos-<clusterID>` default and logs a warning.
* **Internal Improvements**
  * PowerVS machine specifications now consistently reference the resolved boot image when configuring the machine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->