### PR TITLE
OCPBUGS-93627: destroy/aws: delete vpc endpoints earlier

### DIFF
--- a/pkg/destroy/aws/ec2helpers.go
+++ b/pkg/destroy/aws/ec2helpers.go
@@ -827,12 +827,12 @@ func deleteEC2VPC(ctx context.Context, ec2Client *ec2v2.Client, elbClient *elb.C
 		helper   func(ctx context.Context, client *ec2v2.Client, vpc string, failFast bool, logger logrus.FieldLogger) error
 		failFast bool
 	}{
+		{helper: deleteEC2VPCEndpointsByVPC, failFast: true},     // must precede NICs and subnets
 		{helper: deleteEC2NATGatewaysByVPC, failFast: true},      // not always tagged
 		{helper: deleteEC2NetworkInterfaceByVPC, failFast: true}, // not always tagged
 		{helper: deleteEC2RouteTablesByVPC, failFast: true},      // not always tagged
 		{helper: deleteEC2SecurityGroupsByVPC, failFast: false},  // not always tagged
 		{helper: deleteEC2SubnetsByVPC, failFast: true},          // not always tagged
-		{helper: deleteEC2VPCEndpointsByVPC, failFast: true},     // not taggable
 	} {
 		err := child.helper(ctx, ec2Client, id, child.failFast, logger)
 		if err != nil {


### PR DESCRIPTION
VPC endpoints must be destroyed before other networking resources, so this commit moves them earlier in the destroy VPC function.

In the happy bath, VPC endpoints are tagged which leads to them being discovered and destroyed independently of the VPC. But this commit fixes a bug when the VPC endpoints are not tagged, and therefore discovered off the network, in which case they need to be deleted first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the order of VPC cleanup so endpoints are removed earlier, helping avoid deletion conflicts with other network resources.
  * Made resource teardown more reliable by ensuring endpoint cleanup runs before related NIC and subnet removal steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->