### PR TITLE
Add OSImageStream to machine pools

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -164,6 +164,13 @@ spec:
                   For the compute machine pools, the only valid name is "worker".
                   For the arbiter machine pools, the only valid name is "arbiter".
                 type: string
+              osImageStream:
+                description: OSImageStream represents the name of an OS Image Stream
+                  to use in a pool.
+                enum:
+                - rhel-9
+                - rhel-10
+                type: string
               platform:
                 description: Platform is configuration for machine pool specific to
                   the platform.
@@ -1770,6 +1777,13 @@ spec:
                     For the compute machine pools, the only valid name is "worker".
                     For the arbiter machine pools, the only valid name is "arbiter".
                   type: string
+                osImageStream:
+                  description: OSImageStream represents the name of an OS Image Stream
+                    to use in a pool.
+                  enum:
+                  - rhel-9
+                  - rhel-10
+                  type: string
                 platform:
                   description: Platform is configuration for machine pool specific
                     to the platform.
@@ -3333,6 +3347,13 @@ spec:
                   For the control plane machine pool, the name will always be "master".
                   For the compute machine pools, the only valid name is "worker".
                   For the arbiter machine pools, the only valid name is "arbiter".
+                type: string
+              osImageStream:
+                description: OSImageStream represents the name of an OS Image Stream
+                  to use in a pool.
+                enum:
+                - rhel-9
+                - rhel-10
                 type: string
               platform:
                 description: Platform is configuration for machine pool specific to
@@ -6264,6 +6285,8 @@ spec:
                           type: string
                         networkConfig:
                           x-kubernetes-preserve-unknown-fields: true
+                        osImageStream:
+                          type: string
                         role:
                           type: string
                         rootDeviceHints:

--- a/pkg/asset/machines/aws/awsmachines.go
+++ b/pkg/asset/machines/aws/awsmachines.go
@@ -205,7 +205,7 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 			}),
 		}
 		awsMachine.SetGroupVersionKind(capa.GroupVersion.WithKind("AWSMachine"))
-		utils.SetMachineOSStreamLabels(awsMachine, in.Config)
+		utils.SetMachineOSStreamLabels(awsMachine, in.Config, in.Pool)
 
 		if in.Role == "bootstrap" {
 			awsMachine.Name = capiutils.GenerateBoostrapMachineName(clusterID)
@@ -245,7 +245,7 @@ func GenerateMachines(clusterID string, in *MachineInput) ([]*asset.RuntimeFile,
 			},
 		}
 		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(machine, in.Config)
+		utils.SetMachineOSStreamLabels(machine, in.Config, in.Pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},

--- a/pkg/asset/machines/aws/clusterapi_machinesets.go
+++ b/pkg/asset/machines/aws/clusterapi_machinesets.go
@@ -209,7 +209,7 @@ func ClusterAPIMachineSets(in *MachineSetInput) ([]capa.AWSMachineTemplate, []ca
 		}
 		// Machine labels will be synced from the Machine to the corresponding Node
 		maps.Copy(machineSet.Spec.Template.ObjectMeta.Labels, nodeLabels)
-		utils.SetCAPIMachineSetOSStreamLabels(&machineSet, in.Config)
+		utils.SetCAPIMachineSetOSStreamLabels(&machineSet, in.Config, in.Pool)
 
 		machineSets = append(machineSets, machineSet)
 	}

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -108,7 +108,7 @@ func Machines(clusterID string, region string, subnets aws.SubnetsByZone, pool *
 				// we don't need to set Versions, because we control those via operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 
@@ -189,7 +189,7 @@ func Machines(clusterID string, region string, subnets aws.SubnetsByZone, pool *
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 	return machines, controlPlaneMachineSet, nil
 }
 

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -159,7 +159,7 @@ func MachineSets(in *MachineSetInput) ([]*machineapi.MachineSet, error) {
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(mset, in.Config)
+		utils.SetMachineSetOSStreamLabels(mset, in.Config, in.Pool)
 		machinesets = append(machinesets, mset)
 	}
 

--- a/pkg/asset/machines/azure/azuremachines.go
+++ b/pkg/asset/machines/azure/azuremachines.go
@@ -199,7 +199,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 				DataDisks:              mpool.DataDisks,
 			},
 		}
-		utils.SetMachineOSStreamLabels(azureMachine, in.Config)
+		utils.SetMachineOSStreamLabels(azureMachine, in.Config, in.Pool)
 
 		if len(zone) == 0 {
 			// FailureDomain must be nil (not empty) to trigger availability set.
@@ -246,7 +246,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 			},
 		}
 		controlPlaneMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(controlPlaneMachine, in.Config)
+		utils.SetMachineOSStreamLabels(controlPlaneMachine, in.Config, in.Pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", azureMachine.Name)},
@@ -278,7 +278,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 			UserAssignedIdentities:     userAssignedIdentities,
 		},
 	}
-	utils.SetMachineOSStreamLabels(bootstrapAzureMachine, in.Config)
+	utils.SetMachineOSStreamLabels(bootstrapAzureMachine, in.Config, in.Pool)
 
 	if len(mpool.Zones[0]) == 0 {
 		// FailureDomain must be nil (not empty) to trigger availability set.
@@ -326,7 +326,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 		},
 	}
 	bootstrapMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-	utils.SetMachineOSStreamLabels(bootstrapMachine, in.Config)
+	utils.SetMachineOSStreamLabels(bootstrapMachine, in.Config, in.Pool)
 
 	result = append(result, &asset.RuntimeFile{
 		File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapMachine.Name)},

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -89,7 +89,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		}
 		*machineSetProvider = *provider
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 
@@ -150,7 +150,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 
 	if len(failureDomains) > 0 {
 		controlPlaneMachineSet.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains = &machinev1.FailureDomains{

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -123,7 +123,7 @@ func MachineSets(clusterID string, ic *installconfig.InstallConfig, pool *types.
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(mset, ic.Config)
+		utils.SetMachineSetOSStreamLabels(mset, ic.Config, pool)
 		machinesets = append(machinesets, mset)
 	}
 	return machinesets, nil
@@ -246,7 +246,7 @@ func getMultiZoneMachineSets(in multiZoneMachineSetInput) ([]*clusterapi.Machine
 					},
 				},
 			}
-			utils.SetMachineSetOSStreamLabels(mset, in.ic.Config)
+			utils.SetMachineSetOSStreamLabels(mset, in.ic.Config, in.pool)
 			machineSets = append(machineSets, mset)
 			replicasToCreate -= currentReplica
 		}

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -124,13 +124,23 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 	numMasters := 0
 
 	controlPlaneArch := ""
+	controlPlaneOSImageStream := ""
 	if config.ControlPlane != nil {
 		controlPlaneArch = arch.RpmArch(string(config.ControlPlane.Architecture))
+		controlPlaneOSImageStream = string(config.ControlPlane.OSImageStream)
+		if controlPlaneOSImageStream == "" {
+			controlPlaneOSImageStream = string(config.OSImageStream)
+		}
 	}
 	computeArch := ""
+	computeOSImageStream := ""
 
 	if len(config.Compute) > 0 {
 		computeArch = arch.RpmArch(string(config.Compute[0].Architecture))
+		computeOSImageStream = string(config.Compute[0].OSImageStream)
+		if computeOSImageStream == "" {
+			computeOSImageStream = string(config.OSImageStream)
+		}
 	}
 
 	for _, host := range config.Platform.BareMetal.Hosts {
@@ -175,9 +185,14 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 				Method: "install_coreos",
 			}
 
+			hostStream := host.OSImageStream
+			if hostStream == "" {
+				hostStream = controlPlaneOSImageStream
+			}
+
 			newHost.ObjectMeta.Labels = map[string]string{
 				"installer.openshift.io/role": "control-plane",
-				streamLabelKey:                string(config.OSImageStream),
+				streamLabelKey:                hostStream,
 			}
 
 			// Link the new host to the currently available machine
@@ -196,9 +211,17 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine, userDataS
 			numMasters++
 		} else {
 			newHost.Spec.Architecture = computeArch
-			newHost.ObjectMeta.Labels = map[string]string{
-				streamLabelKey: string(config.OSImageStream),
+
+			hostStream := host.OSImageStream
+
+			if hostStream == "" {
+				hostStream = computeOSImageStream
 			}
+
+			newHost.ObjectMeta.Labels = map[string]string{
+				streamLabelKey: hostStream,
+			}
+
 			// Pause workers until the real control plane is up.
 			newHost.ObjectMeta.Annotations = map[string]string{
 				"baremetalhost.metal3.io/paused": "",
@@ -232,8 +255,13 @@ func ArbiterHosts(config *types.InstallConfig, machines []machineapi.Machine, us
 	numArbiters := 0
 
 	arbiterArch := ""
+	arbiterOSImageStream := ""
 	if config.Arbiter != nil {
 		arbiterArch = arch.RpmArch(string(config.Arbiter.Architecture))
+		arbiterOSImageStream = string(config.Arbiter.OSImageStream)
+		if arbiterOSImageStream == "" {
+			arbiterOSImageStream = string(config.OSImageStream)
+		}
 	}
 
 	for _, host := range config.Platform.BareMetal.Hosts {
@@ -280,9 +308,14 @@ func ArbiterHosts(config *types.InstallConfig, machines []machineapi.Machine, us
 				Method: "install_coreos",
 			}
 
+			hostStream := host.OSImageStream
+			if hostStream == "" {
+				hostStream = arbiterOSImageStream
+			}
+
 			newHost.ObjectMeta.Labels = map[string]string{
 				"installer.openshift.io/role": "control-plane",
-				streamLabelKey:                string(config.OSImageStream),
+				streamLabelKey:                hostStream,
 			}
 
 			// Link the new host to the currently available machine

--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -31,7 +31,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider, err := provider(platform, userDataSecret, config.OSImageStream)
+	provider, err := provider(platform, userDataSecret, pool, config.OSImageStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}
@@ -58,14 +58,19 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				// we don't need to set Versions, because we control those via cluster operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 
 	return machines, nil
 }
 
-func provider(platform *baremetal.Platform, userDataSecret string, osImageStream types.OSImageStream) (*baremetalprovider.BareMetalMachineProviderSpec, error) {
+func provider(platform *baremetal.Platform, userDataSecret string, pool *types.MachinePool, osImageStream types.OSImageStream) (*baremetalprovider.BareMetalMachineProviderSpec, error) {
+	stream := pool.OSImageStream
+	if stream == "" {
+		stream = osImageStream
+	}
+
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "baremetal.cluster.k8s.io/v1alpha1",
@@ -75,7 +80,7 @@ func provider(platform *baremetal.Platform, userDataSecret string, osImageStream
 			Method: "install_coreos",
 		},
 		UserData:     &corev1.SecretReference{Name: userDataSecret},
-		HostSelector: hostSelectorForStream(osImageStream),
+		HostSelector: hostSelectorForStream(stream),
 	}
 	return config, nil
 }

--- a/pkg/asset/machines/baremetal/machinesets.go
+++ b/pkg/asset/machines/baremetal/machinesets.go
@@ -33,10 +33,11 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider, err := provider(platform, userDataSecret, config.OSImageStream)
+	provider, err := provider(platform, userDataSecret, pool, config.OSImageStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}
+
 	name := fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, 0)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{
@@ -78,7 +79,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			},
 		},
 	}
-	utils.SetMachineSetOSStreamLabels(mset, config)
+
+	utils.SetMachineSetOSStreamLabels(mset, config, pool)
 
 	return []*machineapi.MachineSet{mset}, nil
 }

--- a/pkg/asset/machines/gcp/gcpmachines.go
+++ b/pkg/asset/machines/gcp/gcpmachines.go
@@ -51,7 +51,7 @@ func GenerateMachines(installConfig *installconfig.InstallConfig, infraID string
 	// Create GCP and CAPI machines for all master replicas in pool
 	for idx := int64(0); idx < total; idx++ {
 		name := fmt.Sprintf("%s-%s-%d", infraID, pool.Name, idx)
-		gcpMachine, err := createGCPMachine(name, installConfig, infraID, mpool, imageName)
+		gcpMachine, err := createGCPMachine(name, installConfig, infraID, mpool, imageName, pool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create control plane (%d): %w", idx, err)
 		}
@@ -62,7 +62,7 @@ func GenerateMachines(installConfig *installconfig.InstallConfig, infraID string
 		})
 
 		dataSecret := fmt.Sprintf("%s-%s", infraID, masterRole)
-		capiMachine := createCAPIMachine(gcpMachine.Name, dataSecret, infraID, installConfig.Config)
+		capiMachine := createCAPIMachine(gcpMachine.Name, dataSecret, infraID, installConfig.Config, pool)
 
 		if len(mpool.Zones) > 0 {
 			// When there are fewer zones than the number of control plane instances,
@@ -88,7 +88,7 @@ func GenerateBootstrapMachines(name string, installConfig *installconfig.Install
 	mpool := pool.Platform.GCP
 
 	// Create one GCP and CAPI machine for bootstrap
-	bootstrapGCPMachine, err := createGCPMachine(name, installConfig, infraID, mpool, imageName)
+	bootstrapGCPMachine, err := createGCPMachine(name, installConfig, infraID, mpool, imageName, pool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bootstrap machine: %w", err)
 	}
@@ -105,7 +105,7 @@ func GenerateBootstrapMachines(name string, installConfig *installconfig.Install
 	})
 
 	dataSecret := fmt.Sprintf("%s-%s", infraID, "bootstrap")
-	bootstrapCapiMachine := createCAPIMachine(bootstrapGCPMachine.Name, dataSecret, infraID, installConfig.Config)
+	bootstrapCapiMachine := createCAPIMachine(bootstrapGCPMachine.Name, dataSecret, infraID, installConfig.Config, pool)
 
 	result = append(result, &asset.RuntimeFile{
 		File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapCapiMachine.Name)},
@@ -115,7 +115,7 @@ func GenerateBootstrapMachines(name string, installConfig *installconfig.Install
 }
 
 // Create a CAPG-specific machine.
-func createGCPMachine(name string, installConfig *installconfig.InstallConfig, infraID string, mpool *gcptypes.MachinePool, imageName string) (*capg.GCPMachine, error) {
+func createGCPMachine(name string, installConfig *installconfig.InstallConfig, infraID string, mpool *gcptypes.MachinePool, imageName string, pool *types.MachinePool) (*capg.GCPMachine, error) {
 	// Use the rhcosImage as image name if not defined
 	osImage := imageName
 	if mpool.OSImage != nil {
@@ -148,7 +148,7 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 		},
 	}
 	gcpMachine.SetGroupVersionKind(capg.GroupVersion.WithKind("GCPMachine"))
-	utils.SetMachineOSStreamLabels(gcpMachine, installConfig.Config)
+	utils.SetMachineOSStreamLabels(gcpMachine, installConfig.Config, pool)
 	// Set optional values from machinepool
 	if mpool.OnHostMaintenance != "" {
 		gcpMachine.Spec.OnHostMaintenance = ptr.To(capg.HostMaintenancePolicy(mpool.OnHostMaintenance))
@@ -192,7 +192,7 @@ func createGCPMachine(name string, installConfig *installconfig.InstallConfig, i
 }
 
 // Create a CAPI machine based on the CAPG machine.
-func createCAPIMachine(name, dataSecret, infraID string, config *types.InstallConfig) *capi.Machine {
+func createCAPIMachine(name, dataSecret, infraID string, config *types.InstallConfig, pool *types.MachinePool) *capi.Machine {
 	machine := &capi.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -213,7 +213,7 @@ func createCAPIMachine(name, dataSecret, infraID string, config *types.InstallCo
 		},
 	}
 	machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-	utils.SetMachineOSStreamLabels(machine, config)
+	utils.SetMachineOSStreamLabels(machine, config, pool)
 
 	return machine
 }

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -66,7 +66,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		}
 		*machineSetProvider = *provider
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 	replicas := int32(total)
@@ -125,7 +125,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 
 	return machines, controlPlaneMachineSet, nil
 }

--- a/pkg/asset/machines/gcp/machinesets.go
+++ b/pkg/asset/machines/gcp/machinesets.go
@@ -84,7 +84,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(mset, config)
+		utils.SetMachineSetOSStreamLabels(mset, config, pool)
 		machinesets = append(machinesets, mset)
 	}
 

--- a/pkg/asset/machines/ibmcloud/capimachines.go
+++ b/pkg/asset/machines/ibmcloud/capimachines.go
@@ -167,7 +167,7 @@ func GenerateMachines(ctx context.Context, infraID string, config *types.Install
 			},
 		}
 		capibmcloudMachine.SetGroupVersionKind(capibmcloud.GroupVersion.WithKind("IBMVPCMachine"))
-		utils.SetMachineOSStreamLabels(capibmcloudMachine, config)
+		utils.SetMachineOSStreamLabels(capibmcloudMachine, config, pool)
 		capibmcloudMachines = append(capibmcloudMachines, capibmcloudMachine)
 
 		result = append(result, &asset.RuntimeFile{
@@ -196,7 +196,7 @@ func GenerateMachines(ctx context.Context, infraID string, config *types.Install
 			},
 		}
 		capiMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(capiMachine, config)
+		utils.SetMachineOSStreamLabels(capiMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", capiMachine.Name)},
@@ -223,7 +223,7 @@ func GenerateMachines(ctx context.Context, infraID string, config *types.Install
 			Spec: bootstrapSpec,
 		}
 		bootstrapMachine.SetGroupVersionKind(capibmcloud.GroupVersion.WithKind("IBMVPCMachine"))
-		utils.SetMachineOSStreamLabels(bootstrapMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapMachine.Name)},
@@ -250,7 +250,7 @@ func GenerateMachines(ctx context.Context, infraID string, config *types.Install
 			},
 		}
 		bootstrapCAPIMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(bootstrapCAPIMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapCAPIMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapMachine.Name)},

--- a/pkg/asset/machines/ibmcloud/machines.go
+++ b/pkg/asset/machines/ibmcloud/machines.go
@@ -60,7 +60,7 @@ func Machines(clusterID string, config *types.InstallConfig, subnets map[string]
 				},
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 

--- a/pkg/asset/machines/ibmcloud/machinesets.go
+++ b/pkg/asset/machines/ibmcloud/machinesets.go
@@ -80,7 +80,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, subnets map[stri
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(mset, config)
+		utils.SetMachineSetOSStreamLabels(mset, config, pool)
 		machinesets = append(machinesets, mset)
 	}
 	return machinesets, nil

--- a/pkg/asset/machines/nutanix/capimachines.go
+++ b/pkg/asset/machines/nutanix/capimachines.go
@@ -43,7 +43,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 		}
 
 		// create the NutanixMachine object.
-		ntxMachine := generateNutanixMachine(machine.Name, providerSpec, categoryIdentifiers, config)
+		ntxMachine := generateNutanixMachine(machine.Name, providerSpec, categoryIdentifiers, config, pool)
 		ntxMachines = append(ntxMachines, ntxMachine)
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", ntxMachine.Name)},
@@ -72,7 +72,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			},
 		}
 		capiMachine.SetGroupVersionKind(capv1.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(capiMachine, config)
+		utils.SetMachineOSStreamLabels(capiMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", capiMachine.Name)},
@@ -103,7 +103,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			Spec: *bootstrapSpec,
 		}
 		bootstrapNtxMachine.SetGroupVersionKind(capnv1.GroupVersion.WithKind("NutanixMachine"))
-		utils.SetMachineOSStreamLabels(bootstrapNtxMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapNtxMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapNtxMachine.Name)},
@@ -131,7 +131,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			},
 		}
 		bootstrapCapiMachine.SetGroupVersionKind(capv1.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(bootstrapCapiMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapCapiMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapCapiMachine.Name)},
@@ -142,7 +142,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 	return result, nil
 }
 
-func generateNutanixMachine(machineName string, providerSpec *machinev1.NutanixMachineProviderConfig, categoryIdentifiers []capnv1.NutanixCategoryIdentifier, config *types.InstallConfig) *capnv1.NutanixMachine {
+func generateNutanixMachine(machineName string, providerSpec *machinev1.NutanixMachineProviderConfig, categoryIdentifiers []capnv1.NutanixCategoryIdentifier, config *types.InstallConfig, pool *types.MachinePool) *capnv1.NutanixMachine {
 	ntxMachine := &capnv1.NutanixMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: capiutils.Namespace,
@@ -171,7 +171,7 @@ func generateNutanixMachine(machineName string, providerSpec *machinev1.NutanixM
 		},
 	}
 	ntxMachine.SetGroupVersionKind(capnv1.GroupVersion.WithKind("NutanixMachine"))
-	utils.SetMachineOSStreamLabels(ntxMachine, config)
+	utils.SetMachineOSStreamLabels(ntxMachine, config, pool)
 
 	for _, subnet := range providerSpec.Subnets {
 		ntxMachine.Spec.Subnets = append(ntxMachine.Spec.Subnets, capnv1.NutanixResourceIdentifier{

--- a/pkg/asset/machines/nutanix/machines.go
+++ b/pkg/asset/machines/nutanix/machines.go
@@ -75,7 +75,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				// we don't need to set Versions, because we control those via operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machineSetProvider = provider.DeepCopy()
 		machines = append(machines, machine)
 	}
@@ -117,7 +117,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 
 	if len(failureDomains) > 0 {
 		fdRefs := make([]machinev1.NutanixFailureDomainReference, 0, len(failureDomains))

--- a/pkg/asset/machines/nutanix/machinesets.go
+++ b/pkg/asset/machines/nutanix/machinesets.go
@@ -138,7 +138,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(mset, config)
+		utils.SetMachineSetOSStreamLabels(mset, config, pool)
 		machinesets = append(machinesets, mset)
 		idx++
 	}

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -97,7 +97,7 @@ func Machines(ctx context.Context, clusterID string, config *types.InstallConfig
 				// we don't need to set Versions, because we control those via operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 
@@ -159,7 +159,7 @@ func Machines(ctx context.Context, clusterID string, config *types.InstallConfig
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 
 	if CPMSFailureDomains := pruneFailureDomains(failureDomains); CPMSFailureDomains != nil {
 		controlPlaneMachineSet.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains = &machinev1.FailureDomains{

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -122,7 +122,7 @@ func MachineSets(ctx context.Context, clusterID string, config *types.InstallCon
 				},
 			},
 		}
-		utils.SetMachineSetOSStreamLabels(machinesets[idx], config)
+		utils.SetMachineSetOSStreamLabels(machinesets[idx], config, pool)
 	}
 
 	return machinesets, nil

--- a/pkg/asset/machines/openstack/openstackmachines.go
+++ b/pkg/asset/machines/openstack/openstackmachines.go
@@ -75,7 +75,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			Spec: *machineSpec,
 		}
 		openStackMachine.SetGroupVersionKind(capo.SchemeGroupVersion.WithKind("OpenStackMachine"))
-		utils.SetMachineOSStreamLabels(openStackMachine, config)
+		utils.SetMachineOSStreamLabels(openStackMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", openStackMachine.Name)},
@@ -107,7 +107,7 @@ func GenerateMachines(clusterID string, config *types.InstallConfig, pool *types
 			},
 		}
 		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(machine, config)
+		utils.SetMachineOSStreamLabels(machine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},

--- a/pkg/asset/machines/ovirt/machines.go
+++ b/pkg/asset/machines/ovirt/machines.go
@@ -53,7 +53,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				// we don't need to set Versions, because we control those via cluster operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 

--- a/pkg/asset/machines/ovirt/machinesets.go
+++ b/pkg/asset/machines/ovirt/machinesets.go
@@ -71,6 +71,6 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			},
 		},
 	}
-	utils.SetMachineSetOSStreamLabels(mset, config)
+	utils.SetMachineSetOSStreamLabels(mset, config, pool)
 	return []*machineapi.MachineSet{mset}, nil
 }

--- a/pkg/asset/machines/powervs/machines.go
+++ b/pkg/asset/machines/powervs/machines.go
@@ -64,7 +64,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				},
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 		machines = append(machines, machine)
 	}
 	replicas := int32(total)
@@ -109,7 +109,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(controlPlaneMachineSet, config, pool)
 	return machines, controlPlaneMachineSet, nil
 }
 

--- a/pkg/asset/machines/powervs/machinesets.go
+++ b/pkg/asset/machines/powervs/machinesets.go
@@ -75,7 +75,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			},
 		},
 	}
-	utils.SetMachineSetOSStreamLabels(mset, config)
+	utils.SetMachineSetOSStreamLabels(mset, config, pool)
 	machinesets = append(machinesets, mset)
 
 	return machinesets, nil

--- a/pkg/asset/machines/powervs/powervsmachines.go
+++ b/pkg/asset/machines/powervs/powervsmachines.go
@@ -57,7 +57,7 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 	for idx := int64(0); idx < total; idx++ {
 		name = fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx)
 
-		powerVSMachine = GenerateMachine(ic, service, mpool, name, image)
+		powerVSMachine = GenerateMachine(ic, service, mpool, name, image, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", powerVSMachine.Name)},
@@ -65,7 +65,7 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 		})
 
 		dataSecret = fmt.Sprintf("%s-%s", clusterID, "master")
-		machine = GenerateCAPIMachine(clusterID, powerVSMachine.Name, dataSecret, ic)
+		machine = GenerateCAPIMachine(clusterID, powerVSMachine.Name, dataSecret, ic, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},
@@ -74,7 +74,7 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 	}
 
 	name = fmt.Sprintf("%s-bootstrap", clusterID)
-	powerVSMachine = GenerateMachine(ic, service, mpool, name, image)
+	powerVSMachine = GenerateMachine(ic, service, mpool, name, image, pool)
 	powerVSMachine.Labels["install.openshift.io/bootstrap"] = ""
 
 	result = append(result, &asset.RuntimeFile{
@@ -83,7 +83,7 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 	})
 
 	dataSecret = fmt.Sprintf("%s-%s", clusterID, "bootstrap")
-	machine = GenerateCAPIMachine(clusterID, powerVSMachine.Name, dataSecret, ic)
+	machine = GenerateCAPIMachine(clusterID, powerVSMachine.Name, dataSecret, ic, pool)
 	machine.Labels["install.openshift.io/bootstrap"] = ""
 
 	result = append(result, &asset.RuntimeFile{
@@ -95,7 +95,7 @@ func GenerateMachines(clusterID string, ic *types.InstallConfig, pool *types.Mac
 }
 
 // GenerateMachine creates a capibm.IBMPowerVSMachine struct.
-func GenerateMachine(ic *types.InstallConfig, service capibm.IBMPowerVSResourceReference, mpool *powervs.MachinePool, name string, image string) *capibm.IBMPowerVSMachine {
+func GenerateMachine(ic *types.InstallConfig, service capibm.IBMPowerVSResourceReference, mpool *powervs.MachinePool, name string, image string, pool *types.MachinePool) *capibm.IBMPowerVSMachine {
 	machine := &capibm.IBMPowerVSMachine{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: capibm.GroupVersion.String(),
@@ -121,12 +121,12 @@ func GenerateMachine(ic *types.InstallConfig, service capibm.IBMPowerVSResourceR
 			MemoryGiB:     mpool.MemoryGiB,
 		},
 	}
-	utils.SetMachineOSStreamLabels(machine, ic)
+	utils.SetMachineOSStreamLabels(machine, ic, pool)
 	return machine
 }
 
 // GenerateCAPIMachine creates a capi.Machine struct.
-func GenerateCAPIMachine(clusterID, name, dataSecret string, config *types.InstallConfig) *capi.Machine {
+func GenerateCAPIMachine(clusterID, name, dataSecret string, config *types.InstallConfig, pool *types.MachinePool) *capi.Machine {
 	machine := &capi.Machine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Machine",
@@ -150,6 +150,6 @@ func GenerateCAPIMachine(clusterID, name, dataSecret string, config *types.Insta
 			},
 		},
 	}
-	utils.SetMachineOSStreamLabels(machine, config)
+	utils.SetMachineOSStreamLabels(machine, config, pool)
 	return machine
 }

--- a/pkg/asset/machines/vsphere/capimachines.go
+++ b/pkg/asset/machines/vsphere/capimachines.go
@@ -149,7 +149,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 				},
 			},
 		}
-		utils.SetMachineOSStreamLabels(vsphereMachine, config)
+		utils.SetMachineOSStreamLabels(vsphereMachine, config, pool)
 
 		// only set failureDomainName if VMGroup is defined as vm-host group
 		// is the only scenario we create vspherefailuredomainspec and vspheredeploymentzone
@@ -215,7 +215,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			},
 		}
 		machine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(machine, config)
+		utils.SetMachineOSStreamLabels(machine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", machine.Name)},
@@ -248,7 +248,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			Spec: bootstrapSpec,
 		}
 		bootstrapVSphereMachine.SetGroupVersionKind(capv.GroupVersion.WithKind("VSphereMachine"))
-		utils.SetMachineOSStreamLabels(bootstrapVSphereMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapVSphereMachine, config, pool)
 
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_inframachine_%s.yaml", bootstrapVSphereMachine.Name)},
@@ -284,7 +284,7 @@ func GenerateMachines(ctx context.Context, clusterID string, config *types.Insta
 			},
 		}
 		bootstrapMachine.SetGroupVersionKind(capi.GroupVersion.WithKind("Machine"))
-		utils.SetMachineOSStreamLabels(bootstrapMachine, config)
+		utils.SetMachineOSStreamLabels(bootstrapMachine, config, pool)
 		result = append(result, &asset.RuntimeFile{
 			File:   asset.File{Filename: fmt.Sprintf("10_machine_%s.yaml", bootstrapVSphereMachine.Name)},
 			Object: bootstrapMachine,

--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -138,7 +138,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				// we don't need to set Versions, because we control those via operators.
 			},
 		}
-		utils.SetMachineOSStreamLabels(&machine, config)
+		utils.SetMachineOSStreamLabels(&machine, config, pool)
 
 		data.MachineFailureDomain[machine.Name] = failureDomain.Name
 
@@ -235,7 +235,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 		},
 	}
-	utils.SetCPMSOSStreamLabels(data.ControlPlaneMachineSet, config)
+	utils.SetCPMSOSStreamLabels(data.ControlPlaneMachineSet, config, pool)
 
 	return data, nil
 }

--- a/pkg/asset/machines/vsphere/machinesets.go
+++ b/pkg/asset/machines/vsphere/machinesets.go
@@ -25,7 +25,8 @@ func getMachineSetWithPlatform(
 	role,
 	userDataSecret string,
 	hosts []*vsphere.Host,
-	config *types.InstallConfig) (*machineapi.MachineSet, error) {
+	config *types.InstallConfig,
+	pool *types.MachinePool) (*machineapi.MachineSet, error) {
 	provider, err := provider(clusterID, vcenter, failureDomain, mpool, osImage, userDataSecret)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
@@ -93,7 +94,7 @@ func getMachineSetWithPlatform(
 			},
 		},
 	}
-	utils.SetMachineSetOSStreamLabels(mset, config)
+	utils.SetMachineSetOSStreamLabels(mset, config, pool)
 	return mset, nil
 }
 
@@ -178,11 +179,12 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			role,
 			userDataSecret,
 			platform.Hosts,
-			config)
+			config,
+			pool)
 		if err != nil {
 			return machinesets, err
 		}
-		utils.SetMachineSetOSStreamLabels(machineset, config)
+		utils.SetMachineSetOSStreamLabels(machineset, config, pool)
 		machinesets = append(machinesets, machineset)
 	}
 

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -44,6 +44,7 @@ type Host struct {
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
 	BootMode        BootMode         `json:"bootMode,omitempty"`
 	NetworkConfig   *apiextv1.JSON   `json:"networkConfig,omitempty"`
+	OSImageStream   string           `json:"osImageStream,omitempty"`
 }
 
 // IsMaster checks if the current host is a master

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -421,6 +422,19 @@ func validateBootMode(hosts []*baremetal.Host, fldPath *field.Path) (errors fiel
 	return
 }
 
+func validateHostOSImageStream(hosts []*baremetal.Host, fldPath *field.Path) (errors field.ErrorList) {
+	validStreams := types.OSImageStreamValues()
+	for idx, host := range hosts {
+		if host.OSImageStream != "" {
+			stream := types.OSImageStream(host.OSImageStream)
+			if !slices.Contains(validStreams, stream) {
+				errors = append(errors, field.NotSupported(fldPath.Index(idx).Child("osImageStream"), host.OSImageStream, validStreams))
+			}
+		}
+	}
+	return
+}
+
 // ValidateHostRootDeviceHints checks that a rootDeviceHints field contains no
 // invalid values.
 func ValidateHostRootDeviceHints(rdh *baremetal.RootDeviceHints, fldPath *field.Path) (errors field.ErrorList) {
@@ -540,6 +554,7 @@ func ValidateHosts(p *baremetal.Platform, fldPath *field.Path, c *types.InstallC
 	allErrs = append(allErrs, validateNetworkConfig(p.Hosts, fldPath)...)
 
 	allErrs = append(allErrs, validateHostsName(p.Hosts, fldPath)...)
+	allErrs = append(allErrs, validateHostOSImageStream(p.Hosts, fldPath)...)
 	return allErrs
 }
 

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -141,6 +141,8 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum=ClusterAPI;MachineAPI
 	// +optional
 	Management MachineManagementAPI `json:"management,omitempty"`
+
+	OSImageStream OSImageStream `json:"osImageStream,omitempty"`
 }
 
 // MachinePoolPlatform is the platform-specific configuration for a machine

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
@@ -73,6 +74,9 @@ func ValidateMachinePool(platform *types.Platform, p *types.MachinePool, fldPath
 	}
 	if !validArchitectures[p.Architecture] {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("architecture"), p.Architecture, validArchitectureValues))
+	}
+	if p.OSImageStream != "" && !slices.Contains(types.OSImageStreamValues(), p.OSImageStream) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("osImageStream"), p.OSImageStream, types.OSImageStreamValues()))
 	}
 	if platform.AWS != nil {
 		allErrs = append(allErrs, awsvalidation.ValidateMachinePoolArchitecture(p, fldPath.Child("architecture"))...)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -11,8 +11,9 @@ import (
 )
 
 // SetMachineOSStreamLabels adds the OS image stream label to a Machine if the OSStreams
-// feature gate is enabled.
-func SetMachineOSStreamLabels[T metav1.Object](obj T, ic *types.InstallConfig) {
+// feature gate is enabled. If pool is non-nil and has an OSImageStream set, the
+// pool-level value is used; otherwise the global ic.OSImageStream is used.
+func SetMachineOSStreamLabels[T metav1.Object](obj T, ic *types.InstallConfig, pool *types.MachinePool) {
 	if ic == nil || !ic.Enabled(features.FeatureGateOSStreams) {
 		return
 	}
@@ -20,60 +21,63 @@ func SetMachineOSStreamLabels[T metav1.Object](obj T, ic *types.InstallConfig) {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	labels[types.OSStreamLabelKey] = string(resolveOSImageStream(ic, pool))
 	obj.SetLabels(labels)
 }
 
 // SetMachineSetOSStreamLabels adds the OS image stream label to a MachineSet's metadata
 // and Spec.Template if the OSStreams feature gate is enabled.
-func SetMachineSetOSStreamLabels(machineSet *machineapi.MachineSet, ic *types.InstallConfig) {
+func SetMachineSetOSStreamLabels(machineSet *machineapi.MachineSet, ic *types.InstallConfig, pool *types.MachinePool) {
 	if ic == nil || !ic.Enabled(features.FeatureGateOSStreams) {
 		return
 	}
+	stream := string(resolveOSImageStream(ic, pool))
 	// Set the metadata labels
 	labels := machineSet.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	labels[types.OSStreamLabelKey] = stream
 	machineSet.SetLabels(labels)
 	// Set the Spec.Template labels
 	if machineSet.Spec.Template.Labels == nil {
 		machineSet.Spec.Template.Labels = make(map[string]string)
 	}
-	machineSet.Spec.Template.Labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	machineSet.Spec.Template.Labels[types.OSStreamLabelKey] = stream
 }
 
 // SetCAPIMachineSetOSStreamLabels adds the OS image stream label to a CAPI MachineSet's
 // metadata and Spec.Template if the OSStreams feature gate is enabled.
-func SetCAPIMachineSetOSStreamLabels(machineSet *capi.MachineSet, ic *types.InstallConfig) {
+func SetCAPIMachineSetOSStreamLabels(machineSet *capi.MachineSet, ic *types.InstallConfig, pool *types.MachinePool) {
 	if ic == nil || !ic.Enabled(features.FeatureGateOSStreams) {
 		return
 	}
+	stream := string(resolveOSImageStream(ic, pool))
 	labels := machineSet.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	labels[types.OSStreamLabelKey] = stream
 	machineSet.SetLabels(labels)
 	if machineSet.Spec.Template.ObjectMeta.Labels == nil {
 		machineSet.Spec.Template.ObjectMeta.Labels = make(map[string]string)
 	}
-	machineSet.Spec.Template.ObjectMeta.Labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	machineSet.Spec.Template.ObjectMeta.Labels[types.OSStreamLabelKey] = stream
 }
 
 // SetCPMSOSStreamLabels adds the OS image stream label to a ControlPlaneMachineSet's
 // metadata and Spec.Template if the OSStreams feature gate is enabled.
-func SetCPMSOSStreamLabels(cpms *machinev1.ControlPlaneMachineSet, ic *types.InstallConfig) {
+func SetCPMSOSStreamLabels(cpms *machinev1.ControlPlaneMachineSet, ic *types.InstallConfig, pool *types.MachinePool) {
 	if ic == nil || !ic.Enabled(features.FeatureGateOSStreams) {
 		return
 	}
+	stream := string(resolveOSImageStream(ic, pool))
 	// Set the metadata labels
 	labels := cpms.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	labels[types.OSStreamLabelKey] = stream
 	cpms.SetLabels(labels)
 	// Set the Spec.Template labels
 	if cpms.Spec.Template.OpenShiftMachineV1Beta1Machine == nil {
@@ -82,5 +86,12 @@ func SetCPMSOSStreamLabels(cpms *machinev1.ControlPlaneMachineSet, ic *types.Ins
 	if cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels == nil {
 		cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels = make(map[string]string)
 	}
-	cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels[types.OSStreamLabelKey] = string(ic.OSImageStream)
+	cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels[types.OSStreamLabelKey] = stream
+}
+
+func resolveOSImageStream(ic *types.InstallConfig, pool *types.MachinePool) types.OSImageStream {
+	if pool != nil && pool.OSImageStream != "" {
+		return pool.OSImageStream
+	}
+	return ic.OSImageStream
 }


### PR DESCRIPTION
Now we can specify the OS Image Stream per machine pool.  This will allow us to test a scenario where the control plane is RHEL 10 but workers are RHEL 9.

We also make it possible to specify the stream per BMH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OS image stream selection for machine pools.
  * Added per-bare-metal-host OS image stream overrides with deployment-level fallback.
  * Applied pool-aware OS stream labeling consistently across machine, machine set, and control-plane resources for supported infrastructure providers.
* **Bug Fixes**
  * Improved OS stream label accuracy when pool or host settings differ from deployment defaults.
* **Validation**
  * Rejects unsupported OS image streams for machine pools and bare-metal hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->