### PR TITLE
OCPBUGS-104455: Add a 10sec restart interval for ICC service, so that there is enough time for CRDs to become available

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/containers/systemd/image-customization.container
+++ b/data/data/bootstrap/baremetal/files/etc/containers/systemd/image-customization.container
@@ -34,6 +34,7 @@ Environment="CA_BUNDLE=/tmp/ca.crt"
 [Service]
 EnvironmentFile=/etc/ironic.env
 Restart=always
+RestartSec=10
 ExecStartPre=/usr/local/bin/setup-image-data.sh
 TimeoutStartSec=600
 ExecStopPost=podman secret rm pull-secret


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10-second delay before restarting the image customization service, improving restart stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->