### PR TITLE
no-jira: Update hack scripts to set min go version to 1.26

### DIFF
--- a/hack/build-node-joiner.sh
+++ b/hack/build-node-joiner.sh
@@ -5,7 +5,7 @@ set -ex
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 
-minimum_go_version=1.25
+minimum_go_version=1.26
 current_go_version=$(go version | cut -d " " -f 3)
 
 if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version")" ]; then

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,7 +9,7 @@ set -ex
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 
-minimum_go_version=1.25
+minimum_go_version=1.26
 current_go_version=$(go version | cut -d " " -f 3)
 
 if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version")" ]; then

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-genmock.sh
+++ b/hack/go-genmock.sh
@@ -10,6 +10,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/go-genmock.sh "${@}"
 fi

--- a/hack/go-sec.sh
+++ b/hack/go-sec.sh
@@ -12,6 +12,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/go-sec.sh "${@}"
 fi

--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -13,6 +13,6 @@ else
     --env LDFLAGS="${LDFLAGS}" \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/go-test.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -6,6 +6,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/hack/verify-capi-manifests.sh
+++ b/hack/verify-capi-manifests.sh
@@ -121,6 +121,6 @@ else
 		--env IS_CONTAINER=TRUE \
 		--volume "${PWD}:/go/src/github.com/openshift/installer:z" \
 		--workdir /go/src/github.com/openshift/installer \
-		docker.io/golang:1.25 \
+		docker.io/golang:1.26 \
 		./hack/verify-capi-manifests.sh "${@}"
 fi

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -10,6 +10,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/verify-codegen.sh "${@}"
 fi

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -31,6 +31,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golang:1.25 \
+    docker.io/golang:1.26 \
     ./hack/verify-vendor.sh "${@}"
 fi


### PR DESCRIPTION
Update all container image references from golang:1.25 to golang:1.26 and bump minimum_go_version checks to 1.26 to match the go.mod toolchain requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.26 for builds and development tooling.
  * Standardized formatting, testing, security checks, validation, code generation, and vendor verification on Go 1.26.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->