### PR TITLE
OCPBUGS-86133: dont allow duplicate failure domains and fields

### DIFF
--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -103,9 +105,30 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 		if err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("failureDomain", "name"), fmt.Errorf("fail to compile the pattern %q: %w", pattern, err)))
 		} else {
-			for _, fd := range p.FailureDomains {
+			fdNames := make(map[string]bool, len(p.FailureDomains))
+			fdTopologies := make(map[string]string, len(p.FailureDomains))
+			for i := range p.FailureDomains {
+				fd := &p.FailureDomains[i]
 				if !rexp.MatchString(fd.Name) {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain name should match the pattern %q.", pattern)))
+				}
+
+				// A failure domain name must be unique so that machines can be
+				// unambiguously assigned to a failure domain.
+				if fdNames[fd.Name] {
+					allErrs = append(allErrs, field.Duplicate(fldPath.Child("failureDomain", "name"), fd.Name))
+				} else {
+					fdNames[fd.Name] = true
+				}
+
+				// Two failure domains that reference the same Prism Element and
+				// the same set of subnets point to identical underlying
+				// infrastructure, so they provide no additional fault tolerance.
+				topology := failureDomainTopologyKey(fd)
+				if existing, ok := fdTopologies[topology]; ok {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("failureDomain", "name"), fd.Name, fmt.Sprintf("failureDomain has the same topology (prismElement %q and subnetUUIDs) as failureDomain %q, each failureDomain must reference distinct infrastructure", fd.PrismElement.UUID, existing)))
+				} else {
+					fdTopologies[topology] = fd.Name
 				}
 
 				if fd.PrismElement.UUID == "" {
@@ -141,6 +164,16 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path, c *types.Install
 	}
 
 	return allErrs
+}
+
+// failureDomainTopologyKey returns a string that uniquely identifies the
+// underlying infrastructure (Prism Element and subnets) that a failure domain
+// references. Two failure domains with the same key point to the same
+// infrastructure and therefore provide no additional fault tolerance.
+func failureDomainTopologyKey(fd *nutanix.FailureDomain) string {
+	subnets := append([]string(nil), fd.SubnetUUIDs...)
+	sort.Strings(subnets)
+	return fmt.Sprintf("%s/[%s]", fd.PrismElement.UUID, strings.Join(subnets, ","))
 }
 
 // validateLoadBalancer returns an error if the load balancer is not valid.

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -410,6 +410,104 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 		},
 		{
+			name: "failureDomains with duplicate names",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1"},
+					},
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomain\.name: Duplicate value: "fd-1"$`,
+		},
+		{
+			name: "failureDomains with duplicate topology",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomain\.name: Invalid value: "fd-2": failureDomain has the same topology \(prismElement "fd-pe-uuid" and subnetUUIDs\) as failureDomain "fd-1", each failureDomain must reference distinct infrastructure$`,
+		},
+		{
+			name: "failureDomains with duplicate topology regardless of subnet order",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1", "fd-subnet-uuid-2"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2", "fd-subnet-uuid-1"},
+					},
+				}
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomain\.name: Invalid value: "fd-2": failureDomain has the same topology \(prismElement "fd-pe-uuid" and subnetUUIDs\) as failureDomain "fd-1", each failureDomain must reference distinct infrastructure$`,
+		},
+		{
+			name: "valid failureDomains with distinct topologies",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-1", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-1", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid-2", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe-2", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2"},
+					},
+				}
+				return p
+			}(),
+		},
+		{
+			name: "valid failureDomains same prismElement distinct subnets",
+			platform: func() *nutanix.Platform {
+				p := validPlatform()
+				p.FailureDomains = []nutanix.FailureDomain{
+					{
+						Name:         "fd-1",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-1"},
+					},
+					{
+						Name:         "fd-2",
+						PrismElement: nutanix.PrismElement{UUID: "fd-pe-uuid", Endpoint: nutanix.PrismEndpoint{Address: "fd-pe", Port: 9440}},
+						SubnetUUIDs:  []string{"fd-subnet-uuid-2"},
+					},
+				}
+				return p
+			}(),
+		},
+		{
 			name: "valid failureDomain with multiple subnets for multi-NIC",
 			platform: func() *nutanix.Platform {
 				p := validPlatform()


### PR DESCRIPTION
Failure domains in the install-config exist to spread workloads across independent infrastructure for fault tolerance. On Nutanix, two gaps allowed configurations that undermine this guarantee to pass validation silently:

Duplicate failure domain names — two failure domains could share the same name. Machines could not be unambiguously assigned to a failure domain, and the resulting Infrastructure CR contained two entries with the same name.
Duplicate topology — two failure domains with different names could reference the same Prism Element UUID and the same set of subnets. Machines appear spread across zones but actually run on identical underlying infrastructure, providing no additional protection against an infrastructure failure.
Both cases now fail validation during create manifests / create cluster, before any manifests are written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nutanix platform validation to reject duplicate failure-domain names.
  * Prevented configurations with duplicate failure-domain infrastructure from being accepted, regardless of subnet ordering.
  * Continued allowing valid configurations with distinct topologies or shared Prism Elements using different subnets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->