### PR TITLE
NO-ISSUE: Remove workaround for boot image version mismatch

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
+++ b/data/data/bootstrap/files/usr/local/bin/node-image-overlay.sh
@@ -19,6 +19,3 @@ rsync -a --exclude crypto-policies "${ostree_checkout}/usr/etc/" /etc
 # reload the new policy
 echo "Reloading SELinux policy"
 semodule -R
-
-# handle upgrade of sshd between RHEL 9.6 and 9.8
-systemctl --no-block try-restart sshd.service


### PR DESCRIPTION
Now that boot image versions match node image versions again, we can remove this [workaround](https://github.com/openshift/installer/pull/10452) that was required for ssh when the former was using RHCOS 9.6 and the latter RHCOS 9.8 ([OCPBUGS-81470](https://redhat.atlassian.net/browse/OCPBUGS-81470)).