### PR TITLE
OCPBUGS-98586: Don't wait on oc delete in konnectivity_cleanup

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/konnectivity.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/konnectivity.sh.template
@@ -76,7 +76,8 @@ konnectivity_cleanup() {
         echo "Cleaning up bootstrap konnectivity resources..."
         oc delete namespace openshift-bootstrap-konnectivity \
             --kubeconfig=/opt/openshift/auth/kubeconfig \
-            --ignore-not-found=true
+            --ignore-not-found=true \
+            --wait=false
         rm -f /etc/kubernetes/manifests/konnectivity-server-pod.yaml
         touch konnectivity-cleanup.done
         record_service_stage_success


### PR DESCRIPTION
Remove the wait on the `oc delete namespac`e command in konnectivity_cleanup. The namespace deletion request will be submitted but oc delete won't block waiting for finalization to complete. bootkube.sh proceeds immediately to touch` /opt/openshift/.bootkube.done`, unblocking `report-progress.sh` and the rest of the bootstrap chain.

The namespace will eventually be cleaned up by the namespace controller once the conversion webhook becomes available (or the CRDs are removed). There's no functional reason to wait for it synchronously — the bootstrap konnectivity resources just need to be requested for deletion, not fully finalized, before bootkube can move on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap cleanup reliability by allowing namespace deletion to proceed without blocking.
  * Preserved safe handling when the namespace is already absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->