### PR TITLE
Increase GCP network infrastructure timeout to 30 minutes

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
@@ -33,6 +34,7 @@ var _ clusterapi.IgnitionProvider = (*Provider)(nil)
 var _ clusterapi.InfraReadyProvider = (*Provider)(nil)
 var _ clusterapi.PostProvider = (*Provider)(nil)
 var _ clusterapi.BootstrapDestroyer = (*Provider)(nil)
+var _ clusterapi.Timeouts = (*Provider)(nil)
 
 // Name returns the name for the platform.
 func (p Provider) Name() string {
@@ -42,6 +44,16 @@ func (p Provider) Name() string {
 // PublicGatherEndpoint indicates that machine ready checks should wait for an ExternalIP
 // in the status and use that when gathering bootstrap log bundles.
 func (Provider) PublicGatherEndpoint() clusterapi.GatherEndpoint { return clusterapi.ExternalIP }
+
+// NetworkTimeout for the network infrastructure to become ready.
+func (p Provider) NetworkTimeout() time.Duration {
+	return 30 * time.Minute
+}
+
+// ProvisionTimeout for the machines to be provisioned.
+func (p Provider) ProvisionTimeout() time.Duration {
+	return 15 * time.Minute
+}
 
 // PreProvision is called before provisioning using CAPI controllers has initiated.
 // GCP resources that are not created by CAPG (and are required for other stages of the install) are

--- a/pkg/infrastructure/gcp/clusterapi/clusterapi_test.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi_test.go
@@ -1,0 +1,15 @@
+package clusterapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderTimeouts(t *testing.T) {
+	provider := Provider{}
+
+	assert.Equal(t, 30*time.Minute, provider.NetworkTimeout())
+	assert.Equal(t, 15*time.Minute, provider.ProvisionTimeout())
+}


### PR DESCRIPTION
### Overview

GCP CAPI network infrastructure provisioning intermittently hangs on backendServices.insert, exhausting the default 15 minute timeout and failing the install with "infrastructure was not ready within 15m0s".

IBM Cloud and PowerVS already override this to 30 minutes for similar reasons; my proposed approach is to do the same for GCP. ProvisionTimeout is set explicitly to the default 15 minutes since only network provisioning is affected.

### Testing
- Added `TestProviderTimeouts` unit test asserting the returned values.
- `go build`, `go vet`, and `gofmt` pass on the changed package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added defined timeout settings for network operations and resource provisioning.
  * Network operations now allow up to 30 minutes.
  * Provisioning operations now allow up to 15 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->