### PR TITLE
OCPBUGS-99637: iterate PEM blocks in PemToPrivateKey to handle EC PARAMETERS

### DIFF
--- a/pkg/asset/tls/utils.go
+++ b/pkg/asset/tls/utils.go
@@ -67,6 +67,7 @@ func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 // EC PARAMETERS that OpenSSL may prepend to EC private keys.
 func PemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
 	rest := data
+	var parseErr error
 	for {
 		var block *pem.Block
 		block, rest = pem.Decode(rest)
@@ -76,13 +77,24 @@ func PemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
 
 		switch block.Type {
 		case "RSA PRIVATE KEY":
-			return x509.ParsePKCS1PrivateKey(block.Bytes)
+			key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				parseErr = err
+				continue
+			}
+			return key, nil
 		case "EC PRIVATE KEY":
-			return x509.ParseECPrivateKey(block.Bytes)
+			key, err := x509.ParseECPrivateKey(block.Bytes)
+			if err != nil {
+				parseErr = err
+				continue
+			}
+			return key, nil
 		case "PRIVATE KEY":
 			key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 			if err != nil {
-				return nil, err
+				parseErr = err
+				continue
 			}
 			switch key.(type) {
 			case *rsa.PrivateKey, *ecdsa.PrivateKey:
@@ -93,6 +105,9 @@ func PemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
 		default:
 			continue
 		}
+	}
+	if parseErr != nil {
+		return nil, parseErr
 	}
 	return nil, errors.Errorf("could not find a PEM block with a supported private key type")
 }

--- a/pkg/asset/tls/utils.go
+++ b/pkg/asset/tls/utils.go
@@ -63,31 +63,38 @@ func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 }
 
 // PemToPrivateKey converts a PEM data block to a private key (RSA or ECDSA).
+// It iterates through all PEM blocks to tolerate non-key blocks such as
+// EC PARAMETERS that OpenSSL may prepend to EC private keys.
 func PemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.Errorf("could not find a PEM block in the private key")
-	}
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
 
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
-	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		switch key.(type) {
-		case *rsa.PrivateKey, *ecdsa.PrivateKey:
-			return key, nil
+		switch block.Type {
+		case "RSA PRIVATE KEY":
+			return x509.ParsePKCS1PrivateKey(block.Bytes)
+		case "EC PRIVATE KEY":
+			return x509.ParseECPrivateKey(block.Bytes)
+		case "PRIVATE KEY":
+			key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			switch key.(type) {
+			case *rsa.PrivateKey, *ecdsa.PrivateKey:
+				return key, nil
+			default:
+				return nil, fmt.Errorf("unsupported PKCS#8 key type: %T", key)
+			}
 		default:
-			return nil, fmt.Errorf("unsupported PKCS#8 key type: %T", key)
+			continue
 		}
-	default:
-		return nil, fmt.Errorf("unsupported PEM block type: %s", block.Type)
 	}
+	return nil, errors.Errorf("could not find a PEM block with a supported private key type")
 }
 
 // PemToPublicKey converts a data block to rsa.PublicKey.

--- a/pkg/asset/tls/utils_test.go
+++ b/pkg/asset/tls/utils_test.go
@@ -122,7 +122,9 @@ func TestPemToPrivateKeyFormats(t *testing.T) {
 			Type:  "EC PRIVATE KEY",
 			Bytes: ecDER,
 		})
-		combined := append(paramBlock, keyBlock...)
+		combined := make([]byte, 0, len(paramBlock)+len(keyBlock))
+		combined = append(combined, paramBlock...)
+		combined = append(combined, keyBlock...)
 
 		decoded, err := PemToPrivateKey(combined)
 		assert.NoError(t, err)
@@ -149,7 +151,9 @@ func TestPemToPrivateKeyFormats(t *testing.T) {
 		assert.NoError(t, err)
 		goodPem, err := PrivateKeyToPem(key)
 		assert.NoError(t, err)
-		combined := append(badBlock, goodPem...)
+		combined := make([]byte, 0, len(badBlock)+len(goodPem))
+		combined = append(combined, badBlock...)
+		combined = append(combined, goodPem...)
 
 		decoded, err := PemToPrivateKey(combined)
 		assert.NoError(t, err)

--- a/pkg/asset/tls/utils_test.go
+++ b/pkg/asset/tls/utils_test.go
@@ -107,4 +107,53 @@ func TestPemToPrivateKeyFormats(t *testing.T) {
 		_, ok := decoded.(*rsa.PrivateKey)
 		assert.True(t, ok, "expected *rsa.PrivateKey")
 	})
+
+	t.Run("EC key with EC PARAMETERS prefix", func(t *testing.T) {
+		ecKey, err := GenerateECDSAPrivateKey(types.ECDSACurveP256)
+		assert.NoError(t, err)
+		ecDER, err := x509.MarshalECPrivateKey(ecKey)
+		assert.NoError(t, err)
+
+		paramBlock := pem.EncodeToMemory(&pem.Block{
+			Type:  "EC PARAMETERS",
+			Bytes: []byte{0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07},
+		})
+		keyBlock := pem.EncodeToMemory(&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: ecDER,
+		})
+		combined := append(paramBlock, keyBlock...)
+
+		decoded, err := PemToPrivateKey(combined)
+		assert.NoError(t, err)
+		_, ok := decoded.(*ecdsa.PrivateKey)
+		assert.True(t, ok, "expected *ecdsa.PrivateKey")
+	})
+
+	t.Run("unsupported block type only", func(t *testing.T) {
+		pemBytes := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: []byte("not a key"),
+		})
+		_, err := PemToPrivateKey(pemBytes)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "could not find a PEM block with a supported private key type")
+	})
+
+	t.Run("malformed key block followed by valid key", func(t *testing.T) {
+		badBlock := pem.EncodeToMemory(&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: []byte("malformed key data"),
+		})
+		key, err := GenerateECDSAPrivateKey(types.ECDSACurveP256)
+		assert.NoError(t, err)
+		goodPem, err := PrivateKeyToPem(key)
+		assert.NoError(t, err)
+		combined := append(badBlock, goodPem...)
+
+		decoded, err := PemToPrivateKey(combined)
+		assert.NoError(t, err)
+		_, ok := decoded.(*ecdsa.PrivateKey)
+		assert.True(t, ok, "expected *ecdsa.PrivateKey")
+	})
 }


### PR DESCRIPTION
## Summary

- Fixes PemToPrivateKey to iterate through all PEM blocks instead of only reading the first one
- OpenSSL-generated EC private keys can include an EC PARAMETERS block before the EC PRIVATE KEY block, which caused the function to fail with 'unsupported PEM block type: EC PARAMETERS'

Fixes https://issues.redhat.com/browse/OCPBUGS-99637

## Details

The previous implementation used a single pem.Decode call, so it would fail on any PEM file where the first block was not a recognized key type. The fix loops through all PEM blocks, skipping unrecognized types (like EC PARAMETERS), and returns an error only if no supported key block is found.

This is the same approach used in the cluster-network-operator fix (CNO PR #2958).

## Test plan

- [ ] Code compiles successfully (go build ./cmd/openshift-install/...)
- [ ] Existing tests pass
- [ ] Follows the same fix pattern as CNO PR #2958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private key import to handle files containing multiple PEM blocks.
  * Updated the importer to skip unsupported or unrelated PEM blocks until a supported private key is found.
  * Refined error handling to continue past parse issues for supported block types and return the most relevant failure when no supported key is present.
  * Enhanced test coverage for concatenated PEM inputs, unsupported-only PEM content, and mixed malformed/valid key material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->