### PR TITLE
CORS-3898: azure: Fix the dualstack errors

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -479,9 +479,14 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 	var extLBFQDN string
 	if in.InstallConfig.Config.PublicAPI() {
 		var publicIPv6 *armnetwork.PublicIPAddress
+		v4InfraID := in.InfraID
+		v6InfraID := ""
+		if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
+			v6InfraID = fmt.Sprintf("%s-v6", in.InfraID)
+		}
 		publicIP, err := createPublicIP(ctx, &pipInput{
 			name:          fmt.Sprintf("%s-pip-v4", in.InfraID),
-			infraID:       in.InfraID,
+			infraID:       v4InfraID,
 			region:        in.InstallConfig.Config.Azure.Region,
 			resourceGroup: resourceGroupName,
 			pipClient:     networkClientFactory.NewPublicIPAddressesClient(),
@@ -495,7 +500,7 @@ func (p *Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput
 		if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
 			publicIPv6, err = createPublicIP(ctx, &pipInput{
 				name:          fmt.Sprintf("%s-pip-v6", in.InfraID),
-				infraID:       in.InfraID,
+				infraID:       v6InfraID,
 				region:        in.InstallConfig.Config.Azure.Region,
 				resourceGroup: resourceGroupName,
 				pipClient:     networkClientFactory.NewPublicIPAddressesClient(),
@@ -661,27 +666,6 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 
 		// For dual-stack, create IPv6 inbound rule for SSH access to bootstrap.
 		if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
-			publicIPv6outbound, err := createPublicIP(ctx, &pipInput{
-				name:          fmt.Sprintf("%s-pip-v6-outbound-lb", in.InfraID),
-				infraID:       in.InfraID,
-				region:        in.InstallConfig.Config.Azure.Region,
-				resourceGroup: p.ResourceGroupName,
-				pipClient:     p.NetworkClientFactory.NewPublicIPAddressesClient(),
-				tags:          p.Tags,
-				ipversion:     armnetwork.IPVersionIPv6,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to create public ipv6 for outbound ipv6 lb: %w", err)
-			}
-			logrus.Debugf("created public ipv6 for outbound ipv6 lb: %s", *publicIPv6outbound.ID)
-
-			// Update the outbound node IPv6 load balancer.
-			outboundLBName := fmt.Sprintf("%s-ipv6-outbound-node-lb", in.InfraID)
-			err = updateOutboundIPv6LoadBalancer(ctx, publicIPv6outbound, p.NetworkClientFactory.NewLoadBalancersClient(), p.ResourceGroupName, outboundLBName, in.InfraID)
-			if err != nil {
-				return fmt.Errorf("failed to set public ipv6 to outbound ipv6 lb: %w", err)
-			}
-			logrus.Debugf("updated outbound ipv6 lb %s with public ipv6: %s", outboundLBName, *publicIPv6outbound.ID)
 			frontendIPv6ConfigName := "public-lb-ip-v6"
 			sshRuleNameV6 := fmt.Sprintf("%s_ssh_in_v6", in.InfraID)
 			frontendIPv6ConfigID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s",
@@ -716,6 +700,42 @@ func (p *Provider) PostProvision(ctx context.Context, in clusterapi.PostProvisio
 				return fmt.Errorf("failed to associate IPv6 SSH inbound nat rule to interface: %w", err)
 			}
 		}
+	}
+
+	if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
+		bootstrapNicName := fmt.Sprintf("%s-bootstrap-nic", in.InfraID)
+		nicClient := p.NetworkClientFactory.NewInterfacesClient()
+		bootstrapNic, err := nicClient.Get(ctx, p.ResourceGroupName, bootstrapNicName, nil)
+		if err != nil {
+			return fmt.Errorf("failed to get bootstrap nic: %w", err)
+		}
+		for _, ipconfig := range bootstrapNic.Properties.IPConfigurations {
+			if ipconfig.Properties.PrivateIPAddressVersion != nil && *ipconfig.Properties.PrivateIPAddressVersion == armnetwork.IPVersionIPv6 {
+				existing := make(map[string]bool)
+				for _, ep := range ipconfig.Properties.LoadBalancerBackendAddressPools {
+					if ep.ID != nil {
+						existing[*ep.ID] = true
+					}
+				}
+				for _, pool := range p.lbBackendAddressPools {
+					if pool.Name != nil && strings.HasSuffix(*pool.Name, "-v6") && pool.ID != nil && !existing[*pool.ID] {
+						ipconfig.Properties.LoadBalancerBackendAddressPools = append(
+							ipconfig.Properties.LoadBalancerBackendAddressPools,
+							pool,
+						)
+					}
+				}
+			}
+		}
+		pollerResp, err := nicClient.BeginCreateOrUpdate(ctx, p.ResourceGroupName, bootstrapNicName, bootstrapNic.Interface, nil)
+		if err != nil {
+			return fmt.Errorf("failed to update bootstrap nic with IPv6 backend pools: %w", err)
+		}
+		_, err = pollerResp.PollUntilDone(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to update bootstrap nic with IPv6 backend pools: %w", err)
+		}
+		logrus.Debugf("associated bootstrap NIC with IPv6 backend pools")
 	}
 
 	return nil

--- a/pkg/infrastructure/azure/dns.go
+++ b/pkg/infrastructure/azure/dns.go
@@ -38,7 +38,7 @@ type recordPrivateList struct {
 }
 
 // Create DNS entries for azure.
-func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBFQDN, publicIP, intIPv6IP, resourceGroup string, opts *arm.ClientOptions) error {
+func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBFQDN, publicIP, publicIPv6, resourceGroup string, opts *arm.ClientOptions) error {
 	baseDomainResourceGroup := in.InstallConfig.Config.Azure.BaseDomainResourceGroupName
 	zone := in.InstallConfig.Config.BaseDomain
 	privatezone := in.InstallConfig.Config.ClusterDomain()
@@ -123,18 +123,19 @@ func createDNSEntries(ctx context.Context, in clusterapi.InfraReadyInput, extLBF
 	// Create the records for api and api-int in the private zone and api.<clustername> for public zone.
 	// CAPI currently creates a record called "apiserver" instead of "api" so creating "api" for the installer in the private zone.
 	if in.InstallConfig.Config.PublicAPI() {
-		cnameRecordName := apiExternalName
-		// if useIPv6 {
-		// 	cnameRecordName = apiExternalNameV6
-		// }
-		publicRecords := createRecordSet(cnameRecordName, azureTags, ttl, cname, "", extLBFQDN)
-		_, err = recordSetClient.CreateOrUpdate(ctx, baseDomainResourceGroup, zone, publicRecords.Name, publicRecords.RecordType, publicRecords.RecordSet, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create public record set: %w", err)
-		}
 		if in.InstallConfig.Config.Azure.IPFamily.DualStackEnabled() {
-			apiExternalNameV6 := fmt.Sprintf("api.%s", in.InstallConfig.Config.ObjectMeta.Name)
-			publicRecords := createRecordSet(apiExternalNameV6, azureTags, ttl, cname, "", extLBFQDN)
+			aRecord := createRecordSet(apiExternalName, azureTags, ttl, arecord, publicIP, "")
+			_, err = recordSetClient.CreateOrUpdate(ctx, baseDomainResourceGroup, zone, aRecord.Name, aRecord.RecordType, aRecord.RecordSet, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create public A record set: %w", err)
+			}
+			aaaaRecord := createRecordSet(apiExternalName, azureTags, ttl, aaaarecord, publicIPv6, "")
+			_, err = recordSetClient.CreateOrUpdate(ctx, baseDomainResourceGroup, zone, aaaaRecord.Name, aaaaRecord.RecordType, aaaaRecord.RecordSet, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create public AAAA record set: %w", err)
+			}
+		} else {
+			publicRecords := createRecordSet(apiExternalName, azureTags, ttl, cname, "", extLBFQDN)
 			_, err = recordSetClient.CreateOrUpdate(ctx, baseDomainResourceGroup, zone, publicRecords.Name, publicRecords.RecordType, publicRecords.RecordSet, nil)
 			if err != nil {
 				return fmt.Errorf("failed to create public record set: %w", err)

--- a/pkg/infrastructure/azure/network.go
+++ b/pkg/infrastructure/azure/network.go
@@ -73,6 +73,15 @@ type inboundNatRuleInput struct {
 }
 
 func createPublicIP(ctx context.Context, in *pipInput) (*armnetwork.PublicIPAddress, error) {
+	properties := &armnetwork.PublicIPAddressPropertiesFormat{
+		PublicIPAddressVersion:   to.Ptr(in.ipversion),
+		PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+	}
+	if in.infraID != "" {
+		properties.DNSSettings = &armnetwork.PublicIPAddressDNSSettings{
+			DomainNameLabel: to.Ptr(in.infraID),
+		}
+	}
 	pollerResp, err := in.pipClient.BeginCreateOrUpdate(
 		ctx,
 		in.resourceGroup,
@@ -84,14 +93,8 @@ func createPublicIP(ctx context.Context, in *pipInput) (*armnetwork.PublicIPAddr
 				Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
 				Tier: to.Ptr(armnetwork.PublicIPAddressSKUTierRegional),
 			},
-			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
-				PublicIPAddressVersion:   to.Ptr(in.ipversion),
-				PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
-				DNSSettings: &armnetwork.PublicIPAddressDNSSettings{
-					DomainNameLabel: to.Ptr(in.infraID),
-				},
-			},
-			Tags: in.tags,
+			Properties: properties,
+			Tags:       in.tags,
 		},
 		nil,
 	)
@@ -274,27 +277,30 @@ func updateOutboundLoadBalancerToAPILoadBalancer(ctx context.Context, pip, pipv6
 		})
 
 	// Add IPv4 load balancing rule
-	extLB.Properties.LoadBalancingRules = append(extLB.Properties.LoadBalancingRules,
-		&armnetwork.LoadBalancingRule{
-			Name: to.Ptr("api-v4"),
-			Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
-				Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
-				FrontendPort:         to.Ptr[int32](6443),
-				BackendPort:          to.Ptr[int32](6443),
-				IdleTimeoutInMinutes: to.Ptr[int32](30),
-				EnableFloatingIP:     to.Ptr(false),
-				LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
-				FrontendIPConfiguration: &armnetwork.SubResource{
-					ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s-v4", in.idPrefix, in.loadBalancerName, in.frontendIPConfigName)),
-				},
-				BackendAddressPool: &armnetwork.SubResource{
-					ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, in.backendAddressPoolName)),
-				},
-				Probe: &armnetwork.SubResource{
-					ID: to.Ptr(fmt.Sprintf("/%s/%s/probes/%s", in.idPrefix, in.loadBalancerName, probeName)),
-				},
+	loadBalancerv4Rule := armnetwork.LoadBalancingRule{
+		Name: to.Ptr("api-v4"),
+		Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+			Protocol:             to.Ptr(armnetwork.TransportProtocolTCP),
+			FrontendPort:         to.Ptr[int32](6443),
+			BackendPort:          to.Ptr[int32](6443),
+			IdleTimeoutInMinutes: to.Ptr[int32](30),
+			EnableFloatingIP:     to.Ptr(false),
+			LoadDistribution:     to.Ptr(armnetwork.LoadDistributionDefault),
+			FrontendIPConfiguration: &armnetwork.SubResource{
+				ID: to.Ptr(fmt.Sprintf("/%s/%s/frontendIPConfigurations/%s-v4", in.idPrefix, in.loadBalancerName, in.frontendIPConfigName)),
 			},
-		})
+			BackendAddressPool: &armnetwork.SubResource{
+				ID: to.Ptr(fmt.Sprintf("/%s/%s/backendAddressPools/%s", in.idPrefix, in.loadBalancerName, in.backendAddressPoolName)),
+			},
+			Probe: &armnetwork.SubResource{
+				ID: to.Ptr(fmt.Sprintf("/%s/%s/probes/%s", in.idPrefix, in.loadBalancerName, probeName)),
+			},
+		},
+	}
+	if in.isDualstack {
+		loadBalancerv4Rule.Properties.DisableOutboundSnat = to.Ptr(true)
+	}
+	extLB.Properties.LoadBalancingRules = append(extLB.Properties.LoadBalancingRules, &loadBalancerv4Rule)
 
 	if in.isDualstack {
 		frontendIPv6Name := to.Ptr(fmt.Sprintf("%s-v6", in.frontendIPConfigName))
@@ -763,32 +769,4 @@ func associateNatGatewayToSubnet(ctx context.Context, in natGatewayInput) error 
 		}
 	}
 	return nil
-}
-
-func updateOutboundIPv6LoadBalancer(ctx context.Context, pipv6 *armnetwork.PublicIPAddress, lbClient *armnetwork.LoadBalancersClient, resourceGroup, loadBalancerName, infraID string) error {
-	outboundIPv6LB, err := lbClient.Get(ctx, resourceGroup, loadBalancerName, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get external load balancer: %w", err)
-	}
-
-	loadBalancer := outboundIPv6LB.LoadBalancer
-	loadBalancer.Properties.FrontendIPConfigurations = append(loadBalancer.Properties.FrontendIPConfigurations, &armnetwork.FrontendIPConfiguration{
-		Name: to.Ptr(fmt.Sprintf("%s-frontend-ipv6", infraID)),
-		Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-			PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
-			PublicIPAddress:           pipv6,
-		},
-	})
-
-	pollerResp, err := lbClient.BeginCreateOrUpdate(ctx,
-		resourceGroup,
-		loadBalancerName,
-		loadBalancer, nil)
-
-	if err != nil {
-		return fmt.Errorf("cannot update outbound node ipv6 load balancer: %w", err)
-	}
-
-	_, err = pollerResp.PollUntilDone(ctx, nil)
-	return err
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -439,7 +439,7 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv4 network in this list"))
 			}
 
-			allErrs = append(allErrs, validateNetworkEntryOrder(p, v, addresses[k], allowV6Primary, field.NewPath("networking", k))...)
+			allErrs = append(allErrs, validateNetworkEntryOrder(p, v, addresses[k], allowV6Primary, k, field.NewPath("networking", k))...)
 		}
 
 	case hasIPv6:
@@ -490,7 +490,7 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 // - IPv4 primary dual-stack: IPv4 CIDR first in list
 // - IPv6 primary dual-stack: IPv6 CIDR first in list
 // Some platforms have an explicit field to define the dual-stack variant, for example, platform.aws.ipFamily on AWS.
-func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, networks []ipnet.IPNet, allowV6Primary bool, fldPath *field.Path) field.ErrorList {
+func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, networks []ipnet.IPNet, allowV6Primary bool, networkType string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// If missing either IPv4 or IPv6 CIDR, order validation is not applicable
@@ -510,6 +510,14 @@ func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, n
 		if ipFamily == network.DualStackIPv6Primary && ipAddressType.Primary == corev1.IPv4Protocol {
 			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "DualStackIPv6Primary requires an IPv6 network first in this list"))
 		}
+	case p.Azure != nil:
+		// Azure nodes always have IPv4 as the primary NIC address, so serviceNetwork
+		// must have IPv4 first regardless of ipFamily. The kube-apiserver requires the
+		// primary service IP family to match the node's address family.
+		if networkType == networkTypeService && ipAddressType.Primary != corev1.IPv4Protocol {
+			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "Azure requires an IPv4 service network first in this list because node primary addresses are always IPv4"))
+		}
+
 	default:
 		// For platforms that don't support IPv6-primary dual-stack, reject configurations with IPv6 CIDRs listed first.
 		if !allowV6Primary && ipAddressType.Primary != corev1.IPv4Protocol {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -318,7 +318,7 @@ func TestValidateInstallConfig(t *testing.T) {
 		name             string
 		installConfig    *types.InstallConfig
 		expectedError    string
-		restoreFnFactory func(*types.InstallConfig) func()
+		restoreFnFactory func(*testing.T, *types.InstallConfig) func()
 	}{
 		{
 			name:          "minimal",
@@ -1977,6 +1977,80 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `networking.serviceNetwork: Invalid value: "ffd1::/112": when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type`,
 		},
 		{
+			name: "azure: valid dual-stack with DualStackIPv6Primary and IPv4-first serviceNetwork",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform.Azure.IPFamily = network.DualStackIPv6Primary
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"AzureDualStackInstall=true"}
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				c.Networking.ServiceNetwork = []ipnet.IPNet{
+					*ipnet.MustParseCIDR("172.30.0.0/16"),
+					*ipnet.MustParseCIDR("ffd1::/112"),
+				}
+				return c
+			}(),
+			restoreFnFactory: func(t *testing.T, _ *types.InstallConfig) func() {
+				t.Helper()
+				t.Setenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK", "true")
+				return func() {}
+			},
+		},
+		{
+			name: "azure: valid dual-stack with DualStackIPv4Primary",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform.Azure.IPFamily = network.DualStackIPv4Primary
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"AzureDualStackInstall=true"}
+				c.Networking = validDualStackNetworkingConfig()
+				return c
+			}(),
+			restoreFnFactory: func(t *testing.T, _ *types.InstallConfig) func() {
+				t.Helper()
+				t.Setenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK", "true")
+				return func() {}
+			},
+		},
+		{
+			name: "azure: invalid dual-stack with IPv6-first serviceNetwork",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform.Azure.IPFamily = network.DualStackIPv6Primary
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"AzureDualStackInstall=true"}
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `networking.serviceNetwork: Invalid value: "ffd1::/112, 172.30.0.0/16": Azure requires an IPv4 service network first in this list because node primary addresses are always IPv4`,
+			restoreFnFactory: func(t *testing.T, _ *types.InstallConfig) func() {
+				t.Helper()
+				t.Setenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK", "true")
+				return func() {}
+			},
+		},
+		{
+			name: "azure: invalid dual-stack with DualStackIPv4Primary but IPv6-primary networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform.Azure.IPFamily = network.DualStackIPv4Primary
+				c.FeatureSet = configv1.CustomNoUpgrade
+				c.FeatureGates = []string{"AzureDualStackInstall=true"}
+				c.Networking = validPrimaryV6DualStackNetworkingConfig()
+				return c
+			}(),
+			expectedError: `^\Qnetworking.serviceNetwork: Invalid value: "ffd1::/112, 172.30.0.0/16": Azure requires an IPv4 service network first in this list because node primary addresses are always IPv4\E$`,
+			restoreFnFactory: func(t *testing.T, _ *types.InstallConfig) func() {
+				t.Helper()
+				t.Setenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK", "true")
+				return func() {}
+			},
+		},
+		{
 			name: "invalid IPv6 hostprefix",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -3063,7 +3137,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: "osImageStream: Unsupported value: \"rhel-10\": supported values: \"centos-10\"",
-			restoreFnFactory: func(config *types.InstallConfig) func() {
+			restoreFnFactory: func(_ *testing.T, config *types.InstallConfig) func() {
 				old := types.SCOS
 				types.SCOS = true
 				return func() {
@@ -3150,7 +3224,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			if tc.restoreFnFactory != nil {
 				// Call the FN getter to allow restore function to grab
 				// pre-test values if needed
-				fn := tc.restoreFnFactory(tc.installConfig)
+				fn := tc.restoreFnFactory(t, tc.installConfig)
 				defer fn()
 			}
 


### PR DESCRIPTION
Fixing a few errors like DNS conflict with ipv4 and ipv6 entry,
setting the right load balancer backend pools and adding a validation
check since serviceNetwork ips need to be ipv4 first irrespective
of ipfamily primary type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Azure dual-stack provisioning by creating distinct IPv4 and IPv6 public IP resources and wiring IPv6 backend pools appropriately.
* **Bug Fixes**
  * Fixed Azure service network CIDR ordering validation to require IPv4-first for dual-stack scenarios.
  * Updated Azure public IP DNS behavior for dual-stack (AAAAs for IPv6 instead of CNAMEs, with safer DNS-label handling).
  * Refined dual-stack outbound load balancer behavior and removed an unnecessary IPv6 public IP step during SSH inbound setup.
* **Tests**
  * Expanded Azure dual-stack install-config validation coverage for multiple service-network ordering cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->