### PR TITLE
CORS-4539: Support sovereign cloud service account email format for gcp/gcd

### DIFF
--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/installer/pkg/types/dns"
 )
@@ -185,7 +186,15 @@ func GetConfiguredServiceAccount(platform *Platform, mpool *MachinePool) string 
 // GetDefaultServiceAccount returns the default service account email to use based on role.
 // The default should be used when an existing service account is not configured.
 func GetDefaultServiceAccount(platform *Platform, clusterID string, role string) string {
-	return fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
+	projectID := platform.ProjectID
+
+	// Domain-scoped project IDs (e.g. "eu0:openshift") use a reversed
+	// dot-separated format in SA emails: "openshift.eu0".
+	if parts := strings.SplitN(projectID, ":", 2); len(parts) == 2 {
+		projectID = parts[1] + "." + parts[0]
+	}
+
+	return fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], projectID)
 }
 
 // ShouldUseEndpointForInstaller returns true when the endpoint should be used for GCP api endpoint overrides in the

--- a/pkg/types/gcp/platform_test.go
+++ b/pkg/types/gcp/platform_test.go
@@ -1,0 +1,54 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultServiceAccount(t *testing.T) {
+	cases := []struct {
+		name      string
+		projectID string
+		clusterID string
+		role      string
+		expected  string
+	}{
+		{
+			name:      "standard GCP project",
+			projectID: "my-project",
+			clusterID: "012345678",
+			role:      "master",
+			expected:  "012345678-m@my-project.iam.gserviceaccount.com",
+		},
+		{
+			name:      "domain-scoped project",
+			projectID: "eu0:my-project",
+			clusterID: "012345678",
+			role:      "master",
+			expected:  "012345678-m@my-project.eu0.iam.gserviceaccount.com",
+		},
+		{
+			name:      "domain-scoped project worker role",
+			projectID: "eu0:my-project",
+			clusterID: "012345678",
+			role:      "worker",
+			expected:  "012345678-w@my-project.eu0.iam.gserviceaccount.com",
+		},
+		{
+			name:      "domain-scoped project with different prefix",
+			projectID: "other-prefix:my-project",
+			clusterID: "012345678",
+			role:      "master",
+			expected:  "012345678-m@my-project.other-prefix.iam.gserviceaccount.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			platform := &Platform{ProjectID: tc.projectID}
+			result := GetDefaultServiceAccount(platform, tc.clusterID, tc.role)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
GCP sovereign clouds use a different service account email domain than standard GCP. Standard GCP uses the format:

  name@project-id.iam.gserviceaccount.com

Sovereign clouds include the cloud prefix in the domain:

  name@project-id.eu0.iam.gserviceaccount.com

The prefix (e.g., "eu0") is derived from the sovereign cloud project ID format "eu0:project-id". Previously, GetDefaultServiceAccount hardcoded "iam.gserviceaccount.com", producing incorrect service account emails for sovereign cloud installations. This caused the installer to reference service accounts that did not match the accounts actually created by the GCP IAM API.

Update GetDefaultServiceAccount to detect known sovereign cloud prefixes in the project ID and construct the correct email domain. Non-sovereign project IDs (including org-scoped "orgname:project-id") are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default Google Cloud service account email generation for sovereign-domain project IDs by correctly translating the project portion before constructing the IAM email.
  * Preserved the existing behavior for standard (non-sovereign) project IDs.
* **Tests**
  * Added table-driven unit tests covering multiple project ID formats, including sovereign-domain (`prefix:project`) cases, and verified both master and worker role email generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->