### PR TITLE
OCPBUGS-100300: Add scale-from-zero annotations to CAPI worker MachineSets

### DIFF
--- a/pkg/asset/machines/aws/clusterapi_machinesets.go
+++ b/pkg/asset/machines/aws/clusterapi_machinesets.go
@@ -4,6 +4,7 @@ package aws
 import (
 	"fmt"
 	"maps"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -210,6 +211,21 @@ func ClusterAPIMachineSets(in *MachineSetInput) ([]capa.AWSMachineTemplate, []ca
 		// Machine labels will be synced from the Machine to the corresponding Node
 		maps.Copy(machineSet.Spec.Template.ObjectMeta.Labels, nodeLabels)
 		utils.SetCAPIMachineSetOSStreamLabels(&machineSet, in.Config)
+
+		if info, ok := in.InstanceTypes[instanceType]; ok && in.Architecture != "" {
+			machineSet.ObjectMeta.Annotations = map[string]string{
+				// Legacy keys (Machine API provider)
+				"machine.openshift.io/vCPU":     strconv.FormatInt(info.DefaultVCpus, 10),
+				"machine.openshift.io/memoryMb": strconv.FormatInt(info.MemInMiB, 10),
+				// TODO: GPU count is not yet available in InstanceType metadata; default to 0
+				"machine.openshift.io/GPU": "0",
+				// CAPI keys (cluster-autoscaler CAPI provider)
+				"capacity.cluster-autoscaler.kubernetes.io/cpu":       strconv.FormatInt(info.DefaultVCpus, 10),
+				"capacity.cluster-autoscaler.kubernetes.io/memory":    fmt.Sprintf("%dMi", info.MemInMiB),
+				"capacity.cluster-autoscaler.kubernetes.io/gpu-count": "0",
+				"capacity.cluster-autoscaler.kubernetes.io/labels":    fmt.Sprintf("kubernetes.io/arch=%s", in.Architecture),
+			}
+		}
 
 		machineSets = append(machineSets, machineSet)
 	}

--- a/pkg/asset/machines/aws/clusterapi_machinesets_test.go
+++ b/pkg/asset/machines/aws/clusterapi_machinesets_test.go
@@ -259,6 +259,112 @@ func TestClusterAPIMachineSets(t *testing.T) {
 			validate: validateAdditionalSecurityGroups,
 		},
 		{
+			name: "scale-from-zero annotations set when instance type info and architecture provided",
+			input: func() *MachineSetInput {
+				in := defaultMachineSetInput()
+				in.Pool.Platform.AWS.Zones = []string{"us-east-1a"}
+				in.Pool.Replicas = ptr.To(int64(1))
+				in.Architecture = "amd64"
+				in.InstanceTypes = map[string]icaws.InstanceType{
+					"m5.xlarge": {DefaultVCpus: 4, MemInMiB: 16384},
+				}
+				return in
+			}(),
+			validate: func(t *testing.T, _ []capa.AWSMachineTemplate, machineSets []capi.MachineSet) {
+				t.Helper()
+				if len(machineSets) != 1 {
+					t.Fatalf("expected 1 machineset, got %d", len(machineSets))
+				}
+				ann := machineSets[0].ObjectMeta.Annotations
+				wantAnnotations := map[string]string{
+					"machine.openshift.io/vCPU":                           "4",
+					"machine.openshift.io/memoryMb":                       "16384",
+					"machine.openshift.io/GPU":                            "0",
+					"capacity.cluster-autoscaler.kubernetes.io/cpu":       "4",
+					"capacity.cluster-autoscaler.kubernetes.io/memory":    "16384Mi",
+					"capacity.cluster-autoscaler.kubernetes.io/gpu-count": "0",
+					"capacity.cluster-autoscaler.kubernetes.io/labels":    "kubernetes.io/arch=amd64",
+				}
+				for k, want := range wantAnnotations {
+					if got, ok := ann[k]; !ok || got != want {
+						t.Errorf("annotation %s = %q (present=%v), want %q", k, got, ok, want)
+					}
+				}
+			},
+		},
+		{
+			name: "no annotations when instance types map is nil",
+			input: func() *MachineSetInput {
+				in := defaultMachineSetInput()
+				in.Pool.Platform.AWS.Zones = []string{"us-east-1a"}
+				in.Pool.Replicas = ptr.To(int64(1))
+				in.Architecture = "amd64"
+				return in
+			}(),
+			validate: func(t *testing.T, _ []capa.AWSMachineTemplate, machineSets []capi.MachineSet) {
+				t.Helper()
+				if len(machineSets[0].ObjectMeta.Annotations) != 0 {
+					t.Errorf("expected no annotations, got %v", machineSets[0].ObjectMeta.Annotations)
+				}
+			},
+		},
+		{
+			name: "no annotations when architecture is empty",
+			input: func() *MachineSetInput {
+				in := defaultMachineSetInput()
+				in.Pool.Platform.AWS.Zones = []string{"us-east-1a"}
+				in.Pool.Replicas = ptr.To(int64(1))
+				in.InstanceTypes = map[string]icaws.InstanceType{
+					"m5.xlarge": {DefaultVCpus: 4, MemInMiB: 16384},
+				}
+				return in
+			}(),
+			validate: func(t *testing.T, _ []capa.AWSMachineTemplate, machineSets []capi.MachineSet) {
+				t.Helper()
+				if len(machineSets[0].ObjectMeta.Annotations) != 0 {
+					t.Errorf("expected no annotations, got %v", machineSets[0].ObjectMeta.Annotations)
+				}
+			},
+		},
+		{
+			name: "edge pool annotations use per-zone preferred instance type",
+			input: func() *MachineSetInput {
+				in := defaultMachineSetInput()
+				in.Pool.Name = types.MachinePoolEdgeRoleName
+				in.Pool.Replicas = ptr.To(int64(1))
+				in.Pool.Platform.AWS.InstanceType = ""
+				in.Pool.Platform.AWS.Zones = []string{"us-east-1-bos-1a"}
+				in.Architecture = "amd64"
+				in.Zones = icaws.Zones{
+					"us-east-1-bos-1a": &icaws.Zone{
+						Name:                  "us-east-1-bos-1a",
+						Type:                  "local-zone",
+						GroupName:             "us-east-1-bos-1",
+						ParentZoneName:        "us-east-1c",
+						PreferredInstanceType: "c5.xlarge",
+					},
+				}
+				in.InstanceTypes = map[string]icaws.InstanceType{
+					"m5.xlarge": {DefaultVCpus: 4, MemInMiB: 16384},
+					"c5.xlarge": {DefaultVCpus: 4, MemInMiB: 8192},
+				}
+				return in
+			}(),
+			validate: func(t *testing.T, _ []capa.AWSMachineTemplate, machineSets []capi.MachineSet) {
+				t.Helper()
+				if len(machineSets) != 1 {
+					t.Fatalf("expected 1 machineset, got %d", len(machineSets))
+				}
+				ann := machineSets[0].ObjectMeta.Annotations
+				if got := ann["machine.openshift.io/memoryMb"]; got != "8192" {
+					t.Errorf("expected memoryMb=8192 (c5.xlarge), got %q", got)
+				}
+				if got := ann["capacity.cluster-autoscaler.kubernetes.io/memory"]; got != "8192Mi" {
+					t.Errorf("expected memory=8192Mi (c5.xlarge), got %q", got)
+				}
+			},
+		},
+		{
 			name: "edge pool adds labels taints and preferred instance type",
 			input: func() *MachineSetInput {
 				in := defaultMachineSetInput()

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -28,6 +28,8 @@ type MachineSetInput struct {
 	UserDataSecret           string
 	Hosts                    map[string]icaws.Host
 	Config                   *types.InstallConfig
+	InstanceTypes            map[string]icaws.InstanceType
+	Architecture             string
 }
 
 // MachineSets returns a list of machinesets for a machinepool.

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -560,6 +560,15 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 
 			pool.Platform.AWS = &mpool
 
+			computeArch := string(pool.Architecture)
+			if computeArch == "" {
+				computeArch = string(installConfig.Config.ControlPlane.Architecture)
+			}
+			allInstanceTypes, itErr := installConfig.AWS.InstanceTypes(ctx)
+			if itErr != nil {
+				logrus.Warn("failed to look up instance type info for scale-from-zero annotations")
+			}
+
 			input := &aws.MachineSetInput{
 				ClusterID:                clusterID.InfraID,
 				InstallConfigPlatformAWS: installConfig.Config.Platform.AWS,
@@ -571,6 +580,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				UserDataSecret:           workerUserDataSecretName,
 				Hosts:                    dHosts,
 				Config:                   installConfig.Config,
+				InstanceTypes:            allInstanceTypes,
+				Architecture:             computeArch,
 			}
 
 			if pool.Management == types.ClusterAPI {


### PR DESCRIPTION
## Summary

CAPI worker MachineSets were missing the cluster-autoscaler scale-from-zero annotations (`machine.openshift.io/vCPU`, `machine.openshift.io/memoryMb`, `machine.openshift.io/GPU`, and `capacity.cluster-autoscaler.kubernetes.io/labels`), which prevented the cluster-autoscaler from scaling up from zero replicas.

This fix stamps those annotations at MachineSet generation time using existing instance type metadata already available from the AWS API.

## Changes

- **`pkg/asset/machines/aws/machinesets.go`**: Added `InstanceTypeInfo` and `Architecture` fields to `MachineSetInput`.
- **`pkg/asset/machines/aws/clusterapi_machinesets.go`**: Stamps autoscaler annotations on CAPI MachineSets.
- **`pkg/asset/machines/worker.go`**: Looks up instance type metadata and passes it to `MachineSetInput`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS worker machine sets now include available instance capacity details, including vCPUs, memory, GPUs, and architecture.
  * Instance type metadata is automatically applied to support more accurate scale-from-zero capacity estimates and autoscaling decisions.
  * Capacity annotations use the preferred instance type for each applicable zone.

* **Bug Fixes**
  * Machine set generation now continues when instance metadata is unavailable, with a warning recorded for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->