### PR TITLE
CORS-4537: GCP: gracefully handle 503 in disk type check

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -200,10 +200,11 @@ func validateDiskTypeAvailability(client API, fieldPath *field.Path, project, re
 	dt, dtZones, err := client.GetDiskTypeWithZones(context.TODO(), project, region, diskType)
 	if err != nil {
 		var gerr *googleapi.Error
-		if errors.As(err, &gerr) {
+		if errors.As(err, &gerr) && gerr.Code < 500 {
 			return append(allErrs, field.Invalid(fieldPath.Child("diskType"), diskType, err.Error()))
 		}
-		return append(allErrs, field.InternalError(fieldPath.Child("diskType"), err))
+		logrus.Warnf("could not verify disk type %s availability in %s, skipping API check: %v", diskType, region, err)
+		return allErrs
 	}
 
 	if dt == nil {

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1399,6 +1399,7 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 		mockErr        error
 		expectedError  bool
 		expectedErrMsg string
+		expectedWarn   string
 	}{
 		{
 			name:          "Empty disk type is a no-op",
@@ -1448,16 +1449,22 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 			expectedErrMsg: `forbidden`,
 		},
 		{
-			name:           "Non-API error returns internal error",
-			diskType:       "pd-ssd",
-			mockErr:        fmt.Errorf("network timeout"),
-			expectedError:  true,
-			expectedErrMsg: `network timeout`,
+			name:         "GCP 503 server error degrades gracefully",
+			diskType:     "pd-ssd",
+			mockErr:      &googleapi.Error{Code: http.StatusServiceUnavailable, Message: "backend error"},
+			expectedWarn: `could not verify disk type pd-ssd availability`,
+		},
+		{
+			name:         "Non-API error degrades gracefully",
+			diskType:     "pd-ssd",
+			mockErr:      fmt.Errorf("network timeout"),
+			expectedWarn: `could not verify disk type pd-ssd availability`,
 		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			hook := logrusTest.NewGlobal()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			gcpClient := mock.NewMockAPI(mockCtrl)
@@ -1472,6 +1479,10 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 				assert.Regexp(t, test.expectedErrMsg, errs.ToAggregate().Error())
 			} else {
 				assert.Empty(t, errs)
+			}
+			if test.expectedWarn != "" {
+				assert.NotEmpty(t, hook.Entries)
+				assert.Regexp(t, test.expectedWarn, hook.LastEntry().Message)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up #10687 

Handles failures like: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cloud-provider-gcp/131/pull-ci-openshift-cloud-provider-gcp-main-e2e-gcp-ovn/2082552071290097664

Add 500-type errors, such as 503 Service Unavailable to the graceful handling of the disk type validation. The disk type validation is supposed to prevent known failures, but if for some reason the API call fails we do not want that in and of itself to be fatal.

That was the original design of the validation, this commit just adds 503 to that handling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk type validation to handle cloud service errors more gracefully.
  * Validation now reports invalid disk types when appropriate, while temporary service or network issues generate a warning instead of blocking the process.
  * Added coverage to verify warning behavior for unavailable services and connectivity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->