### PR TITLE
CORS-4514: Set sovereign cloud defaults for machine types

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -202,7 +202,22 @@ func validateServiceAccountPresent(client API, ic *types.InstallConfig) field.Er
 }
 
 // DefaultInstanceTypeForArch returns the appropriate instance type based on the target architecture.
-func DefaultInstanceTypeForArch(arch types.Architecture) string {
+func DefaultInstanceTypeForArch(arch types.Architecture, projectID string) string {
+	return DefaultInstanceTypeForArchAndProjectID(arch, projectID)
+}
+
+// DefaultInstanceTypeForArchAndProjectID returns the appropriate instance type based on the target architecture and project ID.
+// For sovereign cloud environments, it returns c3-standard-4 which is available in those regions.
+// For public GCP, it returns n2-standard-4 (x86) or t2a-standard-4 (ARM64).
+func DefaultInstanceTypeForArchAndProjectID(arch types.Architecture, projectID string) string {
+	cloudEnv := gcp.GetCloudEnvironment(projectID)
+
+	// Sovereign cloud uses c3-standard-4 for all architectures
+	if cloudEnv == gcp.CloudEnvironmentSovereign {
+		return "c3-standard-4"
+	}
+
+	// Public GCP: ARM64 uses t2a, x86 uses n2
 	if arch == types.ArchitectureARM64 {
 		return "t2a-standard-4"
 	}
@@ -232,7 +247,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		if ic.GCP.DefaultMachinePlatform.DiskType != "" {
 			defaultDiskType = ic.GCP.DefaultMachinePlatform.DiskType
 		} else {
-			defaultDiskType = gcp.DefaultDiskTypeForInstance(defaultInstanceType)
+			defaultDiskType = gcp.DefaultDiskTypeForInstance(defaultInstanceType, ic.GCP.ProjectID)
 		}
 
 		if ic.GCP.DefaultMachinePlatform.OnHostMaintenance != "" {
@@ -270,7 +285,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	if ic.ControlPlane != nil {
 		arch = string(ic.ControlPlane.Architecture)
 		if instanceType == "" {
-			instanceType = DefaultInstanceTypeForArch(ic.ControlPlane.Architecture)
+			instanceType = DefaultInstanceTypeForArch(ic.ControlPlane.Architecture, ic.GCP.ProjectID)
 		}
 		if ic.ControlPlane.Platform.GCP != nil {
 			if ic.ControlPlane.Platform.GCP.InstanceType != "" {
@@ -291,7 +306,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
 					))
 				}
-				cpDiskType = gcp.DefaultDiskTypeForInstance(instanceType)
+				cpDiskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID)
 			}
 			if ic.ControlPlane.Platform.GCP.OnHostMaintenance != "" {
 				cpOnHostMaintenance = ic.ControlPlane.Platform.GCP.OnHostMaintenance
@@ -334,7 +349,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		onHostMaintenance := defaultOnHostMaintenance
 		confidentialCompute := defaultConfidentialCompute
 		if instanceType == "" {
-			instanceType = DefaultInstanceTypeForArch(compute.Architecture)
+			instanceType = DefaultInstanceTypeForArch(compute.Architecture, ic.GCP.ProjectID)
 		}
 		if diskType == "" {
 			diskType = gcp.PDSSD
@@ -365,7 +380,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
 					))
 				}
-				diskType = gcp.DefaultDiskTypeForInstance(instanceType)
+				diskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID)
 			}
 		}
 

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -326,7 +326,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		c.FileList = append(c.FileList, azureMachines...)
 	case gcptypes.Name:
 		// Generate GCP master machines using ControPlane machinepool
-		mpool := defaultGCPMachinePoolPlatform(pool.Architecture)
+		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -278,7 +278,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		}
 		aws.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish)
 	case gcptypes.Name:
-		mpool := defaultGCPMachinePoolPlatform(pool.Architecture)
+		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -141,13 +141,13 @@ func defaultAzureMachinePoolPlatform(env azuretypes.CloudEnvironment) azuretypes
 	}
 }
 
-func defaultGCPMachinePoolPlatform(arch types.Architecture) gcptypes.MachinePool {
-	instanceType := icgcp.DefaultInstanceTypeForArch(arch)
+func defaultGCPMachinePoolPlatform(arch types.Architecture, projectID string) gcptypes.MachinePool {
+	instanceType := icgcp.DefaultInstanceTypeForArchAndProjectID(arch, projectID)
 	return gcptypes.MachinePool{
 		InstanceType: instanceType,
 		OSDisk: gcptypes.OSDisk{
 			DiskSizeGB: powerOfTwoRootVolumeSize,
-			DiskType:   gcptypes.DefaultDiskTypeForInstance(instanceType),
+			DiskType:   gcptypes.DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID),
 		},
 	}
 }
@@ -684,7 +684,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				}
 			}
 		case gcptypes.Name:
-			mpool := defaultGCPMachinePoolPlatform(pool.Architecture)
+			mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
 			mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.GCP)
 			if len(mpool.Zones) == 0 {

--- a/pkg/types/gcp/defaults/machinepool.go
+++ b/pkg/types/gcp/defaults/machinepool.go
@@ -35,7 +35,7 @@ func SetMachinePoolDefaults(platform *types.Platform, pool *gcp.MachinePool) {
 	if pool.InstanceType != "" && pool.OSDisk.DiskType == "" {
 		family := gcp.GetGCPInstanceFamily(pool.InstanceType)
 		if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; ok {
-			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstance(pool.InstanceType)
+			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstanceAndProjectID(pool.InstanceType, platform.GCP.ProjectID)
 		}
 	}
 }

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -372,24 +372,32 @@ func GetGCPInstanceFamily(instanceType string) string {
 }
 
 // DefaultDiskTypeForInstance returns the default disk type for a GCP instance type. If instance type is not
-// recognized, pd-ssd is return.
-func DefaultDiskTypeForInstance(instanceType string) string {
-	defaultDiskType := PDSSD
+// recognized, pd-ssd is returned. For sovereign cloud instances, hyperdisk-balanced is preferred when available.
+func DefaultDiskTypeForInstance(instanceType, projectID string) string {
+	return DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID)
+}
+
+// DefaultDiskTypeForInstanceAndProjectID returns the default disk type for a GCP instance type and project ID.
+// The cloud environment is automatically detected from the project ID.
+// For sovereign cloud, hyperdisk-balanced is preferred. For public GCP, pd-ssd is preferred.
+func DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID string) string {
 	diskTypes, ok := GetDiskTypes(instanceType)
-	if ok {
-		supportedDiskTypes := sets.New(diskTypes...)
-		switch {
-		case supportedDiskTypes.Has(PDSSD):
-			defaultDiskType = PDSSD
-		case supportedDiskTypes.Has(HyperDiskBalanced):
-			defaultDiskType = HyperDiskBalanced
-		default:
-			// this shouldn't happen because all supported instance types
-			// have either pd-ssd or hyperdisk balanced
-			defaultDiskType = diskTypes[0]
+	if !ok {
+		return PDSSD
+	}
+
+	preferred := []string{PDSSD, HyperDiskBalanced}
+	if GetCloudEnvironment(projectID) == CloudEnvironmentSovereign {
+		preferred = []string{HyperDiskBalanced, PDSSD}
+	}
+
+	supportedDiskTypes := sets.New(diskTypes...)
+	for _, dt := range preferred {
+		if supportedDiskTypes.Has(dt) {
+			return dt
 		}
 	}
-	return defaultDiskType
+	return diskTypes[0]
 }
 
 // GetDiskTypes gets the disk types associated with a (supported) GCP instance type.

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/installer/pkg/types/dns"
 )
 
@@ -18,6 +20,18 @@ const (
 	// UnmanagedFirewallRules indicates that the firewall rules should be managed by the user. The
 	// firewall rules should exist prior to the installation occurs.
 	UnmanagedFirewallRules FirewallRulesManagementPolicy = "Unmanaged"
+
+	// CloudEnvironmentSovereign is the cloud environment identifier for GCP sovereign clouds.
+	CloudEnvironmentSovereign = "sovereign"
+)
+
+var (
+	// sovereignCloudProjectPrefixes contains known project ID prefixes for sovereign clouds.
+	// Project IDs in sovereign clouds use the format: <prefix>:<project-id>
+	// This list helps distinguish from organization-scoped public GCP projects (orgname:project-id).
+	sovereignCloudProjectPrefixes = []string{
+		"eu0", // European sovereign cloud (Germany)
+	}
 )
 
 // DNS contains the gcp dns zone information for the cluster.
@@ -201,4 +215,26 @@ func GetDefaultServiceAccount(platform *Platform, clusterID string, role string)
 // installer.
 func ShouldUseEndpointForInstaller(endpoint *PSCEndpoint) bool {
 	return endpoint != nil && endpoint.ClusterUseOnly != nil && !(*endpoint.ClusterUseOnly)
+}
+
+// GetCloudEnvironment determines the cloud environment from the project ID format.
+// Returns CloudEnvironmentSovereign for sovereign cloud environments, empty string for public GCP.
+// Uses known sovereign cloud project ID prefixes to distinguish from organization-scoped
+// public GCP projects (orgname:project-id).
+func GetCloudEnvironment(projectID string) string {
+	// Check if project ID has a known sovereign cloud prefix
+	parts := strings.SplitN(projectID, ":", 2)
+	if len(parts) == 2 && sets.New(sovereignCloudProjectPrefixes...).Has(parts[0]) {
+		// Known sovereign prefix is definitive - this IS a sovereign cloud project
+		return CloudEnvironmentSovereign
+	}
+	// No known sovereign prefix found
+	return ""
+}
+
+// IsNonDefaultUniverseDomain returns true if the universe domain is non-empty
+// and not the default "googleapis.com" value.
+// This indicates a sovereign cloud or custom universe domain configuration.
+func IsNonDefaultUniverseDomain(universeDomain string) bool {
+	return universeDomain != "" && universeDomain != "googleapis.com"
 }


### PR DESCRIPTION
Configure default instance and disk types for sovereign cloud regions. Sovereign clouds have limited machine type availability compared to public GCP.

Use c3-standard-4 instances and hyperdisk-balanced disks as defaults for sovereign cloud regions (those with 'u-' prefix), as these types are available in sovereign clouds while the standard defaults (n2-standard-4 and pd-ssd) are not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for GCP sovereign cloud environments.
  * Added detection for non-default GCP universe domains.
* **Improvements**
  * Updated default GCP instance and OS disk selections to vary by the target project.
  * GCP control-plane and worker machine pool defaults now better reflect sovereign vs non-sovereign capabilities, improving generated infrastructure configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->