### PR TITLE
OCPBUGS-98157: redact machineconfigs.json from "gather bootstrap"

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
@@ -77,6 +77,12 @@ function cluster_bootstrap_gather() {
         sed -E -i \
             's/%22auth%22%3A%22([A-Za-z0-9_-]|%3D|%2B|%2F)*%22/%22auth%22%3A%22REDACTED%22/g' \
             "${ARTIFACTS_TEMP}/resources/machineconfigs.json"
+
+        # Redact private keys embedded in MachineConfig Ignition data
+        # as URL-encoded PEM.
+        sed -E -i \
+            's/-----BEGIN%20((RSA|EC|DSA|OPENSSH)%20)?PRIVATE%20KEY-----[^"]*-----END%20((RSA|EC|DSA|OPENSSH)%20)?PRIVATE%20KEY-----/REDACTED/g' \
+            "${ARTIFACTS_TEMP}/resources/machineconfigs.json"
     fi
 
     if (( $(stat -c%s "${ARTIFACTS_TEMP}/resources/openapi.json.gz") <= 20 ))


### PR DESCRIPTION
URL-encoded RSA private keys embedded in MachineConfig Ignition data were included unredacted in machineconfigs.json within the bootstrap log bundle. Extend the existing pull-secret redaction to also strip these keys from the gathered data.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction in collected cluster diagnostics by masking additional sensitive private key material within MachineConfig ignition content.
  * Replaced URL-encoded embedded private key blocks (including multiple key formats) with `REDACTED` to further reduce the risk of exposing secrets in exported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->