### PR TITLE
OCPBUGS-88740: Update RHCOS-release-4.21 data/data/coreos/rhcos.json to 9.6.20260616-0

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,106 +1,106 @@
 {
   "stream": "rhcos-4.21",
   "metadata": {
-    "last-modified": "2026-05-28T18:28:07Z",
-    "generator": "plume cosa2stream af5d9c3"
+    "last-modified": "2026-06-23T20:45:07Z",
+    "generator": "plume cosa2stream ee5caee"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-aws.aarch64.vmdk.gz",
-                "sha256": "d5ac6bec2edcc0a3a18ddefd57cd1d23d4b9786762e674e4a888977ea4470980",
-                "uncompressed-sha256": "3774ffda30205b7efc3a024fd08cfc55ac9ecc8f9594ad651690aa4ba8749218"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-aws.aarch64.vmdk.gz",
+                "sha256": "81ca8585800386973f359467e6295d1936bbd94bfe84a1b9959b68e8e03f1aa9",
+                "uncompressed-sha256": "8ceec1b815018c1e30e62949395c9f37b09cd8dda908d392a14ef5512057e086"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-azure.aarch64.vhd.gz",
-                "sha256": "2e485b1045de1163ce35ae87da348fd7ac9c053a1dd195154d80e801f76c51b6",
-                "uncompressed-sha256": "df4fc9b063434ef793234eb9d40110be5ac1afdc44bc32d7aef9cd8bdd27a004"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-azure.aarch64.vhd.gz",
+                "sha256": "412780daf3b161463c82041c9de20001f601480ff421ea8bae71d4d1df0ee320",
+                "uncompressed-sha256": "87ec289f3993b9c4e40d42d9cf499ec530a1a0b49cbcfcb65acb26a7ce053f03"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-gcp.aarch64.tar.gz",
-                "sha256": "31106206825d891e66b02992d283e324d3b4505458ff1ce192172c46087785c6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-gcp.aarch64.tar.gz",
+                "sha256": "d01710a210697f75aaaaf2401c78b93508d4da28366558c50505acd3aae68540"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-metal4k.aarch64.raw.gz",
-                "sha256": "4ef5379b3f83c2935b89bd3202ef8b7f52f656948ca5ff78e6174f60d5018bcc",
-                "uncompressed-sha256": "c3652a4b9721b5d70fbc7aca8ba764be6f708619dafa4700762d8c09b4ae24d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-metal4k.aarch64.raw.gz",
+                "sha256": "3c38420e51af585b7c3e07735a2d75d714d1479ed1c4132834120934d4ae877d",
+                "uncompressed-sha256": "d87c2b98f57bc06dc6627a11bbf0df5830ada7d9086f6f15845a7cc5b5228c13"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-iso.aarch64.iso",
-                "sha256": "f95235fc13fe764b6a67ab7ac4fbd6072067a564916dcdc470c66726b4a5ac89"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-live-iso.aarch64.iso",
+                "sha256": "397c1c52a544a6fdbe37d300a8f230ba9b2c2679f3753d7c9821066344ccc4ea"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-kernel.aarch64",
-                "sha256": "a91a728781bc16daa2190bd4b6031c5eeef49af5fc60e6fe61dd28515f1f48f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-live-kernel.aarch64",
+                "sha256": "6a5ad998e54a554d4b0695b7673c6caec7ef54a1d6050cd443b1b0a18fca5e37"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-initramfs.aarch64.img",
-                "sha256": "670c31edf8e1c2d93bf5c445f35ee505ce87a8c2b159a07d1cdf4d037d57830e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-live-initramfs.aarch64.img",
+                "sha256": "f66972d9c7e2d452e66897d78c0c833c7d91cac6386e2095c4f777bf9b2b56a9"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-rootfs.aarch64.img",
-                "sha256": "51b0d660affcf813b53bd873db94f3964e91c6b92ddc95b506a3fad8eb227a7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-live-rootfs.aarch64.img",
+                "sha256": "5977cc92f9a37200920c779d5f55adcf54c2b70986cce68a65b1d091f5bc7578"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-metal.aarch64.raw.gz",
-                "sha256": "4e0ef2e3cf869dffd534b12d0ed67ec0c521811900a1bc3a34e55ffb9a25cbfa",
-                "uncompressed-sha256": "4d61303d52c5c4683ef6b0876e7668c308fe858489f5db70ae6d8b2cd96d74f7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-metal.aarch64.raw.gz",
+                "sha256": "c2d53dafe128e5e341319f2a22a69287463aea0366e21314dbe844cee78abb3a",
+                "uncompressed-sha256": "798e5d18c8c032f87e63d27f6d0dabaac3864dc7cafc24d360bee58a97121a02"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-openstack.aarch64.qcow2.gz",
-                "sha256": "6e10f3a8d669e2fa02eeb0fdab4dee53ed157f22d52ddbf14f015cd39c6b5b37",
-                "uncompressed-sha256": "6566b040f14c89c06e12e6ea08f51d7ef2f8f4fd5e54e04f8fbf4bbde246a342"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-openstack.aarch64.qcow2.gz",
+                "sha256": "deefb1735dd3f6ae47520f0a15f89825c607feb6bb17a2d33e0b8c2bbd96ee1a",
+                "uncompressed-sha256": "d400f5b55e7d9adb8de7615c2e7e3a5bd59d3812986a83fd13081b579426f9bd"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-qemu.aarch64.qcow2.gz",
-                "sha256": "91d018291203e72d0a29aa58a4ec4c944f908fc64666cb34c15f453634b3482f",
-                "uncompressed-sha256": "71b1e3fe17260a1ee8a9cac9ac6941e4dd51a02610dc88f385c48dc46255c84e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-qemu.aarch64.qcow2.gz",
+                "sha256": "88b94be2319a98440f127983cbb2d62c46a2c08b86cea71392b965a59843df6e",
+                "uncompressed-sha256": "f0bc9fb3215ad4256b672443c95877fdb8a505476c80b7bbb2ebe2488ffc1c06"
               }
             }
           }
@@ -110,229 +110,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0d61f2c1b27d06a5e"
+              "release": "9.6.20260616-0",
+              "image": "ami-09ea3eaa627b5178f"
             },
             "ap-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-089ce2f9fd0160eed"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f4f5b97291d204aa"
             },
             "ap-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-08245280328443a81"
+              "release": "9.6.20260616-0",
+              "image": "ami-01139e7c4a549ace7"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0711c9c3a6f1c9456"
+              "release": "9.6.20260616-0",
+              "image": "ami-08f3e51a462061b0c"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-05442fa917a851745"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d9b38cb5fb04bc56"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06b1959f0c1123129"
+              "release": "9.6.20260616-0",
+              "image": "ami-058bbedca83d22dc7"
             },
             "ap-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0646f372940f1385d"
+              "release": "9.6.20260616-0",
+              "image": "ami-0fe270d47b42d792f"
             },
             "ap-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0abb3883c77105ae9"
+              "release": "9.6.20260616-0",
+              "image": "ami-0e28cfa9dfe94750b"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-03e9e076d8c965bbb"
+              "release": "9.6.20260616-0",
+              "image": "ami-09049ac628197a75a"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0433fc9a0f0e93610"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b0f5505d6b702748"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-08a02768cd3890eff"
+              "release": "9.6.20260616-0",
+              "image": "ami-08edd6ac362f718da"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0072359ad9cdc53bd"
+              "release": "9.6.20260616-0",
+              "image": "ami-072c37a2bca4cee98"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06650e9d43dfa508c"
+              "release": "9.6.20260616-0",
+              "image": "ami-044f13722a79a0208"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0d17f3468c70c7601"
+              "release": "9.6.20260616-0",
+              "image": "ami-09355c65369f31a1d"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0c7b82d118063048c"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d403a738034cc4ba"
             },
             "ca-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-07f4b006a3ee17258"
+              "release": "9.6.20260616-0",
+              "image": "ami-05583a00d8046c0bb"
             },
             "ca-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04d6d9c8beda63813"
+              "release": "9.6.20260616-0",
+              "image": "ami-07125b53ffcf514d5"
             },
             "eu-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0f2a4d3e2a95e5ea8"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b028d6ce8a85608c"
             },
             "eu-central-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09d94afe83d21f6cb"
+              "release": "9.6.20260616-0",
+              "image": "ami-05d9f649ef2e37e0e"
             },
             "eu-north-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-092e45482b1eb9602"
+              "release": "9.6.20260616-0",
+              "image": "ami-04768f98f0966da06"
             },
             "eu-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0ab12b62d54edf1fd"
+              "release": "9.6.20260616-0",
+              "image": "ami-0faffb65920395904"
             },
             "eu-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0deb02ff16cb956c9"
+              "release": "9.6.20260616-0",
+              "image": "ami-08684e6c45a4208e5"
             },
             "eu-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0ebc3bffc0ef5b733"
+              "release": "9.6.20260616-0",
+              "image": "ami-0643a176caef20a5a"
             },
             "eu-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-07258c815b9f7461d"
+              "release": "9.6.20260616-0",
+              "image": "ami-0c2fa21676b0c5da7"
             },
             "eu-west-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0577d7b1f657656e5"
+              "release": "9.6.20260616-0",
+              "image": "ami-0aba307990b251dc7"
             },
             "il-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06e2bdb6dad0411de"
+              "release": "9.6.20260616-0",
+              "image": "ami-0a4b19220461b4eef"
             },
             "mx-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0d3ebb657d5820262"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f2437eccc7fc749c"
             },
             "sa-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-01d251ce232f14619"
+              "release": "9.6.20260616-0",
+              "image": "ami-0c6539b8a76036e0a"
             },
             "us-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0240d1810ac82bbe3"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f2a86d8b92162a42"
             },
             "us-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0727757daa31e67c2"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b24ccaf1c9bb50e5"
             },
             "us-gov-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0eda8aa9aa1d84883"
+              "release": "9.6.20260616-0",
+              "image": "ami-05ad4a46d6a376604"
             },
             "us-gov-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-079436bad139f2aee"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d68c4f205b058750"
             },
             "us-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-077212aa77fab4847"
+              "release": "9.6.20260616-0",
+              "image": "ami-0a0720ec141a9a4a7"
             },
             "us-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04c3da7d0017748d1"
+              "release": "9.6.20260616-0",
+              "image": "ami-0497dae99ba75723d"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20260520-0-gcp-aarch64"
+          "name": "rhcos-9-6-20260616-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.6.20260520-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260520-0-azure.aarch64.vhd"
+          "release": "9.6.20260616-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260616-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-metal4k.ppc64le.raw.gz",
-                "sha256": "4de2d3a3e9933ea487c2be46c73c0838eceb89cd3eaf6d4f8ef45b7cdd1bed7e",
-                "uncompressed-sha256": "31736ff532132f693e9f6f536150c6e11128d62d07ec7bfef8ba8fc06c79cad1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-metal4k.ppc64le.raw.gz",
+                "sha256": "82b98919c156b5a72ed497ed3ccd5feb7b84b38a46fc812b0fa2c26f3578d9c3",
+                "uncompressed-sha256": "82740bd6926fce27a364b52cf0ac6fa73b2a309efd8f5de563ba079442fb551f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-iso.ppc64le.iso",
-                "sha256": "9dacfc2437f00120455f8b0fc04faa005855efcb4b57115942d0184dee8ae911"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-live-iso.ppc64le.iso",
+                "sha256": "0cccdb125ef6617c965d0c9b143241036b1cff174d385f2a33ff5a0942d302a8"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-kernel.ppc64le",
-                "sha256": "2b5c68b988227c68df0229f29e7367db96796abe2eb7dcd8acb7e6765d63319c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-live-kernel.ppc64le",
+                "sha256": "4f1c692a6983cf579d019e1b861d76b8839d0f7ddb0e6ec8274d50dbaedf63bd"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-initramfs.ppc64le.img",
-                "sha256": "261b67f2f5ddfea2e9c1b31e06d08c06beb6a2ee14ec4611b432b2d079998678"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-live-initramfs.ppc64le.img",
+                "sha256": "93bb14798837f6dfcc1ad7888b78a45938796642a62d7c5becbb6ee9295f85be"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-rootfs.ppc64le.img",
-                "sha256": "f97b349245f2e22154d6c640a58966577efb90c727bbb9da46c11daa92b37cac"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-live-rootfs.ppc64le.img",
+                "sha256": "bd1b099d4b06b0c991294aea6285bfb4dd9b6143c918d9ee6c7cfba3bc44ac77"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-metal.ppc64le.raw.gz",
-                "sha256": "8480dfe445b1c161441e9f85931ae7c71407e88c22fa9e76f52b247bb80ff001",
-                "uncompressed-sha256": "185065ec94b9406c79cfc877c7634dd717cd01d402cc3a1ed3ebb64b47006c8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-metal.ppc64le.raw.gz",
+                "sha256": "13ef676146c545b72f7b38728a92f51a5ae4d836ba4b99c515a4cdef1b86a067",
+                "uncompressed-sha256": "c665940bbbb9b31d8754de6e9876b572e8dc1b498c1973711f7cf8b419a29611"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "395ac291fd1edbd2df7bc07a6b22b31cfe159175eafeeb123fa4f851788d107c",
-                "uncompressed-sha256": "e1b139338b97fd27534df16522f86e2fba043f46817f88f292075bed36fc0150"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "e0745b4a91c57a5eb35645f62405d2d8a5df565e22e818bae4bda4035c910949",
+                "uncompressed-sha256": "5afd93c33db1753bc483c538cee62ccdcf00d40a4e4adef8e551680d93a9b333"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-powervs.ppc64le.ova.gz",
-                "sha256": "d9755b7f565316b211d3d424ce5123835bcf641d17faa0f4c2f05f63611c25ad",
-                "uncompressed-sha256": "52637ea364c433358b40f93c259e14d10ba5e4e65e61b094ad26ab9cc4108796"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-powervs.ppc64le.ova.gz",
+                "sha256": "48135456fda3293d8bf2c576ef835e361745948943d60215d0aacafe959bf11a",
+                "uncompressed-sha256": "a49772093de426f85eaafea354e5c5a5c0a8239f21a7b8132cccacdb0284fa3b"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "247383070819071ea6c811f325c1665742aa2deb573f95f44a960edc6d84155f",
-                "uncompressed-sha256": "5817d6df25ee0365f0fd832f086f48146b13447c067825f2df7ecd12cbe66274"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "7d82ee96f69ea7f0714b7db675ac7debbe812d4135cbbaa2bae02ced54d70723",
+                "uncompressed-sha256": "8a29cc9f8ce4d7c542b597a570c0098bfe8a5453f716b1d205987f190ad2ac6a"
               }
             }
           }
@@ -342,64 +342,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.6.20260520-0",
-              "object": "rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.6.20260616-0",
+              "object": "rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-6-20260616-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -408,99 +408,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "08b5548a5eb730e3c083128fec64febd5f1f12f4faaad1a014bc7e57b28b4ced",
-                "uncompressed-sha256": "e5feda27a305c86348ca7a461a5a1bf95bd430a586e1373d1eb37d615a56fb9b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "6dde8b98e2e1554091e5872a339ce0234f3bb48f6c72629256f787e323ebd3cb",
+                "uncompressed-sha256": "baf13e37bfc456193043611449edd9b489e37c48860073d244e4bc2088def635"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-kubevirt.s390x.ociarchive",
-                "sha256": "43104a64980b9755b78226603a031d86623a6152469d0278dc2d119a64aa616a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-kubevirt.s390x.ociarchive",
+                "sha256": "d758ab02e5c4250b544a6f1828fc8bb7d83d8eda3056d0ea22f36e38e4bc0d41"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-metal4k.s390x.raw.gz",
-                "sha256": "ada2954beab8c70acd2d05f2413cbb9f9df9f94fdc8ab41e5ce5f21e341d66cf",
-                "uncompressed-sha256": "433ede93d19ef8dbbe0e1c2202274d35df11dd2c532498cfa3f267b0b15ac346"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-metal4k.s390x.raw.gz",
+                "sha256": "95769798365d671a00a1c9d9ba5034f58126eb40cad841f1381113f765b6deb4",
+                "uncompressed-sha256": "1d9f1bc534ab8a7d8af2b9d8532040c79101658fe9c62071ff878a3975bf79a9"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-iso.s390x.iso",
-                "sha256": "10933a001012f33dc8ffd8b984c5b2f4ffd6e5cdf51855000142343309f4a704"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-live-iso.s390x.iso",
+                "sha256": "e39cbecfd3fe8e71ed16410936d21287286a34077d29c1fa46fc8b6c51a87348"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-kernel.s390x",
-                "sha256": "3d311df1dcfeb64f4430423b922649fa231c70df163a5ea91500bf38562fae46"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-live-kernel.s390x",
+                "sha256": "eb5360dbefd6bb4f6386689c615d9f37b8821a9e0bc57d9fdf0bef49ceffead5"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-initramfs.s390x.img",
-                "sha256": "772095b610c84af7d838ed9cca17160bf8dec80d6bab50d1757c641f3221bb38"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-live-initramfs.s390x.img",
+                "sha256": "00a2d56e8e3537fda76b2666f3750ae9c1beddbe4232b217bfc4cbc4cfecf395"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-rootfs.s390x.img",
-                "sha256": "87a072b7dc0f0f5f883049ca9d632b0907d02ce0f7a8067d3462a7a051c66421"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-live-rootfs.s390x.img",
+                "sha256": "4cf555354abbc1aa10938e214ec66de8cc94aa6a6080b55e9c3731c5c517a641"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-metal.s390x.raw.gz",
-                "sha256": "a68f6c64ab39db04b06f308feb40553c1e39ba6b543677db45b2ebf35a7f7a43",
-                "uncompressed-sha256": "04c0e00d080ef4f6eb52dec4b55e0f5c6b84049a65c34d70800214c39cf35d3f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-metal.s390x.raw.gz",
+                "sha256": "6887df9e628d202a528540d0f120a41a9b3797f22ad6d0e66bf4b5ccd05ff264",
+                "uncompressed-sha256": "083b725bad2ecbd9304e53f0be916c84f8942201c8b59bc62327f1225c0b06e6"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-openstack.s390x.qcow2.gz",
-                "sha256": "97252b4594d57aac6ffbb5a884650fe39ba6f25dd96ea97936c84f7440e2e30c",
-                "uncompressed-sha256": "1de76be5d171c7eb0e599b2871a5f2dec10a33d913086d6f5e699a952291e6c5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-openstack.s390x.qcow2.gz",
+                "sha256": "f688de2ac1f5872c03f0b0f2d479cca94dbe058c2131aee5127e3ddee8cc49bd",
+                "uncompressed-sha256": "21f763fbcd1ea96e9639e189ed3ebf3be734dffcbcd248389056392d133fba79"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-qemu.s390x.qcow2.gz",
-                "sha256": "507fdecaa79f149a68f1a44a7e795951766125a9151c4eb46adad19749100de1",
-                "uncompressed-sha256": "ef0feea3f868ae966aea98850cab67f2ce333a921a96a2a9970fbe3dfbd6e86e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-qemu.s390x.qcow2.gz",
+                "sha256": "22feb3ea535da643a5f1a97f663f94f3a3bca36cd7c7b4daf1065d44609d849f",
+                "uncompressed-sha256": "14c9c2d136da81be41a1799ce26c90e6634454e379281c6a9241937283b73911"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "06e7a623896d3c2d5a6698b423936e8b2003003ed7f9ae4be27c0c60325edd25",
-                "uncompressed-sha256": "f6dcdd36cc0b5101f64755fe2fa977e02efd2e19a8849dc8c7b64ea7b97ddf3d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "09c3a8a4961d714a8af0833617f1ab844f4735c368bcbd74629b8b645a74db0c",
+                "uncompressed-sha256": "aeb4513289dc5d51cecfc6d94a4f07054703a4b3fe9078a04af9c140fd89db46"
               }
             }
           }
@@ -508,165 +508,165 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9e498a892022c5bec60dacedea1af9f081690a02941197932eceb06415f5ed3b"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2e744e1ef99caf18253f688097a458387ad4eb1ce0243468cb68e9ea7e05bbaf"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-aws.x86_64.vmdk.gz",
-                "sha256": "b9a87e6b9f6dafda3a34671dc7954f86deda98297a4e7c943d0a80dd2414d2d9",
-                "uncompressed-sha256": "99705ff3ecff21a97bdc528005291a2534b3baf5c2d796c81e477eeb3c7650b3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-aws.x86_64.vmdk.gz",
+                "sha256": "9e811e3ca5b7dfb829d06bcf72b852a54bf7bdad95f3dcd3a2be4d5214a3d61e",
+                "uncompressed-sha256": "9d97a581ab858f90bfcb40cd72d43af5b37c8c445e9239ccbe716a8e53ac64a3"
               }
             }
           }
         },
         "azure": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-azure.x86_64.vhd.gz",
-                "sha256": "eeb4ea96d672a67818162345b015e6df54e124302b36084281ca1696006b3ce2",
-                "uncompressed-sha256": "3f12ef0d3f7e78abf63c9d8e1ab3e301e2b93bd0b9ece763bac4cd9369429821"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-azure.x86_64.vhd.gz",
+                "sha256": "6b8c7c7bd276d492ef7beec4629e0f7a0af0c0434445bde9423738737a79e755",
+                "uncompressed-sha256": "95688fcc9c49d3716a5932f57b400ec38b1d4257137b3769897eaa395b98879a"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-azurestack.x86_64.vhd.gz",
-                "sha256": "f2f2d165646de37f0ada28ecda9e79cf90d331660664d7d65d4ee1a80f1ba490",
-                "uncompressed-sha256": "02706cfb2c3ac1c5e6a16e74f7b819de8e14ab1aa78044afa1c85bd74fa2e1da"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-azurestack.x86_64.vhd.gz",
+                "sha256": "477efd90b21c04c473c6298a20f9b3cf608b7958ee798c8e76f9e82ca46d3ba2",
+                "uncompressed-sha256": "7d633262f1e21026638f95ed13da8587caa289a443c9c248eb752aaf7d877fa5"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-gcp.x86_64.tar.gz",
-                "sha256": "cf5cfba6d3000bc99c02593807477e4e5203cfc94333947b8c1bf4b559c35ef9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-gcp.x86_64.tar.gz",
+                "sha256": "9fefd75ede171fbcf455d1722b99941b6ec91b1645e97830adc6464ed1ba7c7c"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "acbf76fa75ee975035324c67c861a72ee47ce6b2e17d33238562b312375a1ffd",
-                "uncompressed-sha256": "eac100794dc01cce73f14926f9be94330c5086454a43e8eeab11584650a18898"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "241455b4c7f83cdfedd59838b8b844a6bc7e1515b176d65e36a9c7cb7e0da3be",
+                "uncompressed-sha256": "aaafd2aec88508367a29f457e8be9164250b393f9ca9d5729a44c4ba445d9da9"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-kubevirt.x86_64.ociarchive",
-                "sha256": "3dc2b67366aaadb7bae087df8f0aaf73ce466ef3206c31dd96b66ba997abafe6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-kubevirt.x86_64.ociarchive",
+                "sha256": "4b48647e7ca7db0ffa43e110eeabf6d35f52e15f097164b868bfd9424cff672b"
               }
             }
           }
         },
         "metal": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-metal4k.x86_64.raw.gz",
-                "sha256": "5671a8b409b1202abdc44e3d2c6f98340b72f7e1b16a52ad760e4d4ad69d8f7a",
-                "uncompressed-sha256": "778e3461b9ec563a402a159201b864f8442a578af3452cd8796149b2b1d9abdf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-metal4k.x86_64.raw.gz",
+                "sha256": "981a4dc74367acf5f25df3d45fc45c2b79c7e1b9623797e1c7737b7efe1de3a5",
+                "uncompressed-sha256": "2f2353e333fa9f9927470ba2dfb5276e85f32f934706af85905826f04de3b331"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-iso.x86_64.iso",
-                "sha256": "84d091a663eb4c192f0f4655ab501de43b570004b1650f6fbbd79f237310b581"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-live-iso.x86_64.iso",
+                "sha256": "dee4156b6ec28f25fa32c189d883fce29bf614af500714e77f673489883f29db"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-kernel.x86_64",
-                "sha256": "0e90dbd4f468fd31e8cbcd1a1c67948b86547693ee229eb5851d96b5338df93c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-live-kernel.x86_64",
+                "sha256": "4b1f47b7b13bc2593e3958e43a0185c741c7c6992614f0e0fc6b0a05e5a5dd1d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-initramfs.x86_64.img",
-                "sha256": "2fc4b72cc57ce5662a0fa87306eafe0f9faa18b7b204dc54fec9e5e5411b682b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-live-initramfs.x86_64.img",
+                "sha256": "c403ca40ee8b29ae52d341f19ec779f85c947ad6d04f122cd3881478917b4853"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-rootfs.x86_64.img",
-                "sha256": "a8ccc17ce859fe81df6334a3ea6d5410a7449609a8d69c126dd585170d4a3602"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-live-rootfs.x86_64.img",
+                "sha256": "1ab4ea402b061a0c26e5c7bde9d9eab2570e1308a7e1a41621b75fae09a57f06"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-metal.x86_64.raw.gz",
-                "sha256": "22ff26326df25a1fe45e515c7eda4c6d604bd9f4c58202aaf2e892c649b5d0b8",
-                "uncompressed-sha256": "bda67eae9b820a14227176e5ca6cfb910370042063fe55a2bdf954f3b972ff53"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-metal.x86_64.raw.gz",
+                "sha256": "3ddc1d0cbab1110ffdee77e90d78bc1e7c380cd2416e214d31a2be28cdbda848",
+                "uncompressed-sha256": "7d9f905eb293f3b5c0bb2765c16f085b3b4e9bb57003b4dc4b415302a98f2b50"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-nutanix.x86_64.qcow2",
-                "sha256": "6f493408f35399cf47e44fa1464fcaee2f767df9191c8af00a4b8fe759b4ddbc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-nutanix.x86_64.qcow2",
+                "sha256": "d3a8577c7f17790a4ff8d05cc4bf5c9824520ca507025283f5e5363de75ea725"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-openstack.x86_64.qcow2.gz",
-                "sha256": "c80ebe3ace21a7ab59286c57545e3f7cfa9082f3114610fbb80c51769f2ac471",
-                "uncompressed-sha256": "ee11fc8e6a0a2c795907f5ee7bd7b8889f12474bf0cf8e98f8904f7ddcc1f2b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-openstack.x86_64.qcow2.gz",
+                "sha256": "0d17b529b5a4dfe5bb9211b8a1d239f2a3299d67924338ba350da58d95f7c2d0",
+                "uncompressed-sha256": "9a506cf185ea506819a9a9fe01cd87cf373399358d75bd401ac462b288f7f546"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-qemu.x86_64.qcow2.gz",
-                "sha256": "1e13019dfad15a8813995a9df4a0f5370648e1b81f1432536e50ba55b745db89",
-                "uncompressed-sha256": "c736887ce8d73b0562776ba4796b087a3230ebfd603d3a06b3be1de113451b26"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-qemu.x86_64.qcow2.gz",
+                "sha256": "67957da8dc9074487fc9878a867043193b9867700d02dd5e3abb9e2787a5e85b",
+                "uncompressed-sha256": "b27c3c63319b8a00d2f34c18e48d7a7f911b358ec2ad419d93ea8e70e15b7de3"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-vmware.x86_64.ova",
-                "sha256": "3756ba40964e93779640ca7d20abbe981498eec94c410e6cbfcc6ddcd051728a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-vmware.x86_64.ova",
+                "sha256": "8b93c541c865761af2e4a19e549b3e22305bf6f03a606f2c1a79a60a5badfebd"
               }
             }
           }
@@ -676,290 +676,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-069ec25f081cb5cff"
+              "release": "9.6.20260616-0",
+              "image": "ami-07a3f62910edeeb2f"
             },
             "ap-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06a2691ae27fe2f37"
+              "release": "9.6.20260616-0",
+              "image": "ami-07ff0af64f64d97e7"
             },
             "ap-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0568f3afd49332306"
+              "release": "9.6.20260616-0",
+              "image": "ami-0710f3c820fe97d27"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00785c74b02b6f722"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f9c2cdfa1e965dcc"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00c6e17c9645be69f"
+              "release": "9.6.20260616-0",
+              "image": "ami-0af00425fed7729b2"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06039543d5c8d5f3e"
+              "release": "9.6.20260616-0",
+              "image": "ami-0aece3afd09f87c4d"
             },
             "ap-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-07c85cc08d4bc0d98"
+              "release": "9.6.20260616-0",
+              "image": "ami-01b0e8f81ef7e1f90"
             },
             "ap-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04035ca91d49e6735"
+              "release": "9.6.20260616-0",
+              "image": "ami-0778febe791f7a147"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04a762864127fd5ac"
+              "release": "9.6.20260616-0",
+              "image": "ami-0aca5cb2df4f2bb2a"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-086d4cabcd06ba59a"
+              "release": "9.6.20260616-0",
+              "image": "ami-04f3cd740e144f007"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0ff0fd0ccdb0d31c2"
+              "release": "9.6.20260616-0",
+              "image": "ami-0727f69726af1e7cd"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0059f9be0ccdfd4f1"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b788baf223113bd2"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0f8a95d604562562b"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d2377ce2f7e13d61"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260520-0",
-              "image": "ami-045092ba047642020"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d9555bc3adcae8dc"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00ffe3c651aa7f1b7"
+              "release": "9.6.20260616-0",
+              "image": "ami-0467c5123ecbb3cbb"
             },
             "ca-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0c554f16216af806b"
+              "release": "9.6.20260616-0",
+              "image": "ami-03d00b9f9240a261a"
             },
             "ca-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-08bc06f8a5f8564aa"
+              "release": "9.6.20260616-0",
+              "image": "ami-0915771aa462f853d"
             },
             "eu-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0b31eb834d5676043"
+              "release": "9.6.20260616-0",
+              "image": "ami-09c5c4bc0b71bb2ca"
             },
             "eu-central-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-067c8ed2801cc0693"
+              "release": "9.6.20260616-0",
+              "image": "ami-03bd70f20838f77a2"
             },
             "eu-north-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0f8259fb88cd731a9"
+              "release": "9.6.20260616-0",
+              "image": "ami-03139233329e92153"
             },
             "eu-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0dd4df7a128ebdc01"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b0e8ad5c334ddcd3"
             },
             "eu-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-02c3b1b12be3a773e"
+              "release": "9.6.20260616-0",
+              "image": "ami-002500067c42572a4"
             },
             "eu-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09bd7a48295c3e52f"
+              "release": "9.6.20260616-0",
+              "image": "ami-08fd1bf9720dcf92a"
             },
             "eu-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00bb16f1535810e64"
+              "release": "9.6.20260616-0",
+              "image": "ami-0d37132df321da103"
             },
             "eu-west-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0788b88cffa35a98e"
+              "release": "9.6.20260616-0",
+              "image": "ami-06d453e6678ff73df"
             },
             "il-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0fedec19a27a5eb0d"
+              "release": "9.6.20260616-0",
+              "image": "ami-091cade5a5c322bb0"
             },
             "mx-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0a24006031e26190a"
+              "release": "9.6.20260616-0",
+              "image": "ami-079bceaf7aa8476fc"
             },
             "sa-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0d4e81477fe9a1073"
+              "release": "9.6.20260616-0",
+              "image": "ami-0c1ee520443376ddd"
             },
             "us-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-02807a245a41410eb"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b7812c349a73ee5c"
             },
             "us-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0904e5e509c505775"
+              "release": "9.6.20260616-0",
+              "image": "ami-066f6520fec24bf28"
             },
             "us-gov-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09150a1378faa930d"
+              "release": "9.6.20260616-0",
+              "image": "ami-037ade8da555b96dc"
             },
             "us-gov-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06512f09d894326a7"
+              "release": "9.6.20260616-0",
+              "image": "ami-0a851af0c334249ef"
             },
             "us-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-03728955b9e5f218b"
+              "release": "9.6.20260616-0",
+              "image": "ami-0ead99f7c0c2202e7"
             },
             "us-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0f518858c9c61520f"
+              "release": "9.6.20260616-0",
+              "image": "ami-00ed84a07420727b7"
             }
           }
         },
         "gcp": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-6-20260520-0-gcp-x86-64"
+          "name": "rhcos-9-6-20260616-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.6.20260520-0",
+          "release": "9.6.20260616-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aa9f0af3dd0180af3693021a8ac58134cfa73727d99c1f339265430ec2786b46"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0879374df1ae993f6422f0f8fc24ad0e044e66769542052727c6f643a01df3a4"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04d2a975eee689fc4"
+              "release": "9.6.20260616-0",
+              "image": "ami-0ae6f99094809f85d"
             },
             "ap-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09727182661090fd9"
+              "release": "9.6.20260616-0",
+              "image": "ami-02fc548a2da5f950e"
             },
             "ap-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-023a55d2f06f1480a"
+              "release": "9.6.20260616-0",
+              "image": "ami-04dc68555e4615089"
             },
             "ap-northeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-05627624911920688"
+              "release": "9.6.20260616-0",
+              "image": "ami-0bf1758df21ea0664"
             },
             "ap-northeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-054138b8f6ecd7385"
+              "release": "9.6.20260616-0",
+              "image": "ami-04060a95bcdef0931"
             },
             "ap-northeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-020fa1a0a37df5029"
+              "release": "9.6.20260616-0",
+              "image": "ami-03ee9833cd0dab807"
             },
             "ap-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-01b0fc3eb9511e5ac"
+              "release": "9.6.20260616-0",
+              "image": "ami-081eca0b9cd68c4b7"
             },
             "ap-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-05f8e4731d31e606b"
+              "release": "9.6.20260616-0",
+              "image": "ami-00fd8011522d0dc89"
             },
             "ap-southeast-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-068e9f19d41e3fa46"
+              "release": "9.6.20260616-0",
+              "image": "ami-02917341d27e2961a"
             },
             "ap-southeast-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0181476ce34b94faa"
+              "release": "9.6.20260616-0",
+              "image": "ami-02a13471f7e327836"
             },
             "ap-southeast-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0df1c20285cd7bde8"
+              "release": "9.6.20260616-0",
+              "image": "ami-05c2702fdcd353d3f"
             },
             "ap-southeast-4": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09299807162fad231"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f85f0de1b8ffb89f"
             },
             "ap-southeast-5": {
-              "release": "9.6.20260520-0",
-              "image": "ami-013b8fd48c1c1aaaa"
+              "release": "9.6.20260616-0",
+              "image": "ami-088ff0f1310a55ed3"
             },
             "ap-southeast-6": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0ff7ca07d83e23777"
+              "release": "9.6.20260616-0",
+              "image": "ami-05265010af0fdffc2"
             },
             "ap-southeast-7": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0ab2ff1808712829f"
+              "release": "9.6.20260616-0",
+              "image": "ami-0997625a0b3b17b7b"
             },
             "ca-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-02648dab71c926ccf"
+              "release": "9.6.20260616-0",
+              "image": "ami-0a3d8604d85421c37"
             },
             "ca-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0e9a86f69876d1fa0"
+              "release": "9.6.20260616-0",
+              "image": "ami-047a2019256fc0337"
             },
             "eu-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00825db7899983a0c"
+              "release": "9.6.20260616-0",
+              "image": "ami-0f51e2436e0ed93ef"
             },
             "eu-central-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0e59a9d88cd401e85"
+              "release": "9.6.20260616-0",
+              "image": "ami-03b8eff85f2a58e72"
             },
             "eu-north-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-09a1f839c6a739ed0"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b466c0b9aef94dd0"
             },
             "eu-south-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0fcbfc54371e9351a"
+              "release": "9.6.20260616-0",
+              "image": "ami-06b996a0fda23a630"
             },
             "eu-south-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0dde4bfa70ab40729"
+              "release": "9.6.20260616-0",
+              "image": "ami-0992ef55289facd95"
             },
             "eu-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0464b57c2ed725feb"
+              "release": "9.6.20260616-0",
+              "image": "ami-0dc6207ff4d0d1106"
             },
             "eu-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-03602d58bf40955e9"
+              "release": "9.6.20260616-0",
+              "image": "ami-002073dd8600d9d2a"
             },
             "eu-west-3": {
-              "release": "9.6.20260520-0",
-              "image": "ami-085ba4472d53e106d"
+              "release": "9.6.20260616-0",
+              "image": "ami-0644cd307265d0e99"
             },
             "il-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-01b3fb973a85b1455"
+              "release": "9.6.20260616-0",
+              "image": "ami-03faebf603479dd17"
             },
             "mx-central-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-0c61cc9e0ab985c98"
+              "release": "9.6.20260616-0",
+              "image": "ami-08cbcc05ecf96cae4"
             },
             "sa-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-02399b36bfc535980"
+              "release": "9.6.20260616-0",
+              "image": "ami-0c8960e194067cc7a"
             },
             "us-east-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-04d43de815332996a"
+              "release": "9.6.20260616-0",
+              "image": "ami-0c89129a28e086719"
             },
             "us-east-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-06492635911977bb0"
+              "release": "9.6.20260616-0",
+              "image": "ami-08d9d1178ede60f7f"
             },
             "us-west-1": {
-              "release": "9.6.20260520-0",
-              "image": "ami-00ba9aed278b41571"
+              "release": "9.6.20260616-0",
+              "image": "ami-08fc5e394878f3818"
             },
             "us-west-2": {
-              "release": "9.6.20260520-0",
-              "image": "ami-015f9eac1e40f6935"
+              "release": "9.6.20260616-0",
+              "image": "ami-0b6cd331d00b78789"
             }
           }
         },
         "azure-disk": {
-          "release": "9.6.20260520-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260520-0-azure.x86_64.vhd"
+          "release": "9.6.20260616-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.6.20260616-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
Bootimage-bump done to keep rhel-9.6 in sync with 4.20 bootimage bump - https://redhat.atlassian.net/browse/OCPBUGS-89242

```
plume cosa2stream --target data/data/coreos/rhcos.json                 \
    --distro rhcos --no-signatures --name rhel-9.6                     \
    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \
    x86_64=9.6.20260616-0                                              \
    aarch64=9.6.20260616-0                                             \
    s390x=9.6.20260616-0                                               \
    ppc64le=9.6.20260616-0
```