### PR TITLE
CORS-4516: GCP: Configure cloud provider to use mounted creds

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	awsic "github.com/openshift/installer/pkg/asset/installconfig/aws"
+	gcpic "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	ibmcloudmachines "github.com/openshift/installer/pkg/asset/machines/ibmcloud"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
@@ -204,12 +205,30 @@ NodeIPFamilies=ipv4
 			firewallManagement = gcpmanifests.FirewallManagementDisabled
 		}
 
+		// TODO(padillon): The universe domain comparison can be removed (always set token-url = nil)
+		// when we want to switch all installs to use the credentialsrequest. Or, when
+		// https://github.com/kubernetes/cloud-provider-gcp/pull/1261 merges, we can remove this
+		// entirely from the cloud config.
+		var tokenURL string
+		session, err := gcpic.GetSession(ctx)
+		if err != nil {
+			return fmt.Errorf("could not get GCP session: %w", err)
+		}
+		ud, err := session.Credentials.GetUniverseDomain()
+		if err != nil {
+			return fmt.Errorf("could not get GCP universe domain: %w", err)
+		}
+		if ud != "" && ud != "googleapis.com" {
+			tokenURL = "nil"
+		}
+
 		gcpConfig, err := gcpmanifests.CloudProviderConfig(
 			clusterID.InfraID,
 			installConfig.Config.GCP.ProjectID,
 			subnet,
 			installConfig.Config.GCP.NetworkProjectID,
 			firewallManagement,
+			tokenURL,
 		)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -34,10 +34,12 @@ type global struct {
 	NetworkProjectID string `gcfg:"network-project-id"`
 
 	FirewallManagement string `gcfg:"firewall-rules-management"`
+
+	TokenURL string `gcfg:"token-url"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallManagement string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallManagement, tokenURL string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -59,6 +61,8 @@ func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallM
 			NetworkProjectID: networkProjectID,
 
 			FirewallManagement: firewallManagement,
+
+			TokenURL: tokenURL,
 		},
 	}
 
@@ -82,5 +86,6 @@ external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
 subnetwork-name = {{.Global.SubnetworkName}}
 {{- if ne .Global.NetworkProjectID "" }}{{"\n"}}network-project-id = {{.Global.NetworkProjectID}}{{ end }}
 {{- if ne .Global.FirewallManagement "" }}{{"\n"}}firewall-rules-management = {{.Global.FirewallManagement}}{{ end }}
+{{- if ne .Global.TokenURL "" }}{{"\n"}}token-url = {{.Global.TokenURL}}{{ end }}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -20,7 +20,7 @@ subnetwork-name = uid-worker-subnet
 firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", FirewallManagementEnabled)
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", FirewallManagementEnabled, "")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }
@@ -40,7 +40,7 @@ network-project-id = test-network-project-id
 firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id", FirewallManagementEnabled)
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id", FirewallManagementEnabled, "")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }
@@ -59,7 +59,27 @@ subnetwork-name = uid-worker-subnet
 firewall-rules-management = Enabled
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", FirewallManagementEnabled)
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", FirewallManagementEnabled, "")
+	assert.NoError(t, err, "failed to create cloud provider config")
+	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
+}
+
+func TestCloudProviderConfigWithTokenURL(t *testing.T) {
+	expectedConfig := `[global]
+project-id      = test-project-id
+regional        = true
+multizone       = true
+node-tags       = uid-master
+node-tags       = uid-control-plane
+node-tags       = uid-worker
+node-instance-prefix = uid
+external-instance-groups-prefix = uid
+subnetwork-name = uid-worker-subnet
+firewall-rules-management = Enabled
+token-url = nil
+
+`
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "", FirewallManagementEnabled, "nil")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
By setting the token-url to nil, we cause cloud-provider-gcp to use the mounted credentials provisioned by the credentialsrequest.

/hold

Depends on https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/493

We might want to just do this for all GCP installs. We could then dump some of the roles from the service account or even make it optional (for users that don't need artifact registry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom token URL in generated GCP cloud-provider configuration.
  * Automatically handles non-standard GCP credential domains by setting the appropriate token URL value.

* **Bug Fixes**
  * Improved generated configuration for GCP environments using alternate credential service domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->