### PR TITLE
OCPBUGS-87841: gather: redact pull-secret auth tokens from machineconfigs.json

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
@@ -70,6 +70,15 @@ function cluster_bootstrap_gather() {
     echo "Waiting for logs ..."
     while wait -n; do jobs; done
 
+    # Redact pull-secret auth tokens embedded in MachineConfig Ignition data.
+    # The pull-secret JSON is URL-encoded inside data: URIs, so
+    #   "auth":"<value>"  becomes  %22auth%22%3A%22<base64>%22
+    if [[ -f "${ARTIFACTS_TEMP}/resources/machineconfigs.json" ]]; then
+        sed -E -i \
+            's/%22auth%22%3A%22([A-Za-z0-9_-]|%3D|%2B|%2F)*%22/%22auth%22%3A%22REDACTED%22/g' \
+            "${ARTIFACTS_TEMP}/resources/machineconfigs.json"
+    fi
+
     if (( $(stat -c%s "${ARTIFACTS_TEMP}/resources/openapi.json.gz") <= 20 ))
     then
         rm -rf "${ARTIFACTS_TEMP}"


### PR DESCRIPTION
The bootstrap gather collects machineconfigs.json via `oc get machineconfigs -o json`, which includes MachineConfig resources containing Ignition file definitions for /var/lib/kubelet/config.json. The pull-secret JSON is URL-encoded inside data: URIs and contains real base64 registry auth credentials and Kubernetes service account JWTs.

Add a sed post-processing step after resource collection to replace all URL-encoded "auth" values with REDACTED before the log bundle is assembled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by redacting sensitive pull-secret tokens from gathered cluster artifacts when present.
  * Prevents encoded authentication values from being exposed in exported configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->