### PR TITLE
OCPBUGS-78995: Azure Machines: Accept explicit image ID

### DIFF
--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -399,6 +399,9 @@ func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confiden
 				ThirdPartyImage: false,
 			},
 		}
+	case strings.HasPrefix(rhcosImg, "/subscriptions/"):
+		// An explicit non-marketplace resource path was supplied. Use it as is.
+		return &capz.Image{ID: &rhcosImg}
 	case rhcosImg == "" && !confidentialVM:
 		// hive calls the machines function, but may pass an empty
 		// string for rhcos. In which case, allow MAO to choose default.

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -458,5 +458,9 @@ func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidential
 // for MAPI, by removing the /subspcription/ prefix.
 func trimSubscriptionPrefix(image string) string {
 	rgIndex := strings.Index(image, "/resourceGroups/")
+	// Allow invalid inputs to fail downstream
+	if rgIndex < 0 {
+		return image
+	}
 	return image[rgIndex:]
 }

--- a/pkg/asset/machines/azure/machines_test.go
+++ b/pkg/asset/machines/azure/machines_test.go
@@ -1,0 +1,375 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+
+	aztypes "github.com/openshift/installer/pkg/types/azure"
+)
+
+func TestCapzImage(t *testing.T) {
+	testCases := []struct {
+		name           string
+		osImage        aztypes.OSImage
+		azEnv          aztypes.CloudEnvironment
+		confidentialVM bool
+		gen            string
+		rg             string
+		sub            string
+		infraID        string
+		rhcosImg       string
+		expectedImage  *capz.Image
+	}{
+		{
+			name: "marketplace image from osImage",
+			osImage: aztypes.OSImage{
+				Publisher: "RedHat",
+				Offer:     "RHEL",
+				SKU:       "8-lvm-gen2",
+				Version:   "latest",
+				Plan:      aztypes.ImageWithPurchasePlan,
+			},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "",
+			expectedImage: &capz.Image{
+				Marketplace: &capz.AzureMarketplaceImage{
+					ImagePlan: capz.ImagePlan{
+						Publisher: "RedHat",
+						Offer:     "RHEL",
+						SKU:       "8-lvm-gen2",
+					},
+					Version:         "latest",
+					ThirdPartyImage: true,
+				},
+			},
+		},
+		{
+			name: "marketplace image no purchase plan from osImage",
+			osImage: aztypes.OSImage{
+				Publisher: "RedHat",
+				Offer:     "RHEL",
+				SKU:       "8-lvm-gen2",
+				Version:   "latest",
+				Plan:      aztypes.ImageNoPurchasePlan,
+			},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "",
+			expectedImage: &capz.Image{
+				Marketplace: &capz.AzureMarketplaceImage{
+					ImagePlan: capz.ImagePlan{
+						Publisher: "RedHat",
+						Offer:     "RHEL",
+						SKU:       "8-lvm-gen2",
+					},
+					Version:         "latest",
+					ThirdPartyImage: false,
+				},
+			},
+		},
+		{
+			name:           "azure stack cloud managed image",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.StackCloud,
+			confidentialVM: false,
+			gen:            "V1",
+			rg:             "test-rg",
+			sub:            "test-sub-123",
+			infraID:        "test-cluster-abc",
+			rhcosImg:       "",
+			expectedImage: &capz.Image{
+				ID: strPtr("/subscriptions/test-sub-123/resourceGroups/test-rg/providers/Microsoft.Compute/images/test-cluster-abc"),
+			},
+		},
+		{
+			name:           "marketplace URN format in rhcosImg",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "RedHat:RHEL:8-lvm:latest",
+			expectedImage: &capz.Image{
+				Marketplace: &capz.AzureMarketplaceImage{
+					ImagePlan: capz.ImagePlan{
+						Publisher: "RedHat",
+						Offer:     "RHEL",
+						SKU:       "8-lvm",
+					},
+					Version:         "latest",
+					ThirdPartyImage: false,
+				},
+			},
+		},
+		{
+			name:           "explicit subscription resource path for managed image",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/images/custom-image",
+			expectedImage: &capz.Image{
+				ID: strPtr("/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/images/custom-image"),
+			},
+		},
+		{
+			name:           "explicit subscription resource path for gallery image",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/galleries/gallery_name/images/image_def",
+			expectedImage: &capz.Image{
+				ID: strPtr("/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/galleries/gallery_name/images/image_def"),
+			},
+		},
+		{
+			name:           "empty rhcosImg for non-confidential VM",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "",
+			expectedImage:  &capz.Image{},
+		},
+		{
+			name:           "installer-created gallery image for confidential VM gen V2",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: true,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub-456",
+			infraID:        "test-cluster-xyz",
+			rhcosImg:       "",
+			expectedImage: &capz.Image{
+				ID: strPtr("/subscriptions/test-sub-456/resourceGroups/test-rg/providers/Microsoft.Compute/galleries/gallery_test_cluster_xyz/images/test-cluster-xyz-gen2"),
+			},
+		},
+		{
+			name:           "installer-created gallery image for confidential VM gen V1",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: true,
+			gen:            "V1",
+			rg:             "test-rg",
+			sub:            "test-sub-456",
+			infraID:        "test-cluster-xyz",
+			rhcosImg:       "",
+			expectedImage: &capz.Image{
+				ID: strPtr("/subscriptions/test-sub-456/resourceGroups/test-rg/providers/Microsoft.Compute/galleries/gallery_test_cluster_xyz/images/test-cluster-xyz"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := capzImage(tc.osImage, tc.azEnv, tc.confidentialVM, tc.gen, tc.rg, tc.sub, tc.infraID, tc.rhcosImg)
+			assert.Equal(t, tc.expectedImage, result)
+		})
+	}
+}
+
+func TestTrimSubscriptionPrefix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid full subscription path for managed image",
+			input:    "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/my-rg/providers/Microsoft.Compute/images/my-image",
+			expected: "/resourceGroups/my-rg/providers/Microsoft.Compute/images/my-image",
+		},
+		{
+			name:     "valid full subscription path for gallery image",
+			input:    "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/my-rg/providers/Microsoft.Compute/galleries/my_gallery/images/my_image_def",
+			expected: "/resourceGroups/my-rg/providers/Microsoft.Compute/galleries/my_gallery/images/my_image_def",
+		},
+		{
+			name:     "already trimmed path",
+			input:    "/resourceGroups/my-rg/providers/Microsoft.Compute/images/my-image",
+			expected: "/resourceGroups/my-rg/providers/Microsoft.Compute/images/my-image",
+		},
+		{
+			name:     "invalid path without resourceGroups",
+			input:    "/subscriptions/12345678-1234-1234-1234-123456789abc/providers/Microsoft.Compute/images/my-image",
+			expected: "/subscriptions/12345678-1234-1234-1234-123456789abc/providers/Microsoft.Compute/images/my-image",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "marketplace URN not an ID",
+			input:    "RedHat:RHEL:8-lvm:latest",
+			expected: "RedHat:RHEL:8-lvm:latest",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := trimSubscriptionPrefix(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestMapiImage(t *testing.T) {
+	testCases := []struct {
+		name           string
+		osImage        aztypes.OSImage
+		azEnv          aztypes.CloudEnvironment
+		confidentialVM bool
+		gen            string
+		rg             string
+		sub            string
+		infraID        string
+		rhcosImg       string
+		expected       interface{}
+	}{
+		{
+			name: "marketplace image with purchase plan",
+			osImage: aztypes.OSImage{
+				Publisher: "RedHat",
+				Offer:     "RHEL",
+				SKU:       "8-lvm-gen2",
+				Version:   "latest",
+				Plan:      aztypes.ImageWithPurchasePlan,
+			},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "",
+			expected: struct {
+				publisher string
+				offer     string
+				sku       string
+				version   string
+				imageType string
+			}{
+				publisher: "RedHat",
+				offer:     "RHEL",
+				sku:       "8-lvm-gen2",
+				version:   "latest",
+				imageType: "MarketplaceWithPlan",
+			},
+		},
+		{
+			name: "marketplace image no purchase plan",
+			osImage: aztypes.OSImage{
+				Publisher: "RedHat",
+				Offer:     "RHEL",
+				SKU:       "8-lvm-gen2",
+				Version:   "latest",
+				Plan:      aztypes.ImageNoPurchasePlan,
+			},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "",
+			expected: struct {
+				publisher string
+				offer     string
+				sku       string
+				version   string
+				imageType string
+			}{
+				publisher: "RedHat",
+				offer:     "RHEL",
+				sku:       "8-lvm-gen2",
+				version:   "latest",
+				imageType: "MarketplaceNoPlan",
+			},
+		},
+		{
+			name:           "explicit subscription resource path",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/images/custom-image",
+			expected: struct {
+				resourceID string
+			}{
+				resourceID: "/resourceGroups/custom-rg/providers/Microsoft.Compute/images/custom-image",
+			},
+		},
+		{
+			name:           "gallery image path",
+			osImage:        aztypes.OSImage{},
+			azEnv:          aztypes.PublicCloud,
+			confidentialVM: false,
+			gen:            "V2",
+			rg:             "test-rg",
+			sub:            "test-sub",
+			infraID:        "test-cluster",
+			rhcosImg:       "/subscriptions/custom-sub/resourceGroups/custom-rg/providers/Microsoft.Compute/galleries/gallery_name/images/image_def",
+			expected: struct {
+				resourceID string
+			}{
+				resourceID: "/resourceGroups/custom-rg/providers/Microsoft.Compute/galleries/gallery_name/images/image_def",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapiImage(tc.osImage, tc.azEnv, tc.confidentialVM, tc.gen, tc.rg, tc.sub, tc.infraID, tc.rhcosImg)
+
+			switch expected := tc.expected.(type) {
+			case struct {
+				publisher string
+				offer     string
+				sku       string
+				version   string
+				imageType string
+			}:
+				assert.Equal(t, expected.publisher, result.Publisher)
+				assert.Equal(t, expected.offer, result.Offer)
+				assert.Equal(t, expected.sku, result.SKU)
+				assert.Equal(t, expected.version, result.Version)
+				assert.Equal(t, expected.imageType, string(result.Type))
+			case struct{ resourceID string }:
+				assert.Equal(t, expected.resourceID, result.ResourceID)
+			}
+		})
+	}
+}
+
+// strPtr returns a pointer to the given string.
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Machine API operator is limited in its ability to discover an appropriate default image for Machine[Set]s where it is not specified. Under direct cluster management, the workaround is to specify it. This change facilitates doing that when under remote/fleet management, such as via hive, via the `MachineSets()` function.

It was already possible to supply an explicit *marketplace* image, but the paths for managed and gallery images were written with hardcoded path formats dependent on knowing things about architecture and HyperVGeneration, intended to be used day 0 by the installer itself, where the environment is controlled/known and additional discovery and validation is possible.

With this change, we add a path for `MachineSets()` to accept an arbitrary OS image resource identifier, which may represent a managed or gallery image. This is one part of a two-part solution that will provide hive users an escape hatch if they encounter this MAO defaulting limitation in environments where marketplace images are not available/appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Azure image selection to honor explicitly provided resource identifiers, including managed and gallery image paths.
  * Improved handling of Azure image IDs with missing or unexpected resource-group prefixes, preventing errors and preserving supplied identifiers.
  * Prevented custom image identifiers from being overridden by default installer images.
  * Improved support for Azure marketplace, managed, gallery, URN-based, and confidential VM image configurations across supported image generations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->