### PR TITLE
OCPBUGS-98529: cluster-api: disable diagnostics endpoint for local CAPI controllers

### DIFF
--- a/pkg/clusterapi/system.go
+++ b/pkg/clusterapi/system.go
@@ -262,6 +262,7 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 				&azProvider,
 				[]string{
 					"-v=2",
+					"--diagnostics-address=0",
 					"--health-addr={{suggestHealthHostPort}}",
 					"--webhook-port={{.WebhookPort}}",
 					"--webhook-cert-dir={{.WebhookCertDir}}",
@@ -328,6 +329,7 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 		ibmcloudFlags := []string{
 			"--provider-id-fmt=v2",
 			"-v=2",
+			"--diagnostics-address=0",
 			"--health-addr={{suggestHealthHostPort}}",
 			"--leader-elect=false",
 			"--webhook-port={{.WebhookPort}}",
@@ -425,6 +427,7 @@ func (c *system) Run(ctx context.Context) error { //nolint:gocyclo
 			[]string{
 				"--provider-id-fmt=v2",
 				"--v=2",
+				"--diagnostics-address=0",
 				"--health-addr={{suggestHealthHostPort}}",
 				"--webhook-port={{.WebhookPort}}",
 				"--webhook-cert-dir={{.WebhookCertDir}}",


### PR DESCRIPTION
## Summary

- Add `--diagnostics-address=0` to the Azure (CAPZ), IBM Cloud, and Power VS provider controller args in `pkg/clusterapi/system.go`
- Matches the flag already set by AWS, GCP, vSphere, OpenStack, and Nutanix providers

## Why this approach

OCP 4.22 runs CAPI controllers as local processes on the installer host during `create cluster`. The upstream CAPI flags package (`sigs.k8s.io/cluster-api/util/flags/manager.go`) defaults `--diagnostics-address` to `:8443`, which binds a metrics/diagnostics endpoint. Five providers already override this to `0` (disabled), but Azure, IBM Cloud, and Power VS do not. When port 8443 is occupied on the host, the provider controller fails to start:

```
failed to start metrics server: failed to create listener: listen tcp :8443: bind: address already in use
```

This cascades into a webhook connection-refused error and the install aborts immediately.

The diagnostics endpoint serves no purpose for these ephemeral local controllers. The fix adds the same `--diagnostics-address=0` flag that the other five providers already use.

**Alternative considered:** injecting the flag automatically in `runController` using `process.CheckFlag("diagnostics-address")` to detect support at runtime, with an `argsContainDiagnosticsFlag` helper to skip controllers that use different flag names (ASO's `-metrics-addr`, ORC's `-metrics-bind-address`). We decided against this because `CheckFlag` spawns a subprocess (`binary --help`) for each controller, and the runtime detection adds complexity for a problem that explicit per-provider flags already solve reliably. The per-provider approach is consistent with how the other five providers handle this.

## Cluster verification

Reproduced on an Azure IPI 4.22.4 install where an httpd container (host networking) occupied port 8443 on the installer host. The CAPZ controller failed immediately with the bind error above. After freeing port 8443, the install proceeded past CAPI controller startup.

## Test plan

- [x] `gofmt -d pkg/clusterapi/system.go` produces no diff
- [x] Verified all 8 CAPI providers now consistently set `--diagnostics-address=0`
- [x] Verified ASO (`-metrics-addr=0`) and OpenStackORC (`-metrics-bind-address=0`) are unaffected (they use different flag names specific to their binaries)
- [x] Confirmed the real-world failure and recovery on Azure IPI 4.22.4

OCPBUGS-98529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled diagnostic endpoints for Azure, IBM Cloud, and PowerVS infrastructure controllers by default.
  * Improved security and consistency across supported platform controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->