### PR TITLE
OCPBUGS-78995: Azure: Default Marketplace image (for hive)

### DIFF
--- a/pkg/asset/installconfig/azure/capabilities.go
+++ b/pkg/asset/installconfig/azure/capabilities.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -45,4 +46,14 @@ func GetHyperVGenerationVersions(capabilities map[string]string) (sets.Set[strin
 func GetVMNetworkingCapability(capabilities map[string]string) bool {
 	val, ok := capabilities[string(azure.AcceleratedNetworkingEnabled)]
 	return ok && strings.EqualFold(val, "True")
+}
+
+// GetArchitecture returns one of types.ArchitectureARM64 or types.ArchitectureAMD64.
+func GetArchitecture(capabilities map[string]string) types.Architecture {
+	val, ok := capabilities["CpuArchitectureType"]
+	if ok && val == "Arm64" {
+		return types.ArchitectureARM64
+	}
+	// If not ARM, assume x86. We already validated that it's one or the other.
+	return types.ArchitectureAMD64
 }

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -63,7 +63,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 		return nil, fmt.Errorf("failed to create machineapi.TagSpecifications from UserTags: %w", err)
 	}
 	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
-	image := capzImage(mpool.OSImage, in.Environment, confidentialVM, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
+	image := capzImage(mpool.OSImage, in.Environment, confidentialVM, in.Pool.Architecture, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
 	// Set up OSDisk
 	osDisk := capz.OSDisk{
 		OSType:     "Linux",
@@ -367,7 +367,7 @@ func bootDiagStorageURIBuilder(diag *aztypes.BootDiagnostics, storageEndpointSuf
 	return ""
 }
 
-func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
+func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confidentialVM bool, arch types.Architecture, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
 	switch {
 	case osImage.Publisher != "":
 		return &capz.Image{
@@ -400,9 +400,26 @@ func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confiden
 			},
 		}
 	case rhcosImg == "" && !confidentialVM:
-		// hive calls the machines function, but may pass an empty
-		// string for rhcos. In which case, allow MAO to choose default.
-		return &capz.Image{} // can't be nil or mapiImage will panic
+		// Hardcode the "oldest" image from marketplace-rhcos.json. MCO should update this.
+		sku := "420-arm"
+		if arch != types.ArchitectureARM64 {
+			if gen == "V2" {
+				sku = "420-v2"
+			} else {
+				sku = "aro_420"
+			}
+		}
+		return &capz.Image{
+			Marketplace: &capz.AzureMarketplaceImage{
+				ImagePlan: capz.ImagePlan{
+					Publisher: "azureopenshift",
+					Offer:     "aro4",
+					SKU:       sku,
+				},
+				Version:         "9.6.20251015",
+				ThirdPartyImage: false,
+			},
+		}
 	default: // Installer-created image gallery, for OKD && confidential VMs.
 		// image gallery names cannot have dashes
 		galleryName := strings.ReplaceAll(infraID, "-", "_")

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -183,7 +183,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	rg := platform.ClusterResourceGroupName(clusterID)
 
 	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
-	image := mapiImage(mpool.OSImage, platform.CloudName, confidentialVM, hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
+	image := mapiImage(mpool.OSImage, platform.CloudName, confidentialVM, icazure.GetArchitecture(capabilities), hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
 
 	if mpool.OSDisk.DiskType == "" {
 		mpool.OSDisk.DiskType = "Premium_LRS"
@@ -434,9 +434,9 @@ func generateSecurityProfile(mpool *azure.MachinePool) *machineapi.SecurityProfi
 	return securityProfile
 }
 
-func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
+func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidentialVM bool, arch types.Architecture, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
 	mImg := machineapi.Image{}
-	cImg := capzImage(osImage, azEnv, confidentialVM, gen, rg, sub, infraID, rhcosImg)
+	cImg := capzImage(osImage, azEnv, confidentialVM, arch, gen, rg, sub, infraID, rhcosImg)
 
 	if cImg.ID != nil {
 		mImg.ResourceID = trimSubscriptionPrefix(*cImg.ID)


### PR DESCRIPTION
In a path that _should_ only be reachable from hive's MachinePool controller, if no RHCOS image reference was provided, we were defaulting to an empty `capz.Image{}` and letting MAO/MCO figure out what to use. This wasn't working very well.

Here we hardcode the oldest marketplace image in this path instead. This should end up being forward compatible; and the in-cluster operators should eventually be able to upgrade it as needed.

This is one part of a two-part solution. The other part entails hive improving its discovery of gallery images and (VM and image) HyperVGenerations, which will need to be in place when they vendor this change in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Azure machine deployments now select RHCOS images based on the target CPU architecture.
  - When no custom RHCOS image is provided, Azure marketplace defaults are chosen that match the architecture and generation (including ARM64 and V2 variants).
  - This ensures the installer resolves the correct marketplace image set for the selected hardware type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->