### PR TITLE
OCPBUGS-104587: add done guard and stale container cleanup for wait-for-ceo step

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -636,10 +636,11 @@ else
 
     rm --force /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
 
-    if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+    if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ] && [ ! -f wait-for-ceo.done ]
     then
         record_service_stage_start "wait-for-ceo"
         echo "Waiting for CEO to finish..."
+        podman rm -f wait-for-ceo 2>/dev/null || true
         bootkube_podman_run \
             --name wait-for-ceo \
             --volume "$PWD:/assets:z" \
@@ -647,6 +648,7 @@ else
             /usr/bin/cluster-etcd-operator \
             wait-for-ceo \
             --kubeconfig /assets/auth/kubeconfig
+        touch wait-for-ceo.done
         record_service_stage_success
     fi
 fi


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-104587

## Problem

The `wait-for-ceo` step in `bootkube.sh` is the only major step without a `.done` file guard and has no pre-run cleanup for stale containers. If the bootkube service restarts after the `wait-for-ceo` container was created but before `--rm` cleanup completes, the next attempt fails with:

```
Error: creating container storage: the container name wait-for-ceo is already in use
```

This loops indefinitely, permanently blocking bootstrap completion. In one customer case, this ran over 22,000 times across 5 days.

## Fix

1. **Add `.done` file guard** (`[ ! -f wait-for-ceo.done ]`) -- skips the step on restart if it already completed, matching the pattern used by all other steps (etcd-bootstrap, cvo-bootstrap, mco-bootstrap, etc.)
2. **Add stale container cleanup** (`podman rm -f wait-for-ceo`) before running -- removes any leftover container from a previous attempt, preventing the name collision
3. **Create `.done` file** (`touch wait-for-ceo.done`) after success -- marks the step as complete

This follows the same pattern established by OCPBUGS-5708 which fixed the same class of issue for the `etcdctl` container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling by ensuring the CEO wait step runs only when needed.
  * Prevented conflicts from previously created wait containers.
  * Records completion so the wait step is not repeated unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->