### PR TITLE
OCPBUGS-85296: export Azure Metadata.Region for state file serialization

### DIFF
--- a/pkg/asset/installconfig/azure/metadata.go
+++ b/pkg/asset/installconfig/azure/metadata.go
@@ -22,7 +22,7 @@ type Metadata struct {
 	dnsCfg            *DNSConfig
 	availabilityZones []string
 	vmZones           []string
-	region            string
+	Region            string `json:"region,omitempty"`
 	ZonesSubnetMap    map[string][]string
 
 	controlPlane    *types.MachinePool
@@ -64,7 +64,7 @@ func NewMetadataWithCredentials(az *typesazure.Platform, controlPlane, compute *
 		Credentials:     credentials,
 		controlPlane:    controlPlane,
 		compute:         compute,
-		region:          az.Region,
+		Region:          az.Region,
 		defaultPlatform: az.DefaultMachinePlatform,
 	}
 }
@@ -126,7 +126,7 @@ func (m *Metadata) AvailabilityZones(ctx context.Context) ([]string, error) {
 	defer m.mutex.Unlock()
 
 	if len(m.availabilityZones) == 0 {
-		zones, err := m.client.GetRegionAvailabilityZones(ctx, m.region)
+		zones, err := m.client.GetRegionAvailabilityZones(ctx, m.Region)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving Availability Zones: %w", err)
 		}
@@ -145,7 +145,7 @@ func (m *Metadata) VMAvailabilityZones(ctx context.Context, instanceType string)
 	defer m.mutex.Unlock()
 
 	if len(m.vmZones) == 0 {
-		zones, err := m.client.GetAvailabilityZones(ctx, m.region, instanceType)
+		zones, err := m.client.GetAvailabilityZones(ctx, m.Region, instanceType)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving Availability Zones: %w", err)
 		}
@@ -263,7 +263,7 @@ func (m *Metadata) getCapabilities(mPool *types.MachinePool, defaultInstanceType
 	if mPool == nil {
 		return nil, fmt.Errorf("unable to get capabilities because machinepool is not populated in metadata")
 	}
-	instType := defaultInstanceType(m.CloudName, m.region, mPool.Architecture)
+	instType := defaultInstanceType(m.CloudName, m.Region, mPool.Architecture)
 	if dmp := m.defaultPlatform; dmp != nil && dmp.InstanceType != "" {
 		instType = dmp.InstanceType
 	}
@@ -274,7 +274,7 @@ func (m *Metadata) getCapabilities(mPool *types.MachinePool, defaultInstanceType
 	if err != nil {
 		return nil, fmt.Errorf("failed to get azure client %w", err)
 	}
-	caps, err := client.GetVMCapabilities(context.TODO(), instType, m.region)
+	caps, err := client.GetVMCapabilities(context.TODO(), instType, m.Region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Fixes reentrant Azure IPI installs failing with an empty region during availability zone lookup
- Exports the `region` field in Azure `Metadata` struct with a JSON tag so it persists in the state file

Fixes https://issues.redhat.com/browse/OCPBUGS-85296

## Details

The Azure `Metadata.region` field was unexported (lowercase) with no JSON tag, so it was not serialized to `.openshift_install_state.json`. When resuming an interrupted install with `OPENSHIFT_INSTALL_REENTRANT=true`, the installer loaded `InstallConfig` from the state file but `region` came back empty. This caused `VMAvailabilityZones()` to query the Azure API with an empty location filter, failing with `location information not found for Standard_D8s_v3 in `.

The fix follows the same pattern used by AWS metadata, which already exports `Region` with a JSON tag.

## Test plan

- [x] Code compiles successfully (`go build ./pkg/asset/installconfig/azure/...`)
- [x] Existing tests pass (`go test ./pkg/asset/installconfig/azure/...`)
- [ ] Reentrant Azure IPI install no longer fails with empty region (requires Azure environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Azure metadata now exposes the region field for broader compatibility.
  * Region-based availability zone and VM capability lookups continue to work consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->