### PR TITLE
OCPBUGS-88511: Pass live ingress domain into import-cluster-config

### DIFF
--- a/cmd/node-joiner/nodejoiner_integration_test.go
+++ b/cmd/node-joiner/nodejoiner_integration_test.go
@@ -241,6 +241,8 @@ func getGVR(obj *unstructured.Unstructured) (schema.GroupVersionResource, error)
 		gvr = v1.GroupVersion.WithResource("infrastructures")
 	case "Proxy":
 		gvr = v1.SchemeGroupVersion.WithResource("proxies")
+	case "Ingress":
+		gvr = v1.SchemeGroupVersion.WithResource("ingresses")
 	case "ImageDigestMirrorSet":
 		gvr = v1.SchemeGroupVersion.WithResource("imagedigestmirrorsets")
 	case "MachineConfig":

--- a/cmd/node-joiner/testdata/add-nodes.txt
+++ b/cmd/node-joiner/testdata/add-nodes.txt
@@ -43,4 +43,4 @@ AUTH_TOKEN_EXPIRY=.*
 -- expected/grub.cfg --
 .*fips=1.*
 -- expected/import-cluster-config.json --
-.*"userManagedNetworking": false.*
+.*"userManagedNetworking": false.*"ingressDomain": "apps.ostest.test.metalkube.org".*

--- a/cmd/node-joiner/testdata/setup/crds/0000_ingresses_crd.yaml
+++ b/cmd/node-joiner/testdata/setup/crds/0000_ingresses_crd.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Ingress
+    listKind: IngressList
+    plural: ingresses
+    singular: ingress
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              domain:
+                type: string
+              appsDomain:
+                type: string
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/cmd/node-joiner/testdata/setup/default/0010_ingress.yaml
+++ b/cmd/node-joiner/testdata/setup/default/0010_ingress.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  domain: apps.ostest.test.metalkube.org

--- a/pkg/asset/agent/joiner/clusterinfo.go
+++ b/pkg/asset/agent/joiner/clusterinfo.go
@@ -73,6 +73,9 @@ type ClusterInfo struct {
 	Nodes                         *corev1.NodeList
 	ChronyConf                    *igntypes.File
 	BootArtifactsBaseURL          string
+	// IngressDomain is the live application ingress domain from
+	// ingress.config.openshift.io/cluster (spec.appsDomain if set, else spec.domain).
+	IngressDomain string
 }
 
 var _ asset.WritableAsset = (*ClusterInfo)(nil)
@@ -126,6 +129,7 @@ func (ci *ClusterInfo) Generate(ctx context.Context, dependencies asset.Parents)
 		ci.retrieveWorkerChronyConfig,
 		ci.retrieveBootArtifactsBaseURL,
 		ci.retrieveNamespace,
+		ci.retrieveIngressDomain,
 	} {
 		if err := f(); err != nil {
 			return err
@@ -208,6 +212,22 @@ func (ci *ClusterInfo) retrieveProxy() error {
 		NoProxy:    noProxy,
 	}
 
+	return nil
+}
+
+// retrieveIngressDomain reads the live cluster ingress domain so Day-2 apps DNS
+// validation can use the current value instead of the install-time default.
+func (ci *ClusterInfo) retrieveIngressDomain() error {
+	ingress, err := ci.OpenshiftClient.ConfigV1().Ingresses().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	// Prefer appsDomain when set; otherwise domain (OpenShift apps suffix).
+	if ingress.Spec.AppsDomain != "" {
+		ci.IngressDomain = ingress.Spec.AppsDomain
+		return nil
+	}
+	ci.IngressDomain = ingress.Spec.Domain
 	return nil
 }
 

--- a/pkg/asset/agent/joiner/clusterinfo_test.go
+++ b/pkg/asset/agent/joiner/clusterinfo_test.go
@@ -477,6 +477,14 @@ func defaultObjects() func(t *testing.T) ([]runtime.Object, []runtime.Object, []
 					APIServerURL: "https://api.ostest.test.metalkube.org:6443",
 				},
 			},
+			&configv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.IngressSpec{
+					Domain: "apps.ostest.test.metalkube.org",
+				},
+			},
 			&configv1.ImageDigestMirrorSetList{
 				Items: []configv1.ImageDigestMirrorSet{
 					{
@@ -539,7 +547,8 @@ func defaultExpectedClusterInfo() ClusterInfo {
 			URL:           ptr.To("https://192.168.111.5:22623/config/worker"),
 			CaCertificate: ptr.To("LS0tL_FakeCertificate_LS0tCg=="),
 		},
-		FIPS: true,
+		FIPS:          true,
+		IngressDomain: "apps.ostest.test.metalkube.org",
 	}
 }
 
@@ -562,4 +571,5 @@ func verifyClusterInfo(t *testing.T, expectedClusterInfo, clusterInfo ClusterInf
 	assert.Equal(t, expectedClusterInfo.IgnitionEndpointWorker, clusterInfo.IgnitionEndpointWorker)
 	assert.Equal(t, expectedClusterInfo.FIPS, clusterInfo.FIPS)
 	assert.Equal(t, expectedClusterInfo.ChronyConf, clusterInfo.ChronyConf)
+	assert.Equal(t, expectedClusterInfo.IngressDomain, clusterInfo.IngressDomain)
 }

--- a/pkg/asset/agent/joiner/importclusterconfig.go
+++ b/pkg/asset/agent/joiner/importclusterconfig.go
@@ -23,6 +23,9 @@ type ImportClusterConfig struct {
 // ClusterConfig contains any required cluster params.
 type ClusterConfig struct {
 	Networking Networking `json:"networking"`
+	// IngressDomain is consumed by assisted-service as ingress_domain so apps
+	// DNS validation can honor a custom/live ingress domain on Day-2.
+	IngressDomain string `json:"ingressDomain,omitempty"`
 }
 
 // Networking defines the pod network provider in the cluster.
@@ -70,6 +73,7 @@ func (icc *ImportClusterConfig) Generate(_ context.Context, dependencies asset.P
 		Networking: Networking{
 			UserManagedNetworking: agent.GetUserManagedNetworkingByPlatformType(clusterInfo.PlatformType),
 		},
+		IngressDomain: clusterInfo.IngressDomain,
 	}
 	return nil
 }

--- a/pkg/asset/agent/joiner/importclusterconfig_test.go
+++ b/pkg/asset/agent/joiner/importclusterconfig_test.go
@@ -67,6 +67,22 @@ func TestImportClusterConfig_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "include ingress domain from ClusterInfo",
+			dependencies: []asset.Asset{
+				&workflow.AgentWorkflow{Workflow: workflow.AgentWorkflowTypeAddNodes},
+				&ClusterInfo{
+					PlatformType:  v1beta1.BareMetalPlatformType,
+					IngressDomain: "abc.example.com",
+				},
+			},
+			expectedConfig: ClusterConfig{
+				Networking: Networking{
+					UserManagedNetworking: swag.Bool(false),
+				},
+				IngressDomain: "abc.example.com",
+			},
+		},
 	}
 	for _, tc := range cases {
 		icc := &ImportClusterConfig{}


### PR DESCRIPTION
## Summary
- During `node-joiner` add-nodes cluster inspection, read `ingress.config.openshift.io/cluster` and capture `spec.appsDomain` (if set) or `spec.domain`.
- Include that value as `ingressDomain` in `import-cluster-config.json` embedded in the node ISO.
- Assisted-service ([PR #10714](https://github.com/openshift/assisted-service/pull/10714)) consumes this field as `ingress_domain` so Day-2 apps DNS validation uses the live ingress domain instead of always deriving `apps.<name>.<baseDomain>`.

This is the installer/node-joiner companion for [OCPBUGS-88511](https://issues.redhat.com/browse/OCPBUGS-88511).

## Motivation
`oc adm node-image create` fails `apps-domain-name-resolved-correctly` when the cluster ingress domain was changed post-install, because Day-2 validation only had install-time cluster name + base domain.

## Test plan
- [x] Unit tests: `go test ./pkg/asset/agent/joiner/`
- [x] ImportClusterConfig test covers copying `IngressDomain`
- [x] ClusterInfo fixtures include Ingress CR
- [ ] CI / node-joiner integration tests
- [ ] End-to-end with assisted-service PR #10714: patch ingress domain, confirm ISO `import-cluster-config.json` contains it and apps validation uses the custom domain


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting the cluster’s ingress domain.
  * Included the detected ingress domain in generated node-joining cluster configuration.
  * Added fallback handling when the application-specific domain is unavailable.

* **Bug Fixes**
  * Improved processing of OpenShift Ingress resources during cluster configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->