### PR TITLE
OCPBUGS-100189: Patch GCP Load Balancer Health Checks

### DIFF
--- a/pkg/infrastructure/gcp/clusterapi/clusterapi.go
+++ b/pkg/infrastructure/gcp/clusterapi/clusterapi.go
@@ -263,6 +263,14 @@ func (p Provider) InfraReady(ctx context.Context, in clusterapi.InfraReadyInput)
 		}
 	}
 
+	// The default health checks in CAPG are too lax & are non-configurable, so we update
+	// them in a hook to provide more resiliency during bootstrapping.
+	// TODO(padillon): https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1732 makes health checks configurable;
+	// once that merges, we can remove this call and the healthcheck.go file, and edit the values in the manifests.
+	if err := updateHealthChecks(ctx, in); err != nil {
+		return fmt.Errorf("failed to update health checks: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/infrastructure/gcp/clusterapi/healthcheck.go
+++ b/pkg/infrastructure/gcp/clusterapi/healthcheck.go
@@ -1,0 +1,101 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+
+	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	"github.com/openshift/installer/pkg/infrastructure/clusterapi"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
+)
+
+const (
+	// Health check names follow CAPG naming: {infraID}-{lbname}.
+	apiServerHealthCheckSuffix   = "apiserver"
+	apiInternalHealthCheckSuffix = "api-internal"
+
+	// Target health check values matching legacy Terraform IPI.
+	// Worst-case unhealthy detection: interval * threshold = 2s * 3 = 6s,
+	// well within the 30s requirement from docs/dev/kube-apiserver-health-check.md.
+	hcCheckIntervalSec   = int64(2)
+	hcTimeoutSec         = int64(2)
+	hcHealthyThreshold   = int64(3)
+	hcUnhealthyThreshold = int64(3)
+)
+
+// updateHealthChecks patches the load balancer health checks created by CAPG
+// to use faster timing values that match the legacy Terraform IPI configuration.
+func updateHealthChecks(ctx context.Context, in clusterapi.InfraReadyInput) error {
+	projectID := in.InstallConfig.Config.GCP.ProjectID
+	region := in.InstallConfig.Config.GCP.Region
+
+	opts := []option.ClientOption{option.WithScopes(compute.CloudPlatformScope)}
+	pscEndpoint := in.InstallConfig.Config.GCP.Endpoint
+	if gcptypes.ShouldUseEndpointForInstaller(pscEndpoint) {
+		opts = append(opts, gcpconfig.CreateEndpointOption(pscEndpoint.Name, gcpconfig.ServiceNameGCPCompute))
+	}
+	svc, err := gcpconfig.GetComputeService(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create compute service for health check updates: %w", err)
+	}
+
+	hcPatch := &compute.HealthCheck{
+		CheckIntervalSec:   hcCheckIntervalSec,
+		TimeoutSec:         hcTimeoutSec,
+		HealthyThreshold:   hcHealthyThreshold,
+		UnhealthyThreshold: hcUnhealthyThreshold,
+	}
+
+	if in.InstallConfig.Config.PublicAPI() {
+		hcName := fmt.Sprintf("%s-%s", in.InfraID, apiServerHealthCheckSuffix)
+		logrus.Infof("Updating global health check %s", hcName)
+		if err := patchGlobalHealthCheck(ctx, svc, projectID, hcName, hcPatch); err != nil {
+			return fmt.Errorf("failed to update global health check %s: %w", hcName, err)
+		}
+	}
+
+	hcName := fmt.Sprintf("%s-%s", in.InfraID, apiInternalHealthCheckSuffix)
+	logrus.Infof("Updating regional health check %s", hcName)
+	if err := patchRegionalHealthCheck(ctx, svc, projectID, region, hcName, hcPatch); err != nil {
+		return fmt.Errorf("failed to update regional health check %s: %w", hcName, err)
+	}
+
+	return nil
+}
+
+func patchGlobalHealthCheck(ctx context.Context, svc *compute.Service, projectID, hcName string, hcPatch *compute.HealthCheck) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*3)
+	defer cancel()
+
+	op, err := svc.HealthChecks.Patch(projectID, hcName, hcPatch).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to patch global health check %s: %w", hcName, err)
+	}
+
+	if err := WaitForOperationGlobal(ctx, svc, projectID, op); err != nil {
+		return fmt.Errorf("failed waiting for global health check patch %s: %w", hcName, err)
+	}
+
+	return nil
+}
+
+func patchRegionalHealthCheck(ctx context.Context, svc *compute.Service, projectID, region, hcName string, hcPatch *compute.HealthCheck) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*3)
+	defer cancel()
+
+	op, err := svc.RegionHealthChecks.Patch(projectID, region, hcName, hcPatch).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to patch regional health check %s: %w", hcName, err)
+	}
+
+	if err := WaitForOperationRegional(ctx, svc, projectID, region, op); err != nil {
+		return fmt.Errorf("failed waiting for regional health check patch %s: %w", hcName, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a hook to patch the default load balancer health check values populated by CAPG in order to match the values used by Terraform. The non-configurable CAPG defaults are very lax & this can cause failures during bootstrapping, because the API server on a node frequently goes offline as it bootstraps. The lax health checks means the offline node will stay in the pool and the LB will continue to serve connections to the offline node.

As pods try to connect to the API server and fail because the request is sent to an offline API server, the pod may throw an error and fall into CrashLoopBackoff.

Instead, the offline API server should be pulled from the LB pool very quickly so that traffic continues to be routed to the bootstrap API server, which stays available throughout bootstrapping.

The preferred method for handling this is through CAPG:

https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1732

proposes an API for the health checks. Once that merges, we can remove this hook, but this hook is valuable for immediate gain as well as backporting to previous versions, where we might not be able to bump CAPG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GCP cluster load balancer health checks with faster legacy-style intervals and timeouts, plus updated healthy and unhealthy thresholds.
  * Applies optimized settings to both public and internal API health checks where applicable.

* **Bug Fixes**
  * Cluster post-provisioning now reports health-check update failures instead of silently completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->