### PR TITLE
no-jira: fix vCenter validation error to use correct field name

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -143,7 +143,7 @@ func validateVCenters(p *vsphere.Platform, fldPath *field.Path) field.ErrorList 
 			}
 		}
 		if len(vCenter.Username) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Index(index).Child("username"), "must specify the username"))
+			allErrs = append(allErrs, field.Required(fldPath.Index(index).Child("user"), "must specify the user"))
 		}
 		if len(vCenter.Password) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Index(index).Child("password"), "must specify the password"))

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -455,7 +455,7 @@ func TestValidatePlatform(t *testing.T) {
 				p.VCenters[0].Username = ""
 				return p
 			}(),
-			expectedError: `^test-path\.vcenters\[0].username: Required value: must specify the username$`,
+			expectedError: `^test-path\.vcenters\[0].user: Required value: must specify the user$`,
 		},
 		{
 			name: "Multi-zone missing password",


### PR DESCRIPTION
## Summary

- The vCenter validation error for a missing username references the field path `username`, but the actual YAML field is `user` (defined with `json:"user"` tag on the VCenter struct).
- Users following the error message add the wrong field to their `install-config.yaml`, causing further confusion.

## Fix

Changed the field path from `Child("username")` to `Child("user")` and updated the error message from `"must specify the username"` to `"must specify the user"` to match the actual install-config.yaml schema.

Updated the corresponding unit test to match.

## Before

```
platform.vsphere.vcenters[0].username: Required value: must specify the username
```

## After

```
platform.vsphere.vcenters[0].user: Required value: must specify the user
```

Fixes: https://github.com/openshift/installer/issues/10398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation messages for vCenter configuration so missing credentials now point to the correct user field path.
  * Aligned related validation checks to report the expected field location in error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->