### PR TITLE
OCPBUGS-94441: upgrade CLOUDSDK_PYTHON to python3.11 in upi-installer

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -60,7 +60,7 @@ RUN yum update -y && \
       unzip \
       openssh-clients \
       openssl \      
-      python3-pip \
+      python3.11-pip \
       python3-pyyaml \
       util-linux \
       xz \
@@ -74,13 +74,13 @@ COPY --from=yq4 /usr/bin/yq /bin/yq-v4
 
 # Not packaged, but required by gcloud. See https://cloud.google.com/sdk/crypto
 # Pin version because of https://github.com/GoogleCloudPlatform/gsutil/issues/1753
-RUN pip3.11 install cryptography pyOpenSSL==23.2.0
+RUN pip3.11 install --no-cache-dir cryptography pyOpenSSL==23.2.0
 
 ENV CLOUDSDK_PYTHON=/usr/bin/python3.11
 ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
 
 # aicli
-RUN pip3.11 install aicli==99.0.202407291433
+RUN pip3.11 install --no-cache-dir aicli==99.0.202407291433
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -53,6 +53,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \      
       gettext \
+      python3.11 \
       google-cloud-cli-563.0.0-1 \
       gzip \
       jq \
@@ -73,13 +74,13 @@ COPY --from=yq4 /usr/bin/yq /bin/yq-v4
 
 # Not packaged, but required by gcloud. See https://cloud.google.com/sdk/crypto
 # Pin version because of https://github.com/GoogleCloudPlatform/gsutil/issues/1753
-RUN pip-3 install cryptography pyOpenSSL==23.2.0
+RUN pip3.11 install cryptography pyOpenSSL==23.2.0
 
-ENV CLOUDSDK_PYTHON=/usr/bin/python
+ENV CLOUDSDK_PYTHON=/usr/bin/python3.11
 ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
 
 # aicli
-RUN pip-3 install aicli==99.0.202407291433
+RUN pip3.11 install aicli==99.0.202407291433
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \


### PR DESCRIPTION
## Summary

- Upgrades CLOUDSDK_PYTHON from Python 3.9 to Python 3.11 in the upi-installer CI image
- Google Cloud CLI dropped Python 3.9 support, producing warnings on every gcloud invocation
- Installs python3.11 via yum and updates pip and env var references accordingly

Fixes https://issues.redhat.com/browse/OCPBUGS-94441

## Details

The upi-installer image sets CLOUDSDK_PYTHON=/usr/bin/python (Python 3.9 on RHEL 9). The Google Cloud CLI no longer supports Python 3.9, producing deprecation warnings before every gcloud command. This change installs python3.11, updates the CLOUDSDK_PYTHON env var, and switches pip install commands from pip-3 to pip3.11.

## Test plan

- [ ] CI image builds successfully with python3.11
- [ ] gcloud commands no longer produce Python version warnings
- [ ] HyperShift GCP/GKE CI steps pass without regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI installer environment to use Python 3.11 for cloud tooling and related packages.
  * Improved consistency across Python package installation and runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->