### PR TITLE
no-jira: Update GCD ability to identify project

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -240,15 +240,15 @@ func validateServiceAccountPresent(client API, ic *types.InstallConfig) field.Er
 }
 
 // DefaultInstanceTypeForArch returns the appropriate instance type based on the target architecture.
-func DefaultInstanceTypeForArch(arch types.Architecture, projectID string) string {
-	return DefaultInstanceTypeForArchAndProjectID(arch, projectID)
+func DefaultInstanceTypeForArch(arch types.Architecture, projectID, region string) string {
+	return DefaultInstanceTypeForArchAndProjectID(arch, projectID, region)
 }
 
 // DefaultInstanceTypeForArchAndProjectID returns the appropriate instance type based on the target architecture and project ID.
 // For sovereign cloud environments, it returns c3-standard-4 which is available in those regions.
 // For public GCP, it returns n2-standard-4 (x86) or t2a-standard-4 (ARM64).
-func DefaultInstanceTypeForArchAndProjectID(arch types.Architecture, projectID string) string {
-	cloudEnv := gcp.GetCloudEnvironment(projectID)
+func DefaultInstanceTypeForArchAndProjectID(arch types.Architecture, projectID, region string) string {
+	cloudEnv := gcp.GetCloudEnvironment(projectID, region)
 
 	// Sovereign cloud uses c3-standard-4 for all architectures
 	if cloudEnv == gcp.CloudEnvironmentSovereign {
@@ -285,7 +285,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		if ic.GCP.DefaultMachinePlatform.DiskType != "" {
 			defaultDiskType = ic.GCP.DefaultMachinePlatform.DiskType
 		} else {
-			defaultDiskType = gcp.DefaultDiskTypeForInstance(defaultInstanceType, ic.GCP.ProjectID)
+			defaultDiskType = gcp.DefaultDiskTypeForInstance(defaultInstanceType, ic.GCP.ProjectID, ic.GCP.Region)
 		}
 
 		if ic.GCP.DefaultMachinePlatform.OnHostMaintenance != "" {
@@ -323,7 +323,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 	if ic.ControlPlane != nil {
 		arch = string(ic.ControlPlane.Architecture)
 		if instanceType == "" {
-			instanceType = DefaultInstanceTypeForArch(ic.ControlPlane.Architecture, ic.GCP.ProjectID)
+			instanceType = DefaultInstanceTypeForArch(ic.ControlPlane.Architecture, ic.GCP.ProjectID, ic.GCP.Region)
 		}
 		if ic.ControlPlane.Platform.GCP != nil {
 			if ic.ControlPlane.Platform.GCP.InstanceType != "" {
@@ -344,7 +344,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
 					))
 				}
-				cpDiskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID)
+				cpDiskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID, ic.GCP.Region)
 			}
 			if ic.ControlPlane.Platform.GCP.OnHostMaintenance != "" {
 				cpOnHostMaintenance = ic.ControlPlane.Platform.GCP.OnHostMaintenance
@@ -387,7 +387,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		onHostMaintenance := defaultOnHostMaintenance
 		confidentialCompute := defaultConfidentialCompute
 		if instanceType == "" {
-			instanceType = DefaultInstanceTypeForArch(compute.Architecture, ic.GCP.ProjectID)
+			instanceType = DefaultInstanceTypeForArch(compute.Architecture, ic.GCP.ProjectID, ic.GCP.Region)
 		}
 		if diskType == "" {
 			diskType = gcp.PDSSD
@@ -418,7 +418,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 						fmt.Sprintf("instance type %s requires a disk type to be set", instanceType),
 					))
 				}
-				diskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID)
+				diskType = gcp.DefaultDiskTypeForInstance(instanceType, ic.GCP.ProjectID, ic.GCP.Region)
 			}
 		}
 
@@ -1111,7 +1111,7 @@ func validateServiceEndpointOverride(client API, ic *types.InstallConfig, fieldP
 		return nil
 	}
 
-	if gcp.GetCloudEnvironment(ic.GCP.ProjectID) == gcp.CloudEnvironmentSovereign {
+	if gcp.GetCloudEnvironment(ic.GCP.ProjectID, ic.GCP.Region) == gcp.CloudEnvironmentSovereign {
 		// Custom endpoints are not supported for sovereign clouds
 		return append(allErrs, field.Forbidden(fieldPath.Child("endpoint").Child("name"), "endpoint overrides are not supported in sovereign clouds"))
 	}

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1777,6 +1777,7 @@ func TestValidateServiceEndpointOverride(t *testing.T) {
 			name: "Sovereign cloud project with endpoint",
 			edits: editFunctions{func(ic *types.InstallConfig) {
 				ic.GCP.ProjectID = "eu0:my-project"
+				ic.GCP.Region = "u-de-1"
 				ic.GCP.Endpoint = &gcp.PSCEndpoint{Name: "test-endpoint"}
 			}},
 			expectedError:  true,
@@ -1801,6 +1802,7 @@ func TestValidateServiceEndpointOverride(t *testing.T) {
 			name: "Sovereign cloud project without endpoint",
 			edits: editFunctions{func(ic *types.InstallConfig) {
 				ic.GCP.ProjectID = "s-cloud-domain:my-project"
+				ic.GCP.Region = "u-fr-1"
 			}},
 			expectedError: false,
 		},

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -326,7 +326,7 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 		c.FileList = append(c.FileList, azureMachines...)
 	case gcptypes.Name:
 		// Generate GCP master machines using ControPlane machinepool
-		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
+		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region)
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -278,7 +278,7 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 		}
 		aws.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish)
 	case gcptypes.Name:
-		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
+		mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region)
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.GCP)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -141,13 +141,13 @@ func defaultAzureMachinePoolPlatform(env azuretypes.CloudEnvironment) azuretypes
 	}
 }
 
-func defaultGCPMachinePoolPlatform(arch types.Architecture, projectID string) gcptypes.MachinePool {
-	instanceType := icgcp.DefaultInstanceTypeForArchAndProjectID(arch, projectID)
+func defaultGCPMachinePoolPlatform(arch types.Architecture, projectID, region string) gcptypes.MachinePool {
+	instanceType := icgcp.DefaultInstanceTypeForArchAndProjectID(arch, projectID, region)
 	return gcptypes.MachinePool{
 		InstanceType: instanceType,
 		OSDisk: gcptypes.OSDisk{
 			DiskSizeGB: powerOfTwoRootVolumeSize,
-			DiskType:   gcptypes.DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID),
+			DiskType:   gcptypes.DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID, region),
 		},
 	}
 }
@@ -684,7 +684,7 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				}
 			}
 		case gcptypes.Name:
-			mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID)
+			mpool := defaultGCPMachinePoolPlatform(pool.Architecture, ic.Platform.GCP.ProjectID, ic.Platform.GCP.Region)
 			mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.GCP)
 			if len(mpool.Zones) == 0 {

--- a/pkg/types/gcp/defaults/machinepool.go
+++ b/pkg/types/gcp/defaults/machinepool.go
@@ -35,7 +35,7 @@ func SetMachinePoolDefaults(platform *types.Platform, pool *gcp.MachinePool) {
 	if pool.InstanceType != "" && pool.OSDisk.DiskType == "" {
 		family := gcp.GetGCPInstanceFamily(pool.InstanceType)
 		if _, ok := gcp.InstanceTypeToDiskTypeMap[family]; ok {
-			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstanceAndProjectID(pool.InstanceType, platform.GCP.ProjectID)
+			pool.OSDisk.DiskType = gcp.DefaultDiskTypeForInstanceAndProjectID(pool.InstanceType, platform.GCP.ProjectID, platform.GCP.Region)
 		}
 	}
 }

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -373,21 +373,21 @@ func GetGCPInstanceFamily(instanceType string) string {
 
 // DefaultDiskTypeForInstance returns the default disk type for a GCP instance type. If instance type is not
 // recognized, pd-ssd is returned. For sovereign cloud instances, hyperdisk-balanced is preferred when available.
-func DefaultDiskTypeForInstance(instanceType, projectID string) string {
-	return DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID)
+func DefaultDiskTypeForInstance(instanceType, projectID, region string) string {
+	return DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID, region)
 }
 
 // DefaultDiskTypeForInstanceAndProjectID returns the default disk type for a GCP instance type and project ID.
-// The cloud environment is automatically detected from the project ID.
+// The cloud environment is automatically detected from the project ID and region.
 // For sovereign cloud, hyperdisk-balanced is preferred. For public GCP, pd-ssd is preferred.
-func DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID string) string {
+func DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID, region string) string {
 	diskTypes, ok := GetDiskTypes(instanceType)
 	if !ok {
 		return PDSSD
 	}
 
 	preferred := []string{PDSSD, HyperDiskBalanced}
-	if GetCloudEnvironment(projectID) == CloudEnvironmentSovereign {
+	if GetCloudEnvironment(projectID, region) == CloudEnvironmentSovereign {
 		preferred = []string{HyperDiskBalanced, PDSSD}
 	}
 

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/openshift/installer/pkg/types/dns"
 )
 
@@ -23,15 +21,6 @@ const (
 
 	// CloudEnvironmentSovereign is the cloud environment identifier for GCP sovereign clouds.
 	CloudEnvironmentSovereign = "sovereign"
-)
-
-var (
-	// sovereignCloudProjectPrefixes contains known project ID prefixes for sovereign clouds.
-	// Project IDs in sovereign clouds use the format: <prefix>:<project-id>
-	// This list helps distinguish from organization-scoped public GCP projects (orgname:project-id).
-	sovereignCloudProjectPrefixes = []string{
-		"eu0", // European sovereign cloud (Germany)
-	}
 )
 
 // DNS contains the gcp dns zone information for the cluster.
@@ -217,18 +206,14 @@ func ShouldUseEndpointForInstaller(endpoint *PSCEndpoint) bool {
 	return endpoint != nil && endpoint.ClusterUseOnly != nil && !(*endpoint.ClusterUseOnly)
 }
 
-// GetCloudEnvironment determines the cloud environment from the project ID format.
+// GetCloudEnvironment determines the cloud environment from the project ID and region.
 // Returns CloudEnvironmentSovereign for sovereign cloud environments, empty string for public GCP.
-// Uses known sovereign cloud project ID prefixes to distinguish from organization-scoped
-// public GCP projects (orgname:project-id).
-func GetCloudEnvironment(projectID string) string {
-	// Check if project ID has a known sovereign cloud prefix
-	parts := strings.SplitN(projectID, ":", 2)
-	if len(parts) == 2 && sets.New(sovereignCloudProjectPrefixes...).Has(parts[0]) {
-		// Known sovereign prefix is definitive - this IS a sovereign cloud project
+// Sovereign cloud is identified by both a domain-scoped project ID (containing ":")
+// and a sovereign region (prefixed with "u-").
+func GetCloudEnvironment(projectID, region string) string {
+	if strings.Contains(projectID, ":") && strings.HasPrefix(region, "u-") {
 		return CloudEnvironmentSovereign
 	}
-	// No known sovereign prefix found
 	return ""
 }
 

--- a/pkg/types/gcp/platform_test.go
+++ b/pkg/types/gcp/platform_test.go
@@ -6,6 +6,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetCloudEnvironment(t *testing.T) {
+	cases := []struct {
+		name      string
+		projectID string
+		region    string
+		expected  string
+	}{
+		{
+			name:      "standard project",
+			projectID: "my-project",
+			region:    "us-central1",
+			expected:  "",
+		},
+		{
+			name:      "eu0 sovereign cloud",
+			projectID: "eu0:my-project",
+			region:    "u-de-1",
+			expected:  CloudEnvironmentSovereign,
+		},
+		{
+			name:      "s3ns sovereign cloud",
+			projectID: "s3ns:my-project",
+			region:    "u-fr-1",
+			expected:  CloudEnvironmentSovereign,
+		},
+		{
+			name:      "domain-scoped project without sovereign region is not sovereign",
+			projectID: "other-prefix:my-project",
+			region:    "us-central1",
+			expected:  "",
+		},
+		{
+			name:      "sovereign region without domain-scoped project is not sovereign",
+			projectID: "my-project",
+			region:    "u-de-1",
+			expected:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetCloudEnvironment(tc.projectID, tc.region)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestFormatKMSKeyResourcePath(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -81,13 +81,13 @@ func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.Erro
 func ValidateOSImageForSovereignCloud(platform *gcp.Platform, pool *gcp.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if gcp.GetCloudEnvironment(platform.ProjectID) != gcp.CloudEnvironmentSovereign {
+	if gcp.GetCloudEnvironment(platform.ProjectID, platform.Region) != gcp.CloudEnvironmentSovereign {
 		return allErrs
 	}
 
 	if pool == nil || pool.OSImage == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("osImage"),
-			"must specify an OS image for sovereign cloud environments (domain-scoped project ID)"))
+			"must specify an OS image for sovereign cloud environments (domain-scoped project ID and u- region prefix)"))
 		return allErrs
 	}
 

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -20,41 +20,52 @@ func TestValidateOSImageForSovereignCloud(t *testing.T) {
 	}{
 		{
 			name:     "non-sovereign cloud skips validation",
-			platform: &gcp.Platform{ProjectID: "my-project"},
+			platform: &gcp.Platform{ProjectID: "my-project", Region: "us-central1"},
 			pool:     &gcp.MachinePool{},
 		},
 		{
 			name:     "sovereign cloud with os image on pool",
-			platform: &gcp.Platform{ProjectID: "eu0:my-project"},
+			platform: &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-de-1"},
 			pool:     &gcp.MachinePool{OSImage: validOSImage},
 		},
 		{
 			name:          "sovereign cloud missing os image on pool",
-			platform:      &gcp.Platform{ProjectID: "eu0:my-project"},
+			platform:      &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-de-1"},
 			pool:          &gcp.MachinePool{},
-			expectedError: `test-path.osImage: Required value: must specify an OS image for sovereign cloud environments (domain-scoped project ID)`,
+			expectedError: `test-path.osImage: Required value: must specify an OS image for sovereign cloud environments (domain-scoped project ID and u- region prefix)`,
 		},
 		{
 			name:          "sovereign cloud nil pool",
-			platform:      &gcp.Platform{ProjectID: "eu0:my-project"},
+			platform:      &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-de-1"},
 			pool:          nil,
-			expectedError: `test-path.osImage: Required value: must specify an OS image for sovereign cloud environments (domain-scoped project ID)`,
+			expectedError: `test-path.osImage: Required value: must specify an OS image for sovereign cloud environments (domain-scoped project ID and u- region prefix)`,
 		},
 		{
 			name:          "sovereign cloud os image missing name",
-			platform:      &gcp.Platform{ProjectID: "eu0:my-project"},
+			platform:      &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-de-1"},
 			pool:          &gcp.MachinePool{OSImage: &gcp.OSImage{Project: "my-project"}},
 			expectedError: `test-path.osImage.name: Required value: must specify an OS image name for sovereign cloud environments`,
 		},
 		{
 			name:          "sovereign cloud os image missing project",
-			platform:      &gcp.Platform{ProjectID: "eu0:my-project"},
+			platform:      &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-de-1"},
 			pool:          &gcp.MachinePool{OSImage: &gcp.OSImage{Name: "my-image"}},
 			expectedError: `test-path.osImage.project: Required value: must specify an OS image project for sovereign cloud environments`,
 		},
 		{
-			name:     "org-scoped project ID is not sovereign",
-			platform: &gcp.Platform{ProjectID: "myorg:my-project"},
+			name:          "domain-scoped project ID is sovereign",
+			platform:      &gcp.Platform{ProjectID: "s3ns:my-project", Region: "u-fr-1"},
+			pool:          &gcp.MachinePool{},
+			expectedError: `test-path.osImage: Required value: must specify an OS image for sovereign cloud environments (domain-scoped project ID and u- region prefix)`,
+		},
+		{
+			name:     "domain-scoped project ID with os image",
+			platform: &gcp.Platform{ProjectID: "s3ns:my-project", Region: "u-fr-1"},
+			pool:     &gcp.MachinePool{OSImage: validOSImage},
+		},
+		{
+			name:     "domain-scoped project without sovereign region is not sovereign",
+			platform: &gcp.Platform{ProjectID: "myorg:my-project", Region: "us-central1"},
 			pool:     &gcp.MachinePool{},
 		},
 	}


### PR DESCRIPTION
Project IDs are confirmed to always contain colons. This is based on a conversation with Alfred Chung. The two examples we have right now are: 

eu0 - Germany
s3ns - France

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sovereign cloud detection using both project identifiers and regions.
  * Corrected machine pool validation for sovereign projects with or without operating system images.
  * Updated default instance and disk selections for sovereign and public cloud environments.
  * Improved service endpoint override validation for sovereign regions.

* **Tests**
  * Added coverage for standard, domain-scoped, and region-specific project configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->