### PR TITLE
Use CAPI featuregate for CAPI aws worker machinesets

### DIFF
--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -40,21 +40,14 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform *types.Platform, fgat
 		}
 	}
 
-	// Set management to ClusterAPI if the appropriate feature gate is enabled and management is unspecified
-	if p.Management == "" {
-		if p.Name == types.MachinePoolControlPlaneRoleName && fgates.Enabled(features.FeatureGateClusterAPIControlPlaneInstall) {
-			p.Management = types.ClusterAPI
-		}
-		if p.Name == types.MachinePoolComputeRoleName && fgates.Enabled(features.FeatureGateClusterAPIComputeInstall) {
-			p.Management = types.ClusterAPI
-		}
-		if p.Name == types.MachinePoolEdgeRoleName && fgates.Enabled(features.FeatureGateClusterAPIComputeInstall) {
-			p.Management = types.ClusterAPI
-		}
-	}
-
 	switch platform.Name() {
 	case aws.Name:
+		if p.Management == "" && fgates.Enabled(features.FeatureGateClusterAPIMachineManagementAWS) {
+			switch p.Name {
+			case types.MachinePoolComputeRoleName, types.MachinePoolEdgeRoleName:
+				p.Management = types.ClusterAPI
+			}
+		}
 		if p.Platform.AWS == nil && platform.AWS.DefaultMachinePlatform != nil {
 			p.Platform.AWS = &aws.MachinePool{}
 		}

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -7,7 +7,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/aws"
+	gcp "github.com/openshift/installer/pkg/types/gcp"
 )
 
 func defaultMachinePoolWithReplicaCount(name string, replicaCount int) *types.MachinePool {
@@ -144,74 +145,68 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 }
 
 func TestSetMachinePoolDefaultsWithFeatureGates(t *testing.T) {
+	awsPlatform := &types.Platform{AWS: &aws.Platform{}}
+
 	cases := []struct {
 		name               string
 		pool               *types.MachinePool
 		platform           *types.Platform
-		featureSet         configv1.FeatureSet
+		featureGates       []string
 		expectedManagement types.MachineManagementAPI
 	}{
 		{
-			name:               "control plane with DevPreviewNoUpgrade feature set",
-			pool:               &types.MachinePool{Name: types.MachinePoolControlPlaneRoleName},
-			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
+			name:               "AWS compute sets ClusterAPI management when ClusterAPIMachineManagementAWS enabled",
+			pool:               &types.MachinePool{Name: types.MachinePoolComputeRoleName},
+			platform:           awsPlatform,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: types.ClusterAPI,
 		},
 		{
-			name:               "control plane with default feature set",
+			name:               "AWS compute management is unchanged when ClusterAPIMachineManagementAWS disabled",
+			pool:               &types.MachinePool{Name: types.MachinePoolComputeRoleName},
+			platform:           awsPlatform,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=False"},
+			expectedManagement: "",
+		},
+		{
+			name:               "AWS control plane is unaffected by ClusterAPIMachineManagementAWS",
 			pool:               &types.MachinePool{Name: types.MachinePoolControlPlaneRoleName},
-			platform:           &types.Platform{},
-			featureSet:         configv1.Default,
+			platform:           awsPlatform,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: "",
 		},
 		{
-			name:               "compute with DevPreviewNoUpgrade feature set",
+			name:               "non-AWS compute is unaffected by ClusterAPIMachineManagementAWS",
 			pool:               &types.MachinePool{Name: types.MachinePoolComputeRoleName},
 			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
-			expectedManagement: types.ClusterAPI,
-		},
-		{
-			name:               "compute with default feature set",
-			pool:               &types.MachinePool{Name: types.MachinePoolComputeRoleName},
-			platform:           &types.Platform{},
-			featureSet:         configv1.Default,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: "",
 		},
 		{
-			name:               "edge compute with DevPreviewNoUpgrade feature set",
+			name:               "AWS edge compute with ClusterAPIMachineManagementAWS enabled",
 			pool:               &types.MachinePool{Name: types.MachinePoolEdgeRoleName},
-			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
+			platform:           awsPlatform,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: types.ClusterAPI,
 		},
 		{
 			name:               "edge compute with default feature set",
 			pool:               &types.MachinePool{Name: types.MachinePoolEdgeRoleName},
 			platform:           &types.Platform{},
-			featureSet:         configv1.Default,
 			expectedManagement: "",
 		},
 		{
-			name:               "control plane with management already set",
-			pool:               &types.MachinePool{Name: types.MachinePoolControlPlaneRoleName, Management: types.MachineAPI},
-			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
-			expectedManagement: types.MachineAPI,
-		},
-		{
-			name:               "compute with management already set",
+			name:               "AWS compute management is not overwritten when already set",
 			pool:               &types.MachinePool{Name: types.MachinePoolComputeRoleName, Management: types.MachineAPI},
-			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
+			platform:           awsPlatform,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: types.MachineAPI,
 		},
 		{
 			name:               "edge compute with management already set",
 			pool:               &types.MachinePool{Name: types.MachinePoolEdgeRoleName, Management: types.MachineAPI},
 			platform:           &types.Platform{},
-			featureSet:         configv1.DevPreviewNoUpgrade,
+			featureGates:       []string{"ClusterAPIMachineManagementAWS=True"},
 			expectedManagement: types.MachineAPI,
 		},
 	}
@@ -219,7 +214,8 @@ func TestSetMachinePoolDefaultsWithFeatureGates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			config := &types.InstallConfig{
-				FeatureSet: tc.featureSet,
+				FeatureSet:   configv1.CustomNoUpgrade,
+				FeatureGates: tc.featureGates,
 			}
 			SetMachinePoolDefaults(tc.pool, tc.platform, config.EnabledFeatureGates())
 			assert.Equal(t, tc.expectedManagement, tc.pool.Management, "unexpected management API")

--- a/pkg/types/validation/featuregates.go
+++ b/pkg/types/validation/featuregates.go
@@ -42,12 +42,7 @@ func validateMachinePoolFeatureGates(c *types.InstallConfig) []featuregates.Gate
 			Field:           field.NewPath("osImageStream"),
 		},
 		{
-			FeatureGateName: features.FeatureGateClusterAPIControlPlaneInstall,
-			Condition:       c.ControlPlane != nil && c.ControlPlane.Management == types.ClusterAPI,
-			Field:           field.NewPath("controlPlane", "management"),
-		},
-		{
-			FeatureGateName: features.FeatureGateClusterAPIComputeInstall,
+			FeatureGateName: features.FeatureGateClusterAPIMachineManagement,
 			Condition: func() bool {
 				for _, compute := range c.Compute {
 					if compute.Management == types.ClusterAPI {


### PR DESCRIPTION
This removes use of:
* FeatureGateClusterAPIControlPlaneInstall because it is not implemented in either installer or CPMS.
* FeatureGateClusterAPIComputeInstall replaced by FeatureGateClusterAPIMachineManagementAWS and scoped to AWS only, as that is the only platform where it is implemented

The effect of this change is that installer-created worker machinesets will use CAPI as soon as platform support is promoted.

Also updates the tests to use the feature gates explicitly instead of assuming inclusion in a particular feature set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated machine-pool defaulting so `management` is set to Cluster API only for **AWS compute/edge** pools when the relevant machine-management feature gate is enabled.
  * Ensures existing `management` values aren’t overwritten and avoids unintended control-plane or non-AWS changes.
  * Corrected feature-gate validation so the compute `management=ClusterAPI` path uses the appropriate feature gate.
* **Tests**
  * Refactored and expanded test coverage to verify the new defaulting and validation behavior across feature-gate combinations and pre-set `management` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->