### PR TITLE
OCPBUGS-98982: Update RHCOS-release-4.22 bootimage metadata to 9.8.20260715-1 / 10.2.20260715-0

### DIFF
--- a/data/data/coreos/coreos-rhel-10.json
+++ b/data/data/coreos/coreos-rhel-10.json
@@ -1,117 +1,129 @@
 {
   "stream": "rhcos-4.22",
   "metadata": {
-    "last-modified": "2026-05-26T02:00:59Z",
-    "generator": "plume cosa2stream 5f75da4"
+    "last-modified": "2026-07-16T23:16:30Z",
+    "generator": "plume cosa2stream cbcb7c7"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-aws.aarch64.vmdk.gz",
-                "sha256": "bd32b73bb0825206dfbe2f8a597971d559ffab0146ed152096e697ef5475437e",
-                "uncompressed-sha256": "68092d6ac97216c4b4119b095cc6b1818c16e8d8bb2342aa61ba6f7a0fcfe613"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-aws.aarch64.vmdk.gz",
+                "sha256": "300b3f11903ec9c59dce43273c3382709b8cc3513b1c08b4c10da20a7da67361",
+                "uncompressed-sha256": "e94690f5c5f4d0236980b78e9eff5931b280532b5d9ec96fd260c6fd70c36354"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-azure.aarch64.vhd.gz",
-                "sha256": "fbe2ee640c04259e07167c0a84a1b624140c9dca6032d02ffcb55378841bd11c",
-                "uncompressed-sha256": "33005b34dafdcc65ba179620cbc4851f34a99316404bfa8f3bedc98aba75d935"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-azure.aarch64.vhd.gz",
+                "sha256": "cd3445859014632d16bbcf70592ea23af8f1989ef9462a93e48763f62f94b3ba",
+                "uncompressed-sha256": "f3ac6fb12ff57ff8f6dc2e667bff1e1eac71cc75e7b19bfd484734436b9d25fc"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-gcp.aarch64.tar.gz",
-                "sha256": "773b76ccbbbdeb2f13139ce946cae0de2511b0eba165fb68a5377479df490695"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-gcp.aarch64.tar.gz",
+                "sha256": "bbe11221a38af5d2239218b5a873fd076e1441b8bcc47a7327348b4d5edea21c"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-metal4k.aarch64.raw.gz",
-                "sha256": "5ba7f2f7b792b18217c3928c36a2a3201df7dc636a6ad2092b91bdacfd4817a4",
-                "uncompressed-sha256": "6e66e2feae46f52b1191e5fa5ddef0b83e4c2e23c55a0178d776dd6419ecd75a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-metal4k.aarch64.raw.gz",
+                "sha256": "9e1699a5270c402c24254efc37f0aec89b81db7c64fecee21a578cd7d8e627b9",
+                "uncompressed-sha256": "2d854f4d082c75110493c77a66559a70989a5861f96681887584c769faccde6e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-iso.aarch64.iso",
-                "sha256": "f3de8f2a2738bbff8608a04a527b5b9cccaa79004a28e6a8f1d5346d6652bfe1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-live-iso.aarch64.iso",
+                "sha256": "3bdea7fc4d97de68f09b40e02fc8e364487ee5c322f49fce6400688f5bea85b1"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-kernel.aarch64",
-                "sha256": "365986469730ef6cd2317a3a098dd6bb3d128a24d28c028d65f3e538399eaa25"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-live-kernel.aarch64",
+                "sha256": "225bb45a9dcf504a7c338a7ff5847be0de13f7dda94e222b0198401adcb8d322"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-initramfs.aarch64.img",
-                "sha256": "3cf9b99d778920ff7414a1794ff3eb35caaaedf251c893e46e0b8788cce5ad23"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-live-initramfs.aarch64.img",
+                "sha256": "c8618c8adb9eceea08d17f4b16dc7a57fcbfeb76e06f030548b547d863b9fd5e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-rootfs.aarch64.img",
-                "sha256": "14fa9211d61be123629d79455954066716299fd3ffbf06f186947c4ed39b9edd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-live-rootfs.aarch64.img",
+                "sha256": "08bbd9e487e8ca0b96dcda5ed3b9b77db0abc1794323fb7ad70f8c2e498999c9"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-metal.aarch64.raw.gz",
-                "sha256": "dbad89cb3030e8c6a604096aaea25ecef499c26f99fbe3958e25f350302e2e75",
-                "uncompressed-sha256": "0788dee3e530657a02fab3cc9cdd6790584646cb1faadb711a658db1430b1eb3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-metal.aarch64.raw.gz",
+                "sha256": "a96e47bab4d76874af18e6fe3b512e1f43ff6884c89b727f7359c67bf15bb2cc",
+                "uncompressed-sha256": "1e12dd04733f1496f14529a64488e8f0c9bd6e27364c8488b5e78e838515b1ca"
               }
             }
           }
         },
         "nvidiabluefield": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "bfb": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "ecd65bd9222d9e2d5bdbd5f9e4d6a6e7ec4d6126e9e3140eec4f4a3b9303c9e3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-nvidiabluefield.aarch64.bfb",
+                "sha256": "9169b33d9a38dbcd49d491ff63c1979295a1d5397b88370efe1fffc24077f393"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-openstack.aarch64.qcow2.gz",
-                "sha256": "6f45b5b6e92d281784e637c84ec50d8fb16a13b625e741380af3877e40a30b71",
-                "uncompressed-sha256": "4b2864015614b31c109c773cec891809979e55fe3ef805a30bb0748c0c1ddc06"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-openstack.aarch64.qcow2.gz",
+                "sha256": "7b598c82d53d35adb3ed58a47c7cc4c00e328a84cb96c70c9bfeccfb8e56c8f0",
+                "uncompressed-sha256": "febe1a4c1d22ffdc0dc5e87e6a4bb2a100f0a2be5e77c71c9042b65c7b8d84a9"
+              }
+            }
+          }
+        },
+        "oraclecloud": {
+          "release": "10.2.20260715-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-oraclecloud.aarch64.qcow2.gz",
+                "sha256": "739f4c47abfa460a48c8cd17e3a974022f614395d30de09adccb2b6b24fd4fa0",
+                "uncompressed-sha256": "3a7d9ebbe293ad638f4da91aed00008574e431b4f2547c6f334debf147637647"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-qemu.aarch64.qcow2.gz",
-                "sha256": "0689a095bab6701e0b4c3a806d18b3792f901cacde14e9881459a9c0b184e90c",
-                "uncompressed-sha256": "7036887cc41bf84c78abf9c1bd76d0425932d1c18853b46392660ca61de7c1f0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-qemu.aarch64.qcow2.gz",
+                "sha256": "696b809d15a48787f9f91aab285de38d32d0387f141822dc4706f07fdab0d375",
+                "uncompressed-sha256": "ee89e63ba248fd2250caf72a7038573686632a0f714b428bb117b0a6e02d367f"
               }
             }
           }
@@ -121,229 +133,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-07c2492a6e610eb29"
+              "release": "10.2.20260715-0",
+              "image": "ami-08d3e5ac783f96689"
             },
             "ap-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0c081ca051d9066c3"
+              "release": "10.2.20260715-0",
+              "image": "ami-06a0a6cdc31d687b4"
             },
             "ap-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-016834812d68d485e"
+              "release": "10.2.20260715-0",
+              "image": "ami-02264d13cc379c400"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0a93317cde971c817"
+              "release": "10.2.20260715-0",
+              "image": "ami-01402f6fc7fa6e6dd"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-008d018630379e1eb"
+              "release": "10.2.20260715-0",
+              "image": "ami-0de3372c53819aaaa"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-016bf4359ca8f9ea2"
+              "release": "10.2.20260715-0",
+              "image": "ami-0537c012fb351d6a0"
             },
             "ap-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-01c3da87c9088e490"
+              "release": "10.2.20260715-0",
+              "image": "ami-00af5f0251f9d393f"
             },
             "ap-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-089e3dc824dfc53cc"
+              "release": "10.2.20260715-0",
+              "image": "ami-06e5d42796bd6f528"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-047501898db0e6004"
+              "release": "10.2.20260715-0",
+              "image": "ami-0b8305344e0fc7d2d"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-00aa2f8c59143b0ae"
+              "release": "10.2.20260715-0",
+              "image": "ami-0df26f104866e1a9a"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-001bd2512362e7b35"
+              "release": "10.2.20260715-0",
+              "image": "ami-034a47eb2ad3e3ffd"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0c3a562ba17fcc7fe"
+              "release": "10.2.20260715-0",
+              "image": "ami-0a651d826444a4948"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0abc0ee6a009667b2"
+              "release": "10.2.20260715-0",
+              "image": "ami-01734737bbfbe74a1"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0c8b6c104987a0fc3"
+              "release": "10.2.20260715-0",
+              "image": "ami-0507f999c00da7b28"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0fbf9de5c1828e872"
+              "release": "10.2.20260715-0",
+              "image": "ami-0d9e44cb94e3e2314"
             },
             "ca-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06be00da14f45f988"
+              "release": "10.2.20260715-0",
+              "image": "ami-06b4716233fe63dc9"
             },
             "ca-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0260b4a668a59a922"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f5633a3440704a9d"
             },
             "eu-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-001fdc3025ce50006"
+              "release": "10.2.20260715-0",
+              "image": "ami-0286cff0da9d1c1c4"
             },
             "eu-central-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0443b053f6e845524"
+              "release": "10.2.20260715-0",
+              "image": "ami-0bfd310dade0d036f"
             },
             "eu-north-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06bc091c0435adf6f"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f186d1a862e47c8f"
             },
             "eu-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-02ee91218bdc1bb3a"
+              "release": "10.2.20260715-0",
+              "image": "ami-00159303d0698a4e3"
             },
             "eu-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0b8943a7a26627b01"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e6941714240039fa"
             },
             "eu-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-064942d9b57521cf3"
+              "release": "10.2.20260715-0",
+              "image": "ami-016e6fabf9dda07aa"
             },
             "eu-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0e13b80ab624fc7d3"
+              "release": "10.2.20260715-0",
+              "image": "ami-02d27a05c7b8d13df"
             },
             "eu-west-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0b1bd601d3ecde37d"
+              "release": "10.2.20260715-0",
+              "image": "ami-094e87d0b8aab28df"
             },
             "il-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0073de64ca6a1189b"
+              "release": "10.2.20260715-0",
+              "image": "ami-008a7997379c73959"
             },
             "mx-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-03bf73795d8dfac51"
+              "release": "10.2.20260715-0",
+              "image": "ami-0315581cb0f47f844"
             },
             "sa-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f8e239c3eb87df2b"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e0cf94e34dd227cd"
             },
             "us-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-04ec52f48c28d001d"
+              "release": "10.2.20260715-0",
+              "image": "ami-03038bbbf3c588c37"
             },
             "us-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0469df626c198243e"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e651950cf2f78a61"
             },
             "us-gov-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-03557a94deb16be46"
+              "release": "10.2.20260715-0",
+              "image": "ami-07d5097d7ef637209"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06460c1920305cf08"
+              "release": "10.2.20260715-0",
+              "image": "ami-0cd956ca21ed98150"
             },
             "us-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0cd45be3140b38916"
+              "release": "10.2.20260715-0",
+              "image": "ami-066c6f5fba5f747a8"
             },
             "us-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-03206cc79683aa1a6"
+              "release": "10.2.20260715-0",
+              "image": "ami-03572bea3f4251a57"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260521-0-gcp-aarch64"
+          "name": "rhcos-10-2-20260715-0-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "10.2.20260521-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260521-0-azure.aarch64.vhd"
+          "release": "10.2.20260715-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260715-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-metal4k.ppc64le.raw.gz",
-                "sha256": "026a99219cbd059e6a22308379dfff614d8ab078b897dff555a0fcd5c87d9ee7",
-                "uncompressed-sha256": "7268e36c0758b4d66277fa377da841f4d83dd93f9738ab2b6bb803a155f5d379"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-metal4k.ppc64le.raw.gz",
+                "sha256": "0916324aff628333a3d5d06c19256148ea002c7240eb4c958445f3d052f880e1",
+                "uncompressed-sha256": "59126d66aa43c22e30c6be88d79dce69dda31c7c47db6b0413e2ecd6995f1d95"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-iso.ppc64le.iso",
-                "sha256": "81590c320baacdaa8e2b2e69881778eeda40da01e83cb76dce72160760f45166"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-live-iso.ppc64le.iso",
+                "sha256": "527c8dfae86ffad8d5c0639bd3261f3890e5a1ac3f4aea1e3a62306f524907aa"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-kernel.ppc64le",
-                "sha256": "00d01662a7b9da0e27916100111fe671b79ff3fc1ab50f64e4f0559341e85b3a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-live-kernel.ppc64le",
+                "sha256": "920d9244350a9056b52c62594bd1324708fae7b55da3fbe390d9fc310f22c2b0"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-initramfs.ppc64le.img",
-                "sha256": "f3f0f3eeee37d5114b531d30343c8ab439c552bd2a410cfc2031a3b137ba0412"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-live-initramfs.ppc64le.img",
+                "sha256": "cf27b3fd99fda979e4015f232f3c3bb2a32982fc1bcba5f66b1c79fab8501d7f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-rootfs.ppc64le.img",
-                "sha256": "1dd81165197a9edfa2299a51f8ad773693d7c9ed0b213a89a81cdb4d21080514"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-live-rootfs.ppc64le.img",
+                "sha256": "f699cd5a04b01f6cc764e7553a08e52cb326fa3e363f46b975e2be3bca648048"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-metal.ppc64le.raw.gz",
-                "sha256": "d53bbc5d729a4df41362eb035800d36195d13bb5bd9fec6985c6dee4a3a61215",
-                "uncompressed-sha256": "d3e2eb723a3ba28032e5e09bb18ab598e392145b7399e3f5266ceddbf8d8fcc0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-metal.ppc64le.raw.gz",
+                "sha256": "1a9134ebb701b3471ff261d7c35bc5cf90a41a18ca98c7d2a00225b8f68a80bb",
+                "uncompressed-sha256": "d901dbf35957f7137be74380c0e0ba974c732d24afc064d5a224d227e9a35436"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "8f0aee982883aef04ac1c7594ac8a398a79ba813e3725f5fd0fe89e330b2cfb8",
-                "uncompressed-sha256": "1bd66edab0cee310420a295ac0a997b1de506547d96a12cd7a1b8fb1d10244e2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "9573dd63e2d263af3720cb59093ca25056bcbd62f2ba7c3eb59518aaad2a42a8",
+                "uncompressed-sha256": "e19a3d01fb295ddaea1787eda1b1a8f3e4e33daec0800112bea7eabd988265f3"
               }
             }
           }
         },
         "powervs": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-powervs.ppc64le.ova.gz",
-                "sha256": "94d9592da03672e9722640a5eb783a658380f6bbe7d49c2a8e1b94e9f52d7ece",
-                "uncompressed-sha256": "c2559c7ac0237dcf600c0dabdf0624c5d3a4697aff4a98a0236a3d9a527cd1b5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-powervs.ppc64le.ova.gz",
+                "sha256": "9bd847782c9ddf89076b38b925e848cd91e449ca93a332a267d960472c304ef5",
+                "uncompressed-sha256": "5f1c3d4cb650af0e0ccc85bb1145fc2a0226e0a09d0e6da7d4a85aaf10682d76"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "c9df8c5caa0b80e3107c5ea988fc08805116c6829652f582f5ea50f9ec98e2d2",
-                "uncompressed-sha256": "4c507e6bb0592629e41e89e15d6b8f10326fbda0c2e734e94259537874711804"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/ppc64le/rhcos-10.2.20260715-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "e7e42a24f7c82fb614f8bba0244094881ed7bd589a1e9facddc9b105c591accd",
+                "uncompressed-sha256": "858fbdf03f7bf76bad63e08e9d0c9410ae56907862448e0810a8dd9ecedd6dfa"
               }
             }
           }
@@ -353,64 +365,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "10.2.20260521-0",
-              "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+              "release": "10.2.20260715-0",
+              "object": "rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260715-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +431,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "be9128478123b1c8f1c6ae9980ad5969ce57ffdad13c9d72463240be96445cca",
-                "uncompressed-sha256": "ef2531a6fb5b070159148ed0161abac3255079cd302317aceef0f567e0bbbf26"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "50d83930efa937682d870c18be2c3d2732475684e11ac075af7f61038ba8cbfb",
+                "uncompressed-sha256": "e883fc762f5940f19f1967705c2f1123279fb5e621784f6b616d57ee46e09f35"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-kubevirt.s390x.ociarchive",
-                "sha256": "e40618141ea6e6c3716fa98debfdb7643018bb60f686e939bbf60d0bd3f11b24"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-kubevirt.s390x.ociarchive",
+                "sha256": "ae9d59b1dcd0425a1be2236384a1012d5348d58e77e97f84766ce2157a7419ac"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-metal4k.s390x.raw.gz",
-                "sha256": "afa3cb0d123cbf54860405c59520ed27817f874cd88c3e757d314073af7db820",
-                "uncompressed-sha256": "53d4ef3b6c6137a9d9a8e856e4e1b261562486fe5de7e1be5cc534bccbc39bd2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-metal4k.s390x.raw.gz",
+                "sha256": "5830eacfbc4ae68ef21003348123cbc748d34fd2b5ca642534bbd591619a4b1f",
+                "uncompressed-sha256": "3d885b58195ee3f9c566c3bd37a16d53193ea5af63e16f4966129260f45b2951"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-iso.s390x.iso",
-                "sha256": "50fe6c0ed31ad4c3e82ae0a38ff8cdcfb0364c8bfcfd5d43647408a47c4cbdc8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-live-iso.s390x.iso",
+                "sha256": "b3c89e1755608ccffbb24839b311c8fc78d642527a2cceddc1df61b2a2f75c5e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-kernel.s390x",
-                "sha256": "692867f01e6be50813a1f00a28155e849f767668898245cd14a72178b5b2b370"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-live-kernel.s390x",
+                "sha256": "03c78bfd14d2dfb052a062fecde1e8a065db6e6860a98ca04a5aeec1ffa43de4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-initramfs.s390x.img",
-                "sha256": "9c6435d31ff5a07b1cc207374658f6d84dac4e00663fc91cf22de61a9ae848fd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-live-initramfs.s390x.img",
+                "sha256": "762ff11fb71798aa77b9f7a3968688b40eba9d3c23dc41399c1b8bdae45fc58b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-rootfs.s390x.img",
-                "sha256": "3371e495ca82ff82cafeb93021e6f2895682bbbd7f89759771f7a5faace94118"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-live-rootfs.s390x.img",
+                "sha256": "47cc1e57169a6e2d4f570e540377817c56f55eaee2f27a24e5a52a896c563d68"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-metal.s390x.raw.gz",
-                "sha256": "99d5db5944a4010dbe4d49177f6a7661a7774c1dd57a0259023bb7c594579158",
-                "uncompressed-sha256": "3af2bedfdcedf09d0440e3e69921cc1f7eadad674384abfe090a0cfd449dd049"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-metal.s390x.raw.gz",
+                "sha256": "b1f0d0752f71d741dc482b5e70f9631723e095a75b1d485ef4cc13ce2ee68875",
+                "uncompressed-sha256": "38f13ed12bd7931acccaf70c02ff5e658c192ffc1d11e32c64df0d89b529c8c0"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-openstack.s390x.qcow2.gz",
-                "sha256": "5038f843e5b51834f553acb4ec7402025c9e8dacb98dbb6c104fb5f88cacbd09",
-                "uncompressed-sha256": "0ec38edf8d31be1d7d6e3b52c4fde98588d8cbfd71e02036a702c925bf36557a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-openstack.s390x.qcow2.gz",
+                "sha256": "bd18667090f5328e4d6ddffd06598d4bc530a4b9a36510ce3643ab5e3e8205dd",
+                "uncompressed-sha256": "8dac48bdbce8ca1633d0d12c266b385cf6079bda7a07c7d22798249cd600ddd9"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-qemu.s390x.qcow2.gz",
-                "sha256": "b153ea128f33558aea82b28f426f4cf97b0a029a96fb36da3fc7cc791e8f8fc0",
-                "uncompressed-sha256": "5a6fd94e23cd2afdd33ec30e1826e325f93b081ba38e67a877160d3cf1940e64"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-qemu.s390x.qcow2.gz",
+                "sha256": "340c5fb67463301145b17ae51a5ecf4718d0610c7e4f047032f84fa4e5ece9b0",
+                "uncompressed-sha256": "e2067c07c5688b11c445e7f12fbc727cebfa15bce3098b48233eabab91e6493e"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "b3a8ea547b2e968ebac26783852f480dec3d9c551c8cf0dc3518d468a23671f8",
-                "uncompressed-sha256": "29e252f6217ff359892f380709644576ed5092be7467cc9dc3f41ed8bdbd194d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/s390x/rhcos-10.2.20260715-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "03efde8a182eefd0be183782589bcd34071a70143eed94b311345e385d8e0040",
+                "uncompressed-sha256": "e29086e6eafc78ebd9ace2e6a12123bb031d9ea297e5d502915182d59684b85c"
               }
             }
           }
@@ -519,165 +531,177 @@
       },
       "images": {
         "kubevirt": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6860a903823f8456456a0b9eb987ac2a3572745d05903c610e6ba9dde7470438"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8fba1eee8118a5499a46b1f696d24d40432082775a7e0cadfdfa0cc86a3f700c"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-aws.x86_64.vmdk.gz",
-                "sha256": "1a276abe6dd0028afbd58474aa7931a1edfd99d4a604876f694d2f225eafdea2",
-                "uncompressed-sha256": "32029b2027c407600ff99986f56208a90beac6a6aefae62b176f64988922977a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-aws.x86_64.vmdk.gz",
+                "sha256": "226ed517b4e356f596ac1ed983628ef92adef39c369e0b2bcd92b4673f6c7d7f",
+                "uncompressed-sha256": "d4a5f153253ccef3d371c445a02b3676f361d759678a604c1782b99f5ca8e41a"
               }
             }
           }
         },
         "azure": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-azure.x86_64.vhd.gz",
-                "sha256": "6b496cff802fb70f227ba1f4b54ed1c14a4a496588fb289618ef30e8b163202e",
-                "uncompressed-sha256": "d76b8aa8c9914574827db379574b24aa843c68260df18930e50f239c3dde214a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-azure.x86_64.vhd.gz",
+                "sha256": "97cd67b45ae99eb2c6b5e6ea94ebab4ece36171356d3cf6f596484f03a861203",
+                "uncompressed-sha256": "bab602c67ced1be1318b63633f24cbd1e1f31a8fedab08eee1132f829ea30793"
               }
             }
           }
         },
         "azurestack": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-azurestack.x86_64.vhd.gz",
-                "sha256": "21a2aa626358f2a59917320a241650e02243221b8e967d849f28f795a81576f1",
-                "uncompressed-sha256": "d6f7e118d43f59c3475b49b6d7f0ac8530067bafe894c7d543d26ce91ef43233"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-azurestack.x86_64.vhd.gz",
+                "sha256": "46247352c89204deb96a92a7e90d349597fbc3d540362153a833715e34833a50",
+                "uncompressed-sha256": "88ac45c226f474904302bd833351447fd3152c1c8bfd95358a56dc1e5415142b"
               }
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-gcp.x86_64.tar.gz",
-                "sha256": "0d2ba5058178683bc549a3068ee81f25c2f4f638b8f2e93ad7e8e591ccb261d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-gcp.x86_64.tar.gz",
+                "sha256": "65ae29c9752efb175c9027285820e4abc8f670942a317c10fc1c8a5a80451f5c"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "011c1686fec24c9e9993e2f01fa18b2b59238a609896332dc1858bd6af640b32",
-                "uncompressed-sha256": "6af62dc4d00ebf96ec37e5532089efd826574bc667909e21b801955483bee66a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "cf68a4a6dd6e2fec12cfdc83b8bf846055244ae0eb05f8f196cceee38bd2ae11",
+                "uncompressed-sha256": "60177bae1b9029b2ca77877592c2062e15e7a5eb229b8226963264e18f9ceef2"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-kubevirt.x86_64.ociarchive",
-                "sha256": "a414bec70e6ad56fbdc52f6314f0c0c3a157390b14106a7fb532e50277adcc0b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-kubevirt.x86_64.ociarchive",
+                "sha256": "b07c5e880edac55f87e076419d04dd524be938863e0d2898e3716dbec2805bc7"
               }
             }
           }
         },
         "metal": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-metal4k.x86_64.raw.gz",
-                "sha256": "d22a49c34fe481a2b488cf2b8045e974f41b056d52a961d434176872cfbfa830",
-                "uncompressed-sha256": "3a96c60a6520fe5cd894cf7f4618ace15e2aefefed8960ac9394c8f31d770b97"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-metal4k.x86_64.raw.gz",
+                "sha256": "398ba8f924c1bca07b304ef552f960734ca86bbb4ccfface3e0f0335aa31503f",
+                "uncompressed-sha256": "e904edbd1690ca9b29e44add3680a84961c06cd640556ec376a1cc77264af790"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-iso.x86_64.iso",
-                "sha256": "2391c8f0d86b6c14aa9ce02c866af109f360a162ddcdb7e3f5a76eb3a7238b6d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-live-iso.x86_64.iso",
+                "sha256": "7d27ddd567d158b648ffa627089b299289f3a88cd42b736c33df1143fd24b462"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-kernel.x86_64",
-                "sha256": "62f6c048aef362c496f6f7cd3b0bb07d9a648fbacb212e2d1951979dcbe72f75"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-live-kernel.x86_64",
+                "sha256": "4b0899930552d10dee096be3eb2cb4f945f857ca5ad08e27d44f5b8cbc088eb4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-initramfs.x86_64.img",
-                "sha256": "488c4d0f71641de54a54795d594337c8c7d12c1dabb2c3c1de1b87f75b42b97d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-live-initramfs.x86_64.img",
+                "sha256": "0fd8de5e88597c5f235ae259824aa4b5227452332bb480054229a2da8ee73294"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-rootfs.x86_64.img",
-                "sha256": "9651ccaa3c5d99f037368507cd4a56b85d53932613a3b335bbdc4caedb362793"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-live-rootfs.x86_64.img",
+                "sha256": "7d4afc79a6d8c31454d85f6372f0890cdcf1dd0368a8704ac5ec355c9957cb5c"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-metal.x86_64.raw.gz",
-                "sha256": "5c8483811f6ad487b0bed7b00d5a4cc6a72add05b67e0dd4e02d21172e19df83",
-                "uncompressed-sha256": "1061cb3e69b59f5cb27bce34698b8e9e8720d6ff6b2610679375fa1d03af953f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-metal.x86_64.raw.gz",
+                "sha256": "37b8d87ae90e8590c4e0b6103190035b3b8a7a4c9cb8b766e2721e55ded6e3a5",
+                "uncompressed-sha256": "1168c60c43d8db5a06d59400578fbba2d659058acbdb5a0af2aebe75465a5f0e"
               }
             }
           }
         },
         "nutanix": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-nutanix.x86_64.qcow2",
-                "sha256": "5fd345509ef66685fbdc04bef9eec5198e58f0cc77750d7c7712610684c5b020"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-nutanix.x86_64.qcow2",
+                "sha256": "f9f602d73f11390154733d59d67f02f3c6d19fb27d818f98b5ed078a170d4e91"
               }
             }
           }
         },
         "openstack": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-openstack.x86_64.qcow2.gz",
-                "sha256": "763fa94cb70d8543983eb4e15bf154d2bd72d8ffc227ab0b0a210d7d591a022d",
-                "uncompressed-sha256": "a6c820cd306f0112c148d62b4f72581741a79206d6dcd1b186f28008c139f66f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-openstack.x86_64.qcow2.gz",
+                "sha256": "c08303893d6dd11608e7f4613e338591c7d2250e88617ee485ce601b43240049",
+                "uncompressed-sha256": "a55d10f0f3ae4a79a24556e749d7569c28b2c5af7cee2056e6d4e21e60367d4d"
+              }
+            }
+          }
+        },
+        "oraclecloud": {
+          "release": "10.2.20260715-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-oraclecloud.x86_64.qcow2.gz",
+                "sha256": "11454ef30b47bc2ba5b38f38c4b4c616847d81cfedbe98daecf39492e548a59e",
+                "uncompressed-sha256": "d01b7cb760ad2ac548d704ffd6609dc91f6313eb938bf45acce3ae6a9dc45368"
               }
             }
           }
         },
         "qemu": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-qemu.x86_64.qcow2.gz",
-                "sha256": "5b6eb490d8dba2c3057d39498e397509ca3435fcf7be70ee084fb08739a186ef",
-                "uncompressed-sha256": "c5e3ad16c520b75c75025eb7c06f12d2242281683938d11a43bdabba04dc5ebb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-qemu.x86_64.qcow2.gz",
+                "sha256": "9a5c8fe0894db56165a335ef1423bd2b2fde8e6f122c5e2339c6c86b98df6ebd",
+                "uncompressed-sha256": "97dacea542ccc1ff5c0f3503fc98c6dd784a37f71e6bd769cbfb419c97ffb4f6"
               }
             }
           }
         },
         "vmware": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-vmware.x86_64.ova",
-                "sha256": "ee4fd4d7f2d96a5e72344a03a8aacd0c81c0e24f4fec6983dbf3639f241180d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/x86_64/rhcos-10.2.20260715-0-vmware.x86_64.ova",
+                "sha256": "047c1642aca7f6a848f6f239507dacae4329563d543a50790944f7e8038b2ecb"
               }
             }
           }
@@ -687,290 +711,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-00b9419956a1b8301"
+              "release": "10.2.20260715-0",
+              "image": "ami-05c37201878e36dac"
             },
             "ap-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-093ce74a7831d5796"
+              "release": "10.2.20260715-0",
+              "image": "ami-013d71691d6282b85"
             },
             "ap-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f1f5f78fad6126f3"
+              "release": "10.2.20260715-0",
+              "image": "ami-030ca5bf92778d65f"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0b1305ab18da2b503"
+              "release": "10.2.20260715-0",
+              "image": "ami-04f22d56acba8a165"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-089d5b21fb5472656"
+              "release": "10.2.20260715-0",
+              "image": "ami-0fed99e2bf80aea18"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-08b988fa11f0772c3"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f5b937ac530500da"
             },
             "ap-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-030c986c15d7d21fe"
+              "release": "10.2.20260715-0",
+              "image": "ami-08b9fb58c26d81f5d"
             },
             "ap-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0baf89a420726a0c9"
+              "release": "10.2.20260715-0",
+              "image": "ami-03d56fdb1a727352c"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-07db2a2569bf635d5"
+              "release": "10.2.20260715-0",
+              "image": "ami-04a4d537de220f7e6"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0c66ca97b4cb72a96"
+              "release": "10.2.20260715-0",
+              "image": "ami-07c15edaa047a52c1"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0ea4633b5accce1cc"
+              "release": "10.2.20260715-0",
+              "image": "ami-06259340f24c14377"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0b9a19c6d404ebe82"
+              "release": "10.2.20260715-0",
+              "image": "ami-04d95d787cc499e7b"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0860196faab6d36f5"
+              "release": "10.2.20260715-0",
+              "image": "ami-0738a052f29ebb8d4"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260521-0",
-              "image": "ami-05391d944831d449c"
+              "release": "10.2.20260715-0",
+              "image": "ami-06837ef5f71b2333b"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0ea7c99fe14478e31"
+              "release": "10.2.20260715-0",
+              "image": "ami-0dc49d202ca3f9193"
             },
             "ca-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-01a1c5433b11c6040"
+              "release": "10.2.20260715-0",
+              "image": "ami-02134e8468c69e038"
             },
             "ca-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0aaec38c9c3c18973"
+              "release": "10.2.20260715-0",
+              "image": "ami-0cf685d7c4e2f115b"
             },
             "eu-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-050a2036417aa85c9"
+              "release": "10.2.20260715-0",
+              "image": "ami-038087b95229af209"
             },
             "eu-central-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0dc1cab1a5a382089"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f7add16535539145"
             },
             "eu-north-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0ebb900e33852ac20"
+              "release": "10.2.20260715-0",
+              "image": "ami-084bd2f45461b2641"
             },
             "eu-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06794550da69b4d4f"
+              "release": "10.2.20260715-0",
+              "image": "ami-0d1687e928755427e"
             },
             "eu-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-09b9b2363f8b9bf79"
+              "release": "10.2.20260715-0",
+              "image": "ami-076e084cea4ec4903"
             },
             "eu-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-00277e2896ce030cd"
+              "release": "10.2.20260715-0",
+              "image": "ami-0aba7be9d548d8831"
             },
             "eu-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06c08d05f6a1085e5"
+              "release": "10.2.20260715-0",
+              "image": "ami-035c3042668af014c"
             },
             "eu-west-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0c94bd2324f9a7dc4"
+              "release": "10.2.20260715-0",
+              "image": "ami-001eff5ce74306328"
             },
             "il-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-090c5d273c266bcb1"
+              "release": "10.2.20260715-0",
+              "image": "ami-0ccd894c5c2c7c45c"
             },
             "mx-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0127400b1a4f4d8a8"
+              "release": "10.2.20260715-0",
+              "image": "ami-0a7020eb754a9f6fc"
             },
             "sa-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0d636038b33e48e74"
+              "release": "10.2.20260715-0",
+              "image": "ami-035e211736d96d4a9"
             },
             "us-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06c799e44545e8040"
+              "release": "10.2.20260715-0",
+              "image": "ami-026c3565b2e140a8f"
             },
             "us-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0b56c6461b8dfea32"
+              "release": "10.2.20260715-0",
+              "image": "ami-00bceb1d4863de8d5"
             },
             "us-gov-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-00a5a8f684bfe21a4"
+              "release": "10.2.20260715-0",
+              "image": "ami-054a256518f6779b1"
             },
             "us-gov-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0ee3e9e7a587954c3"
+              "release": "10.2.20260715-0",
+              "image": "ami-09493294918f32a0c"
             },
             "us-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0ceb35adb65ceb3ee"
+              "release": "10.2.20260715-0",
+              "image": "ami-030623e6ced67aefc"
             },
             "us-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0a8a99e4004c7938d"
+              "release": "10.2.20260715-0",
+              "image": "ami-09d49112a1306f262"
             }
           }
         },
         "gcp": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-10-2-20260521-0-gcp-x86-64"
+          "name": "rhcos-10-2-20260715-0-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "10.2.20260521-0",
+          "release": "10.2.20260715-0",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aec3a148abce32bebabb41bfb65a3f129ca3d8ef05a9cf904c6b0de814837d6f"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a6ebcfb81d23c56b6efb4774e90ad8f9fbc9c6084796866af79b9372b898dba4"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-04629785741cd0c85"
+              "release": "10.2.20260715-0",
+              "image": "ami-0648fefdfdfd37772"
             },
             "ap-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-04e7b5cda044a345b"
+              "release": "10.2.20260715-0",
+              "image": "ami-0bba320960f966f20"
             },
             "ap-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-09597825db0fdfd3b"
+              "release": "10.2.20260715-0",
+              "image": "ami-038a860637181b890"
             },
             "ap-northeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0a55ac6f11719c822"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e721586ef04044d2"
             },
             "ap-northeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-08b646066f246736b"
+              "release": "10.2.20260715-0",
+              "image": "ami-08a4fe7bbdf941fc9"
             },
             "ap-northeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f736787bf849916b"
+              "release": "10.2.20260715-0",
+              "image": "ami-0fb8045529e752a6f"
             },
             "ap-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-06fe750217b18f5fc"
+              "release": "10.2.20260715-0",
+              "image": "ami-0bd752fae0b2ac2a4"
             },
             "ap-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0690504f72e3b04c0"
+              "release": "10.2.20260715-0",
+              "image": "ami-00edb1c1d604ca98a"
             },
             "ap-southeast-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-01bad64fdf89571fc"
+              "release": "10.2.20260715-0",
+              "image": "ami-083d0fa187efa39e3"
             },
             "ap-southeast-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-025c7ec136eb0cbf8"
+              "release": "10.2.20260715-0",
+              "image": "ami-08fabbfdb4f9e6482"
             },
             "ap-southeast-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-03c8c75788294dba7"
+              "release": "10.2.20260715-0",
+              "image": "ami-0d320aa9cc1633024"
             },
             "ap-southeast-4": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f70c9b515dd1a3b1"
+              "release": "10.2.20260715-0",
+              "image": "ami-0af5f9e96ff66bdf5"
             },
             "ap-southeast-5": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f8c0d70e09800f21"
+              "release": "10.2.20260715-0",
+              "image": "ami-0c500dfe48597e6f6"
             },
             "ap-southeast-6": {
-              "release": "10.2.20260521-0",
-              "image": "ami-043fa8fbc9b96d662"
+              "release": "10.2.20260715-0",
+              "image": "ami-04deeaada42d956a3"
             },
             "ap-southeast-7": {
-              "release": "10.2.20260521-0",
-              "image": "ami-04e24a754fa786364"
+              "release": "10.2.20260715-0",
+              "image": "ami-088ea81e2a08b663e"
             },
             "ca-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-03b7a55496c42fc63"
+              "release": "10.2.20260715-0",
+              "image": "ami-0858193e4c8ee5b62"
             },
             "ca-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0a80835b7278dc187"
+              "release": "10.2.20260715-0",
+              "image": "ami-01086887bd3c994e1"
             },
             "eu-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-02338882f5dafcfc4"
+              "release": "10.2.20260715-0",
+              "image": "ami-0d1755bc956801be0"
             },
             "eu-central-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-04863e0aebc2f44b7"
+              "release": "10.2.20260715-0",
+              "image": "ami-0d6093add7a207886"
             },
             "eu-north-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0e73038567e8437e4"
+              "release": "10.2.20260715-0",
+              "image": "ami-0a7afa68ca22609dd"
             },
             "eu-south-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0931fa534f93a042f"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e0ac57dadcaf1ab9"
             },
             "eu-south-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0fc02e1bd72841712"
+              "release": "10.2.20260715-0",
+              "image": "ami-05b949c2a121f003b"
             },
             "eu-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0182cecfd8a730b77"
+              "release": "10.2.20260715-0",
+              "image": "ami-04fe481e7565ae103"
             },
             "eu-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0348960515ef650db"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f752ff59c8b0d39f"
             },
             "eu-west-3": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0bf738ff0aa9bcab8"
+              "release": "10.2.20260715-0",
+              "image": "ami-0cb61ac0cd757c89c"
             },
             "il-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-09d3310d723b575c2"
+              "release": "10.2.20260715-0",
+              "image": "ami-0e47406ea13abefd8"
             },
             "mx-central-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0d01c8db5fe377d0a"
+              "release": "10.2.20260715-0",
+              "image": "ami-0ec2f94496976cb5f"
             },
             "sa-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0df670278a153b916"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f480726bfb767807"
             },
             "us-east-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-025b0888df6c921ee"
+              "release": "10.2.20260715-0",
+              "image": "ami-01b8ebd9b3d74d74c"
             },
             "us-east-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0d7cc58bab2be7cbb"
+              "release": "10.2.20260715-0",
+              "image": "ami-0f567edf0859e3b39"
             },
             "us-west-1": {
-              "release": "10.2.20260521-0",
-              "image": "ami-0f0c99139c39f0f5b"
+              "release": "10.2.20260715-0",
+              "image": "ami-0feb18654dafb55c6"
             },
             "us-west-2": {
-              "release": "10.2.20260521-0",
-              "image": "ami-08e35831290bf6e10"
+              "release": "10.2.20260715-0",
+              "image": "ami-00f300f51af36e885"
             }
           }
         },
         "azure-disk": {
-          "release": "10.2.20260521-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260521-0-azure.x86_64.vhd"
+          "release": "10.2.20260715-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260715-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/coreos/coreos-rhel-9.json
+++ b/data/data/coreos/coreos-rhel-9.json
@@ -1,117 +1,118 @@
 {
   "stream": "rhcos-4.21",
   "metadata": {
-    "last-modified": "2026-05-26T02:01:01Z",
-    "generator": "plume cosa2stream 5f75da4"
+    "last-modified": "2026-07-16T23:16:28Z",
+    "generator": "plume cosa2stream cbcb7c7"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-aws.aarch64.vmdk.gz",
-                "sha256": "babb75e4dd4a81aeed3b4fe343b8b24511e8e959858d065b3cd86d8e97ec6a65",
-                "uncompressed-sha256": "80d6a781ec13b07ffa8b44ee46ed0d7d3bc7bc747650be8bb03d63bbc8b0d547"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-aws.aarch64.vmdk.gz",
+                "sha256": "917446ad6a925bc9e4fa74b3c6b0f494bc4fc398f6c31448cdf940608a3f0b2a",
+                "uncompressed-sha256": "c478b113a7d14cc55a1209789e6853a52cbb8ee0cf3977c979817ae97bbd2436"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-azure.aarch64.vhd.gz",
-                "sha256": "8079d31ae4f745ba6c2c5da8bafba7d0f3db1691393ebbbb8f995c915ad9a04d",
-                "uncompressed-sha256": "a934425896ec87d313377b5391d23e7da29a3e9e3b80b486a4b1c10fbeae7793"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-azure.aarch64.vhd.gz",
+                "sha256": "3a8f2256d089696feefd9827f98cd55d70efd4f6db1befabf7d108ee5b707fb7",
+                "uncompressed-sha256": "593586fc1fc4d67c41aaa709a8b40ac628b1c2b94f9e981242b4b49140b9b92f"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-gcp.aarch64.tar.gz",
-                "sha256": "9d88450d80e9d5b14572e595296d8e26321b2f80e6c9f3138c8be13db23c170e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-gcp.aarch64.tar.gz",
+                "sha256": "c1db4d485c0e3456d3d93b47e09d7cdb846b67e0aa7da610bd5d92620ccbd02b"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-metal4k.aarch64.raw.gz",
-                "sha256": "fd7aefc04a05c496f270e1e3958c4955e567dcba00c589e4dc456b720566c87f",
-                "uncompressed-sha256": "73e8d2c4ba2f5a2835b7d6b15f7ddfe4c02ba8a74cb1018ae73e44db43f4b940"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-metal4k.aarch64.raw.gz",
+                "sha256": "d9293d0ecd3e7b3e7d944baf96d01fe544c1ff79b8a44270c898c4b0b7554cf0",
+                "uncompressed-sha256": "e8b4a9fa5e1f616c39a6f11e7f82a513f6005d7d9811e0de6f055c33bb641a41"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-iso.aarch64.iso",
-                "sha256": "a7f66f1dd3eca61713a2fa8893f28c4afc1afd4c98993c9ffe6b3ef2a3059bf9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-live-iso.aarch64.iso",
+                "sha256": "8e77b50a6953891df157a75f2b57b71971785a3dc05efabcd4acce343258eab9"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-kernel.aarch64",
-                "sha256": "6c888d8ff349fe44c347bcad2bc7cb7fa6abc2f5297d8b5e8b1564c65c9c682c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-live-kernel.aarch64",
+                "sha256": "2b7e019bc1cfcaa245d273a934f72c46c04022dfc8eeda844b622828c1e13c34"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-initramfs.aarch64.img",
-                "sha256": "e8d315ab836e8712f19b73672f1d435017a3cf37d64c8e0b511e41c1c3578450"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-live-initramfs.aarch64.img",
+                "sha256": "e4c39ca42e479a6136381663b332f2596c9dd8864adce19a2422b67453333e0d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-rootfs.aarch64.img",
-                "sha256": "e791fc8eced9fc65b012cace13689a1d13cfacd2c42334188a634f358c64e975"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-live-rootfs.aarch64.img",
+                "sha256": "dc2de6ee0af2e584d3f57ff249dd6a6795253f5b35bc4ecc5675a590e4bbc759"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-metal.aarch64.raw.gz",
-                "sha256": "8c95a89bfb6e80dbf695ad0f6dab40771705b3cd7138918ee217d808fabaea40",
-                "uncompressed-sha256": "3c37094e9ce89291956d7bc037b0700b3618e610532c220a72c416d311b0dc50"
-              }
-            }
-          }
-        },
-        "nvidiabluefield": {
-          "release": "9.8.20260520-0",
-          "formats": {
-            "bfb": {
-              "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-nvidiabluefield.aarch64.bfb",
-                "sha256": "d3a5458c03857021eaa748698e4116ac33a2dfc850f4895b6d5181da884f1439"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-metal.aarch64.raw.gz",
+                "sha256": "e9a0bc826b8e87d381336fa862b722556ba235e4d5f0360152235e2a3a7663e5",
+                "uncompressed-sha256": "46050f940cb7e3075322e2772e8d285fe339d0085f3561f919136df1953bdb62"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-openstack.aarch64.qcow2.gz",
-                "sha256": "12e8bdd0112dda5d19428a6b8799f76312bb27ffc893b991a950abd331616426",
-                "uncompressed-sha256": "bc4fec3f06c24fc48c6171a9d4df37d679dae7ffd7b187e769b46837fba1b3fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-openstack.aarch64.qcow2.gz",
+                "sha256": "34f78f59b503a22327af9177d1c333155a6cc52812256f2a944b392d77e3b59b",
+                "uncompressed-sha256": "a32a6b14ff064ee38427372f524d187fb5e7719fc116e34cc2e0302a2aeb9e0d"
+              }
+            }
+          }
+        },
+        "oraclecloud": {
+          "release": "9.8.20260715-1",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-oraclecloud.aarch64.qcow2.gz",
+                "sha256": "427f635eaefa930cbbb18f9bcc48a0721804d3934de302c4096e78640d1489d5",
+                "uncompressed-sha256": "d6473590c720d36ace8e944b2f2d613eeba944289ca68cb6b2946230ff1b540c"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-qemu.aarch64.qcow2.gz",
-                "sha256": "ec850a9b055cac5f38b49375464ea14b30058e136be39c935ad7e90b298ed38c",
-                "uncompressed-sha256": "875e0213b3d2a4cc120567f3084177033627b75d35d0562802b7c8b870bac424"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/aarch64/rhcos-9.8.20260715-1-qemu.aarch64.qcow2.gz",
+                "sha256": "ec62b07ac57acda4770e72bd0a5a669e33b096b76790ea0044b50dfebfa5fd96",
+                "uncompressed-sha256": "5bb388ec2c976f3a69fd6990171e3dc6f3399225ee73e67bb71ca32f70855b4c"
               }
             }
           }
@@ -121,229 +122,229 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09b3b126662fe7a18"
+              "release": "9.8.20260715-1",
+              "image": "ami-090e98376b008c24c"
             },
             "ap-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-009fe8f4f06381d2e"
+              "release": "9.8.20260715-1",
+              "image": "ami-02ffc396c2432d05f"
             },
             "ap-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0403657dcda8a5e9c"
+              "release": "9.8.20260715-1",
+              "image": "ami-05b5ed005b5082f42"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0f9d02af671b8f84e"
+              "release": "9.8.20260715-1",
+              "image": "ami-0cab770415626f477"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09fb79703d81dad43"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e3ce644b0d9b5eab"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-038a507ec93b04ce1"
+              "release": "9.8.20260715-1",
+              "image": "ami-0783bed23a0fc3ca6"
             },
             "ap-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0eb4f5b5dbaa33c62"
+              "release": "9.8.20260715-1",
+              "image": "ami-03c5c13a072aae969"
             },
             "ap-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0d0f18aae857f459b"
+              "release": "9.8.20260715-1",
+              "image": "ami-03362167b2060e845"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0519530b4a949ac79"
+              "release": "9.8.20260715-1",
+              "image": "ami-0757ca703a44448d7"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-029b0ef4d6d0872e6"
+              "release": "9.8.20260715-1",
+              "image": "ami-0be21023c7da97e39"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0e04bab1932cc8079"
+              "release": "9.8.20260715-1",
+              "image": "ami-0f99bc65b81da18b0"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260520-0",
-              "image": "ami-03b0fdc3fbc4a0fa4"
+              "release": "9.8.20260715-1",
+              "image": "ami-08dd96b9cd7af93b9"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260520-0",
-              "image": "ami-046fecd472297b7c4"
+              "release": "9.8.20260715-1",
+              "image": "ami-0beed6ca33a1ae42d"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260520-0",
-              "image": "ami-088024b57838dfd53"
+              "release": "9.8.20260715-1",
+              "image": "ami-04d6c62a05dc3820a"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260520-0",
-              "image": "ami-00c84a187abf62194"
+              "release": "9.8.20260715-1",
+              "image": "ami-0c8487cb7aca26300"
             },
             "ca-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0f65ba965f0cdf25b"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e0f89624ae6f6561"
             },
             "ca-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0ce3bfdc385214b60"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e75465363d8378f0"
             },
             "eu-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-077c9e69aa2a7442b"
+              "release": "9.8.20260715-1",
+              "image": "ami-0c19d58cb75d733c0"
             },
             "eu-central-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0843ce8434ed947e0"
+              "release": "9.8.20260715-1",
+              "image": "ami-06593313b37053df5"
             },
             "eu-north-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-047f81c57b0567e80"
+              "release": "9.8.20260715-1",
+              "image": "ami-03fe2813461e69675"
             },
             "eu-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-048742ddf9599b9a3"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d16b2d6a474b4360"
             },
             "eu-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0385fbca30108a3a9"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e099dce9627ef699"
             },
             "eu-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-04631bbd6c1be5b55"
+              "release": "9.8.20260715-1",
+              "image": "ami-0ae75c9607a8862d8"
             },
             "eu-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0915a41744ba40397"
+              "release": "9.8.20260715-1",
+              "image": "ami-07842bb8f69d670e1"
             },
             "eu-west-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09fd8d0e79f45b71a"
+              "release": "9.8.20260715-1",
+              "image": "ami-0c231f4816ba0776a"
             },
             "il-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0853f94ef8841751a"
+              "release": "9.8.20260715-1",
+              "image": "ami-003f9933b627323b8"
             },
             "mx-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-039d2c56cbe869df0"
+              "release": "9.8.20260715-1",
+              "image": "ami-0221fbcd56aa31a7a"
             },
             "sa-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0915393860fee75df"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e6a4ffe9dd1dee56"
             },
             "us-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0e3af3b58f5710e43"
+              "release": "9.8.20260715-1",
+              "image": "ami-07031017151259e76"
             },
             "us-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-017020cb8aeeda203"
+              "release": "9.8.20260715-1",
+              "image": "ami-067f68ab29b40d089"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-014a147dae2cf3359"
+              "release": "9.8.20260715-1",
+              "image": "ami-0fe15e383af1e71d4"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-07113f5ee8cde6fb3"
+              "release": "9.8.20260715-1",
+              "image": "ami-0754d7722527cf959"
             },
             "us-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09ca10147735afd05"
+              "release": "9.8.20260715-1",
+              "image": "ami-0ba2883e0cf3e3558"
             },
             "us-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-00e116f16409da3de"
+              "release": "9.8.20260715-1",
+              "image": "ami-0a85236299582ce82"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260520-0-gcp-aarch64"
+          "name": "rhcos-9-8-20260715-1-gcp-aarch64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "9.8.20260520-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.aarch64.vhd"
+          "release": "9.8.20260715-1",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260715-1-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-metal4k.ppc64le.raw.gz",
-                "sha256": "facd7fc270bff93f8134da6d570fd9f43f2ad75dd3a3484087a37ffc63d1ed32",
-                "uncompressed-sha256": "cdf6170ed2b8ba4fab15eca4206163caad1b356c81cdefd94492e6dde2bd0bf1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-metal4k.ppc64le.raw.gz",
+                "sha256": "6050f86eb9cb502366fc66d67f6eb62c95b0caaa5b2cd31e4d5a1247eeb626d0",
+                "uncompressed-sha256": "8c3157b41ec0cf061daaa4782dd0c680f37e5955df801bbf6e5de234e83cecaf"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-iso.ppc64le.iso",
-                "sha256": "5f7fa3a1b494a4ab5ebec1b510ca0f75fe16a7b6c62872f6d3be58ac32d1ce19"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-live-iso.ppc64le.iso",
+                "sha256": "9e600b96db3ee6a786f5a94fc2748145519f390f877e7f6ba4d21b9844401135"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-kernel.ppc64le",
-                "sha256": "90219684f62e0757f4c3480a1f80c24933fa111d77714c77609da112df1bc9b8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-live-kernel.ppc64le",
+                "sha256": "115706db1c07f26a138e076c59fcec4fb27446ba03cbd6afea5c72e3d807688f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-initramfs.ppc64le.img",
-                "sha256": "bbbe590182a5c010bd6fbfb2939b7ecaef7190be49324dc3a57bc4b53339f8a0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-live-initramfs.ppc64le.img",
+                "sha256": "4625e5373d28b301261ee0dd3364834815b98dc1885d53c4ae8cc0aae880f34e"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-rootfs.ppc64le.img",
-                "sha256": "a89908555ce77be91e06bae735128d8f3fb0bfe9efdb2fc0d07e44cce098262b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-live-rootfs.ppc64le.img",
+                "sha256": "049e270e2464740f72e2a98f86343f490160c2487da3b23e76ebea8cb3c1899d"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-metal.ppc64le.raw.gz",
-                "sha256": "f033a7001b5bd7c24bcb161d87edf1a0403d74031a52feb8099c6e3692115965",
-                "uncompressed-sha256": "310a5da961a2c0e7bc6c2d451609b05b439bc6cbf6060e925d285b71832062cc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-metal.ppc64le.raw.gz",
+                "sha256": "49c3b9f0bd4a19f5f0de736d9202ce3a802db511035ae8512c6c25293ce083ab",
+                "uncompressed-sha256": "932fe7d9b032553a2b2903781c1c47c52338b9403b44ee412cb1afc58ead3bac"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "6ab344908e3ea34ee6bcd7b810533004eba259217a7730d36120383edd82aeb1",
-                "uncompressed-sha256": "e5c50d5689ba92f68f8c5382f03eedbf12f8a31b3be9ae0e9c99242fb429cc9e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-openstack.ppc64le.qcow2.gz",
+                "sha256": "f28ce487eb2f35ce2be3e9f11bdace721d80edad878804b709660f48d7be711b",
+                "uncompressed-sha256": "78b5215987361d2ef4fc17d241f714e203fb24007c0e173a7f8d4e8c1bba41ec"
               }
             }
           }
         },
         "powervs": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-powervs.ppc64le.ova.gz",
-                "sha256": "ddb83d65656e88b9adde29d32c3a3181b9656f1eeed718d14eb07e1ce4268494",
-                "uncompressed-sha256": "26779dad00883c64d11898ee10e14e508008deef65daf83f248371f344fc10d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-powervs.ppc64le.ova.gz",
+                "sha256": "bfa2ad1249495c4e48921b416c37f016b3a4580f9be036aa308e4b9774ff9b16",
+                "uncompressed-sha256": "bae4497b07bfe3cfb8810939471983ac3f9dd293f3053267520bdde12f1a11b6"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "0f79b8749924a5d74dd92f77fdd848033b5cc91eecad41f0aab527566cbd51c3",
-                "uncompressed-sha256": "728aa75818a1c32e27969d2621aacbc077809013a3f87a6d79e322328c182d29"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/ppc64le/rhcos-9.8.20260715-1-qemu.ppc64le.qcow2.gz",
+                "sha256": "d2ea147d26a3edaec0e1b02a7a281bf7a11e3b5838454d062e684fba2db53d8c",
+                "uncompressed-sha256": "a46dd6084a64550eca2fdff8623fa6f6e75674dd3173ba8c17e8ee6154c5714d"
               }
             }
           }
@@ -353,64 +354,64 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "eu-es": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-es",
-              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "9.8.20260520-0",
-              "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+              "release": "9.8.20260715-1",
+              "object": "rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260715-1-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -419,99 +420,99 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "7c579dc338ad4436426071fca5741b8e0865e6ee005f112e2cf8c5e408f89cd1",
-                "uncompressed-sha256": "4e84dfb034760345869400f8c55e86cf391450750c77df217ca95b1b98cba739"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-ibmcloud.s390x.qcow2.gz",
+                "sha256": "aaa80aec1d9af1028f27b457e46b4a29828f6ea0344ee4fd7095e51d52eb4e83",
+                "uncompressed-sha256": "7b971e0a2ec6eff8ea4c4e76b2f6edb6500571ee3ea74541dc67ead528beb7b1"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-kubevirt.s390x.ociarchive",
-                "sha256": "714779e1ab79e3d0ef3bd846c05ddecafc7023520561d62db836cb2c173c979a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-kubevirt.s390x.ociarchive",
+                "sha256": "2c40988482efc96bb283d3bcf6732fb34ac6ffeddb75da5de0c9e52b1767da11"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-metal4k.s390x.raw.gz",
-                "sha256": "8dce196544207435e19e18396f0f8b66f8e66b78fac5c2a2879a21aabd9275f7",
-                "uncompressed-sha256": "6e7e1fd62515435188a2ddf7311f08abb837a6f7322a589e5a86b0047336f3a3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-metal4k.s390x.raw.gz",
+                "sha256": "c932cb1fbc3c3f78c635db34d94d5427f5fae02a1ed5762b3886863f6ec20194",
+                "uncompressed-sha256": "2ffb6a3c6bc1d28d2a557a6496c41136cab78baca66dc3c617bda8eac2952de9"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-iso.s390x.iso",
-                "sha256": "5e97807bc3b835d4ccfe0948eb074e6b007541c523665da73cff0b029368a0ad"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-live-iso.s390x.iso",
+                "sha256": "0e69d5cea340a17d02b979812d204af83f3326ae18265196be3ffc7f23411f29"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-kernel.s390x",
-                "sha256": "a102492869419aaa153dcb3acb71d60eaafd81de9a0c3bc228a606837d04974c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-live-kernel.s390x",
+                "sha256": "d955720cba1d2e157968c0d6f41d6e52d7b32da09a5165e78f7612b84d9d9d24"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-initramfs.s390x.img",
-                "sha256": "ad3b5107756f88ef914214c93019bc3f66e8dd11be803db50233de1fa8d861c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-live-initramfs.s390x.img",
+                "sha256": "ad3bcda56b7481fdcfd02808b21efa24eb7da8c5d46a7d6a09e0e5178836894c"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-rootfs.s390x.img",
-                "sha256": "8994ca03a0465335867b7d8e2f5effef90cbc09e450f19a3d400a538f4a43d40"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-live-rootfs.s390x.img",
+                "sha256": "508bad73c5a63ed842bf70a9022c9abe28e60139a7cb27f5b5c594a9b3fe5e79"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-metal.s390x.raw.gz",
-                "sha256": "340b827b050891d018851ff189443070d0a02fe1692bed94540cd1ee6108b745",
-                "uncompressed-sha256": "55c30b7ae036ab8517756647e3ed1491e7301404af032e867bd35ccf9d673001"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-metal.s390x.raw.gz",
+                "sha256": "d824dd65b1515f2221ea3792aabcb5af3c373395199206b2957fe47c32d1678f",
+                "uncompressed-sha256": "40705943aa5b6fa83e7d98a326aee67520217c2d55a152a9074dc42cf2ac0bbf"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-openstack.s390x.qcow2.gz",
-                "sha256": "633b7bd1a93eb82f98988c77143a82770988a134e772286e5ccbf937a014cdae",
-                "uncompressed-sha256": "8b6d4f7e1f720d148faa8008345af067fa1b01331e6e0c53001e77a6233823ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-openstack.s390x.qcow2.gz",
+                "sha256": "42fab89a3dd8019e86f274786a7e7bef35aefdec0ecf4677278742d9f6d3baed",
+                "uncompressed-sha256": "f92f72d590ba327f6743c2185e9161dc2c5ccae5b786b308ed977bf3c66b1a17"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-qemu.s390x.qcow2.gz",
-                "sha256": "423427590eb9f62e0fc148665baebeb08f2f89197ea8131d263351d2951d0f78",
-                "uncompressed-sha256": "e94c5b6f745df02dd61bd42f2cc533e582de20db0ee58b0b14b8548c4d1a4e78"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-qemu.s390x.qcow2.gz",
+                "sha256": "c89249231017592d140be5ae31a9e376948a6c5556a8f4379f5eb8feba3eacb0",
+                "uncompressed-sha256": "88e71d7431ac86afa3ee34e8362737bccaf498d7b8c1c4c865e96907b0053fa2"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "a2c67eaa121983fd57887bcd1433dd0d20991195e1b9ee7831a23e4784c46fdf",
-                "uncompressed-sha256": "ea0861f09e19a87840b299a5575ec9360815380696984a0931b5cf19e3329b87"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/s390x/rhcos-9.8.20260715-1-qemu-secex.s390x.qcow2.gz",
+                "sha256": "521cbc3403e7297e70b00ab7dbae2d755115c53fe168c2e53cf5b8c3ddc645bc",
+                "uncompressed-sha256": "159670e29034877f52458d34ab9eed1945e9209fc4b46416ca4ea17ee45864a5"
               }
             }
           }
@@ -519,165 +520,177 @@
       },
       "images": {
         "kubevirt": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bcbee9a66fd77578c842adfc29e4f7b1e3433bd86290cc918f35047a9abf2055"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b1406d915d67ad54b739e160ea04981aa1a8bfebfceaa08e3d54a2764183f52c"
         }
       }
     },
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-aws.x86_64.vmdk.gz",
-                "sha256": "997667d50ff8c33932c715879a6865bcd412d305fb63ce3d9a085c6f80b6dbe8",
-                "uncompressed-sha256": "cee668d495aad654c948d81c55fec7b9fc49607f68cfc0cefb14e57b56e3d789"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-aws.x86_64.vmdk.gz",
+                "sha256": "d617de333fceceb822d9eca6da5e4b660d1f3d48e29b876f0387f2e38c0aaebf",
+                "uncompressed-sha256": "5bd94b6b2f87ba8fe9698890e98c212203dbb115339c1f31f5a1ffba3d2ea385"
               }
             }
           }
         },
         "azure": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-azure.x86_64.vhd.gz",
-                "sha256": "1fe5ef5bf54178f1f3013cf3841d37f21d878c56cfcb6b7d0487e0620beb7c64",
-                "uncompressed-sha256": "51d5a7a48c773301dcadfad6e7f7e8cc5e2026d2420345540e8636a9386d0460"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-azure.x86_64.vhd.gz",
+                "sha256": "4067938f321431e473058ab0b73078628b6bab6aaa21b2c62df9a5c8e7590c9d",
+                "uncompressed-sha256": "1b5da350e6cc9daae88b6e05031828c239ddf8b601133950575a8777be6d8a9d"
               }
             }
           }
         },
         "azurestack": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-azurestack.x86_64.vhd.gz",
-                "sha256": "d0de38fb3061aa73b167250e3521ac6fe6409ff7a64f096b55e29d4029350ce1",
-                "uncompressed-sha256": "d475515f6af8b7325dee679411523c376325b328ee06b30b78c5ca7d7dc8855e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-azurestack.x86_64.vhd.gz",
+                "sha256": "d5fc37eb1c9b04c3cf078b72b7fe4838e1a9bb7b6677ab254b83eaef1c357b20",
+                "uncompressed-sha256": "f56a8d52aa5f184c9cc5879a278f7177e6920834ac933b8a973a97704acf1ded"
               }
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-gcp.x86_64.tar.gz",
-                "sha256": "632af30cc4a9d822983136fe5160df8964849ebceaf7886ace86e5c878e2d658"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-gcp.x86_64.tar.gz",
+                "sha256": "83d86e2e4c6158a0264c3eb9ef2b245051a1f3ad16b494df830963dd709f98a6"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "3e8120aae1ceb68c4b6758d0b8d9b370b193ababd58cfe755a6805980a517ac1",
-                "uncompressed-sha256": "9a6b73b6edb86411d69ac10a51973f715193a0bf6c8402cb60c3d78f3b9c49b8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "d4d95983d607658faef838423803161b82cd23b70e4784ad2534e56e9610a38e",
+                "uncompressed-sha256": "48f324274fc7a31aec31e5eb35a3c6bd1793a5fafe819750bf03c27266173c38"
               }
             }
           }
         },
         "kubevirt": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "ociarchive": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-kubevirt.x86_64.ociarchive",
-                "sha256": "e4f06da6e30d03031678ce09c08657a44871ea422da9c8689bc26bd400000262"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-kubevirt.x86_64.ociarchive",
+                "sha256": "de6166872974b19ce1b890e4bb4214e30c4f9810baf6c940a2dbcb0cdf49b5cc"
               }
             }
           }
         },
         "metal": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-metal4k.x86_64.raw.gz",
-                "sha256": "ebf7c696b54bcdc45a443bc7829da3fe4530bf8a39223e3b6a5f4fc93b7fbca4",
-                "uncompressed-sha256": "d5a6d1dd8b92d4eb9821d19409f15b81f411b2a2e8063d239600c56b35fadcdf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-metal4k.x86_64.raw.gz",
+                "sha256": "fb923afc84bcdaf71956ca7dd595d73aa97dc7c747a4ede168e25d0cdbb83826",
+                "uncompressed-sha256": "8f0066dca5320335475d17140818e3a3d55ab92156d4f5d3f863f0ea91d6088e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-iso.x86_64.iso",
-                "sha256": "a5a4f5649f0dca87e381be07f40d2da10b6800b3e0d153c03a4ae441576e076d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-live-iso.x86_64.iso",
+                "sha256": "a834d568436337d72377b64bad9f101f6fc7f0a411ca812f47965b1c2c2bedbc"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-kernel.x86_64",
-                "sha256": "1f0cfbf65799bc1e610433308393055360dbf9e772b37b1179bd70d55bfa8d16"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-live-kernel.x86_64",
+                "sha256": "98d6814ad88e646c595cd5d0705d1d26d315c527f35e4385771b4ae2254ac336"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-initramfs.x86_64.img",
-                "sha256": "855fcdeb65fc74341a36383446805e2bc7fc43b0af9ef586ccf9a75078d21c88"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-live-initramfs.x86_64.img",
+                "sha256": "06b0b09f2e880ff1235a188b887202e2e35aef39ac5c711ccfec41f721aca70a"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-rootfs.x86_64.img",
-                "sha256": "77836ae027501853e4e84f6cd74d72c6d30d3287918aa3faec995685d4cfc850"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-live-rootfs.x86_64.img",
+                "sha256": "7e56af38b7ee422e7ccc33007f0c28872b00b06da5bf4793ba60bd61c828a9c0"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-metal.x86_64.raw.gz",
-                "sha256": "e273adc5c8da35b99c9b60bf850674b37657e7db8cadee691824c961947cc707",
-                "uncompressed-sha256": "0a620d1fdb9725c0e8c8ba9db67743149f9e2b9d0353b07f20ef6096a97194b1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-metal.x86_64.raw.gz",
+                "sha256": "d703a248de8823d1bc2c91533c9ea0327425e53adc7f019a1ba12c5d37607919",
+                "uncompressed-sha256": "de3e581ebe2cd6936589232bd1b018e3edcd8470866a29f6ac66a7a988c1f144"
               }
             }
           }
         },
         "nutanix": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-nutanix.x86_64.qcow2",
-                "sha256": "f89efa4d668129f982f75b17913796b68f285b65a79c18f0ab62816bbd1256d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-nutanix.x86_64.qcow2",
+                "sha256": "20136e4e9679ffcd08bd87baa73036b5af658cf038baf20e444212edf571b88c"
               }
             }
           }
         },
         "openstack": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-openstack.x86_64.qcow2.gz",
-                "sha256": "cbe1fed8954394f1429703f787a24abd37c712a58c4f93b53a5b05519ba8d455",
-                "uncompressed-sha256": "2d373472a1dbe7e54f76fd2f1d3604a57be1f398aef53cf154e5912d3a66f482"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-openstack.x86_64.qcow2.gz",
+                "sha256": "6c09f73c238fbcc9a4fdb86de1af4bb66227c9d9b44a391606ec88bfb8d1bf7e",
+                "uncompressed-sha256": "f02f372f3f802fc65cddb896404dc67cc6350cdaec7ffaeecb659613486cf50d"
+              }
+            }
+          }
+        },
+        "oraclecloud": {
+          "release": "9.8.20260715-1",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-oraclecloud.x86_64.qcow2.gz",
+                "sha256": "a07f81238a9ca72e7d803e83db057fc8c766af4411a339e6bc264723412e6ab5",
+                "uncompressed-sha256": "0ccd63a6c72995fe51429331c08336432521e497a33858fcd872a4a889f5e755"
               }
             }
           }
         },
         "qemu": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-qemu.x86_64.qcow2.gz",
-                "sha256": "eb7eefd2f518a44745fa6e435912f7f5028f92adc52e41b4e2b06dd10cf1f6dd",
-                "uncompressed-sha256": "b3fda398884317472bdf50b70f760b57f2aaf41962f9572488a8a81e0ac85894"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-qemu.x86_64.qcow2.gz",
+                "sha256": "b1c733a288f0980e527a492b6d604621545fe86aadc0189511964ee867a09904",
+                "uncompressed-sha256": "2d0fe4aea97d18a95c601e81a682f474267a95a59403259f3d65b17647032a80"
               }
             }
           }
         },
         "vmware": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-vmware.x86_64.ova",
-                "sha256": "160f7b0395f849fb8056f3b4de23c2ecb396efc6cb52cb954799388afaf1fd5a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260715-1/x86_64/rhcos-9.8.20260715-1-vmware.x86_64.ova",
+                "sha256": "a3ec50999113db0409dc75747e2a3f704224b436927ff0cb79f71db8fd16e43d"
               }
             }
           }
@@ -687,290 +700,290 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0e09db1a117f89982"
+              "release": "9.8.20260715-1",
+              "image": "ami-065229dcdeea5f9b6"
             },
             "ap-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0f3883046e2b590c4"
+              "release": "9.8.20260715-1",
+              "image": "ami-0aee926ea72d3b04c"
             },
             "ap-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05fda30c28d357b97"
+              "release": "9.8.20260715-1",
+              "image": "ami-00aaf7a70b4625181"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0acebf7451fbed435"
+              "release": "9.8.20260715-1",
+              "image": "ami-0c78f64d9a885c173"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-07e85fe3474ab6f53"
+              "release": "9.8.20260715-1",
+              "image": "ami-0fc49ff64e479b1f5"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0bf06ecbd16316390"
+              "release": "9.8.20260715-1",
+              "image": "ami-04322409852db2c85"
             },
             "ap-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-001b087fae6b102a2"
+              "release": "9.8.20260715-1",
+              "image": "ami-04d475d929cabfc98"
             },
             "ap-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-02e59bb73395086de"
+              "release": "9.8.20260715-1",
+              "image": "ami-0a44f8809b6269f6d"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-07e0e4d66f0276e33"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e38d6bd2282d8072"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0656ee074d43ebeb9"
+              "release": "9.8.20260715-1",
+              "image": "ami-076ce220d3f44fa4f"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0b8ac3107bf7b8091"
+              "release": "9.8.20260715-1",
+              "image": "ami-08c4e237a48e8a24d"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260520-0",
-              "image": "ami-06a85e79ca82e97d3"
+              "release": "9.8.20260715-1",
+              "image": "ami-08ae75477cfec863f"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260520-0",
-              "image": "ami-068e811f466ce5eec"
+              "release": "9.8.20260715-1",
+              "image": "ami-0918a6de7debcd942"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260520-0",
-              "image": "ami-01801dc800c336d1f"
+              "release": "9.8.20260715-1",
+              "image": "ami-0720c264eaffd3628"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260520-0",
-              "image": "ami-01b449b1bf9c95caf"
+              "release": "9.8.20260715-1",
+              "image": "ami-03e766cc0ac5a9d5e"
             },
             "ca-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-016a214bc34aed24c"
+              "release": "9.8.20260715-1",
+              "image": "ami-0a7b15fc279056718"
             },
             "ca-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0279542db8d76fe7c"
+              "release": "9.8.20260715-1",
+              "image": "ami-090627c0bd0ce09e3"
             },
             "eu-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-02b4be39da643ac06"
+              "release": "9.8.20260715-1",
+              "image": "ami-016bcb89d328ec1ac"
             },
             "eu-central-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09e9173753792f284"
+              "release": "9.8.20260715-1",
+              "image": "ami-0c3faadd1797e3868"
             },
             "eu-north-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0b4a484d5db49d4a5"
+              "release": "9.8.20260715-1",
+              "image": "ami-071372b5430c069a2"
             },
             "eu-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-02f2692568ca70d48"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d8a13644e176f1f8"
             },
             "eu-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0777de9170dd480a0"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e3f9a41df3b903c6"
             },
             "eu-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0754b5979bce4f62f"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d598411cb2c6a0e5"
             },
             "eu-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05a2b3abb8cf0cc92"
+              "release": "9.8.20260715-1",
+              "image": "ami-00667f67a54be771a"
             },
             "eu-west-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-01ba91ba1e67b52fa"
+              "release": "9.8.20260715-1",
+              "image": "ami-05754d266e357951a"
             },
             "il-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0be1e841b9475abc2"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e9a0f9e1a4c49b92"
             },
             "mx-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-04e5e190abb398aef"
+              "release": "9.8.20260715-1",
+              "image": "ami-0cbb81ed4429c0503"
             },
             "sa-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09b6c03d247ba3007"
+              "release": "9.8.20260715-1",
+              "image": "ami-084f80cae5527784a"
             },
             "us-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-09a04cae40b5df1b1"
+              "release": "9.8.20260715-1",
+              "image": "ami-0980843632a1c3a66"
             },
             "us-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-008f91aec6651d818"
+              "release": "9.8.20260715-1",
+              "image": "ami-03b58703d4e9ea61a"
             },
             "us-gov-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-083a079a4e93810d0"
+              "release": "9.8.20260715-1",
+              "image": "ami-05b3066122ae9e9ec"
             },
             "us-gov-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-03c270b5f712d93c5"
+              "release": "9.8.20260715-1",
+              "image": "ami-0a90a0dc9913213aa"
             },
             "us-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-000065c53330c76d2"
+              "release": "9.8.20260715-1",
+              "image": "ami-0399f6912ea26e33c"
             },
             "us-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0106a1d635d4a36c0"
+              "release": "9.8.20260715-1",
+              "image": "ami-01d48aa6b50f9d0df"
             }
           }
         },
         "gcp": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "project": "rhcos-cloud",
-          "name": "rhcos-9-8-20260520-0-gcp-x86-64"
+          "name": "rhcos-9-8-20260715-1-gcp-x86-64"
         },
         "kubevirt": {
-          "release": "9.8.20260520-0",
+          "release": "9.8.20260715-1",
           "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
-          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:024cb7de8d9e21ef7fc2bcb90f8dd77e7f742d937822c95e4ec72b9ab48fea7d"
+          "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2b0eabefc64da4df51e6d7b7ab84e98417558f19847b6f136e54cbd2359d9204"
         }
       },
       "rhel-coreos-extensions": {
         "aws-winli": {
           "regions": {
             "af-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0f714f6517c9d016f"
+              "release": "9.8.20260715-1",
+              "image": "ami-0dd185285ca843d25"
             },
             "ap-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0577eeeae04d22229"
+              "release": "9.8.20260715-1",
+              "image": "ami-00543bb0095fa7d23"
             },
             "ap-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0292a0a795c3f3d41"
+              "release": "9.8.20260715-1",
+              "image": "ami-07f067e13ec1f3eb6"
             },
             "ap-northeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0a4a58bace1eec1bf"
+              "release": "9.8.20260715-1",
+              "image": "ami-0001b45ada7d2dc51"
             },
             "ap-northeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-024f9af412e8e5fda"
+              "release": "9.8.20260715-1",
+              "image": "ami-002a19eea3002d594"
             },
             "ap-northeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-062da8b605d19e1f0"
+              "release": "9.8.20260715-1",
+              "image": "ami-018a94206d329a769"
             },
             "ap-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-06c9a5797035f6ec5"
+              "release": "9.8.20260715-1",
+              "image": "ami-0e79be45f2303f422"
             },
             "ap-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-006a3ba40b81e7e68"
+              "release": "9.8.20260715-1",
+              "image": "ami-087ff0fa7fd5aa606"
             },
             "ap-southeast-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-02d836c02d12549da"
+              "release": "9.8.20260715-1",
+              "image": "ami-0de2f48ef57114708"
             },
             "ap-southeast-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05ef34bbc717783b5"
+              "release": "9.8.20260715-1",
+              "image": "ami-035fc3102b495e061"
             },
             "ap-southeast-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0ef2955291a017868"
+              "release": "9.8.20260715-1",
+              "image": "ami-03fcff06b8c5ac019"
             },
             "ap-southeast-4": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0698dbb27842933e5"
+              "release": "9.8.20260715-1",
+              "image": "ami-02e98f28520c61cd3"
             },
             "ap-southeast-5": {
-              "release": "9.8.20260520-0",
-              "image": "ami-053a4e24d78ed0d67"
+              "release": "9.8.20260715-1",
+              "image": "ami-08d5a47fb2f53f23a"
             },
             "ap-southeast-6": {
-              "release": "9.8.20260520-0",
-              "image": "ami-07ca2f504ecb9314f"
+              "release": "9.8.20260715-1",
+              "image": "ami-01c8bfb2576fb7da8"
             },
             "ap-southeast-7": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05bf98f73e9241182"
+              "release": "9.8.20260715-1",
+              "image": "ami-0a4c225c885068069"
             },
             "ca-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0c3338c7efad3ec9a"
+              "release": "9.8.20260715-1",
+              "image": "ami-059f37640c6141981"
             },
             "ca-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0992376ec4897fc46"
+              "release": "9.8.20260715-1",
+              "image": "ami-0bddd3545406608aa"
             },
             "eu-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-036c68d29575b583e"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d6e91c6dae1b3c98"
             },
             "eu-central-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0f19f652bb725f295"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d68739d819850b39"
             },
             "eu-north-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0055f4b25c33781ab"
+              "release": "9.8.20260715-1",
+              "image": "ami-0477b3b24fd452453"
             },
             "eu-south-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0e72c26fb402fbe28"
+              "release": "9.8.20260715-1",
+              "image": "ami-01f10c1ca2ec66aa1"
             },
             "eu-south-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-07f86962840bf77e4"
+              "release": "9.8.20260715-1",
+              "image": "ami-0625d6961800b66ab"
             },
             "eu-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0ad984e0dd8c08040"
+              "release": "9.8.20260715-1",
+              "image": "ami-061e04994c7f50e3d"
             },
             "eu-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0be3668bd2cafc141"
+              "release": "9.8.20260715-1",
+              "image": "ami-087614ea800b0b80a"
             },
             "eu-west-3": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0c2c852546612d7e6"
+              "release": "9.8.20260715-1",
+              "image": "ami-0450d6616ff432cfd"
             },
             "il-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05229890b9fc0e77f"
+              "release": "9.8.20260715-1",
+              "image": "ami-07cb628f267b263d1"
             },
             "mx-central-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0862a29bb196d26ed"
+              "release": "9.8.20260715-1",
+              "image": "ami-0540d29d57768211f"
             },
             "sa-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-05dd182f06c736610"
+              "release": "9.8.20260715-1",
+              "image": "ami-0d05715541d4175e7"
             },
             "us-east-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-08298b57bfd602d1b"
+              "release": "9.8.20260715-1",
+              "image": "ami-0754162aa1a6d247e"
             },
             "us-east-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-0245c7e4c6c909c70"
+              "release": "9.8.20260715-1",
+              "image": "ami-06fd07583064ed540"
             },
             "us-west-1": {
-              "release": "9.8.20260520-0",
-              "image": "ami-015f92b61a17c928d"
+              "release": "9.8.20260715-1",
+              "image": "ami-0b5fba6fa0c7197d8"
             },
             "us-west-2": {
-              "release": "9.8.20260520-0",
-              "image": "ami-01ca3b6c80acda171"
+              "release": "9.8.20260715-1",
+              "image": "ami-05c6c3d4e9396d633"
             }
           }
         },
         "azure-disk": {
-          "release": "9.8.20260520-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.x86_64.vhd"
+          "release": "9.8.20260715-1",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260715-1-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION

Update data/data/coreos/coreos-rhel-9.json to 9.8.20260715-1

Bumps the boot image to 4.22 to support https://github.com/coreos/coreos-assembler/pull/4594.
This updates OSBuild to generate "nvidiabluefield" BFB images with GRUB shims instead of kernels, enabling secure boot for their upcoming GA release.

```
plume cosa2stream --target data/data/coreos/coreos-rhel-9.json                 \n    --distro rhcos --no-signatures --name rhel-9.8                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=9.8.20260715-1                                       \n    aarch64=9.8.20260715-1                                      \n    s390x=9.8.20260715-1                                        \n    ppc64le=9.8.20260715-1
```
                    
Update data/data/coreos/coreos-rhel-10.json to 10.2.20260715-0

Bumps the boot image to 4.22 to support https://github.com/coreos/coreos-assembler/pull/4594.
This updates OSBuild to generate "nvidiabluefield" BFB images with GRUB shims instead of kernels, enabling secure boot for their upcoming GA release.

```
plume cosa2stream --target data/data/coreos/coreos-rhel-10.json                 \n    --distro rhcos --no-signatures --name rhel-10.2                     \n    --url https://rhcos.mirror.openshift.com/art/storage/prod/streams  \n    x86_64=10.2.20260715-0                                       \n    aarch64=10.2.20260715-0                                      \n    s390x=10.2.20260715-0                                        \n    ppc64le=10.2.20260715-0
```
                        