### PR TITLE
OCPBUGS-98700: Azure: delete bootstrap ignition storage during bootstrap destroy

### DIFF
--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -828,6 +829,15 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 			return fmt.Errorf("failed to delete konnectivity security rule: %w", err)
 		}
 	}
+
+	// Clean up bootstrap storage account (ignition container and optionally
+	// the entire account if no image gallery containers remain).
+	if in.Metadata.Azure.CloudName != aztypes.StackCloud {
+		if err := deleteBootstrapIgnition(ctx, session, opts, resourceGroupName, in.Metadata.InfraID); err != nil {
+			logrus.Warnf("Failed to clean up bootstrap storage: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -882,6 +892,71 @@ func randomString(length int) string {
 	}
 
 	return string(s)
+}
+
+// deleteBootstrapIgnition removes the ignition container and, if no other
+// containers remain, deletes the storage account created for bootstrap.
+func deleteBootstrapIgnition(ctx context.Context, session *azconfig.Session, opts *arm.ClientOptions, resourceGroupName, infraID string) error {
+	storageAccountName := aztypes.GetStorageAccountName(infraID)
+
+	storageClientFactory, err := armstorage.NewClientFactory(
+		session.Credentials.SubscriptionID,
+		session.TokenCreds,
+		opts,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client factory: %w", err)
+	}
+
+	blobContainersClient := storageClientFactory.NewBlobContainersClient()
+	_, err = blobContainersClient.Delete(ctx, resourceGroupName, storageAccountName, "ignition", nil)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return fmt.Errorf("failed to delete ignition container: %w", err)
+		}
+		logrus.Debugf("Ignition container already deleted from storage account %s", storageAccountName)
+	} else {
+		logrus.Infof("Deleted bootstrap ignition container from storage account %s", storageAccountName)
+	}
+
+	pager := blobContainersClient.NewListPager(resourceGroupName, storageAccountName, nil)
+	hasContainers := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if isNotFoundError(err) {
+				break
+			}
+			logrus.Warnf("Failed to list containers in storage account %s, skipping account deletion: %v", storageAccountName, err)
+			return nil
+		}
+		if len(page.Value) > 0 {
+			hasContainers = true
+			break
+		}
+	}
+
+	accountsClient := storageClientFactory.NewAccountsClient()
+	if !hasContainers {
+		_, err = accountsClient.Delete(ctx, resourceGroupName, storageAccountName, nil)
+		if err != nil {
+			if isNotFoundError(err) {
+				logrus.Debugf("Storage account %s already deleted", storageAccountName)
+				return nil
+			}
+			return fmt.Errorf("failed to delete storage account %s: %w", storageAccountName, err)
+		}
+		logrus.Infof("Deleted bootstrap storage account %s", storageAccountName)
+	} else {
+		logrus.Infof("Storage account %s has remaining containers, skipping deletion (will be removed with resource group)", storageAccountName)
+	}
+
+	return nil
+}
+
+func isNotFoundError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 // Ignition provisions the Azure container that holds the bootstrap ignition


### PR DESCRIPTION
## Summary

* On Azure IPI (CAPI) installs, the installer creates a storage account (`{infraID-no-hyphens}sa`) to host `bootstrap.ign`, but never deletes it during bootstrap destroy. The account can persist for the life of the cluster with sensitive bootstrap material.
* Regression from [CORS-2525](https://redhat.atlassian.net/browse/CORS-2525): Terraform-era fix ([#7642](https://github.com/openshift/installer/pull/7642)) was reverted ([#7822](https://github.com/openshift/installer/pull/7822) / OCPBUGS-24995). CAPI reimplemented creation but not deletion.
* Extend existing `PostDestroy` to delete the ignition container and, if no other containers remain (e.g. OKD/CVM `vhd` image gallery), delete the storage account. Azure Stack excluded. Best-effort (warn, do not fail install). Idempotent on 404.

## Fix details

1. Delete `ignition` container (always safe)
2. List remaining containers; skip SA delete if any remain
3. Conditionally delete storage account
4. Treat `ResourceNotFound`/404 as success
5. Skip Azure Stack (different storage SDK)

Pattern: AWS `PostDestroy` S3 ignition cleanup; GCP equivalent in [#8489](https://github.com/openshift/installer/pull/8489) (OCPBUGS-33681).

## What this does NOT change

* Existing SSH/NAT/konnectivity cleanup in `PostDestroy`
* Full `destroy cluster` (RG deletion still cleans up)
* Azure Stack storage path

## Test plan

- [x] `gofmt` / `go vet` clean on `pkg/infrastructure/azure/...`
- [x] Darwin/arm64 and Linux/amd64 builds of `openshift-install`
- [x] Pre-fix cluster: confirmed storage account `{infraID}sa` remains after install complete
- [ ] Post-fix install: confirm logs show ignition container (+ SA) deleted after bootstrap destroy
- [ ] OKD/CVM path: ignition deleted, SA retained when `vhd` container remains
- [ ] Azure Stack path: storage cleanup skipped

### Build evidence

```
$ go version
go version go1.25.8 darwin/arm64
$ gofmt -d pkg/infrastructure/azure/azure.go
(clean)
$ go vet ./pkg/infrastructure/azure/...
(clean)
$ go build -o bin/openshift-install-azure-fix ./cmd/openshift-install/
(success)
$ GOOS=linux GOARCH=amd64 go build -o bin/openshift-install-azure-fix-linux ./cmd/openshift-install/
(success)
```

Fixes: https://issues.redhat.com/browse/OCPBUGS-98700

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of bootstrap storage resources after infrastructure deletion.
  * Automatically removes empty bootstrap storage accounts when applicable.
  * Cleanup now safely handles resources that have already been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->