### PR TITLE
[release-4.22] Bug OCPBUGS-99399: baremetal: fix provisioning ISO kernel arguments

### DIFF
--- a/pkg/infrastructure/baremetal/bootstrap.go
+++ b/pkg/infrastructure/baremetal/bootstrap.go
@@ -241,6 +241,26 @@ RequiredBy=localfs.target
 	}, nil
 }
 
+func buildBootstrapKargs(arch string, fips bool) []byte {
+	consoleDevice := map[string]string{
+		"x86_64":  "ttyS0,115200n8",
+		"aarch64": "ttyAMA0,115200",
+		"s390x":   "ttysclp0",
+		"ppc64le": "hvc0",
+	}
+	var kargs string
+	if dev, ok := consoleDevice[arch]; ok {
+		kargs += " console=" + dev
+	}
+	if fips {
+		kargs += " fips=1"
+	}
+	if kargs == "" {
+		return nil
+	}
+	return []byte(kargs + "\n")
+}
+
 func createLiveVolume(virConn *libvirt.Libvirt, config baremetalConfig, pool libvirt.StoragePool) (libvirt.StorageVol, error) {
 	capabilities, err := getHostCapabilities(virConn)
 	if err != nil {
@@ -258,24 +278,12 @@ func createLiveVolume(virConn *libvirt.Libvirt, config baremetalConfig, pool lib
 	if err != nil {
 		return libvirt.StorageVol{}, err
 	}
-	consoleDevice := map[string]string{
-		"x86_64":  "ttyS0",
-		"aarch64": "ttyAMA0",
-		"s390x":   "ttysclp0",
-		"ppc64le": "hvc0",
-	}
-	var kargs string
-	if dev, ok := consoleDevice[arch]; ok {
-		kargs += " console=" + dev
-	}
-	if config.FIPS {
-		kargs += " fips=1"
-	}
+	kargsBytes := buildBootstrapKargs(arch, config.FIPS)
 	stream, err := isoeditor.NewRHCOSStreamReader(
 		isoFile,
 		ignition,
 		nil,
-		[]byte(kargs),
+		kargsBytes,
 	)
 	if err != nil {
 		return libvirt.StorageVol{}, err

--- a/pkg/infrastructure/baremetal/bootstrap_test.go
+++ b/pkg/infrastructure/baremetal/bootstrap_test.go
@@ -102,3 +102,76 @@ func TestConfigureDomainArchPreservesOtherFields(t *testing.T) {
 	assert.Equal(t, "hvm", dom.OS.Type.Type, "OS type should remain hvm")
 	assert.Equal(t, "kvm", dom.Type, "domain type should remain kvm")
 }
+
+func TestBuildBootstrapKargs(t *testing.T) {
+	tests := []struct {
+		name           string
+		arch           string
+		fips           bool
+		expectContains []string
+		expectMissing  []string
+	}{
+		{
+			name:           "x86_64 default",
+			arch:           "x86_64",
+			fips:           false,
+			expectContains: []string{"console=ttyS0,115200n8"},
+			expectMissing:  []string{"fips=1"},
+		},
+		{
+			name:           "x86_64 with FIPS",
+			arch:           "x86_64",
+			fips:           true,
+			expectContains: []string{"console=ttyS0,115200n8", "fips=1"},
+		},
+		{
+			name:           "aarch64 default",
+			arch:           "aarch64",
+			fips:           false,
+			expectContains: []string{"console=ttyAMA0,115200"},
+			expectMissing:  []string{"fips=1"},
+		},
+		{
+			name:           "s390x default",
+			arch:           "s390x",
+			fips:           false,
+			expectContains: []string{"console=ttysclp0"},
+			expectMissing:  []string{"fips=1"},
+		},
+		{
+			name:           "ppc64le default",
+			arch:           "ppc64le",
+			fips:           false,
+			expectContains: []string{"console=hvc0"},
+			expectMissing:  []string{"fips=1"},
+		},
+		{
+			name:          "unknown arch returns nil",
+			arch:          "riscv64",
+			fips:          false,
+			expectMissing: []string{"console="},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildBootstrapKargs(tc.arch, tc.fips)
+
+			if len(tc.expectContains) == 0 && len(tc.expectMissing) > 0 {
+				assert.Nil(t, result, "kargs should be nil for unknown arch without FIPS")
+				return
+			}
+
+			assert.NotNil(t, result, "kargs should not be nil")
+			kargs := string(result)
+			assert.True(t, kargs[len(kargs)-1] == '\n', "kargs should end with newline")
+
+			for _, s := range tc.expectContains {
+				assert.Contains(t, kargs, s)
+			}
+			for _, s := range tc.expectMissing {
+				assert.NotContains(t, kargs, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The provisioning ISO was missing ip=dhcp, causing bare metal nodes to fail to obtain an IP on the provisioning network. Additionally, console=ttyS0 without baud/parity data was causing lockups on some hardware.

Add ip=dhcp to the kernel arguments and specify baud rate and parity for serial console devices. Also append a trailing newline to preserve the COREOS_KARG_EMBED_AREA boundary for downstream consumers.