### PR TITLE
CNTRLPLANE-2847: bootstrap: pass rendered manifests and payload version to etcd render

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -234,7 +234,9 @@ then
 		--cluster-configmap-file=/assets/manifests/cluster-config.yaml \
 		--etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
 		--infra-config-file=/assets/manifests/cluster-infrastructure-02-config.yml \
-		--network-config-file=/assets/manifests/cluster-network-02-config.yml
+		--network-config-file=/assets/manifests/cluster-network-02-config.yml \
+		--rendered-manifest-files=/assets/manifests \
+		--payload-version=$VERSION
 
 	# Copy configuration required to start etcd
 	cp --recursive etcd-bootstrap/etc-kubernetes/* /etc/kubernetes/


### PR DESCRIPTION
## Summary

Add `--rendered-manifest-files` and `--payload-version` flags to the etcd-render invocation in `bootkube.sh` so the cluster-etcd-operator render command can read the FeatureGate CR from pre-rendered manifests.

## Background

The `api-render` step already runs before `etcd-render` and produces the fully-resolved FeatureGate CR (with `featureSet` expanded into individual gates) in `/assets/manifests/`. The etcd-render step was the only operator render that didn't consume these manifests — it parsed feature gates from the raw install-config instead, which missed `featureSet` resolution.

This aligns the etcd-render invocation with the pattern already used by `kube-apiserver-render`, `kube-controller-manager-render`, and `config-render`, all of which pass `--rendered-manifest-files=/assets/manifests` and `--payload-version=$VERSION`.

## Coordinated change

Requires [openshift/cluster-etcd-operator#1648](https://github.com/openshift/cluster-etcd-operator/pull/1648) to accept the new flags. Both PRs must land in the same payload.

## Test plan

- [ ] CI with coordinated CEO PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster bootstrap rendering by supplying the required manifest output location and payload version.
  * Preserved network configuration handling during etcd setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->