### PR TITLE
OCPBUGS-74510: vsphere: remove VSphereMultiDisk feature gate references

### DIFF
--- a/pkg/asset/machines/util.go
+++ b/pkg/asset/machines/util.go
@@ -53,19 +53,15 @@ func NodeDiskSetup(installConfig *installconfig.InstallConfig, role string, disk
 			return nil, errors.Errorf("unsupported azure data disk type")
 		}
 	case vspheretypes.Name:
-		if installConfig.Config.Enabled(features.FeatureGateVSphereMultiDisk) {
-			if vsphereDataDisk, ok := dataDisk.(vsphere.DiskInfo); ok {
-				// We need to find the index of the datadisk in the array.  Each disk is added in order to the VM so
-				// we'll map to that location.  First disk is OS disk so add 1 to index for scsi location
-				device := fmt.Sprintf(VsphereScsiByPath, vsphereDataDisk.Index+1)
-				diskSetupIgn, err := machineconfig.ForDiskSetup(role, device, label, path, diskSetup.Type)
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to create ignition to setup disks for master machines")
-				}
-				return diskSetupIgn, nil
+		if vsphereDataDisk, ok := dataDisk.(vsphere.DiskInfo); ok {
+			device := fmt.Sprintf(VsphereScsiByPath, vsphereDataDisk.Index+1)
+			diskSetupIgn, err := machineconfig.ForDiskSetup(role, device, label, path, diskSetup.Type)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create ignition to setup disks for master machines")
 			}
-			return nil, errors.Errorf("unsupported vsphere data disk type")
+			return diskSetupIgn, nil
 		}
+		return nil, errors.Errorf("unsupported vsphere data disk type")
 	default:
 		return nil, errors.Errorf("unsupported platform %q", ic.Platform.Name())
 	}

--- a/pkg/types/vsphere/validation/featuregates.go
+++ b/pkg/types/vsphere/validation/featuregates.go
@@ -23,9 +23,6 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 		}
 	}
 
-	cpDef := c.ControlPlane.Platform.VSphere
-	computeDefs := c.Compute
-
 	return []featuregates.GatedInstallConfigFeature{
 		{
 			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
@@ -38,30 +35,9 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 			Field:           field.NewPath("platform", "vsphere", "nodeNetworking"),
 		},
 		{
-			FeatureGateName: features.FeatureGateVSphereMultiDisk,
-			Condition:       cpDef != nil && len(cpDef.DataDisks) > 0, // Here we need to check disk count
-			Field:           field.NewPath("controlPlane", "platform", "vsphere", "dataDisks"),
-		},
-		{
-			FeatureGateName: features.FeatureGateVSphereMultiDisk,
-			Condition:       hasDataDisks(computeDefs), // Here we need to check disk count
-			Field:           field.NewPath("compute", "platform", "vsphere", "dataDisks"),
-		},
-		{
 			FeatureGateName: features.FeatureGateOnPremDNSRecords,
 			Condition:       v.DNSRecordsType == configv1.DNSRecordsTypeExternal,
 			Field:           field.NewPath("platform", "vsphere", "dnsRecordsType"),
 		},
 	}
-}
-
-func hasDataDisks(pool []types.MachinePool) bool {
-	foundDataDisks := false
-	for _, machine := range pool {
-		if machine.Platform.VSphere != nil && len(machine.Platform.VSphere.DataDisks) > 0 {
-			foundDataDisks = true
-			break
-		}
-	}
-	return foundDataDisks
 }


### PR DESCRIPTION
OCPBUGS-74510

### Changes
- Removed VSphereMultiDisk references

### Notes
The VSphereMultiDisk feature gate has been GA for several releases. Remove the gating checks so vSphere multi-disk functionality runs unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * vSphere disk setup now works without requiring the multi-disk feature gate.
  * Improved validation and handling of vSphere data disks, including clearer handling of unsupported disk data.
  * Removed unnecessary feature-gate checks for control-plane and compute data disks.
  * Existing multi-network, node-networking, and DNS-record validation remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->