### PR TITLE
NO-ISSUE: Render OSImageStream in OKD too

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -5065,6 +5065,7 @@ spec:
             enum:
             - rhel-9
             - rhel-10
+            - centos-10
             type: string
           pki:
             description: |-

--- a/pkg/asset/manifests/osimagestream.go
+++ b/pkg/asset/manifests/osimagestream.go
@@ -41,11 +41,8 @@ func (f *OSImageStream) Generate(_ context.Context, dependencies asset.Parents) 
 	installConfig := &installconfig.InstallConfig{}
 	dependencies.Get(installConfig)
 
-	// If one of the following are true the OSImageStream CR is not generated
-	// 1. The feature is not enabled
-	// 2. The target is CentOS Stream CoreOS
-	if ic := installConfig.Config; !ic.Enabled(features.FeatureGateOSStreams) || ic.IsSCOS() {
-		// FG disabled or not OCP
+	// If OS Image Streams are not enabled don't generate the OSImageStream CR
+	if ic := installConfig.Config; !ic.Enabled(features.FeatureGateOSStreams) {
 		return nil
 	}
 

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -136,7 +136,7 @@ the cluster.
       OperatorPublishingStrategy controls the visibility of ingress and apiserver. Defaults to public.
 
     osImageStream <string>
-      Valid Values: "rhel-9","rhel-10"
+      Valid Values: "rhel-9","rhel-10","centos-10"
       OSImageStream is the global OS Image Stream to be used for all machines in the cluster.
 
     pki <object>

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -771,7 +771,7 @@ func (c *InstallConfig) PublicIngress() bool {
 }
 
 // OSImageStream represents the name of an OS Image Stream to use in a pool.
-// +kubebuilder:validation:Enum=rhel-9;rhel-10
+// +kubebuilder:validation:Enum=rhel-9;rhel-10;centos-10
 type OSImageStream string
 
 const (


### PR DESCRIPTION
The MCO is already creating the OSImageStream for OKD as we have GAed the feature in OKD and OCP. If not passed by the installer the MCO itself creates the resource but it would be nice to generate it from the installer like we do for OCP to align the behavior with OCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting `centos-10` as an OS image stream.

* **Bug Fixes**
  * OS image stream manifests are now generated consistently whenever the OS streams feature is enabled, including for SCOS targets.
  * Removed an additional condition that could prevent manifest generation for certain install configurations, so behavior is now determined solely by the OS streams feature gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->