### PR TITLE
CORS-4334: konnectivity: remove hostNetwork from konnectivity agent

### DIFF
--- a/data/data/bootstrap/files/opt/openshift/konnectivity-agent-daemonset.yaml
+++ b/data/data/bootstrap/files/opt/openshift/konnectivity-agent-daemonset.yaml
@@ -15,8 +15,6 @@ spec:
       labels:
         app: konnectivity-agent
     spec:
-      hostNetwork: true
-      dnsPolicy: Default
       priorityClassName: system-node-critical
       tolerations:
       - operator: Exists


### PR DESCRIPTION
The bootstrap konnectivity agent DaemonSet was configured with `hostNetwork: true`, which requires an SCC that allows host networking.

Since pods can reach the bootstrap node IP from the pod network, hostNetwork is not required. Remove it along with the associated `dnsPolicy: Default` override.

Follow-up for https://github.com/openshift/installer/pull/10344. See https://github.com/openshift/installer/pull/10659#issuecomment-4815313170 for investigation details.

## References

- https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/
- https://github.com/openshift/hypershift/blob/main/control-plane-operator/controllers/hostedcontrolplane/v2/assets/konnectivity-agent/deployment.yaml
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Konnectivity agent deployment configuration by removing explicit host networking and default DNS settings.
  * This may affect how the agent connects and resolves names in the cluster, aligning it with the standard runtime network setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->