### PR TITLE
no-jira: dynamically set CVO upgrade version

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,7 +8,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.22
+  channel: {{.CVOChannel}}
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/templates/content/manifests"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/version/versioninfo"
 	"github.com/openshift/library-go/pkg/crypto"
 )
 
@@ -170,8 +172,12 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		rootCA,
 	)
 
+	versionInfo := versioninfo.GetInfo()
+	cvoChannel := fmt.Sprintf("stable-%d.%d", versionInfo.Major, versionInfo.Minor)
+
 	templateData := &bootkubeTemplateData{
 		CVOCapabilities:       installConfig.Config.Capabilities,
+		CVOChannel:            cvoChannel,
 		CVOClusterID:          clusterID.UUID,
 		McsTLSCert:            base64.StdEncoding.EncodeToString(mcsCertKey.Cert()),
 		McsTLSKey:             base64.StdEncoding.EncodeToString(mcsCertKey.Key()),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -67,6 +67,7 @@ type cloudCredsSecretData struct {
 
 type bootkubeTemplateData struct {
 	CVOCapabilities            *types.Capabilities
+	CVOChannel                 string
 	CVOClusterID               string
 	EtcdCaBundle               string
 	EtcdMetricCaCert           string


### PR DESCRIPTION
Utilize version info from build & git tags so that we no longer need to manually update the hardcoded version in the CVO upgrade manifest.

For CI & local development, we will need to make sure git tags are updated after branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The installer now automatically sets the release channel based on the detected OpenShift version for SCOS-based environments.
  * Channel selection is no longer fixed to a single version, improving compatibility across supported releases.

* **Bug Fixes**
  * Updated cluster version configuration to avoid using a hardcoded channel value in SCOS scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->