### PR TITLE
OCPQUAL-24: docs: add test documentation structure with GCD examples

### DIFF
--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -9,6 +9,9 @@ The goal is traceability: every testable behavior should have a documented
 scenario that links to a JIRA feature or bug, the source code under test, and
 the automated test that verifies it.
 
+For a cross-platform overview of which features are tested and how, see the
+[Platform Feature Matrix](platform_feature_matrix.md).
+
 ## Directory Structure
 
 ```text
@@ -28,6 +31,7 @@ higher-level test plans and `cases/` holds detailed test case documents.
 
 ```text
 test/docs/
+  platform_feature_matrix.md          # Cross-platform feature test coverage matrix
   gcd/
     plans/
       gcd-feature.md                 # Feature test plan for GCD (OCPSTRAT-3006)

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -1,0 +1,476 @@
+# Installer Test Documentation
+
+This directory contains structured test documentation for the OpenShift
+Installer. Test plans and test cases are written as markdown files, organized
+by platform or topic, and cross-linked to the Go test files that implement
+them.
+
+The goal is traceability: every testable behavior should have a documented
+scenario that links to a JIRA feature or bug, the source code under test, and
+the automated test that verifies it.
+
+## Directory Structure
+
+```
+test/docs/
+  README.md                          # This file
+  <platform-or-topic>/
+    plans/
+      <feature-or-component>.md      # Test plans (higher-level)
+    cases/
+      <scenario-group>.md            # Test cases (scenario-level)
+```
+
+Each platform or topic gets its own directory. Within it, `plans/` holds
+higher-level test plans and `cases/` holds detailed test case documents.
+
+### Current contents
+
+```
+test/docs/
+  gcd/
+    plans/
+      gcd-feature.md                 # Feature test plan for GCD (OCPSTRAT-3006)
+    cases/
+      gcd_sovereign_install.md       # Detailed test cases for GCD installation
+```
+
+### Planned directories
+
+As test documentation expands, add directories following the same pattern:
+
+```
+test/docs/
+  gcd/           # Google Cloud Dedicated (sovereign cloud)
+  gcp/           # Google Cloud Platform (public cloud)
+  aws/           # Amazon Web Services
+  azure/         # Microsoft Azure
+  vsphere/       # VMware vSphere
+  baremetal/     # Bare metal / Agent-based
+  nutanix/       # Nutanix
+  ibmcloud/      # IBM Cloud
+  powervs/       # IBM Power VS
+  openstack/     # Red Hat OpenStack
+  bugs/          # Bug-specific test plans (cross-platform)
+```
+
+The `bugs/` directory is for complex bugs that warrant their own test plan,
+typically named after the JIRA key (e.g., `bugs/cases/OCPBUGS-12345.md`).
+
+## Document Types
+
+### Test Plan
+
+A test plan is a higher-level document covering a feature, release, or
+component. It answers: what are we testing, why, how, and what does "done"
+look like.
+
+**Location:** `<platform>/plans/<name>.md`
+
+**Required sections:**
+
+| Section | Purpose |
+|---------|---------|
+| 1. Introduction | Overview, scope (in/out), key features, JIRA references |
+| 2. Testing Strategy | Schedule, test types (unit/integration/E2E), environments |
+| 3. Test Areas and Test Cases | Activity table, links to case documents, coverage map |
+| 4. Test Details | Technical details specific to the feature under test |
+| 5. Risks | Risk table with impact and mitigation |
+| 6. Exit Criteria | Conditions that must be met to consider testing complete |
+
+### Test Case
+
+A test case document describes specific test scenarios with enough detail that
+someone could execute them manually or verify the automated test covers the
+right behavior.
+
+**Location:** `<platform>/cases/<name>.md`
+
+**Required sections:**
+
+| Section | Purpose |
+|---------|---------|
+| Metadata | Table with feature JIRA, component, test type, assignee |
+| Description | What the test cases cover and how they are organized |
+| Scenarios | Table with scenario number, link, and status (Automated/Manual) |
+| Per-scenario | Test file, function, description, execution, pass/fail criteria |
+| Manual Test Checklist | Checkbox checklist of all manual scenarios (only if file has manual tests) |
+| Related Links | JIRA issues, PRs, parent test plan |
+
+**Per-scenario fields:**
+
+Each scenario should include:
+
+- **Test file** - path to the `_test.go` file (or CI job name for E2E)
+- **Function under test** - the Go function or CI workflow being validated
+- **Automation status** - Automated (unit test), Automated (Prow CI), or Manual
+- **Description** - what the scenario validates and why it matters
+- **Execution** - code snippet or CLI command showing how to run it
+- **Expected Result** - what a passing test produces
+- **Pass/Fail Criteria** - table of inputs and expected outputs
+
+## How to Add a New Test Plan
+
+### 1. Create the directory
+
+If the platform or topic directory does not exist yet, create it:
+
+```sh
+mkdir -p test/docs/<platform>/plans test/docs/<platform>/cases
+```
+
+### 2. Write the test plan
+
+Create `test/docs/<platform>/plans/<name>.md` using this template:
+
+```markdown
+# Feature Test Plan: <Feature Name>
+
+## 1. Introduction
+
+### 1.1. Overview
+
+<One paragraph describing the feature and its significance.>
+
+### 1.2. Scope
+
+**In Scope**
+
+- <What is being tested>
+
+**Out of Scope**
+
+- <What is explicitly not being tested>
+
+### 1.3. Key Features
+
+- **<JIRA-KEY>** - <Feature description>
+
+### 1.4. References
+
+- Strategy: [<JIRA-KEY>](https://redhat.atlassian.net/browse/<JIRA-KEY>)
+- <Other relevant PRs, docs, or links>
+
+## 2. Testing Strategy
+
+### 2.1. Schedule
+
+| Milestone | Date / Sprint | Notes |
+|-----------|---------------|-------|
+| <Milestone> | TBD | <Notes> |
+
+### 2.2. Test Types
+
+- **Unit Tests:** <What unit tests cover>
+- **Integration Tests:** <What integration tests cover>
+- **E2E Tests:** <What E2E tests cover>
+
+### 2.3. Test Environments
+
+- **Unit/Integration:** <Environment description>
+- **E2E CI:** <CI job and environment details>
+
+## 3. Test Areas and Test Cases
+
+### 3.1. Key Test Activities
+
+| Activity | Type | Est. Duration |
+|----------|------|---------------|
+| <Activity> | <Unit/Integration/E2E> | <Duration> |
+
+### 3.2. Test Cases
+
+| Test Case | Doc | Test File(s) |
+|-----------|-----|--------------|
+| <Case name> | [<filename>.md](../cases/<filename>.md) | <Go test file paths> |
+
+### 3.3. Unit Test Coverage Map
+
+| Behavior | Source | Test File |
+|----------|--------|-----------|
+| <Behavior> | `<source-file>` `<Function>()` | `<test-file>` |
+
+## 4. Test Details
+
+<Technical details, invariants, configuration tables, E2E workflow steps.>
+
+## 5. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| <Risk> | <Impact> | <Mitigation> |
+
+## 6. Exit Criteria
+
+- <Condition 1>
+- <Condition 2>
+```
+
+### 3. Link to test cases
+
+The test plan should reference its test case documents in section 3.2
+using relative links:
+
+```markdown
+| GCD Sovereign Install | [gcd_sovereign_install.md](../cases/gcd_sovereign_install.md) | Multiple |
+```
+
+## How to Add New Test Cases
+
+### 1. Create the test case file
+
+Create `test/docs/<platform>/cases/<name>.md` using this template:
+
+```markdown
+# Test Case: <Case Name>
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Feature** | [<JIRA-KEY>](https://redhat.atlassian.net/browse/<JIRA-KEY>) - <Description> |
+| **Component** | Installer / <platform> |
+| **Test type** | <Unit, Integration, E2E> |
+| **Assignee** | <Name or TBD> |
+
+## Description
+
+<What these test cases cover and how they are organized.>
+
+## Scenarios
+
+| # | Scenario | Status |
+|---|----------|--------|
+| 1 | [<Scenario title>](#1-scenario-title) | Automated (unit test) |
+| 2 | [<Scenario title>](#2-scenario-title) | Manual |
+
+---
+
+## 1. <Scenario title>
+
+- **Test file:** `<path/to/file_test.go>`
+- **Function under test:** `<FunctionName>()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+<What this scenario validates and why it matters.>
+
+### Execution
+
+\```go
+result := pkg.FunctionUnderTest(input)
+// Expected: <expected value>
+\```
+
+### Expected Result
+
+- <What the function returns or what the test asserts>
+
+### Pass/Fail Criteria
+
+| Input | Expected Output |
+|-------|-----------------|
+| `<input>` | `<output>` |
+
+---
+
+## 2. <Scenario title>
+
+- **Automation status:** Manual
+- **Requires:** <Running cluster, credentials, etc.>
+
+### Description
+
+<What this scenario validates and why manual verification is needed.>
+
+### Prerequisites
+
+- <What must be in place before running this test>
+
+### Execution
+
+<Step-by-step instructions with commands to run.>
+
+### Pass/Fail Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| <Check> | <Condition> |
+
+---
+
+## Manual Test Checklist
+
+<\!-- MANUAL_TESTS_START -->
+
+- [ ] **2. <Scenario title>**
+  - [ ] <Sub-check from pass/fail criteria>
+
+<\!-- MANUAL_TESTS_END -->
+
+---
+
+## Related Links
+
+- Feature test plan: [<plan-name>.md](../plans/<plan-name>.md)
+- <JIRA links, PR links>
+```
+
+### 2. Add the case to the test plan
+
+Update the parent test plan's section 3.2 (Test Cases table) to include a row
+linking to the new case file.
+
+### 3. Add to the coverage map
+
+If the test case covers unit-tested functions, add rows to the test plan's
+section 3.3 (Unit Test Coverage Map) linking each behavior to its source and
+test file.
+
+## Conventions
+
+### File naming
+
+- **Plans:** Use kebab-case. Name after the feature or component:
+  `gcd-feature.md`, `ipi-install.md`, `shared-vpc.md`.
+- **Cases:** Use snake_case. Name after the scenario group:
+  `gcd_sovereign_install.md`, `aws_govcloud_validation.md`.
+- **Bug cases:** Name after the JIRA key: `OCPBUGS-12345.md`.
+
+### Cross-linking
+
+- Plans link down to cases using relative paths: `[name](../cases/file.md)`
+- Cases link up to plans using relative paths: `[name](../plans/file.md)`
+- Both link to JIRA using full URLs:
+  `[JIRA-KEY](https://redhat.atlassian.net/browse/JIRA-KEY)`
+- Both link to source code using repo-relative paths:
+  `pkg/types/gcp/platform.go`
+
+### JIRA references
+
+Always include JIRA references in the metadata. For features, link the
+strategy or epic. For bugs, link the bug issue directly. Use the format:
+
+```markdown
+| **Feature** | [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006) - Description |
+```
+
+### Automation status
+
+Use one of these values in test case scenarios:
+
+| Value | Meaning |
+|-------|---------|
+| Automated (unit test) | Covered by a Go `_test.go` file |
+| Automated (Prow CI) | Covered by a CI job in the release repo |
+| Manual | Requires manual execution by a human |
+| TBD | Automation status not yet determined |
+
+Every scenario must have an automation status in two places:
+
+1. **Scenarios table** - the `Status` column at the top of the case file
+2. **Per-scenario metadata** - the `Automation status` field in the scenario
+
+### Manual tests
+
+Manual test scenarios are tests that cannot be (or are not yet) automated and
+require a human to execute and verify. Common reasons for manual testing:
+
+- Verifying cloud console state that is not exposed through CLI or API
+- Validating behavior that depends on network topology (e.g., private DNS
+  reachability from outside the VPC)
+- Confirming resource cleanup after cluster destroy
+- Validating error messages during interactive install-config creation
+- Exploratory testing of new features before automation is written
+
+#### Marking a scenario as manual
+
+In the scenario's metadata, set:
+
+```markdown
+- **Automation status:** Manual
+- **Requires:** <what is needed - running cluster, credentials, etc.>
+```
+
+In the scenarios table at the top of the file, set the Status column to
+`Manual`:
+
+```markdown
+| 14 | [Verify cluster nodes use correct machine type](#14-...) | Manual |
+```
+
+#### Manual Test Checklist section
+
+Every case file that contains manual scenarios must include a
+**Manual Test Checklist** section near the end (before Related Links). This
+section provides a runnable checklist with `- [ ]` checkboxes that can be
+copied and used to track progress during a manual verification run.
+
+Wrap the checklist with HTML comments so it can be found programmatically:
+
+```markdown
+<!-- MANUAL_TESTS_START -->
+...checklist content...
+<!-- MANUAL_TESTS_END -->
+```
+
+See [gcd_sovereign_install.md](gcd/cases/gcd_sovereign_install.md) for a
+complete example.
+
+#### Finding manual tests
+
+To list all case files that have manual tests:
+
+```bash
+grep -rl "MANUAL_TESTS_START" test/docs/*/cases/
+```
+
+To list all case files with manual tests for a specific platform:
+
+```bash
+grep -rl "MANUAL_TESTS_START" test/docs/gcd/cases/
+```
+
+To see a quick summary of which scenarios are manual across all case files:
+
+```bash
+grep -n "| Manual" test/docs/*/cases/*.md
+```
+
+To extract just the manual test checklist from a specific file:
+
+```bash
+sed -n '/MANUAL_TESTS_START/,/MANUAL_TESTS_END/p' test/docs/gcd/cases/gcd_sovereign_install.md
+```
+
+To count manual vs automated scenarios across all platforms:
+
+```bash
+echo "Manual:    $(grep -rc '| Manual' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+echo "Automated: $(grep -rc '| Automated' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+```
+
+### Keeping docs in sync
+
+Test documentation should be updated when:
+
+- A new feature adds testable installer behavior
+- A test file is added, renamed, or deleted
+- A CI job is added or modified
+- A complex bug fix warrants its own test case
+- Test coverage gaps are identified during review
+
+The documentation does not need to mirror every individual Go test function.
+Focus on documenting behaviors and scenarios, not individual assertions.
+
+## References
+
+These external examples informed the structure used here:
+
+- [Kueue operator test docs](https://github.com/openshift/kueue-operator/pull/1994) -
+  test plans and test cases with CI job traceability
+- [Node runc deprecation cases](https://github.com/asahay19/origin/blob/f1280dc76adb20a53ea1291b2496545a4eec5da5/test/extended/node/runcdeprecationcases.md) -
+  scenario-level test case format with metadata tables and pass/fail criteria
+- [Node runc upgrade cases](https://github.com/asahay19/origin/blob/4258dcd738b8cb62aa946dd4886beb962133b7e8/test/extended/node/runc_upgrade_cases.md) -
+  step-by-step test case format with prerequisites and expected results

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -12,6 +12,65 @@ the automated test that verifies it.
 For a cross-platform overview of which features are tested and how, see the
 [Platform Feature Matrix](platform_feature_matrix.md).
 
+## Traceability
+
+The test documentation supports end-to-end traceability through this chain:
+
+```text
+JIRA issue -> Feature -> Test Plan -> Test Cases -> Scenarios -> CI Job (Prow)
+```
+
+Each link in the chain is navigable:
+
+| From | To | How |
+|------|----|-----|
+| JIRA issue | Test plan | JIRA issue description should link to the test plan file (see [JIRA linking](#jira-linking)) |
+| Test plan | JIRA issue | `References` section contains JIRA links |
+| Test plan | Test cases | Section 3.2 links to case files in `../cases/` |
+| Test case | Test plan | `Related Links` section links back to the parent plan |
+| Test case | Scenarios | Scenarios table at the top with anchor links |
+| Scenario | Source code | `Test file` field with repo-relative path |
+| Scenario | CI job logs | `CI job history` field with Prow URL (for Prow CI scenarios) |
+
+### Navigating to Prow logs
+
+For scenarios with status `Automated (Prow CI)`, include a `CI job history`
+link using this URL pattern:
+
+```text
+https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/<full-job-name>
+```
+
+The full job name follows the Prow naming convention:
+
+```text
+periodic-ci-openshift-release-<branch>-ci-<version>-<job-suffix>
+```
+
+For example, the GCD E2E job `e2e-gcd-ovn-private-techpreview` on the `main`
+branch for version `5.0` becomes:
+
+```text
+periodic-ci-openshift-release-main-ci-5.0-e2e-gcd-ovn-private-techpreview
+```
+
+To find the full job name for a CI job, search the
+[openshift/release](https://github.com/openshift/release) repo for the job
+suffix in `ci-operator/config/openshift/installer/openshift-installer-main.yaml`.
+
+### JIRA linking
+
+To complete the reverse link from JIRA to test docs, add a comment or update
+the JIRA issue description with a link to the test plan in the repo:
+
+```text
+Test plan: https://github.com/openshift/installer/blob/main/test/docs/<platform>/plans/<plan>.md
+Test cases: https://github.com/openshift/installer/blob/main/test/docs/<platform>/cases/<case>.md
+```
+
+This makes the chain navigable in both directions: from JIRA into the test
+docs, and from the test docs back to JIRA.
+
 ## Directory Structure
 
 ```text
@@ -244,10 +303,10 @@ Create `test/docs/<platform>/cases/<name>.md` using this template:
 
 ## Scenarios
 
-| # | Scenario | Status |
-|---|----------|--------|
-| 1 | [<Scenario title>](#1-scenario-title) | Automated (unit test) |
-| 2 | [<Scenario title>](#2-scenario-title) | Manual |
+| # | Scenario | Status | Priority |
+|---|----------|--------|----------|
+| 1 | [<Scenario title>](#1-scenario-title) | Automated (unit test) | |
+| 2 | [<Scenario title>](#2-scenario-title) | Manual | P1 |
 
 ---
 
@@ -377,6 +436,28 @@ Every scenario must have an automation status in two places:
 1. **Scenarios table** - the `Status` column at the top of the case file
 2. **Per-scenario metadata** - the `Automation status` field in the scenario
 
+### Automation priority
+
+The Scenarios table has an optional `Priority` column for tracking which
+Manual or TBD scenarios should be automated and when:
+
+| Value | Meaning |
+|-------|---------|
+| P1 | Automate next sprint |
+| P2 | Automate soon (next 1-2 sprints) |
+| P3 | Keep manual (automation not cost-effective) |
+| (empty) | Already automated, or priority not yet assessed |
+
+Leave the Priority column empty for already-automated scenarios. Use this
+column to help Technical Leads and Software Engineers prioritize automation
+work during sprint planning.
+
+To list all scenarios awaiting automation, sorted by priority:
+
+```bash
+grep -n "| P[123]" test/docs/*/cases/*.md | sort -t'|' -k5
+```
+
 ### Manual tests
 
 Manual test scenarios are tests that cannot be (or are not yet) automated and
@@ -468,6 +549,97 @@ Test documentation should be updated when:
 
 The documentation does not need to mirror every individual Go test function.
 Focus on documenting behaviors and scenarios, not individual assertions.
+
+## Execution Status and Reporting
+
+This section helps Engineering Managers and Technical Leads assess test
+execution status and coverage readiness.
+
+### Checking CI execution status
+
+View recent Prow job runs for the installer:
+
+- **All installer jobs:** [Prow job list](https://prow.ci.openshift.org/?repo=openshift%2Finstaller)
+- **Specific job history:** Use the URL pattern from the [Traceability](#navigating-to-prow-logs) section
+
+### Generating a coverage report
+
+Use `check.py` and `grep` to produce a quick coverage summary:
+
+```bash
+# Validate all test docs and show errors
+python3 test/docs/check.py
+
+# Count scenarios by automation status across all platforms
+echo "=== Scenario counts ==="
+echo "Automated (unit): $(grep -rc '| Automated (unit test)' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+echo "Automated (Prow): $(grep -rc '| Automated (Prow CI)' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+echo "Manual:           $(grep -rc '| Manual' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+echo "TBD:              $(grep -rc '| TBD' test/docs/*/cases/*.md | awk -F: '{s+=$NF}END{print s}')"
+
+# List scenarios awaiting automation, sorted by priority
+echo "=== Automation backlog ==="
+grep -n "| P[123]" test/docs/*/cases/*.md | sort -t'|' -k5
+
+# Count platforms with test documentation
+echo "=== Platform coverage ==="
+grep -c "| Yes" test/docs/platform_feature_matrix.md
+```
+
+### Release readiness assessment
+
+Use the [Platform Feature Matrix](platform_feature_matrix.md) to assess
+readiness. Key indicators:
+
+- **NT (Not Tested)** cells for features being shipped indicate coverage gaps
+- **Test Documentation** rows (bottom of matrix) show which platforms have
+  documented test plans and cases
+- Footnotes provide context on CI job counts and known limitations
+
+## Test Lifecycle
+
+### When to update test documentation
+
+Update scenario documentation when:
+
+- A test file is renamed, moved, or deleted
+- The function under test changes signature or behavior
+- A CI job is renamed or reconfigured in the release repo
+- A Manual scenario is automated (change status and add test file reference)
+
+### When to retire a scenario
+
+Remove a scenario when:
+
+- The feature it tests is removed from the installer
+- The scenario is fully replaced by a different scenario (not just refactored)
+- The CI job it references is permanently deleted
+
+Before removing, check that no other documents link to the scenario's anchor.
+
+### Deprecation process
+
+When a scenario will be retired but is not yet removed:
+
+1. Add `(deprecated)` to the scenario title in the Scenarios table
+2. Add a note at the top of the scenario detail section explaining why and
+   what replaces it
+3. Remove the scenario in the next PR that touches the same case file
+
+Do not leave deprecated scenarios for more than one release cycle.
+
+### Keeping source references current
+
+When a test file or function is renamed, update all references to it across
+the test docs. Use grep to find stale references:
+
+```bash
+# Find references to a specific test file
+grep -rn "old_file_test.go" test/docs/
+
+# Find references to a specific function
+grep -rn "OldFunctionName" test/docs/
+```
 
 ## References
 

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -31,6 +31,7 @@ higher-level test plans and `cases/` holds detailed test case documents.
 
 ```text
 test/docs/
+  install_config_field_index.md       # Install-config field to feature mapping
   platform_feature_matrix.md          # Cross-platform feature test coverage matrix
   gcd/
     plans/

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -11,7 +11,7 @@ the automated test that verifies it.
 
 ## Directory Structure
 
-```
+```text
 test/docs/
   README.md                          # This file
   <platform-or-topic>/
@@ -26,7 +26,7 @@ higher-level test plans and `cases/` holds detailed test case documents.
 
 ### Current contents
 
-```
+```text
 test/docs/
   gcd/
     plans/
@@ -39,7 +39,7 @@ test/docs/
 
 As test documentation expands, add directories following the same pattern:
 
-```
+```text
 test/docs/
   gcd/           # Google Cloud Dedicated (sovereign cloud)
   gcp/           # Google Cloud Platform (public cloud)
@@ -221,7 +221,7 @@ using relative links:
 
 Create `test/docs/<platform>/cases/<name>.md` using this template:
 
-```markdown
+````markdown
 # Test Case: <Case Name>
 
 ## Metadata
@@ -258,10 +258,10 @@ Create `test/docs/<platform>/cases/<name>.md` using this template:
 
 ### Execution
 
-\```go
+```go
 result := pkg.FunctionUnderTest(input)
 // Expected: <expected value>
-\```
+```
 
 ### Expected Result
 
@@ -302,12 +302,12 @@ result := pkg.FunctionUnderTest(input)
 
 ## Manual Test Checklist
 
-<\!-- MANUAL_TESTS_START -->
+<!-- MANUAL_TESTS_START -->
 
 - [ ] **2. <Scenario title>**
   - [ ] <Sub-check from pass/fail criteria>
 
-<\!-- MANUAL_TESTS_END -->
+<!-- MANUAL_TESTS_END -->
 
 ---
 
@@ -315,7 +315,7 @@ result := pkg.FunctionUnderTest(input)
 
 - Feature test plan: [<plan-name>.md](../plans/<plan-name>.md)
 - <JIRA links, PR links>
-```
+````
 
 ### 2. Add the case to the test plan
 

--- a/test/docs/check.py
+++ b/test/docs/check.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""Validate test documentation metadata and structure.
+
+Usage:
+    python3 check.py                          # validate all files
+    python3 check.py cases                    # validate only test case files
+    python3 check.py plans                    # validate only test plan files
+    python3 check.py matrix                   # validate only the feature matrix
+    python3 check.py gcd/cases/gcd_sovereign_install.md  # validate a specific file
+"""
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).parent
+
+# -- Enumerations -----------------------------------------------------------
+
+AUTOMATION_STATUSES = {
+    "Automated (unit test)",
+    "Automated (Prow CI)",
+    "Manual",
+    "TBD",
+}
+
+TEST_TYPES = {"Unit", "Integration", "E2E"}
+
+MATRIX_CELL_VALUES = {"AT", "MT", "AT/MT", "PT", "NT", "NA", "Yes", "No"}
+
+MATRIX_CELL_PATTERN = re.compile(
+    r"^(?:"
+    r"(?:AT|MT|AT/MT|PT|NT|NA)(?:\[\d+\])?"
+    r"|Yes(?:\[\d+\])?"
+    r"|No"
+    r"|"  # empty cell (section header rows)
+    r")$"
+)
+
+JIRA_LINK_PATTERN = re.compile(
+    r"\[([A-Z]+-\d+)\]\(https://redhat\.atlassian\.net/browse/[A-Z]+-\d+\)"
+)
+
+# Required metadata fields for test case files (the Metadata table).
+CASE_METADATA_FIELDS = {"Feature", "Component", "Test type", "Assignee"}
+
+# Required top-level sections for test plan files.
+PLAN_REQUIRED_SECTIONS = [
+    "1. Introduction",
+    "2. Testing Strategy",
+    "3. Test Areas and Test Cases",
+    "4. Test Details",
+    "5. Risks",
+    "6. Exit Criteria",
+]
+
+
+# -- Helpers ----------------------------------------------------------------
+
+
+class ValidationError:
+    def __init__(self, file, line, message):
+        self.file = file
+        self.line = line
+        self.message = message
+
+    def __str__(self):
+        rel = self.file
+        if self.line:
+            return f"{rel}:{self.line}: {self.message}"
+        return f"{rel}: {self.message}"
+
+
+def relative_path(path):
+    """Return path relative to DOCS_DIR, or the path itself if outside."""
+    try:
+        return path.relative_to(DOCS_DIR)
+    except ValueError:
+        return path
+
+
+def parse_md_table(lines, start):
+    """Parse a markdown table starting at line index `start`.
+
+    Returns a list of rows, where each row is a list of cell strings
+    (stripped of leading/trailing whitespace and pipes).  The separator
+    row (|---|---|) is skipped.
+    """
+    rows = []
+    i = start
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line.startswith("|"):
+            break
+        cells = [c.strip() for c in line.split("|")[1:-1]]
+        if cells and not all(re.fullmatch(r"-+|:-+|-+:|:-+:", c) for c in cells):
+            rows.append(cells)
+        i += 1
+    return rows
+
+
+def find_table_after_heading(lines, heading_text):
+    """Find the first markdown table that appears after a heading containing
+    `heading_text`.  Returns (header_row, data_rows, line_number) or None."""
+    for i, line in enumerate(lines):
+        stripped = line.strip().lstrip("#").strip()
+        if heading_text.lower() in stripped.lower():
+            for j in range(i + 1, min(i + 10, len(lines))):
+                if lines[j].strip().startswith("|"):
+                    rows = parse_md_table(lines, j)
+                    if len(rows) >= 1:
+                        return rows[0], rows[1:], j + 1
+                    break
+    return None
+
+
+def strip_bold(text):
+    """Remove markdown bold markers from text."""
+    return text.replace("**", "").strip()
+
+
+# -- File type detection ----------------------------------------------------
+
+
+def detect_file_type(path, lines):
+    """Detect whether a file is a 'case', 'plan', or 'matrix'."""
+    name = path.name
+    if name == "platform_feature_matrix.md":
+        return "matrix"
+
+    first_heading = ""
+    for line in lines[:5]:
+        if line.startswith("# "):
+            first_heading = line.strip()
+            break
+
+    if first_heading.startswith("# Test Case:"):
+        return "case"
+    if first_heading.startswith("# Feature Test Plan:"):
+        return "plan"
+    if first_heading.startswith("# Platform Feature Matrix"):
+        return "matrix"
+
+    # Fall back to path-based detection.
+    parts = path.parts
+    if "cases" in parts:
+        return "case"
+    if "plans" in parts:
+        return "plan"
+
+    return "unknown"
+
+
+# -- Validators -------------------------------------------------------------
+
+
+def validate_case(path, lines):
+    """Validate a test case file."""
+    errors = []
+    rel = relative_path(path)
+
+    # 1. Title must start with "# Test Case:"
+    title_found = False
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            if not line.strip().startswith("# Test Case:"):
+                errors.append(ValidationError(
+                    rel, i + 1,
+                    f"title must start with '# Test Case:' (got: {line.strip()!r})",
+                ))
+            else:
+                title_text = line.strip().removeprefix("# Test Case:").strip()
+                if not title_text:
+                    errors.append(ValidationError(
+                        rel, i + 1, "title after '# Test Case:' is empty",
+                    ))
+            title_found = True
+            break
+    if not title_found:
+        errors.append(ValidationError(rel, None, "no top-level heading found"))
+
+    # 2. Metadata table
+    result = find_table_after_heading(lines, "Metadata")
+    if result is None:
+        errors.append(ValidationError(rel, None, "missing '## Metadata' section with table"))
+    else:
+        header, rows, line_num = result
+        found_fields = {}
+        for row_idx, row in enumerate(rows):
+            if len(row) < 2:
+                errors.append(ValidationError(
+                    rel, line_num + row_idx + 1,
+                    f"metadata row has fewer than 2 columns: {row}",
+                ))
+                continue
+            field_name = strip_bold(row[0])
+            field_value = row[1].strip()
+            found_fields[field_name] = (field_value, line_num + row_idx + 1)
+
+        for required in CASE_METADATA_FIELDS:
+            if required not in found_fields:
+                errors.append(ValidationError(
+                    rel, None,
+                    f"missing required metadata field: '{required}'",
+                ))
+
+        # Feature must contain a JIRA link.
+        if "Feature" in found_fields:
+            val, ln = found_fields["Feature"]
+            if not JIRA_LINK_PATTERN.search(val):
+                errors.append(ValidationError(
+                    rel, ln,
+                    "Feature field must contain a JIRA link "
+                    "(e.g. [KEY-123](https://redhat.atlassian.net/browse/KEY-123))",
+                ))
+
+        # Test type must be from the allowed set (comma-separated).
+        if "Test type" in found_fields:
+            val, ln = found_fields["Test type"]
+            parts = [p.strip() for p in val.split(",")]
+            for part in parts:
+                if part not in TEST_TYPES:
+                    errors.append(ValidationError(
+                        rel, ln,
+                        f"invalid test type '{part}' "
+                        f"(expected one of: {', '.join(sorted(TEST_TYPES))})",
+                    ))
+
+        # Assignee must not be empty.
+        if "Assignee" in found_fields:
+            val, ln = found_fields["Assignee"]
+            if not val:
+                errors.append(ValidationError(
+                    rel, ln, "Assignee field is empty",
+                ))
+
+    # 3. Scenarios table
+    result = find_table_after_heading(lines, "Scenarios")
+    if result is None:
+        errors.append(ValidationError(rel, None, "missing '## Scenarios' section with table"))
+    else:
+        header, rows, line_num = result
+        if len(header) < 3:
+            errors.append(ValidationError(
+                rel, line_num,
+                f"scenarios table must have at least 3 columns (got {len(header)})",
+            ))
+        has_manual = False
+        for row_idx, row in enumerate(rows):
+            if len(row) < 3:
+                continue
+            status = row[2].strip()
+            if status not in AUTOMATION_STATUSES:
+                errors.append(ValidationError(
+                    rel, line_num + row_idx + 1,
+                    f"invalid automation status '{status}' "
+                    f"(expected one of: {', '.join(sorted(AUTOMATION_STATUSES))})",
+                ))
+            if status == "Manual":
+                has_manual = True
+
+            # Scenario number should be a positive integer.
+            num_str = row[0].strip()
+            if not num_str.isdigit() or int(num_str) < 1:
+                errors.append(ValidationError(
+                    rel, line_num + row_idx + 1,
+                    f"scenario number must be a positive integer (got '{num_str}')",
+                ))
+
+        # If there are manual scenarios, MANUAL_TESTS_START must exist.
+        if has_manual:
+            full_text = "\n".join(lines)
+            if "MANUAL_TESTS_START" not in full_text:
+                errors.append(ValidationError(
+                    rel, None,
+                    "file has Manual scenarios but missing "
+                    "<!-- MANUAL_TESTS_START --> marker",
+                ))
+            if "MANUAL_TESTS_END" not in full_text:
+                errors.append(ValidationError(
+                    rel, None,
+                    "file has Manual scenarios but missing "
+                    "<!-- MANUAL_TESTS_END --> marker",
+                ))
+
+    # 4. Per-scenario automation status must match scenarios table.
+    scenario_pattern = re.compile(r"^##\s+(\d+)\.\s+")
+    for i, line in enumerate(lines):
+        m = scenario_pattern.match(line)
+        if m:
+            # Look for "Automation status:" in the next few lines.
+            found_status = False
+            for j in range(i + 1, min(i + 8, len(lines))):
+                if "**Automation status:**" in lines[j]:
+                    found_status = True
+                    status_val = lines[j].split("**Automation status:**")[1].strip()
+                    if status_val not in AUTOMATION_STATUSES:
+                        errors.append(ValidationError(
+                            rel, j + 1,
+                            f"invalid per-scenario automation status '{status_val}'",
+                        ))
+                    break
+            if not found_status:
+                errors.append(ValidationError(
+                    rel, i + 1,
+                    f"scenario {m.group(1)} missing '**Automation status:**' field",
+                ))
+
+    # 5. Related Links section should exist.
+    if not any(line.strip().startswith("## Related Links") for line in lines):
+        errors.append(ValidationError(
+            rel, None, "missing '## Related Links' section",
+        ))
+
+    return errors
+
+
+def validate_plan(path, lines):
+    """Validate a test plan file."""
+    errors = []
+    rel = relative_path(path)
+
+    # 1. Title must start with "# Feature Test Plan:"
+    title_found = False
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            if not line.strip().startswith("# Feature Test Plan:"):
+                errors.append(ValidationError(
+                    rel, i + 1,
+                    f"title must start with '# Feature Test Plan:' "
+                    f"(got: {line.strip()!r})",
+                ))
+            else:
+                title_text = line.strip().removeprefix("# Feature Test Plan:").strip()
+                if not title_text:
+                    errors.append(ValidationError(
+                        rel, i + 1, "title after '# Feature Test Plan:' is empty",
+                    ))
+            title_found = True
+            break
+    if not title_found:
+        errors.append(ValidationError(rel, None, "no top-level heading found"))
+
+    # 2. Required sections.
+    section_headings = []
+    for i, line in enumerate(lines):
+        m = re.match(r"^##\s+(.+)", line)
+        if m:
+            section_headings.append((m.group(1).strip(), i + 1))
+
+    found_sections = {h for h, _ in section_headings}
+    for required in PLAN_REQUIRED_SECTIONS:
+        if not any(required.lower() in h.lower() for h in found_sections):
+            errors.append(ValidationError(
+                rel, None, f"missing required section: '## {required}'",
+            ))
+
+    # 3. Introduction must contain Overview, Scope, Key Features, References.
+    intro_subsections = {"Overview", "Scope", "Key Features", "References"}
+    found_subsections = set()
+    for i, line in enumerate(lines):
+        m = re.match(r"^###\s+\d+\.\d+\.\s+(.+)", line)
+        if m:
+            found_subsections.add(m.group(1).strip())
+    for sub in intro_subsections:
+        if sub not in found_subsections:
+            errors.append(ValidationError(
+                rel, None,
+                f"Introduction missing subsection '### x.x. {sub}'",
+            ))
+
+    # 4. Must contain at least one JIRA link.
+    full_text = "\n".join(lines)
+    if not JIRA_LINK_PATTERN.search(full_text):
+        errors.append(ValidationError(
+            rel, None,
+            "test plan must contain at least one JIRA link "
+            "(e.g. [KEY-123](https://redhat.atlassian.net/browse/KEY-123))",
+        ))
+
+    # 5. Testing Strategy should list test types.
+    if not any("Unit Tests" in line or "Unit tests" in line for line in lines):
+        errors.append(ValidationError(
+            rel, None,
+            "Testing Strategy should describe unit test coverage",
+        ))
+
+    # 6. Test Cases table should exist in section 3.
+    result = find_table_after_heading(lines, "Test Cases")
+    if result is None:
+        errors.append(ValidationError(
+            rel, None,
+            "section 3 should contain a 'Test Cases' table linking to case docs",
+        ))
+
+    # 7. Exit Criteria should have at least one bullet.
+    in_exit = False
+    has_criteria = False
+    for line in lines:
+        if re.match(r"^##\s+.*Exit Criteria", line, re.IGNORECASE):
+            in_exit = True
+            continue
+        if in_exit:
+            if line.startswith("## "):
+                break
+            if line.strip().startswith("- "):
+                has_criteria = True
+                break
+    if not has_criteria:
+        errors.append(ValidationError(
+            rel, None,
+            "Exit Criteria section should have at least one bullet point",
+        ))
+
+    return errors
+
+
+def find_section_table(lines, section_heading):
+    """Find a table under a heading that exactly matches `## <section_heading>`.
+
+    Unlike find_table_after_heading, this matches the exact section heading
+    (case-insensitive) and only searches within that section (stops at the
+    next ## heading).
+    """
+    in_section = False
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s+" + re.escape(section_heading) + r"\s*$", line, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section:
+            if line.startswith("## "):
+                break
+            if line.strip().startswith("|"):
+                rows = parse_md_table(lines, i)
+                if rows:
+                    return rows[0], rows[1:], i + 1
+    return None
+
+
+def validate_matrix(path, lines):
+    """Validate the platform feature matrix file."""
+    errors = []
+    rel = relative_path(path)
+
+    # 1. Find the Legend table and extract valid codes.
+    legend_result = find_section_table(lines, "Legend")
+    if legend_result is None:
+        errors.append(ValidationError(rel, None, "missing '## Legend' section with table"))
+    else:
+        _, legend_rows, _ = legend_result
+        legend_codes = set()
+        for row in legend_rows:
+            if row:
+                legend_codes.add(row[0].strip())
+        expected_codes = {"AT", "MT", "AT/MT", "PT", "NT", "NA"}
+        missing = expected_codes - legend_codes
+        if missing:
+            errors.append(ValidationError(
+                rel, None,
+                f"Legend table missing codes: {', '.join(sorted(missing))}",
+            ))
+
+    # 2. Find the Feature Matrix table.
+    result = find_section_table(lines, "Feature Matrix")
+    if result is None:
+        errors.append(ValidationError(
+            rel, None, "missing '## Feature Matrix' section with table",
+        ))
+        return errors
+
+    header, rows, line_num = result
+
+    # Header should have Feature + at least one platform.
+    if len(header) < 2:
+        errors.append(ValidationError(
+            rel, line_num,
+            f"matrix table header must have at least 2 columns (got {len(header)})",
+        ))
+        return errors
+
+    platform_count = len(header) - 1  # first column is "Feature"
+
+    # 3. Validate each row.
+    referenced_footnotes = set()
+    footnote_ref_pattern = re.compile(r"\[(\d+)\]")
+
+    for row_idx, row in enumerate(rows):
+        row_line = line_num + row_idx + 1  # +1 for separator row
+        feature = row[0].strip() if row else ""
+
+        # Section header rows have bold text and empty platform cells.
+        is_section_header = feature.startswith("**") and feature.endswith("**")
+
+        if len(row) != len(header):
+            errors.append(ValidationError(
+                rel, row_line,
+                f"row has {len(row)} columns but header has {len(header)}: "
+                f"'{feature}'",
+            ))
+            continue
+
+        for col_idx in range(1, len(row)):
+            cell = row[col_idx].strip()
+
+            # Collect footnote references.
+            for m in footnote_ref_pattern.finditer(cell):
+                referenced_footnotes.add(int(m.group(1)))
+
+            # Strip footnote references for validation.
+            clean_cell = footnote_ref_pattern.sub("", cell).strip()
+
+            if not MATRIX_CELL_PATTERN.match(cell):
+                if is_section_header and clean_cell == "":
+                    continue
+                errors.append(ValidationError(
+                    rel, row_line,
+                    f"invalid cell value '{cell}' in column "
+                    f"'{header[col_idx]}' for feature '{feature}' "
+                    f"(expected one of: {', '.join(sorted(MATRIX_CELL_VALUES))} "
+                    f"with optional [N] footnote)",
+                ))
+
+    # 4. Validate footnotes section exists and all referenced footnotes are
+    #    defined.
+    defined_footnotes = set()
+    in_footnotes = False
+    footnote_def_pattern = re.compile(r"^(\d+)\.\s+")
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s+Footnotes\s*$", line):
+            in_footnotes = True
+            continue
+        if in_footnotes:
+            if line.startswith("## "):
+                break
+            m = footnote_def_pattern.match(line.strip())
+            if m:
+                defined_footnotes.add(int(m.group(1)))
+
+    if not in_footnotes:
+        errors.append(ValidationError(rel, None, "missing '## Footnotes' section"))
+
+    undefined = referenced_footnotes - defined_footnotes
+    if undefined:
+        errors.append(ValidationError(
+            rel, None,
+            f"footnotes referenced but not defined: "
+            f"{', '.join(str(n) for n in sorted(undefined))}",
+        ))
+
+    unused = defined_footnotes - referenced_footnotes
+    if unused:
+        errors.append(ValidationError(
+            rel, None,
+            f"footnotes defined but not referenced in table: "
+            f"{', '.join(str(n) for n in sorted(unused))}",
+        ))
+
+    # 5. Platform Key table should exist.
+    platform_key = find_section_table(lines, "Platform Key")
+    if platform_key is None:
+        errors.append(ValidationError(rel, None, "missing '## Platform Key' section"))
+
+    return errors
+
+
+# -- Discovery and dispatch -------------------------------------------------
+
+
+def find_files(filter_arg=None):
+    """Find markdown files to validate based on CLI argument."""
+    if filter_arg is None:
+        # All files: matrix + all cases + all plans.
+        files = []
+        matrix = DOCS_DIR / "platform_feature_matrix.md"
+        if matrix.exists():
+            files.append(matrix)
+        for md in sorted(DOCS_DIR.rglob("*.md")):
+            if md == matrix or md.name == "README.md":
+                continue
+            files.append(md)
+        return files
+
+    if filter_arg == "matrix":
+        matrix = DOCS_DIR / "platform_feature_matrix.md"
+        return [matrix] if matrix.exists() else []
+
+    if filter_arg == "cases":
+        return sorted(DOCS_DIR.rglob("*/cases/*.md"))
+
+    if filter_arg == "plans":
+        return sorted(DOCS_DIR.rglob("*/plans/*.md"))
+
+    # Specific path (relative to DOCS_DIR or absolute).
+    target = Path(filter_arg)
+    if not target.is_absolute():
+        target = DOCS_DIR / target
+    if target.exists():
+        return [target]
+
+    print(f"error: file not found: {filter_arg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def validate_file(path):
+    """Validate a single file, returning a list of ValidationErrors."""
+    lines = path.read_text().splitlines()
+    file_type = detect_file_type(path, lines)
+
+    if file_type == "case":
+        return validate_case(path, lines)
+    elif file_type == "plan":
+        return validate_plan(path, lines)
+    elif file_type == "matrix":
+        return validate_matrix(path, lines)
+    else:
+        return [ValidationError(
+            relative_path(path), None,
+            f"could not detect file type (expected case, plan, or matrix)",
+        )]
+
+
+def main():
+    filter_arg = sys.argv[1] if len(sys.argv) > 1 else None
+
+    if filter_arg in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    files = find_files(filter_arg)
+    if not files:
+        print("No files to validate.", file=sys.stderr)
+        sys.exit(2)
+
+    total_errors = 0
+    for path in files:
+        errors = validate_file(path)
+        for err in errors:
+            print(f"  {err}")
+        if errors:
+            total_errors += len(errors)
+        else:
+            rel = relative_path(path)
+            print(f"  {rel}: ok")
+
+    print()
+    files_label = "file" if len(files) == 1 else "files"
+    if total_errors:
+        print(
+            f"FAIL: {total_errors} error(s) in {len(files)} {files_label}",
+        )
+        sys.exit(1)
+    else:
+        print(f"OK: {len(files)} {files_label} validated")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/docs/check.py
+++ b/test/docs/check.py
@@ -23,6 +23,8 @@ AUTOMATION_STATUSES = {
     "TBD",
 }
 
+PRIORITY_VALUES = {"P1", "P2", "P3", ""}
+
 TEST_TYPES = {"Unit", "Integration", "E2E"}
 
 MATRIX_CELL_VALUES = {"AT", "MT", "AT/MT", "PT", "NT", "NA", "Yes", "No"}
@@ -258,6 +260,16 @@ def validate_case(path, lines):
                 ))
             if status == "Manual":
                 has_manual = True
+
+            # Validate priority column if present (4th column).
+            if len(row) >= 4:
+                priority = row[3].strip()
+                if priority not in PRIORITY_VALUES:
+                    errors.append(ValidationError(
+                        rel, line_num + row_idx + 2,
+                        f"invalid priority '{priority}' "
+                        f"(expected one of: P1, P2, P3, or empty)",
+                    ))
 
             num_str = row[0].strip()
             if not num_str.isdigit() or int(num_str) < 1:

--- a/test/docs/check.py
+++ b/test/docs/check.py
@@ -659,10 +659,7 @@ def validate_file(path):
     elif file_type == "matrix":
         return validate_matrix(path, lines)
     else:
-        return [ValidationError(
-            relative_path(path), None,
-            "could not detect file type (expected case, plan, or matrix)",
-        )]
+        return None
 
 
 def main():
@@ -678,8 +675,16 @@ def main():
         sys.exit(2)
 
     total_errors = 0
+    validated = 0
+    skipped = 0
     for path in files:
         errors = validate_file(path)
+        if errors is None:
+            rel = relative_path(path)
+            print(f"  {rel}: skipped (unknown file type)")
+            skipped += 1
+            continue
+        validated += 1
         for err in errors:
             print(f"  {err}")
         if errors:
@@ -689,14 +694,17 @@ def main():
             print(f"  {rel}: ok")
 
     print()
-    files_label = "file" if len(files) == 1 else "files"
+    files_label = "file" if validated == 1 else "files"
+    summary = f"OK: {validated} {files_label} validated"
+    if skipped:
+        summary += f", {skipped} skipped"
     if total_errors:
         print(
-            f"FAIL: {total_errors} error(s) in {len(files)} {files_label}",
+            f"FAIL: {total_errors} error(s) in {validated} {files_label}",
         )
         sys.exit(1)
     else:
-        print(f"OK: {len(files)} {files_label} validated")
+        print(summary)
         sys.exit(0)
 
 

--- a/test/docs/check.py
+++ b/test/docs/check.py
@@ -188,13 +188,13 @@ def validate_case(path, lines):
         for row_idx, row in enumerate(rows):
             if len(row) < 2:
                 errors.append(ValidationError(
-                    rel, line_num + row_idx + 1,
+                    rel, line_num + row_idx + 2,
                     f"metadata row has fewer than 2 columns: {row}",
                 ))
                 continue
             field_name = strip_bold(row[0])
             field_value = row[1].strip()
-            found_fields[field_name] = (field_value, line_num + row_idx + 1)
+            found_fields[field_name] = (field_value, line_num + row_idx + 2)
 
         for required in CASE_METADATA_FIELDS:
             if required not in found_fields:
@@ -234,6 +234,7 @@ def validate_case(path, lines):
                 ))
 
     # 3. Scenarios table
+    table_statuses = {}  # scenario number -> status from table
     result = find_table_after_heading(lines, "Scenarios")
     if result is None:
         errors.append(ValidationError(rel, None, "missing '## Scenarios' section with table"))
@@ -251,22 +252,22 @@ def validate_case(path, lines):
             status = row[2].strip()
             if status not in AUTOMATION_STATUSES:
                 errors.append(ValidationError(
-                    rel, line_num + row_idx + 1,
+                    rel, line_num + row_idx + 2,
                     f"invalid automation status '{status}' "
                     f"(expected one of: {', '.join(sorted(AUTOMATION_STATUSES))})",
                 ))
             if status == "Manual":
                 has_manual = True
 
-            # Scenario number should be a positive integer.
             num_str = row[0].strip()
             if not num_str.isdigit() or int(num_str) < 1:
                 errors.append(ValidationError(
-                    rel, line_num + row_idx + 1,
+                    rel, line_num + row_idx + 2,
                     f"scenario number must be a positive integer (got '{num_str}')",
                 ))
+            else:
+                table_statuses[int(num_str)] = status
 
-        # If there are manual scenarios, MANUAL_TESTS_START must exist.
         if has_manual:
             full_text = "\n".join(lines)
             if "MANUAL_TESTS_START" not in full_text:
@@ -282,12 +283,13 @@ def validate_case(path, lines):
                     "<!-- MANUAL_TESTS_END --> marker",
                 ))
 
-    # 4. Per-scenario automation status must match scenarios table.
+    # 4. Per-scenario automation status - cross-check with scenarios table.
+    detail_statuses = {}  # scenario number -> (status, line)
     scenario_pattern = re.compile(r"^##\s+(\d+)\.\s+")
     for i, line in enumerate(lines):
         m = scenario_pattern.match(line)
         if m:
-            # Look for "Automation status:" in the next few lines.
+            num = int(m.group(1))
             found_status = False
             for j in range(i + 1, min(i + 8, len(lines))):
                 if "**Automation status:**" in lines[j]:
@@ -298,12 +300,30 @@ def validate_case(path, lines):
                             rel, j + 1,
                             f"invalid per-scenario automation status '{status_val}'",
                         ))
+                    detail_statuses[num] = (status_val, j + 1)
                     break
             if not found_status:
                 errors.append(ValidationError(
                     rel, i + 1,
-                    f"scenario {m.group(1)} missing '**Automation status:**' field",
+                    f"scenario {num} missing '**Automation status:**' field",
                 ))
+
+    # Cross-check: statuses in the table must match per-scenario statuses.
+    for num, table_status in table_statuses.items():
+        if num in detail_statuses:
+            detail_status, detail_line = detail_statuses[num]
+            if table_status != detail_status:
+                errors.append(ValidationError(
+                    rel, detail_line,
+                    f"scenario {num} status mismatch: table says "
+                    f"'{table_status}' but detail says '{detail_status}'",
+                ))
+        elif num not in detail_statuses:
+            errors.append(ValidationError(
+                rel, None,
+                f"scenario {num} listed in table but has no "
+                f"'## {num}. ...' detail section",
+            ))
 
     # 5. Related Links section should exist.
     if not any(line.strip().startswith("## Related Links") for line in lines):
@@ -384,13 +404,30 @@ def validate_plan(path, lines):
             "Testing Strategy should describe unit test coverage",
         ))
 
-    # 6. Test Cases table should exist in section 3.
+    # 6. Test Cases table should exist in section 3.2, with valid case links.
     result = find_table_after_heading(lines, "Test Cases")
     if result is None:
         errors.append(ValidationError(
             rel, None,
             "section 3 should contain a 'Test Cases' table linking to case docs",
         ))
+    else:
+        _, case_rows, case_line_num = result
+        link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+        for row_idx, row in enumerate(case_rows):
+            for cell in row:
+                for match in link_pattern.finditer(cell):
+                    link_target = match.group(2)
+                    if link_target.startswith("http://") or link_target.startswith("https://"):
+                        continue
+                    if link_target.startswith("/") or ".." not in link_target:
+                        pass  # relative path, check it resolves
+                    resolved = (path.parent / link_target).resolve()
+                    if not resolved.exists():
+                        errors.append(ValidationError(
+                            rel, case_line_num + row_idx + 2,
+                            f"case link target does not exist: '{link_target}'",
+                        ))
 
     # 7. Exit Criteria should have at least one bullet.
     in_exit = False
@@ -484,7 +521,7 @@ def validate_matrix(path, lines):
     footnote_ref_pattern = re.compile(r"\[(\d+)\]")
 
     for row_idx, row in enumerate(rows):
-        row_line = line_num + row_idx + 1  # +1 for separator row
+        row_line = line_num + row_idx + 2  # +2: 1-based + separator row
         feature = row[0].strip() if row else ""
 
         # Section header rows have bold text and empty platform cells.
@@ -593,6 +630,16 @@ def find_files(filter_arg=None):
     target = Path(filter_arg)
     if not target.is_absolute():
         target = DOCS_DIR / target
+    target = target.resolve()
+
+    docs_root = DOCS_DIR.resolve()
+    if not str(target).startswith(str(docs_root) + "/") and target != docs_root:
+        print(
+            f"error: path is outside docs directory: {filter_arg}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     if target.exists():
         return [target]
 
@@ -614,7 +661,7 @@ def validate_file(path):
     else:
         return [ValidationError(
             relative_path(path), None,
-            f"could not detect file type (expected case, plan, or matrix)",
+            "could not detect file type (expected case, plan, or matrix)",
         )]
 
 

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -22,25 +22,25 @@ validation rules, configuration generation, and end-to-end installation.
 
 ## Scenarios
 
-| # | Scenario | Status |
-|---|----------|--------|
-| 1 | [Sovereign cloud detection from project ID and region](#1-sovereign-cloud-detection-from-project-id-and-region) | Automated (unit test) |
-| 2 | [Domain-scoped project or sovereign region alone is not sovereign](#2-domain-scoped-project-or-sovereign-region-alone-is-not-sovereign) | Automated (unit test) |
-| 3 | [Non-default universe domain detection](#3-non-default-universe-domain-detection) | Automated (unit test) |
-| 4 | [Default instance type for sovereign cloud](#4-default-instance-type-for-sovereign-cloud) | Automated (unit test) |
-| 5 | [Default disk type for sovereign cloud](#5-default-disk-type-for-sovereign-cloud) | Automated (unit test) |
-| 6 | [OS image required for sovereign cloud](#6-os-image-required-for-sovereign-cloud) | Automated (unit test) |
-| 7 | [OS image with missing name or project](#7-os-image-with-missing-name-or-project) | Automated (unit test) |
-| 8 | [PSC endpoint forbidden for sovereign cloud](#8-psc-endpoint-forbidden-for-sovereign-cloud) | Automated (unit test) |
-| 9 | [Service account email for domain-scoped project](#9-service-account-email-for-domain-scoped-project) | Automated (unit test) |
-| 10 | [Cloud provider config uses nil tokenURL](#10-cloud-provider-config-uses-nil-tokenurl) | Automated (unit test) |
-| 11 | [CAPG controller receives universe domain](#11-capg-controller-receives-universe-domain) | Automated (unit test) |
-| 12 | [Credential options for sovereign cloud](#12-credential-options-for-sovereign-cloud) | Automated (unit test) |
-| 13 | [E2E: IPI install on GCD sovereign region](#13-e2e-ipi-install-on-gcd-sovereign-region) | Automated (Prow CI) |
-| 14 | [Verify GCD cluster nodes use correct machine type and disk](#14-verify-gcd-cluster-nodes-use-correct-machine-type-and-disk) | Manual |
-| 15 | [Verify GCD cluster uses private DNS only](#15-verify-gcd-cluster-uses-private-dns-only) | Manual |
-| 16 | [Verify GCD cluster destroy removes all resources](#16-verify-gcd-cluster-destroy-removes-all-resources) | Manual |
-| 17 | [Verify install-config validation rejects public publish on GCD](#17-verify-install-config-validation-rejects-public-publish-on-gcd) | Manual |
+| # | Scenario | Status | Priority |
+|---|----------|--------|----------|
+| 1 | [Sovereign cloud detection from project ID and region](#1-sovereign-cloud-detection-from-project-id-and-region) | Automated (unit test) | |
+| 2 | [Domain-scoped project or sovereign region alone is not sovereign](#2-domain-scoped-project-or-sovereign-region-alone-is-not-sovereign) | Automated (unit test) | |
+| 3 | [Non-default universe domain detection](#3-non-default-universe-domain-detection) | Automated (unit test) | |
+| 4 | [Default instance type for sovereign cloud](#4-default-instance-type-for-sovereign-cloud) | Automated (unit test) | |
+| 5 | [Default disk type for sovereign cloud](#5-default-disk-type-for-sovereign-cloud) | Automated (unit test) | |
+| 6 | [OS image required for sovereign cloud](#6-os-image-required-for-sovereign-cloud) | Automated (unit test) | |
+| 7 | [OS image with missing name or project](#7-os-image-with-missing-name-or-project) | Automated (unit test) | |
+| 8 | [PSC endpoint forbidden for sovereign cloud](#8-psc-endpoint-forbidden-for-sovereign-cloud) | Automated (unit test) | |
+| 9 | [Service account email for domain-scoped project](#9-service-account-email-for-domain-scoped-project) | Automated (unit test) | |
+| 10 | [Cloud provider config uses nil tokenURL](#10-cloud-provider-config-uses-nil-tokenurl) | Automated (unit test) | |
+| 11 | [CAPG controller receives universe domain](#11-capg-controller-receives-universe-domain) | Automated (unit test) | |
+| 12 | [Credential options for sovereign cloud](#12-credential-options-for-sovereign-cloud) | Automated (unit test) | |
+| 13 | [E2E: IPI install on GCD sovereign region](#13-e2e-ipi-install-on-gcd-sovereign-region) | Automated (Prow CI) | |
+| 14 | [Verify GCD cluster nodes use correct machine type and disk](#14-verify-gcd-cluster-nodes-use-correct-machine-type-and-disk) | Manual | P1 |
+| 15 | [Verify GCD cluster uses private DNS only](#15-verify-gcd-cluster-uses-private-dns-only) | Manual | P1 |
+| 16 | [Verify GCD cluster destroy removes all resources](#16-verify-gcd-cluster-destroy-removes-all-resources) | Manual | P2 |
+| 17 | [Verify install-config validation rejects public publish on GCD](#17-verify-install-config-validation-rejects-public-publish-on-gcd) | Manual | P1 |
 
 ---
 
@@ -534,6 +534,8 @@ opts := CredentialOptions(ctx, credJSON)
 ## 13. E2E: IPI install on GCD sovereign region
 
 - **CI job:** `e2e-gcd-ovn-private-techpreview`
+- **CI job history:** [Prow job history](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-gcd-ovn-private-techpreview)
+- **CI job definition:** [openshift/release](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/installer/openshift-installer-main.yaml) (search for `e2e-gcd`)
 - **Workflow:** `openshift-e2e-gcd`
 - **Automation status:** Automated (Prow CI)
 

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -12,9 +12,10 @@
 ## Description
 
 These test cases cover the installer's behavior when targeting a Google Cloud
-Dedicated (GCD) sovereign cloud environment. GCD is detected via the `eu0:`
-project ID prefix and differs from public GCP in machine types, disk types,
-DNS, OS image requirements, and credential handling.
+Dedicated (GCD) sovereign cloud environment. GCD is detected by two conditions:
+a domain-scoped project ID (containing `:`) and a sovereign region (prefixed
+with `u-`). Both must be present. It differs from public GCP in machine types,
+disk types, DNS, OS image requirements, and credential handling.
 
 The cases are organized into groups: sovereign cloud detection, default values,
 validation rules, configuration generation, and end-to-end installation.
@@ -23,8 +24,8 @@ validation rules, configuration generation, and end-to-end installation.
 
 | # | Scenario | Status |
 |---|----------|--------|
-| 1 | [Sovereign cloud detection from project ID](#1-sovereign-cloud-detection-from-project-id) | Automated (unit test) |
-| 2 | [Organization-scoped project is not sovereign](#2-organization-scoped-project-is-not-sovereign) | Automated (unit test) |
+| 1 | [Sovereign cloud detection from project ID and region](#1-sovereign-cloud-detection-from-project-id-and-region) | Automated (unit test) |
+| 2 | [Domain-scoped project or sovereign region alone is not sovereign](#2-domain-scoped-project-or-sovereign-region-alone-is-not-sovereign) | Automated (unit test) |
 | 3 | [Non-default universe domain detection](#3-non-default-universe-domain-detection) | Automated (unit test) |
 | 4 | [Default instance type for sovereign cloud](#4-default-instance-type-for-sovereign-cloud) | Automated (unit test) |
 | 5 | [Default disk type for sovereign cloud](#5-default-disk-type-for-sovereign-cloud) | Automated (unit test) |
@@ -43,71 +44,81 @@ validation rules, configuration generation, and end-to-end installation.
 
 ---
 
-## 1. Sovereign cloud detection from project ID
+## 1. Sovereign cloud detection from project ID and region
 
 - **Test file:** `pkg/types/gcp/platform_test.go`
-- **Function under test:** `GetCloudEnvironment()`
+- **Function under test:** `GetCloudEnvironment(projectID, region)`
 - **Automation status:** Automated (unit test)
 
 ### Description
 
-Verifies that a project ID with the `eu0:` prefix is correctly identified as a
-sovereign cloud environment.
+Verifies that a sovereign cloud environment is correctly identified when both
+conditions are met: the project ID is domain-scoped (contains `:`) and the
+region has the sovereign prefix `u-`. Neither condition alone is sufficient.
 
 ### Execution
 
 ```go
-env := gcp.GetCloudEnvironment("eu0:my-project")
+env := gcp.GetCloudEnvironment("eu0:my-project", "u-germany-northeast1")
+// Expected: "sovereign"
+
+env = gcp.GetCloudEnvironment("s3ns:my-project", "u-france-east1")
 // Expected: "sovereign"
 ```
 
 ### Expected Result
 
-- `GetCloudEnvironment("eu0:my-project")` returns `"sovereign"`
-- `GetCloudEnvironment("eu0:openshift")` returns `"sovereign"`
+- `GetCloudEnvironment("eu0:my-project", "u-germany-northeast1")` returns `"sovereign"`
+- `GetCloudEnvironment("s3ns:my-project", "u-france-east1")` returns `"sovereign"`
 
 ### Pass/Fail Criteria
 
-| Input | Expected Output |
-|-------|-----------------|
-| `"eu0:my-project"` | `"sovereign"` |
-| `"eu0:openshift"` | `"sovereign"` |
-| `"my-project"` | `""` (empty - public GCP) |
+| Project ID | Region | Expected Output |
+|-----------|--------|-----------------|
+| `"eu0:my-project"` | `"u-germany-northeast1"` | `"sovereign"` |
+| `"s3ns:my-project"` | `"u-france-east1"` | `"sovereign"` |
+| `"my-project"` | `"us-central1"` | `""` (empty - public GCP) |
 
 ---
 
-## 2. Organization-scoped project is not sovereign
+## 2. Domain-scoped project or sovereign region alone is not sovereign
 
-- **Test file:** `pkg/types/gcp/validation/machinepool_test.go`
-- **Function under test:** `GetCloudEnvironment()`
+- **Test file:** `pkg/types/gcp/platform_test.go`
+- **Function under test:** `GetCloudEnvironment(projectID, region)`
 - **Automation status:** Automated (unit test)
 
 ### Description
 
-Organization-scoped public GCP projects use a `orgname:project-id` format that
-looks similar to sovereign project IDs. The installer must only treat known
-prefixes (`eu0`) as sovereign, not arbitrary organization names.
+A domain-scoped project ID without a sovereign region, or a sovereign region
+without a domain-scoped project ID, must not be classified as sovereign. Both
+conditions are required together. This prevents false positives from
+organization-scoped public GCP projects or mistyped regions.
 
 ### Execution
 
 ```go
-env := gcp.GetCloudEnvironment("myorg:my-project")
+// Domain-scoped project but public GCP region - not sovereign
+env := gcp.GetCloudEnvironment("other-prefix:my-project", "us-central1")
+// Expected: "" (not sovereign)
+
+// Sovereign region but standard project ID - not sovereign
+env = gcp.GetCloudEnvironment("my-project", "u-germany-northeast1")
 // Expected: "" (not sovereign)
 ```
 
 ### Expected Result
 
-- `GetCloudEnvironment("myorg:my-project")` returns `""` (empty string)
-- No sovereign-specific validation or defaults are applied
-- The `sovereignCloudProjectPrefixes` list is checked, not just the presence of `:`
+- `GetCloudEnvironment("other-prefix:my-project", "us-central1")` returns `""`
+- `GetCloudEnvironment("my-project", "u-germany-northeast1")` returns `""`
+- Only the combination of both triggers sovereign detection
 
 ### Pass/Fail Criteria
 
-| Input | Expected Output |
-|-------|-----------------|
-| `"myorg:my-project"` | `""` (public GCP) |
-| `"example-org:project"` | `""` (public GCP) |
-| `"eu0:project"` | `"sovereign"` (only known prefix) |
+| Project ID | Region | Expected Output |
+|-----------|--------|-----------------|
+| `"other-prefix:my-project"` | `"us-central1"` | `""` (not sovereign - no `u-` region) |
+| `"my-project"` | `"u-germany-northeast1"` | `""` (not sovereign - no `:` in project) |
+| `"eu0:my-project"` | `"u-germany-northeast1"` | `"sovereign"` (both conditions met) |
 
 ---
 
@@ -143,7 +154,7 @@ result := gcp.IsNonDefaultUniverseDomain("apis-berlin-build0.goog")
 ## 4. Default instance type for sovereign cloud
 
 - **Test file:** `pkg/asset/installconfig/gcp/validation_test.go`
-- **Function under test:** `DefaultInstanceTypeForArchAndProjectID()`
+- **Function under test:** `DefaultInstanceTypeForArchAndProjectID(arch, projectID, region)`
 - **Automation status:** Automated (unit test)
 
 ### Description
@@ -157,32 +168,32 @@ x86, `t2a-standard-4` for ARM64).
 
 ```go
 // Sovereign cloud - always c3-standard-4
-instanceType := DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "eu0:my-project")
+instanceType := DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "eu0:my-project", "u-germany-northeast1")
 // Expected: "c3-standard-4"
 
-instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureARM64, "eu0:my-project")
+instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureARM64, "eu0:my-project", "u-germany-northeast1")
 // Expected: "c3-standard-4"
 
 // Public GCP - architecture-specific
-instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "my-project")
+instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "my-project", "us-central1")
 // Expected: "n2-standard-4"
 ```
 
 ### Pass/Fail Criteria
 
-| Architecture | Project ID | Expected Instance Type |
-|-------------|------------|----------------------|
-| x86_64 | `eu0:my-project` | `c3-standard-4` |
-| ARM64 | `eu0:my-project` | `c3-standard-4` |
-| x86_64 | `my-project` | `n2-standard-4` |
-| ARM64 | `my-project` | `t2a-standard-4` |
+| Architecture | Project ID | Region | Expected Instance Type |
+|-------------|------------|--------|----------------------|
+| x86_64 | `eu0:my-project` | `u-germany-northeast1` | `c3-standard-4` |
+| ARM64 | `eu0:my-project` | `u-germany-northeast1` | `c3-standard-4` |
+| x86_64 | `my-project` | `us-central1` | `n2-standard-4` |
+| ARM64 | `my-project` | `us-central1` | `t2a-standard-4` |
 
 ---
 
 ## 5. Default disk type for sovereign cloud
 
 - **Test file:** `pkg/types/gcp/machinepools_test.go`
-- **Function under test:** `DefaultDiskTypeForInstanceAndProjectID()`
+- **Function under test:** `DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID, region)`
 - **Automation status:** Automated (unit test)
 
 ### Description
@@ -195,24 +206,24 @@ prefer `hyperdisk-balanced` for sovereign cloud projects, while preferring
 
 ```go
 // Sovereign cloud
-diskType := gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "eu0:my-project")
+diskType := gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "eu0:my-project", "u-germany-northeast1")
 // Expected: "hyperdisk-balanced"
 
 // Public GCP
-diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "my-project")
+diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "my-project", "us-central1")
 // Expected: "hyperdisk-balanced" (C3 only supports hyperdisk-balanced)
 
-diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("n2-standard-4", "my-project")
+diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("n2-standard-4", "my-project", "us-central1")
 // Expected: "pd-ssd"
 ```
 
 ### Pass/Fail Criteria
 
-| Instance Type | Project ID | Expected Disk Type |
-|--------------|------------|-------------------|
-| `c3-standard-4` | `eu0:my-project` | `hyperdisk-balanced` |
-| `n2-standard-4` | `eu0:my-project` | `hyperdisk-balanced` (sovereign prefers it) |
-| `n2-standard-4` | `my-project` | `pd-ssd` |
+| Instance Type | Project ID | Region | Expected Disk Type |
+|--------------|------------|--------|-------------------|
+| `c3-standard-4` | `eu0:my-project` | `u-germany-northeast1` | `hyperdisk-balanced` |
+| `n2-standard-4` | `eu0:my-project` | `u-germany-northeast1` | `hyperdisk-balanced` (sovereign prefers it) |
+| `n2-standard-4` | `my-project` | `us-central1` | `pd-ssd` |
 
 ---
 
@@ -232,7 +243,7 @@ sovereign cloud environment. Without it, the cluster nodes cannot boot.
 
 ```go
 // Sovereign cloud without OS image - must fail
-platform := &gcp.Platform{ProjectID: "eu0:my-project"}
+platform := &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-germany-northeast1"}
 pool := &gcp.MachinePool{} // no OSImage
 errs := ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
 // Expected: error "must specify an OS image for sovereign cloud environments"
@@ -267,7 +278,7 @@ missing field.
 
 ```go
 // Missing name
-platform := &gcp.Platform{ProjectID: "eu0:my-project"}
+platform := &gcp.Platform{ProjectID: "eu0:my-project", Region: "u-germany-northeast1"}
 pool := &gcp.MachinePool{OSImage: &gcp.OSImage{Project: "eu0-system:rhcos"}}
 errs := ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
 // Expected: error on "test.osImage.name"
@@ -449,7 +460,7 @@ highest-level validation that all sovereign cloud code paths work together.
 | Validate GCD credentials | `gce.json` contains `universe_domain` field |
 | Provision VPC in `u-germany-northeast1` | VPC, subnets, Cloud NAT, firewall rules created |
 | Provision C3 bastion with GVNIC image | Bastion accessible, proxy configured |
-| Generate install-config | Config uses `eu0:` project, `c3-standard-4`, `hyperdisk-balanced`, RHCOS OS image, `Internal` publish |
+| Generate install-config | Config uses domain-scoped project, `u-germany-northeast1`, `c3-standard-4`, `hyperdisk-balanced`, RHCOS OS image, `Internal` publish |
 | Run `openshift-install create cluster` | Cluster installs successfully on GCD |
 | Run conformance tests | Core OpenShift functionality works on GCD |
 | Deprovision cluster | All GCD resources destroyed cleanly |
@@ -513,7 +524,7 @@ as requested.
 ### Prerequisites
 
 - A GCD cluster deployed via `openshift-install create cluster` with a
-  sovereign cloud project (`eu0:` prefix)
+  domain-scoped project ID and sovereign region (`u-` prefix)
 - `oc` CLI authenticated to the cluster
 - `gcloud` CLI authenticated to the GCD project with universe domain configured
 

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -140,6 +140,11 @@ result := gcp.IsNonDefaultUniverseDomain("apis-berlin-build0.goog")
 // Expected: true
 ```
 
+### Expected Result
+
+- `IsNonDefaultUniverseDomain("apis-berlin-build0.goog")` returns `true`
+- `IsNonDefaultUniverseDomain("googleapis.com")` returns `false`
+
 ### Pass/Fail Criteria
 
 | Input | Expected Output |
@@ -179,6 +184,11 @@ instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "
 // Expected: "n2-standard-4"
 ```
 
+### Expected Result
+
+- Sovereign cloud projects always get `c3-standard-4` regardless of architecture
+- Public GCP projects get architecture-specific defaults
+
 ### Pass/Fail Criteria
 
 | Architecture | Project ID | Region | Expected Instance Type |
@@ -216,6 +226,11 @@ diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "my-proje
 diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("n2-standard-4", "my-project", "us-central1")
 // Expected: "pd-ssd"
 ```
+
+### Expected Result
+
+- Sovereign cloud projects prefer `hyperdisk-balanced` over `pd-ssd`
+- Public GCP projects prefer `pd-ssd` when the instance type supports both
 
 ### Pass/Fail Criteria
 
@@ -289,6 +304,11 @@ errs = ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
 // Expected: error on "test.osImage.project"
 ```
 
+### Expected Result
+
+- Each missing field produces a specific `Required` error on the corresponding path
+- Both fields present produces no errors
+
 ### Pass/Fail Criteria
 
 | OS Image State | Expected Error Field |
@@ -361,6 +381,11 @@ sa := gcp.GetDefaultServiceAccount(platform, "test-cluster", "master")
 // Expected: "test-cluster-m@my-project.eu0.iam.gserviceaccount.com"
 ```
 
+### Expected Result
+
+- Domain-scoped project IDs produce reversed dot-separated SA email domains
+- Standard project IDs produce the standard SA email format
+
 ### Pass/Fail Criteria
 
 | Project ID | Cluster ID | Role | Expected SA Email |
@@ -384,11 +409,26 @@ configuration must set `tokenURL` to the literal string `"nil"`. This disables
 the standard OAuth2 token endpoint, which is not available in GCD sovereign
 regions. Instead, the workload uses self-signed JWTs.
 
+### Execution
+
+```go
+// Generate cloud provider config with a non-default universe domain
+// The generated config should contain tokenURL = "nil"
+```
+
 ### Expected Result
 
 - Cloud provider config generated for a sovereign cloud install-config contains
   `tokenURL = "nil"`
 - Cloud provider config for public GCP does not set `tokenURL` to `"nil"`
+
+### Pass/Fail Criteria
+
+| Universe Domain | Expected tokenURL |
+|----------------|-------------------|
+| `apis-berlin-build0.goog` | `"nil"` |
+| `googleapis.com` | Standard OAuth2 URL |
+| (empty) | Standard OAuth2 URL |
 
 ---
 
@@ -404,12 +444,27 @@ When deploying on a non-default universe domain, the Cluster API Provider for
 GCP (CAPG) controller must receive the `GOOGLE_CLOUD_UNIVERSE_DOMAIN`
 environment variable so it can reach the correct sovereign cloud API endpoints.
 
+### Execution
+
+```go
+// Start CAPG controller with sovereign cloud credentials
+// Verify GOOGLE_CLOUD_UNIVERSE_DOMAIN env var is set
+```
+
 ### Expected Result
 
 - When universe domain is `apis-berlin-build0.goog`, the CAPG controller
   process has `GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog` set
 - When universe domain is `googleapis.com` or empty, the environment variable
   is not set
+
+### Pass/Fail Criteria
+
+| Universe Domain | Env Var Set |
+|----------------|-------------|
+| `apis-berlin-build0.goog` | Yes, set to `apis-berlin-build0.goog` |
+| `googleapis.com` | No |
+| (empty) | No |
 
 ---
 
@@ -427,11 +482,26 @@ libraries and use `WithCredentialsJSON` for self-signed JWT authentication,
 since the standard OAuth2 token endpoint (`oauth2.googleapis.com`) is not
 reachable from GCD.
 
+### Execution
+
+```go
+// Load GCD service account key with universe_domain field
+opts := CredentialOptions(ctx, credJSON)
+// Inspect returned client options
+```
+
 ### Expected Result
 
 - `CredentialOptions()` extracts the universe domain from the SA key JSON
 - Client options include `WithCredentialsJSON` (not `WithTokenSource`)
 - Client options include `WithUniverseDomain` set to the credential's domain
+
+### Pass/Fail Criteria
+
+| Credential Field | Expected Client Option |
+|-----------------|----------------------|
+| `universe_domain: apis-berlin-build0.goog` | `WithUniverseDomain("apis-berlin-build0.goog")` |
+| SA key JSON present | `WithCredentialsJSON` used (not `WithTokenSource`) |
 
 ---
 
@@ -612,7 +682,7 @@ gcloud dns managed-zones list \
 
 ```bash
 # From outside the VPC (not through bastion):
-curl -k https://api.<cluster-name>.<base-domain>:6443/healthz
+curl -k "https://api.${CLUSTER_NAME}.${BASE_DOMAIN}:6443/healthz"
 # Expected: connection timeout or DNS resolution failure
 ```
 
@@ -686,7 +756,7 @@ gcloud compute firewall-rules list \
 
 ```bash
 gcloud dns record-sets list \
-  --zone=<cluster-zone> \
+  --zone="${CLUSTER_ZONE}" \
   --filter="name~${INFRA_ID}" \
   --project="eu0:<project-id>"
 # Expected: no results (or zone itself deleted)
@@ -714,6 +784,33 @@ gcloud compute forwarding-rules list \
 # Expected: no results for both
 ```
 
+7. Check for leftover VPC networks:
+
+```bash
+gcloud compute networks list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+8. Check for leftover subnets:
+
+```bash
+gcloud compute networks subnets list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+9. Check for leftover Cloud NAT and routers:
+
+```bash
+gcloud compute routers list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
 ### Pass/Fail Criteria
 
 | Resource Type | Pass Condition |
@@ -725,6 +822,9 @@ gcloud compute forwarding-rules list \
 | Service accounts | Zero SAs matching `INFRA_ID` |
 | Health checks | Zero health checks matching `INFRA_ID` |
 | Forwarding rules | Zero forwarding rules matching `INFRA_ID` |
+| VPC networks | Zero networks matching `INFRA_ID` |
+| Subnets | Zero subnets matching `INFRA_ID` |
+| Cloud NAT / Routers | Zero routers matching `INFRA_ID` |
 
 ---
 
@@ -736,9 +836,9 @@ gcloud compute forwarding-rules list \
 ### Description
 
 GCD only supports private DNS zones. Attempting to create a cluster with
-`publish: External` should be rejected during install-config validation. This
-test verifies the installer catches the misconfiguration before attempting
-any cloud API calls.
+`publish: External` should be rejected during install-config validation.
+Running `create manifests` triggers validation without provisioning any cloud
+resources, confirming the installer catches the misconfiguration early.
 
 ### Prerequisites
 
@@ -777,13 +877,14 @@ publish: External
 pullSecret: '<pull-secret>'
 ```
 
-2. Run `openshift-install create cluster --dir=<dir>` and observe the output.
+2. Run `openshift-install create manifests --dir="${DIR}"` and observe the output.
 
 ### Expected Result
 
-- The installer rejects the configuration with an error indicating that
-  public/external publish is not supported for sovereign cloud environments
-- No cloud resources are created
+- The installer rejects the configuration during manifest generation with an
+  error indicating that public/external publish is not supported for sovereign
+  cloud environments
+- No cloud resources are created (validation fails before any provisioning)
 
 ### Pass/Fail Criteria
 
@@ -835,6 +936,9 @@ files with manual tests.
   - [ ] Zero leftover DNS records
   - [ ] Zero leftover service accounts
   - [ ] Zero leftover health checks and forwarding rules
+  - [ ] Zero leftover VPC networks
+  - [ ] Zero leftover subnets
+  - [ ] Zero leftover Cloud NAT and routers
 
 - [ ] **17. Verify install-config validation rejects public publish on GCD**
   - [ ] Installer rejects `publish: External` with validation error

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -412,8 +412,20 @@ regions. Instead, the workload uses self-signed JWTs.
 ### Execution
 
 ```go
-// Generate cloud provider config with a non-default universe domain
-// The generated config should contain tokenURL = "nil"
+session, _ := gcpic.GetSession(ctx)
+ud, _ := session.Credentials.GetUniverseDomain()
+// ud == "apis-berlin-build0.goog" for GCD
+
+var tokenURL string
+if ud != "" && ud != "googleapis.com" {
+    tokenURL = "nil"
+}
+
+gcpConfig, _ := gcpmanifests.CloudProviderConfig(
+    infraID, projectID, subnet, networkProjectID,
+    firewallManagement, tokenURL,
+)
+// gcpConfig contains tokenURL = "nil" for sovereign cloud
 ```
 
 ### Expected Result
@@ -447,8 +459,15 @@ environment variable so it can reach the correct sovereign cloud API endpoints.
 ### Execution
 
 ```go
-// Start CAPG controller with sovereign cloud credentials
-// Verify GOOGLE_CLOUD_UNIVERSE_DOMAIN env var is set
+session, _ := gcpic.GetSession(ctx)
+ud, _ := session.Credentials.GetUniverseDomain()
+
+capgEnvVars := map[string]string{}
+if ud != "googleapis.com" {
+    capgEnvVars["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = ud
+}
+// For GCD: capgEnvVars["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] == "apis-berlin-build0.goog"
+// For public GCP: capgEnvVars is empty (no GOOGLE_CLOUD_UNIVERSE_DOMAIN key)
 ```
 
 ### Expected Result
@@ -604,12 +623,13 @@ as requested.
 
 ```bash
 export GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog
+export PROJECT_ID="eu0:<your-gcd-project>"
 export INFRA_ID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
 
 gcloud compute instances list \
   --filter="name~${INFRA_ID}" \
   --format="table(name, machineType.basename(), zone)" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 ```
 
 2. Verify disk types for the instances:
@@ -618,7 +638,7 @@ gcloud compute instances list \
 gcloud compute disks list \
   --filter="name~${INFRA_ID}" \
   --format="table(name, type.basename(), sizeGb, zone)" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 ```
 
 3. Verify from the OpenShift side:
@@ -659,6 +679,13 @@ API and ingress endpoints are only reachable through private networking.
 
 ### Execution
 
+Set up environment variables:
+
+```bash
+export GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog
+export PROJECT_ID="eu0:<your-gcd-project>"
+```
+
 1. Verify the cluster's publish strategy:
 
 ```bash
@@ -673,7 +700,7 @@ oc get dns cluster -o jsonpath='{.spec.privateZone}'
 
 ```bash
 gcloud dns managed-zones list \
-  --project="eu0:<project-id>" \
+  --project="${PROJECT_ID}" \
   --format="table(name, dnsName, visibility)"
 # Expected: only "private" visibility zones
 ```
@@ -725,12 +752,20 @@ and leftover resources can block future installs and incur costs.
 
 ### Execution
 
+Set up environment variables:
+
+```bash
+export GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog
+export PROJECT_ID="eu0:<your-gcd-project>"
+export INFRA_ID="<cluster-infra-id-from-metadata>"
+```
+
 1. Check for leftover compute instances:
 
 ```bash
 gcloud compute instances list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -739,7 +774,7 @@ gcloud compute instances list \
 ```bash
 gcloud compute disks list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -748,7 +783,7 @@ gcloud compute disks list \
 ```bash
 gcloud compute firewall-rules list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -758,7 +793,7 @@ gcloud compute firewall-rules list \
 gcloud dns record-sets list \
   --zone="${CLUSTER_ZONE}" \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results (or zone itself deleted)
 ```
 
@@ -767,7 +802,7 @@ gcloud dns record-sets list \
 ```bash
 gcloud iam service-accounts list \
   --filter="email~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -776,11 +811,11 @@ gcloud iam service-accounts list \
 ```bash
 gcloud compute health-checks list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 
 gcloud compute forwarding-rules list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results for both
 ```
 
@@ -789,7 +824,7 @@ gcloud compute forwarding-rules list \
 ```bash
 gcloud compute networks list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -798,7 +833,7 @@ gcloud compute networks list \
 ```bash
 gcloud compute networks subnets list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 
@@ -807,7 +842,7 @@ gcloud compute networks subnets list \
 ```bash
 gcloud compute routers list \
   --filter="name~${INFRA_ID}" \
-  --project="eu0:<project-id>"
+  --project="${PROJECT_ID}"
 # Expected: no results
 ```
 

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -1,0 +1,842 @@
+# Test Case: GCD Sovereign Cloud Installation
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Feature** | [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006) - Google Cloud Dedicated |
+| **Component** | Installer / GCP platform |
+| **Test type** | Unit, Integration, E2E |
+| **Assignee** | TBD |
+
+## Description
+
+These test cases cover the installer's behavior when targeting a Google Cloud
+Dedicated (GCD) sovereign cloud environment. GCD is detected via the `eu0:`
+project ID prefix and differs from public GCP in machine types, disk types,
+DNS, OS image requirements, and credential handling.
+
+The cases are organized into groups: sovereign cloud detection, default values,
+validation rules, configuration generation, and end-to-end installation.
+
+## Scenarios
+
+| # | Scenario | Status |
+|---|----------|--------|
+| 1 | [Sovereign cloud detection from project ID](#1-sovereign-cloud-detection-from-project-id) | Automated (unit test) |
+| 2 | [Organization-scoped project is not sovereign](#2-organization-scoped-project-is-not-sovereign) | Automated (unit test) |
+| 3 | [Non-default universe domain detection](#3-non-default-universe-domain-detection) | Automated (unit test) |
+| 4 | [Default instance type for sovereign cloud](#4-default-instance-type-for-sovereign-cloud) | Automated (unit test) |
+| 5 | [Default disk type for sovereign cloud](#5-default-disk-type-for-sovereign-cloud) | Automated (unit test) |
+| 6 | [OS image required for sovereign cloud](#6-os-image-required-for-sovereign-cloud) | Automated (unit test) |
+| 7 | [OS image with missing name or project](#7-os-image-with-missing-name-or-project) | Automated (unit test) |
+| 8 | [PSC endpoint forbidden for sovereign cloud](#8-psc-endpoint-forbidden-for-sovereign-cloud) | Automated (unit test) |
+| 9 | [Service account email for domain-scoped project](#9-service-account-email-for-domain-scoped-project) | Automated (unit test) |
+| 10 | [Cloud provider config uses nil tokenURL](#10-cloud-provider-config-uses-nil-tokenurl) | Automated (unit test) |
+| 11 | [CAPG controller receives universe domain](#11-capg-controller-receives-universe-domain) | Automated (unit test) |
+| 12 | [Credential options for sovereign cloud](#12-credential-options-for-sovereign-cloud) | Automated (unit test) |
+| 13 | [E2E: IPI install on GCD sovereign region](#13-e2e-ipi-install-on-gcd-sovereign-region) | Automated (Prow CI) |
+| 14 | [Verify GCD cluster nodes use correct machine type and disk](#14-verify-gcd-cluster-nodes-use-correct-machine-type-and-disk) | Manual |
+| 15 | [Verify GCD cluster uses private DNS only](#15-verify-gcd-cluster-uses-private-dns-only) | Manual |
+| 16 | [Verify GCD cluster destroy removes all resources](#16-verify-gcd-cluster-destroy-removes-all-resources) | Manual |
+| 17 | [Verify install-config validation rejects public publish on GCD](#17-verify-install-config-validation-rejects-public-publish-on-gcd) | Manual |
+
+---
+
+## 1. Sovereign cloud detection from project ID
+
+- **Test file:** `pkg/types/gcp/platform_test.go`
+- **Function under test:** `GetCloudEnvironment()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+Verifies that a project ID with the `eu0:` prefix is correctly identified as a
+sovereign cloud environment.
+
+### Execution
+
+```go
+env := gcp.GetCloudEnvironment("eu0:my-project")
+// Expected: "sovereign"
+```
+
+### Expected Result
+
+- `GetCloudEnvironment("eu0:my-project")` returns `"sovereign"`
+- `GetCloudEnvironment("eu0:openshift")` returns `"sovereign"`
+
+### Pass/Fail Criteria
+
+| Input | Expected Output |
+|-------|-----------------|
+| `"eu0:my-project"` | `"sovereign"` |
+| `"eu0:openshift"` | `"sovereign"` |
+| `"my-project"` | `""` (empty - public GCP) |
+
+---
+
+## 2. Organization-scoped project is not sovereign
+
+- **Test file:** `pkg/types/gcp/validation/machinepool_test.go`
+- **Function under test:** `GetCloudEnvironment()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+Organization-scoped public GCP projects use a `orgname:project-id` format that
+looks similar to sovereign project IDs. The installer must only treat known
+prefixes (`eu0`) as sovereign, not arbitrary organization names.
+
+### Execution
+
+```go
+env := gcp.GetCloudEnvironment("myorg:my-project")
+// Expected: "" (not sovereign)
+```
+
+### Expected Result
+
+- `GetCloudEnvironment("myorg:my-project")` returns `""` (empty string)
+- No sovereign-specific validation or defaults are applied
+- The `sovereignCloudProjectPrefixes` list is checked, not just the presence of `:`
+
+### Pass/Fail Criteria
+
+| Input | Expected Output |
+|-------|-----------------|
+| `"myorg:my-project"` | `""` (public GCP) |
+| `"example-org:project"` | `""` (public GCP) |
+| `"eu0:project"` | `"sovereign"` (only known prefix) |
+
+---
+
+## 3. Non-default universe domain detection
+
+- **Test file:** `pkg/types/gcp/platform_test.go`
+- **Function under test:** `IsNonDefaultUniverseDomain()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+Verifies that universe domains other than `googleapis.com` are correctly
+identified as non-default, which triggers sovereign cloud credential handling.
+
+### Execution
+
+```go
+result := gcp.IsNonDefaultUniverseDomain("apis-berlin-build0.goog")
+// Expected: true
+```
+
+### Pass/Fail Criteria
+
+| Input | Expected Output |
+|-------|-----------------|
+| `"apis-berlin-build0.goog"` | `true` |
+| `"s3nsapis.fr"` | `true` |
+| `"googleapis.com"` | `false` |
+| `""` | `false` |
+
+---
+
+## 4. Default instance type for sovereign cloud
+
+- **Test file:** `pkg/asset/installconfig/gcp/validation_test.go`
+- **Function under test:** `DefaultInstanceTypeForArchAndProjectID()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+GCD sovereign regions only have C3, M3, and A3 Edge machine series available.
+The installer must default to `c3-standard-4` for sovereign cloud regardless
+of CPU architecture, instead of the public GCP defaults (`n2-standard-4` for
+x86, `t2a-standard-4` for ARM64).
+
+### Execution
+
+```go
+// Sovereign cloud - always c3-standard-4
+instanceType := DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "eu0:my-project")
+// Expected: "c3-standard-4"
+
+instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureARM64, "eu0:my-project")
+// Expected: "c3-standard-4"
+
+// Public GCP - architecture-specific
+instanceType = DefaultInstanceTypeForArchAndProjectID(types.ArchitectureAMD64, "my-project")
+// Expected: "n2-standard-4"
+```
+
+### Pass/Fail Criteria
+
+| Architecture | Project ID | Expected Instance Type |
+|-------------|------------|----------------------|
+| x86_64 | `eu0:my-project` | `c3-standard-4` |
+| ARM64 | `eu0:my-project` | `c3-standard-4` |
+| x86_64 | `my-project` | `n2-standard-4` |
+| ARM64 | `my-project` | `t2a-standard-4` |
+
+---
+
+## 5. Default disk type for sovereign cloud
+
+- **Test file:** `pkg/types/gcp/machinepools_test.go`
+- **Function under test:** `DefaultDiskTypeForInstanceAndProjectID()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+GCD sovereign regions only support Hyperdisk Balanced. The installer must
+prefer `hyperdisk-balanced` for sovereign cloud projects, while preferring
+`pd-ssd` for public GCP (when the instance type supports both).
+
+### Execution
+
+```go
+// Sovereign cloud
+diskType := gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "eu0:my-project")
+// Expected: "hyperdisk-balanced"
+
+// Public GCP
+diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("c3-standard-4", "my-project")
+// Expected: "hyperdisk-balanced" (C3 only supports hyperdisk-balanced)
+
+diskType = gcp.DefaultDiskTypeForInstanceAndProjectID("n2-standard-4", "my-project")
+// Expected: "pd-ssd"
+```
+
+### Pass/Fail Criteria
+
+| Instance Type | Project ID | Expected Disk Type |
+|--------------|------------|-------------------|
+| `c3-standard-4` | `eu0:my-project` | `hyperdisk-balanced` |
+| `n2-standard-4` | `eu0:my-project` | `hyperdisk-balanced` (sovereign prefers it) |
+| `n2-standard-4` | `my-project` | `pd-ssd` |
+
+---
+
+## 6. OS image required for sovereign cloud
+
+- **Test file:** `pkg/types/gcp/validation/machinepool_test.go`
+- **Function under test:** `ValidateOSImageForSovereignCloud()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+GCD does not have access to public GCP image projects. The installer must
+require an explicit OS image (both name and project) when deploying to a
+sovereign cloud environment. Without it, the cluster nodes cannot boot.
+
+### Execution
+
+```go
+// Sovereign cloud without OS image - must fail
+platform := &gcp.Platform{ProjectID: "eu0:my-project"}
+pool := &gcp.MachinePool{} // no OSImage
+errs := ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
+// Expected: error "must specify an OS image for sovereign cloud environments"
+```
+
+### Pass/Fail Criteria
+
+| Scenario | Expected Result |
+|----------|----------------|
+| Sovereign cloud, OS image with name + project | No errors |
+| Sovereign cloud, nil pool | Error: `osImage` required |
+| Sovereign cloud, nil OS image on pool | Error: `osImage` required |
+| Sovereign cloud, OS image missing name | Error: `osImage.name` required |
+| Sovereign cloud, OS image missing project | Error: `osImage.project` required |
+| Public GCP, no OS image | No errors (optional) |
+
+---
+
+## 7. OS image with missing name or project
+
+- **Test file:** `pkg/types/gcp/validation/machinepool_test.go`
+- **Function under test:** `ValidateOSImageForSovereignCloud()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+When a sovereign cloud install-config provides an OS image but omits either the
+image name or image project, the validation must report a specific error for the
+missing field.
+
+### Execution
+
+```go
+// Missing name
+platform := &gcp.Platform{ProjectID: "eu0:my-project"}
+pool := &gcp.MachinePool{OSImage: &gcp.OSImage{Project: "eu0-system:rhcos"}}
+errs := ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
+// Expected: error on "test.osImage.name"
+
+// Missing project
+pool = &gcp.MachinePool{OSImage: &gcp.OSImage{Name: "rhcos-421"}}
+errs = ValidateOSImageForSovereignCloud(platform, pool, field.NewPath("test"))
+// Expected: error on "test.osImage.project"
+```
+
+### Pass/Fail Criteria
+
+| OS Image State | Expected Error Field |
+|---------------|---------------------|
+| Name present, project missing | `osImage.project: Required` |
+| Project present, name missing | `osImage.name: Required` |
+| Both present | No errors |
+| Both missing (nil OSImage) | `osImage: Required` |
+
+---
+
+## 8. PSC endpoint forbidden for sovereign cloud
+
+- **Test file:** `pkg/asset/installconfig/gcp/validation_test.go`
+- **Function under test:** `validateServiceEndpointOverride()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+Private Service Connect (PSC) endpoint overrides are not supported in sovereign
+cloud environments. GCD uses its own API endpoint domain
+(`apis-berlin-build0.goog`) and custom endpoints would conflict with the
+sovereign infrastructure.
+
+### Execution
+
+Provide an install-config with a sovereign project ID and a PSC endpoint:
+
+```yaml
+platform:
+  gcp:
+    projectID: "eu0:my-project"
+    region: u-germany-northeast1
+    endpoint:
+      name: my-psc-endpoint
+```
+
+### Expected Result
+
+- Validation returns: `platform.gcp.endpoint.name: Forbidden: endpoint overrides are not supported in sovereign clouds`
+
+### Pass/Fail Criteria
+
+| Scenario | Expected Result |
+|----------|----------------|
+| Sovereign project + PSC endpoint | `Forbidden` error |
+| Sovereign project, no endpoint | No errors |
+| Public GCP project + valid PSC endpoint | No errors (allowed) |
+
+---
+
+## 9. Service account email for domain-scoped project
+
+- **Test file:** `pkg/types/gcp/platform_test.go`
+- **Function under test:** `GetDefaultServiceAccount()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+Domain-scoped project IDs use a reversed format in service account email
+addresses. For a project `eu0:my-project`, the SA email domain becomes
+`my-project.eu0.iam.gserviceaccount.com` (the prefix `eu0` and project name
+`my-project` are reversed and joined with a dot).
+
+### Execution
+
+```go
+platform := &gcp.Platform{ProjectID: "eu0:my-project"}
+sa := gcp.GetDefaultServiceAccount(platform, "test-cluster", "master")
+// Expected: "test-cluster-m@my-project.eu0.iam.gserviceaccount.com"
+```
+
+### Pass/Fail Criteria
+
+| Project ID | Cluster ID | Role | Expected SA Email |
+|-----------|-----------|------|-------------------|
+| `eu0:my-project` | `test-cluster` | `master` | `test-cluster-m@my-project.eu0.iam.gserviceaccount.com` |
+| `eu0:my-project` | `test-cluster` | `worker` | `test-cluster-w@my-project.eu0.iam.gserviceaccount.com` |
+| `my-project` | `test-cluster` | `master` | `test-cluster-m@my-project.iam.gserviceaccount.com` |
+
+---
+
+## 10. Cloud provider config uses nil tokenURL
+
+- **Test file:** `pkg/asset/manifests/cloudproviderconfig_test.go`
+- **Function under test:** Cloud provider config generation
+- **Automation status:** Automated (unit test)
+
+### Description
+
+When the universe domain is not the default `googleapis.com`, the cloud provider
+configuration must set `tokenURL` to the literal string `"nil"`. This disables
+the standard OAuth2 token endpoint, which is not available in GCD sovereign
+regions. Instead, the workload uses self-signed JWTs.
+
+### Expected Result
+
+- Cloud provider config generated for a sovereign cloud install-config contains
+  `tokenURL = "nil"`
+- Cloud provider config for public GCP does not set `tokenURL` to `"nil"`
+
+---
+
+## 11. CAPG controller receives universe domain
+
+- **Test file:** `pkg/clusterapi/system_test.go`
+- **Function under test:** CAPG controller environment setup
+- **Automation status:** Automated (unit test)
+
+### Description
+
+When deploying on a non-default universe domain, the Cluster API Provider for
+GCP (CAPG) controller must receive the `GOOGLE_CLOUD_UNIVERSE_DOMAIN`
+environment variable so it can reach the correct sovereign cloud API endpoints.
+
+### Expected Result
+
+- When universe domain is `apis-berlin-build0.goog`, the CAPG controller
+  process has `GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog` set
+- When universe domain is `googleapis.com` or empty, the environment variable
+  is not set
+
+---
+
+## 12. Credential options for sovereign cloud
+
+- **Test file:** `pkg/asset/installconfig/gcp/services_test.go`
+- **Function under test:** `CredentialOptions()`
+- **Automation status:** Automated (unit test)
+
+### Description
+
+GCD service account keys contain a `universe_domain` field (e.g.,
+`apis-berlin-build0.goog`). The installer must pass this to the GCP client
+libraries and use `WithCredentialsJSON` for self-signed JWT authentication,
+since the standard OAuth2 token endpoint (`oauth2.googleapis.com`) is not
+reachable from GCD.
+
+### Expected Result
+
+- `CredentialOptions()` extracts the universe domain from the SA key JSON
+- Client options include `WithCredentialsJSON` (not `WithTokenSource`)
+- Client options include `WithUniverseDomain` set to the credential's domain
+
+---
+
+## 13. E2E: IPI install on GCD sovereign region
+
+- **CI job:** `e2e-gcd-ovn-private-techpreview`
+- **Workflow:** `openshift-e2e-gcd`
+- **Automation status:** Automated (Prow CI)
+
+### Description
+
+Full end-to-end IPI installation of an OpenShift cluster on GCD. This is the
+highest-level validation that all sovereign cloud code paths work together.
+
+### Prerequisites
+
+- GCD service account key in vault (`cluster-secrets-gcd`)
+- DNS zone `ci.gcd.devcluster.openshift.com` created in GCD project
+- RHCOS image uploaded to GCD project with GVNIC support
+- Sufficient C3 machine quota in `u-germany-northeast1`
+
+### Test Steps and Expected Results
+
+| Step | Expected Result |
+|:-----|:----------------|
+| Validate GCD credentials | `gce.json` contains `universe_domain` field |
+| Provision VPC in `u-germany-northeast1` | VPC, subnets, Cloud NAT, firewall rules created |
+| Provision C3 bastion with GVNIC image | Bastion accessible, proxy configured |
+| Generate install-config | Config uses `eu0:` project, `c3-standard-4`, `hyperdisk-balanced`, RHCOS OS image, `Internal` publish |
+| Run `openshift-install create cluster` | Cluster installs successfully on GCD |
+| Run conformance tests | Core OpenShift functionality works on GCD |
+| Deprovision cluster | All GCD resources destroyed cleanly |
+| Deprovision bastion and VPC | Infrastructure cleaned up |
+
+### GCD-Specific Configuration
+
+```yaml
+platform:
+  gcp:
+    projectID: "eu0:<gcd-project>"
+    region: u-germany-northeast1
+controlPlane:
+  platform:
+    gcp:
+      type: c3-standard-4
+      osDisk:
+        diskType: hyperdisk-balanced
+      osImage:
+        name: rhcos10
+        project: "eu0:<gcd-project>"
+compute:
+  - platform:
+      gcp:
+        type: c3-standard-4
+        osDisk:
+          diskType: hyperdisk-balanced
+        osImage:
+          name: rhcos10
+          project: "eu0:<gcd-project>"
+publish: Internal
+featureSet: TechPreviewNoUpgrade
+```
+
+### Pass/Fail Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| Cluster install completes | `openshift-install` exits 0 |
+| ClusterVersion available | `Available=True`, `Progressing=False` |
+| All ClusterOperators healthy | No degraded operators |
+| Nodes ready | All control plane and compute nodes `Ready` |
+| Conformance tests pass | No unexpected test failures |
+| Cluster destroy completes | All GCD resources removed |
+
+---
+
+## 14. Verify GCD cluster nodes use correct machine type and disk
+
+- **Automation status:** Manual
+- **Requires:** Running GCD cluster deployed via IPI
+
+### Description
+
+After a successful GCD IPI installation, verify that the control plane and
+compute nodes are running on the expected machine type (`c3-standard-4`) and
+using Hyperdisk Balanced disks. This confirms that the installer's sovereign
+cloud defaults were applied correctly and that GCD provisioned the resources
+as requested.
+
+### Prerequisites
+
+- A GCD cluster deployed via `openshift-install create cluster` with a
+  sovereign cloud project (`eu0:` prefix)
+- `oc` CLI authenticated to the cluster
+- `gcloud` CLI authenticated to the GCD project with universe domain configured
+
+### Execution
+
+1. Verify node machine types via the GCP console or `gcloud`:
+
+```bash
+export GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog
+export INFRA_ID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
+
+gcloud compute instances list \
+  --filter="name~${INFRA_ID}" \
+  --format="table(name, machineType.basename(), zone)" \
+  --project="eu0:<project-id>"
+```
+
+2. Verify disk types for the instances:
+
+```bash
+gcloud compute disks list \
+  --filter="name~${INFRA_ID}" \
+  --format="table(name, type.basename(), sizeGb, zone)" \
+  --project="eu0:<project-id>"
+```
+
+3. Verify from the OpenShift side:
+
+```bash
+oc get nodes -o wide
+oc get machines -n openshift-machine-api -o wide
+```
+
+### Pass/Fail Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| Control plane machine type | All master instances are `c3-standard-4` |
+| Compute machine type | All worker instances are `c3-standard-4` |
+| Boot disk type | All boot disks are `hyperdisk-balanced` |
+| All nodes Ready | `oc get nodes` shows all nodes in `Ready` state |
+| Zone distribution | Instances spread across `u-germany-northeast1-a/b/c` |
+
+---
+
+## 15. Verify GCD cluster uses private DNS only
+
+- **Automation status:** Manual
+- **Requires:** Running GCD cluster deployed via IPI
+
+### Description
+
+GCD does not support public DNS zones. Verify that the cluster was deployed
+with internal-only DNS, that no public DNS records were created, and that the
+API and ingress endpoints are only reachable through private networking.
+
+### Prerequisites
+
+- A GCD cluster deployed with `publish: Internal`
+- `oc` CLI authenticated to the cluster (through bastion/proxy)
+- `gcloud` CLI authenticated to the GCD project
+
+### Execution
+
+1. Verify the cluster's publish strategy:
+
+```bash
+oc get dns cluster -o jsonpath='{.spec.publicZone}'
+# Expected: empty (no public zone)
+
+oc get dns cluster -o jsonpath='{.spec.privateZone}'
+# Expected: populated with the private zone ID
+```
+
+2. Verify DNS zones in GCD:
+
+```bash
+gcloud dns managed-zones list \
+  --project="eu0:<project-id>" \
+  --format="table(name, dnsName, visibility)"
+# Expected: only "private" visibility zones
+```
+
+3. Verify API server is not publicly accessible:
+
+```bash
+# From outside the VPC (not through bastion):
+curl -k https://api.<cluster-name>.<base-domain>:6443/healthz
+# Expected: connection timeout or DNS resolution failure
+```
+
+4. Verify API server is accessible through private network:
+
+```bash
+# Through the bastion/proxy:
+oc get clusterversion
+# Expected: success, shows cluster version
+```
+
+### Pass/Fail Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| No public DNS zone | `spec.publicZone` is empty on the DNS cluster resource |
+| Private zone exists | `spec.privateZone` is populated |
+| GCD DNS zones are private | `gcloud dns managed-zones list` shows only `private` visibility |
+| API not publicly reachable | External curl to API endpoint fails |
+| API reachable via private network | `oc` commands work through bastion/proxy |
+
+---
+
+## 16. Verify GCD cluster destroy removes all resources
+
+- **Automation status:** Manual
+- **Requires:** A GCD cluster that has been destroyed via `openshift-install destroy cluster`
+
+### Description
+
+After running `openshift-install destroy cluster`, verify that all GCD
+resources created during installation have been removed. GCD has limited quota
+and leftover resources can block future installs and incur costs.
+
+### Prerequisites
+
+- A GCD cluster that was successfully installed and then destroyed
+- `gcloud` CLI authenticated to the GCD project
+- The cluster's `INFRA_ID` (from the metadata or install log)
+
+### Execution
+
+1. Check for leftover compute instances:
+
+```bash
+gcloud compute instances list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+2. Check for leftover disks:
+
+```bash
+gcloud compute disks list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+3. Check for leftover firewall rules:
+
+```bash
+gcloud compute firewall-rules list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+4. Check for leftover DNS records:
+
+```bash
+gcloud dns record-sets list \
+  --zone=<cluster-zone> \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results (or zone itself deleted)
+```
+
+5. Check for leftover service accounts:
+
+```bash
+gcloud iam service-accounts list \
+  --filter="email~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results
+```
+
+6. Check for leftover health checks and forwarding rules:
+
+```bash
+gcloud compute health-checks list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+
+gcloud compute forwarding-rules list \
+  --filter="name~${INFRA_ID}" \
+  --project="eu0:<project-id>"
+# Expected: no results for both
+```
+
+### Pass/Fail Criteria
+
+| Resource Type | Pass Condition |
+|--------------|---------------|
+| Compute instances | Zero instances matching `INFRA_ID` |
+| Disks | Zero disks matching `INFRA_ID` |
+| Firewall rules | Zero rules matching `INFRA_ID` |
+| DNS records | Zero records matching `INFRA_ID` |
+| Service accounts | Zero SAs matching `INFRA_ID` |
+| Health checks | Zero health checks matching `INFRA_ID` |
+| Forwarding rules | Zero forwarding rules matching `INFRA_ID` |
+
+---
+
+## 17. Verify install-config validation rejects public publish on GCD
+
+- **Automation status:** Manual
+- **Requires:** GCD service account key, `openshift-install` binary
+
+### Description
+
+GCD only supports private DNS zones. Attempting to create a cluster with
+`publish: External` should be rejected during install-config validation. This
+test verifies the installer catches the misconfiguration before attempting
+any cloud API calls.
+
+### Prerequisites
+
+- `openshift-install` binary built from a branch with GCD support
+- GCD service account key (`gce.json`) with `universe_domain` field
+- No running cluster needed
+
+### Execution
+
+1. Create an install-config with `publish: External` and a GCD project:
+
+```yaml
+apiVersion: v1
+baseDomain: example.gcd.devcluster.openshift.com
+metadata:
+  name: test-public-reject
+platform:
+  gcp:
+    projectID: "eu0:<project-id>"
+    region: u-germany-northeast1
+controlPlane:
+  platform:
+    gcp:
+      type: c3-standard-4
+      osImage:
+        name: rhcos10
+        project: "eu0:<image-project>"
+compute:
+  - platform:
+      gcp:
+        type: c3-standard-4
+        osImage:
+          name: rhcos10
+          project: "eu0:<image-project>"
+publish: External
+pullSecret: '<pull-secret>'
+```
+
+2. Run `openshift-install create cluster --dir=<dir>` and observe the output.
+
+### Expected Result
+
+- The installer rejects the configuration with an error indicating that
+  public/external publish is not supported for sovereign cloud environments
+- No cloud resources are created
+
+### Pass/Fail Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| Validation error | Installer exits with a validation error mentioning publish or DNS |
+| No resources created | No instances, disks, or DNS zones created in GCD |
+
+---
+
+## Manual Test Checklist
+
+<!-- MANUAL_TESTS_START -->
+
+This section collects all manual test scenarios for quick reference. Use the
+checkboxes to track progress during manual verification runs.
+
+**How to find this section:** search for `MANUAL_TESTS_START` in this file, or
+run `grep -l MANUAL_TESTS_START test/docs/gcd/cases/*.md` to find all case
+files with manual tests.
+
+### Prerequisites for all manual tests
+
+- [ ] GCD service account key available (`gce.json` with `universe_domain`)
+- [ ] `gcloud` CLI installed and configured with `universe_domain=apis-berlin-build0.goog`
+- [ ] `oc` CLI installed
+- [ ] `openshift-install` binary built with GCD support
+- [ ] RHCOS image uploaded to GCD project
+- [ ] Sufficient C3 quota in `u-germany-northeast1`
+
+### Checklist
+
+- [ ] **14. Verify GCD cluster nodes use correct machine type and disk**
+  - [ ] All control plane nodes are `c3-standard-4`
+  - [ ] All compute nodes are `c3-standard-4`
+  - [ ] All boot disks are `hyperdisk-balanced`
+  - [ ] Instances distributed across `u-germany-northeast1-a/b/c`
+
+- [ ] **15. Verify GCD cluster uses private DNS only**
+  - [ ] No public DNS zone on cluster DNS resource
+  - [ ] GCD DNS zones are all private visibility
+  - [ ] API not reachable from outside VPC
+  - [ ] API reachable through bastion/proxy
+
+- [ ] **16. Verify GCD cluster destroy removes all resources**
+  - [ ] Zero leftover compute instances
+  - [ ] Zero leftover disks
+  - [ ] Zero leftover firewall rules
+  - [ ] Zero leftover DNS records
+  - [ ] Zero leftover service accounts
+  - [ ] Zero leftover health checks and forwarding rules
+
+- [ ] **17. Verify install-config validation rejects public publish on GCD**
+  - [ ] Installer rejects `publish: External` with validation error
+  - [ ] No cloud resources created
+
+<!-- MANUAL_TESTS_END -->
+
+---
+
+## Related Links
+
+- Strategy: [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006)
+- Installer PR: [openshift/installer#10630](https://github.com/openshift/installer/pull/10630)
+- CI job PR: [openshift/release#81238](https://github.com/openshift/release/pull/81238)
+- Feature test plan: [gcd-feature.md](../plans/gcd-feature.md)
+- GCD skill reference: `.claude/skills/gcd/`

--- a/test/docs/gcd/cases/gcd_sovereign_install.md
+++ b/test/docs/gcd/cases/gcd_sovereign_install.md
@@ -412,8 +412,11 @@ regions. Instead, the workload uses self-signed JWTs.
 ### Execution
 
 ```go
-session, _ := gcpic.GetSession(ctx)
-ud, _ := session.Credentials.GetUniverseDomain()
+session, err := gcpic.GetSession(ctx)
+// err != nil -> fail: "could not get GCP session"
+
+ud, err := session.Credentials.GetUniverseDomain()
+// err != nil -> fail: "could not get GCP universe domain"
 // ud == "apis-berlin-build0.goog" for GCD
 
 var tokenURL string
@@ -421,10 +424,11 @@ if ud != "" && ud != "googleapis.com" {
     tokenURL = "nil"
 }
 
-gcpConfig, _ := gcpmanifests.CloudProviderConfig(
+gcpConfig, err := gcpmanifests.CloudProviderConfig(
     infraID, projectID, subnet, networkProjectID,
     firewallManagement, tokenURL,
 )
+// err != nil -> fail: "could not create cloud provider config"
 // gcpConfig contains tokenURL = "nil" for sovereign cloud
 ```
 
@@ -459,11 +463,14 @@ environment variable so it can reach the correct sovereign cloud API endpoints.
 ### Execution
 
 ```go
-session, _ := gcpic.GetSession(ctx)
-ud, _ := session.Credentials.GetUniverseDomain()
+session, err := gcpic.GetSession(ctx)
+// err != nil -> fail: "could not get GCP session"
+
+ud, err := session.Credentials.GetUniverseDomain()
+// err != nil -> fail: "could not get GCP universe domain"
 
 capgEnvVars := map[string]string{}
-if ud != "googleapis.com" {
+if ud != "" && ud != "googleapis.com" {
     capgEnvVars["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = ud
 }
 // For GCD: capgEnvVars["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] == "apis-berlin-build0.goog"
@@ -758,6 +765,7 @@ Set up environment variables:
 export GOOGLE_CLOUD_UNIVERSE_DOMAIN=apis-berlin-build0.goog
 export PROJECT_ID="eu0:<your-gcd-project>"
 export INFRA_ID="<cluster-infra-id-from-metadata>"
+export CLUSTER_ZONE="${INFRA_ID}-private-zone"
 ```
 
 1. Check for leftover compute instances:
@@ -787,14 +795,19 @@ gcloud compute firewall-rules list \
 # Expected: no results
 ```
 
-4. Check for leftover DNS records:
+4. Check for leftover DNS records (skip if the zone was already deleted):
 
 ```bash
-gcloud dns record-sets list \
-  --zone="${CLUSTER_ZONE}" \
-  --filter="name~${INFRA_ID}" \
-  --project="${PROJECT_ID}"
-# Expected: no results (or zone itself deleted)
+if gcloud dns managed-zones describe "${CLUSTER_ZONE}" \
+    --project="${PROJECT_ID}" &>/dev/null; then
+  gcloud dns record-sets list \
+    --zone="${CLUSTER_ZONE}" \
+    --filter="name~${INFRA_ID}" \
+    --project="${PROJECT_ID}"
+  # Expected: no results
+else
+  echo "Zone ${CLUSTER_ZONE} already deleted - OK"
+fi
 ```
 
 5. Check for leftover service accounts:

--- a/test/docs/gcd/plans/gcd-feature.md
+++ b/test/docs/gcd/plans/gcd-feature.md
@@ -9,17 +9,19 @@ OpenShift IPI (Installer-Provisioned Infrastructure) support on Google Cloud
 Dedicated (GCD), also known as Trusted Partner Cloud sovereign regions.
 
 GCD is a fully isolated sovereign cloud environment with no network path to
-public Google Cloud. It uses region-specific API endpoints, domain-scoped
-project IDs, and a restricted subset of GCP services. The installer must detect
-sovereign cloud environments, apply correct defaults, enforce constraints, and
-propagate configuration to the cluster components.
+public Google Cloud. It uses region-specific API endpoints (universe domain),
+domain-scoped project IDs, sovereign regions (prefixed with `u-`), and a
+restricted subset of GCP services. The installer detects sovereign cloud
+environments by the combination of a domain-scoped project ID (containing `:`)
+and a sovereign region (prefixed with `u-`), then applies correct defaults,
+enforces constraints, and propagates configuration to the cluster components.
 
 ### 1.2. Scope
 
 **In Scope**
 
 - Install-config validation for sovereign cloud environments
-- Sovereign cloud detection via project ID prefix (`eu0:`)
+- Sovereign cloud detection via domain-scoped project ID and `u-` region prefix
 - Default machine type selection (C3 series for sovereign, N2 for public GCP)
 - Default disk type selection (Hyperdisk Balanced for sovereign, PD-SSD for public GCP)
 - OS image requirement enforcement for sovereign cloud
@@ -42,7 +44,7 @@ propagate configuration to the cluster components.
 ### 1.3. Key Features
 
 - **OCPSTRAT-3006** - Google Cloud Dedicated support in OpenShift
-- Sovereign cloud auto-detection from `eu0:` project ID prefix
+- Sovereign cloud auto-detection from domain-scoped project ID + `u-` region
 - Constrained defaults for machine types, disk types, and OS images
 - Private DNS-only deployment (GCD does not support public DNS zones)
 - Universe domain-aware credential handling
@@ -117,11 +119,11 @@ test file that covers it.
 
 | Behavior | Source | Test File |
 |----------|--------|-----------|
-| Sovereign cloud detection from project ID | `pkg/types/gcp/platform.go` `GetCloudEnvironment()` | `pkg/types/gcp/platform_test.go` |
+| Sovereign cloud detection from project ID and region | `pkg/types/gcp/platform.go` `GetCloudEnvironment(projectID, region)` | `pkg/types/gcp/platform_test.go` |
 | Non-default universe domain check | `pkg/types/gcp/platform.go` `IsNonDefaultUniverseDomain()` | `pkg/types/gcp/platform_test.go` |
 | Service account email for domain-scoped projects | `pkg/types/gcp/platform.go` `GetDefaultServiceAccount()` | `pkg/types/gcp/platform_test.go` |
-| Default machine type (C3 for sovereign) | `pkg/asset/installconfig/gcp/validation.go` `DefaultInstanceTypeForArchAndProjectID()` | `pkg/asset/installconfig/gcp/validation_test.go` |
-| Default disk type (Hyperdisk Balanced for sovereign) | `pkg/types/gcp/machinepools.go` `DefaultDiskTypeForInstanceAndProjectID()` | `pkg/types/gcp/machinepools_test.go` |
+| Default machine type (C3 for sovereign) | `pkg/asset/installconfig/gcp/validation.go` `DefaultInstanceTypeForArchAndProjectID(arch, projectID, region)` | `pkg/asset/installconfig/gcp/validation_test.go` |
+| Default disk type (Hyperdisk Balanced for sovereign) | `pkg/types/gcp/machinepools.go` `DefaultDiskTypeForInstanceAndProjectID(instanceType, projectID, region)` | `pkg/types/gcp/machinepools_test.go` |
 | OS image required for sovereign cloud | `pkg/types/gcp/validation/machinepool.go` `ValidateOSImageForSovereignCloud()` | `pkg/types/gcp/validation/machinepool_test.go` |
 | PSC endpoint forbidden for sovereign cloud | `pkg/asset/installconfig/gcp/validation.go` `validateServiceEndpointOverride()` | `pkg/asset/installconfig/gcp/validation_test.go` |
 | Universe domain credential options | `pkg/asset/installconfig/gcp/services.go` `CredentialOptions()` | `pkg/asset/installconfig/gcp/services_test.go` |
@@ -132,13 +134,15 @@ test file that covers it.
 
 ### 4.1. Sovereign Cloud Detection
 
-The installer identifies GCD environments by inspecting the project ID prefix.
-Project IDs with the `eu0:` prefix are classified as sovereign cloud. This
-detection drives all downstream defaults and validation.
+The installer identifies GCD environments by checking two conditions together:
+the project ID must be domain-scoped (containing `:`) and the region must have
+the sovereign prefix `u-`. Both conditions must be met. This detection drives
+all downstream defaults and validation.
 
-**Key invariant:** Organization-scoped public GCP projects (e.g.,
-`myorg:my-project`) must NOT be classified as sovereign. Only the known prefix
-`eu0` triggers sovereign behavior.
+**Key invariant:** Neither condition alone is sufficient. A domain-scoped
+project ID with a standard region (e.g., `myorg:my-project` in `us-central1`)
+is not sovereign. A sovereign region with a standard project ID (e.g.,
+`my-project` in `u-germany-northeast1`) is also not sovereign.
 
 ### 4.2. Default Values for Sovereign Cloud
 
@@ -181,7 +185,7 @@ installation on GCD. The workflow:
 | DNS: private zones only | `PUBLISH=Internal` in job config |
 | Images: must exist in GCD project | `DEFAULT_MACHINE_OSIMAGE=rhcos10` (pre-uploaded) |
 | Bastion needs GVNIC | Fedora CoreOS image uploaded with `--guest-os-features=GVNIC` |
-| Project IDs use `eu0:` prefix | Cluster profile provides `eu0:` project |
+| Domain-scoped project IDs | Cluster profile provides domain-scoped project (e.g., `eu0:`) |
 | Single region | `u-germany-northeast1` |
 | Universe domain | Read from `gce.json` credentials, set via `gcloud config` and env var |
 
@@ -192,7 +196,7 @@ installation on GCD. The workflow:
 | GCD environment availability | E2E tests cannot run if GCD region is down | Unit tests cover all logic without cloud access |
 | RHCOS image not uploaded to GCD | Install fails on missing boot image | Pre-upload RHCOS to GCD project, track in CI config |
 | OAuth2 token endpoint unavailable in GCD | Credential refresh fails | Use `WithCredentialsJSON` for self-signed JWT (PR #10630) |
-| New `eu0:` prefix not in known list | Future sovereign prefixes not detected | `sovereignCloudProjectPrefixes` slice is extensible |
+| New sovereign region or project prefix | Detection logic may need updates | Detection uses generic `:` + `u-` checks, not hardcoded prefixes |
 | C3 machine quota in GCD | Insufficient quota blocks install | Monitor quota, request increases proactively |
 
 ## 6. Exit Criteria

--- a/test/docs/gcd/plans/gcd-feature.md
+++ b/test/docs/gcd/plans/gcd-feature.md
@@ -1,0 +1,208 @@
+# Feature Test Plan: OpenShift on Google Cloud Dedicated (GCD)
+
+## 1. Introduction
+
+### 1.1. Overview
+
+This document outlines the testing strategy, objectives, and procedures for
+OpenShift IPI (Installer-Provisioned Infrastructure) support on Google Cloud
+Dedicated (GCD), also known as Trusted Partner Cloud sovereign regions.
+
+GCD is a fully isolated sovereign cloud environment with no network path to
+public Google Cloud. It uses region-specific API endpoints, domain-scoped
+project IDs, and a restricted subset of GCP services. The installer must detect
+sovereign cloud environments, apply correct defaults, enforce constraints, and
+propagate configuration to the cluster components.
+
+### 1.2. Scope
+
+**In Scope**
+
+- Install-config validation for sovereign cloud environments
+- Sovereign cloud detection via project ID prefix (`eu0:`)
+- Default machine type selection (C3 series for sovereign, N2 for public GCP)
+- Default disk type selection (Hyperdisk Balanced for sovereign, PD-SSD for public GCP)
+- OS image requirement enforcement for sovereign cloud
+- PSC endpoint override restriction for sovereign cloud
+- Service account email formatting for domain-scoped project IDs
+- Universe domain propagation to CAPG controller
+- Cloud provider config with nil tokenURL for non-default universe domains
+- GCD credential handling (self-signed JWT via `WithCredentialsJSON`)
+- Private cluster deployment on GCD (internal publish only)
+- E2E IPI installation on GCD sovereign region (`u-germany-northeast1`)
+
+**Out of Scope**
+
+- UPI (User-Provisioned Infrastructure) on GCD
+- S3NS (Cloud de Confiance) region testing (same architecture, different identifiers)
+- Post-install Day 2 operations and operator testing
+- Upgrade testing from public GCP to GCD
+- Multi-region or cross-region scenarios (GCD is single-region)
+
+### 1.3. Key Features
+
+- **OCPSTRAT-3006** - Google Cloud Dedicated support in OpenShift
+- Sovereign cloud auto-detection from `eu0:` project ID prefix
+- Constrained defaults for machine types, disk types, and OS images
+- Private DNS-only deployment (GCD does not support public DNS zones)
+- Universe domain-aware credential handling
+
+### 1.4. References
+
+- Strategy: [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006)
+- Installer PR: [openshift/installer#10630](https://github.com/openshift/installer/pull/10630)
+- CI job PR: [openshift/release#81238](https://github.com/openshift/release/pull/81238)
+
+## 2. Testing Strategy
+
+### 2.1. Schedule
+
+| Milestone | Date / Sprint | Notes |
+|-----------|---------------|-------|
+| Unit test coverage complete | TBD | All sovereign cloud code paths covered |
+| CI job green | TBD | `e2e-gcd-ovn-private-techpreview` passing |
+| Feature complete | TBD | GCD IPI install succeeds end-to-end |
+
+### 2.2. Test Types
+
+- **Unit Tests:** Validate sovereign cloud detection, defaults, validation
+  rules, and configuration generation in isolation
+- **Integration Tests:** Verify install-config parsing, asset generation, and
+  credential handling for sovereign cloud configurations
+- **E2E Tests:** Full IPI installation on GCD sovereign region with cluster
+  health verification
+- **Negative Tests:** Confirm that unsupported configurations (e.g., PSC
+  endpoints, public DNS, wrong machine types) are correctly rejected
+
+### 2.3. Test Environments
+
+- **Unit/Integration:** Local Go test environment, no cloud credentials needed
+- **E2E CI:** Prow job `e2e-gcd-ovn-private-techpreview` using `gcd` cluster
+  profile with:
+  - Region: `u-germany-northeast1`
+  - Base domain: `ci.gcd.devcluster.openshift.com`
+  - Feature set: `TechPreviewNoUpgrade`
+  - Publish: `Internal` (private cluster)
+  - Machine type: `c3-standard-4`
+  - OS image: `rhcos10` (uploaded to GCD project)
+  - Bastion: Fedora CoreOS with GVNIC on C3
+
+## 3. Test Areas and Test Cases
+
+### 3.1. Key Test Activities
+
+| Activity | Type | Est. Duration |
+|----------|------|---------------|
+| Sovereign cloud detection unit tests | Unit | < 1 hour |
+| Default values unit tests | Unit | < 1 hour |
+| Validation unit tests | Unit | < 1 hour |
+| Service account formatting unit tests | Unit | < 30 min |
+| Install-config validation integration tests | Integration | < 1 hour |
+| E2E IPI install on GCD | E2E | ~2 hours |
+
+### 3.2. Test Cases
+
+Test case documentation is maintained alongside this plan in the
+[`cases/`](../cases/) directory, with references to the corresponding Go test
+files.
+
+| Test Case | Doc | Test File(s) |
+|-----------|-----|--------------|
+| GCD Sovereign Cloud Install | [gcd_sovereign_install.md](../cases/gcd_sovereign_install.md) | Multiple (see doc) |
+
+### 3.3. Unit Test Coverage Map
+
+The following table maps each GCD-specific behavior to the source code and
+test file that covers it.
+
+| Behavior | Source | Test File |
+|----------|--------|-----------|
+| Sovereign cloud detection from project ID | `pkg/types/gcp/platform.go` `GetCloudEnvironment()` | `pkg/types/gcp/platform_test.go` |
+| Non-default universe domain check | `pkg/types/gcp/platform.go` `IsNonDefaultUniverseDomain()` | `pkg/types/gcp/platform_test.go` |
+| Service account email for domain-scoped projects | `pkg/types/gcp/platform.go` `GetDefaultServiceAccount()` | `pkg/types/gcp/platform_test.go` |
+| Default machine type (C3 for sovereign) | `pkg/asset/installconfig/gcp/validation.go` `DefaultInstanceTypeForArchAndProjectID()` | `pkg/asset/installconfig/gcp/validation_test.go` |
+| Default disk type (Hyperdisk Balanced for sovereign) | `pkg/types/gcp/machinepools.go` `DefaultDiskTypeForInstanceAndProjectID()` | `pkg/types/gcp/machinepools_test.go` |
+| OS image required for sovereign cloud | `pkg/types/gcp/validation/machinepool.go` `ValidateOSImageForSovereignCloud()` | `pkg/types/gcp/validation/machinepool_test.go` |
+| PSC endpoint forbidden for sovereign cloud | `pkg/asset/installconfig/gcp/validation.go` `validateServiceEndpointOverride()` | `pkg/asset/installconfig/gcp/validation_test.go` |
+| Universe domain credential options | `pkg/asset/installconfig/gcp/services.go` `CredentialOptions()` | `pkg/asset/installconfig/gcp/services_test.go` |
+| Cloud provider config nil tokenURL | `pkg/asset/manifests/cloudproviderconfig.go` | `pkg/asset/manifests/cloudproviderconfig_test.go` |
+| CAPG controller universe domain env var | `pkg/clusterapi/system.go` | `pkg/clusterapi/system_test.go` |
+
+## 4. Test Details
+
+### 4.1. Sovereign Cloud Detection
+
+The installer identifies GCD environments by inspecting the project ID prefix.
+Project IDs with the `eu0:` prefix are classified as sovereign cloud. This
+detection drives all downstream defaults and validation.
+
+**Key invariant:** Organization-scoped public GCP projects (e.g.,
+`myorg:my-project`) must NOT be classified as sovereign. Only the known prefix
+`eu0` triggers sovereign behavior.
+
+### 4.2. Default Values for Sovereign Cloud
+
+When a sovereign cloud environment is detected:
+
+| Setting | Public GCP | Sovereign Cloud (GCD) |
+|---------|------------|-----------------------|
+| Default instance type (x86) | `n2-standard-4` | `c3-standard-4` |
+| Default instance type (ARM64) | `t2a-standard-4` | `c3-standard-4` |
+| Default disk type (C3) | `hyperdisk-balanced` | `hyperdisk-balanced` |
+| OS image | Optional | Required (name + project) |
+| PSC endpoint override | Allowed | Forbidden |
+| Token URL in cloud-provider config | Standard OAuth2 URL | `"nil"` |
+| CAPG `GOOGLE_CLOUD_UNIVERSE_DOMAIN` | Not set | Set from credentials |
+
+### 4.3. E2E Test Execution
+
+The E2E test job `e2e-gcd-ovn-private-techpreview` performs a full IPI
+installation on GCD. The workflow:
+
+1. **Credential validation** (`ipi-conf-gcd-creds`) - Validates GCD service
+   account key contains `universe_domain` field
+2. **VPC provisioning** (`gcp-provision-vpc`) - Creates VPC, subnets, Cloud NAT
+   in `u-germany-northeast1`
+3. **Bastion provisioning** (`gcp-provision-bastionhost`) - Creates C3 bastion
+   with Fedora CoreOS (GVNIC-enabled image)
+4. **Proxy setup** - Configures HTTP proxy on bastion for private cluster access
+5. **Install-config generation** (`ipi-conf-gcd`) - Generates install-config
+   with GCD-specific settings
+6. **Cluster installation** - Runs `openshift-install create cluster`
+7. **E2E tests** - Runs conformance tests against the deployed cluster
+8. **Deprovision** - Destroys cluster, bastion, and VPC
+
+### 4.4. GCD-Specific Requirements in E2E
+
+| Requirement | How it is handled |
+|-------------|-------------------|
+| Machine types: C3/M3 only | Default `c3-standard-4`, bastion also C3 |
+| Disks: Hyperdisk Balanced only | Default from `DefaultDiskTypeForInstanceAndProjectID()` |
+| DNS: private zones only | `PUBLISH=Internal` in job config |
+| Images: must exist in GCD project | `DEFAULT_MACHINE_OSIMAGE=rhcos10` (pre-uploaded) |
+| Bastion needs GVNIC | Fedora CoreOS image uploaded with `--guest-os-features=GVNIC` |
+| Project IDs use `eu0:` prefix | Cluster profile provides `eu0:` project |
+| Single region | `u-germany-northeast1` |
+| Universe domain | Read from `gce.json` credentials, set via `gcloud config` and env var |
+
+## 5. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| GCD environment availability | E2E tests cannot run if GCD region is down | Unit tests cover all logic without cloud access |
+| RHCOS image not uploaded to GCD | Install fails on missing boot image | Pre-upload RHCOS to GCD project, track in CI config |
+| OAuth2 token endpoint unavailable in GCD | Credential refresh fails | Use `WithCredentialsJSON` for self-signed JWT (PR #10630) |
+| New `eu0:` prefix not in known list | Future sovereign prefixes not detected | `sovereignCloudProjectPrefixes` slice is extensible |
+| C3 machine quota in GCD | Insufficient quota blocks install | Monitor quota, request increases proactively |
+
+## 6. Exit Criteria
+
+The GCD feature will be considered tested when:
+
+- All unit tests for sovereign cloud detection, defaults, and validation pass
+- No open regressions in existing GCP test suites
+- E2E CI job `e2e-gcd-ovn-private-techpreview` passes (cluster installs and
+  conformance tests succeed)
+- All negative validation cases (PSC endpoint, missing OS image, wrong machine
+  types) are covered by unit tests
+- Service account email formatting is verified for domain-scoped project IDs

--- a/test/docs/install_config_field_index.md
+++ b/test/docs/install_config_field_index.md
@@ -1,0 +1,528 @@
+# Install Config Field Index
+
+This document maps install-config YAML fields to the features tracked in the
+[Platform Feature Matrix](platform_feature_matrix.md). Use it to understand
+which fields drive which features on each platform and where field-level test
+coverage exists.
+
+The index is organized by platform. Platform-agnostic fields that apply to all
+platforms are listed first. Each platform section covers both the
+`.platform.<name>` fields and the machine pool fields under
+`.controlPlane.platform.<name>` and `.compute[].platform.<name>`.
+
+## How to Read This Document
+
+Each table uses five columns:
+
+| Column | Description |
+|--------|-------------|
+| JSON Path | Dot-notation path in install-config YAML |
+| Field | Human-readable name |
+| Type | Go type (what the field accepts) |
+| Feature(s) | Row(s) in the [Platform Feature Matrix](platform_feature_matrix.md) this field relates to |
+| Test Coverage | AT (auto-tested), MT (manual), AT/MT (both), NT (not tested), NA (not applicable) |
+
+JSON paths use `.platform.<name>.` for platform-level fields and
+`.controlPlane.platform.<name>.` or `.compute[].platform.<name>.` for machine
+pool fields. When a machine pool field applies to both control plane and
+compute, the path is shown as `.<pool>.platform.<name>.` where `<pool>` is
+either location.
+
+## Platform-Agnostic Fields
+
+These fields appear at the top level of install-config and apply regardless of
+platform.
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.baseDomain` | Base Domain | `string` | IPI Install, UPI Install | AT |
+| `.publish` | Publish Strategy | `External` / `Internal` / `Mixed` | Private Cluster | AT |
+| `.fips` | FIPS Mode | `bool` | FIPS Mode | NT |
+| `.proxy.httpProxy` | HTTP Proxy | `string` | Proxy Support | NT |
+| `.proxy.httpsProxy` | HTTPS Proxy | `string` | Proxy Support | NT |
+| `.proxy.noProxy` | No Proxy | `string` | Proxy Support | NT |
+| `.networking.networkType` | Network Type | `string` | IPI Install | AT |
+| `.networking.machineNetwork[].cidr` | Machine Network CIDR | `IPNet` | Dual Stack | AT |
+| `.networking.clusterNetwork[].cidr` | Cluster Network CIDR | `IPNet` | Dual Stack | AT |
+| `.networking.serviceNetwork[]` | Service Network CIDR | `IPNet` | Dual Stack | AT |
+| `.networking.clusterNetworkMTU` | Cluster Network MTU | `uint32` | IPI Install | NT |
+| `.controlPlane.replicas` | Control Plane Replicas | `int64` | IPI Install, Single Node | AT |
+| `.controlPlane.architecture` | CPU Architecture | `string` | Default Machine Types | AT |
+| `.compute[].replicas` | Compute Replicas | `int64` | IPI Install | AT |
+| `.credentialsMode` | Credentials Mode | `Mint` / `Passthrough` / `Manual` | IPI Install | AT |
+| `.featureSet` | Feature Set | `string` | Feature Gates | AT |
+| `.featureGates` | Feature Gates | `[]string` | Feature Gates | AT |
+| `.capabilities` | Capabilities | `object` | IPI Install | NT |
+| `.additionalTrustBundle` | Additional Trust Bundle | `string` | Proxy Support | NT |
+| `.sshKey` | SSH Key | `string` | IPI Install | AT |
+| `.pullSecret` | Pull Secret | `string` | IPI Install | AT |
+| `.cpuPartitioningMode` | CPU Partitioning | `None` / `AllNodes` | IPI Install | NT |
+
+## AWS
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.aws.region` | Region | `string` | IPI Install | AT |
+| `.platform.aws.vpc` | VPC | `object` | Existing VPC | AT |
+| `.platform.aws.vpc.subnets` | VPC Subnets | `[]Subnet` | Existing VPC | AT |
+| `.platform.aws.hostedZone` | Hosted Zone | `string` | User-Provisioned DNS | AT |
+| `.platform.aws.hostedZoneRole` | Hosted Zone Role | `string` | User-Provisioned DNS | AT |
+| `.platform.aws.userTags` | User Tags | `map[string]string` | User Tags / Labels | AT |
+| `.platform.aws.serviceEndpoints` | Service Endpoints | `[]ServiceEndpoint` | Service Endpoints / PSC | AT |
+| `.platform.aws.lbType` | Load Balancer Type | `Classic` / `NLB` | Load Balancer Config | NT |
+| `.platform.aws.userProvisionedDNS` | User-Provisioned DNS | `Enabled` / `Disabled` | User-Provisioned DNS | AT |
+| `.platform.aws.ipFamily` | IP Family | `IPv4` / `DualStack` | Dual Stack | AT |
+| `.platform.aws.publicIpv4Pool` | Public IPv4 Pool | `string` | IPI Install | NT |
+| `.platform.aws.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.aws.type` | Instance Type | `string` | Default Machine Types | AT |
+| `.<pool>.platform.aws.zones` | Availability Zones | `[]string` | Failure Domains / Zones | AT |
+| `.<pool>.platform.aws.amiID` | AMI ID | `string` | Custom OS Image | NT |
+| `.<pool>.platform.aws.rootVolume.type` | Root Volume Type | `string` | Custom Disk Types | AT |
+| `.<pool>.platform.aws.rootVolume.size` | Root Volume Size | `int` | Custom Disk Types | AT |
+| `.<pool>.platform.aws.rootVolume.iops` | Root Volume IOPS | `int` | Custom Disk Types | AT |
+| `.<pool>.platform.aws.rootVolume.throughput` | Root Volume Throughput | `int32` | Custom Disk Types | AT |
+| `.<pool>.platform.aws.rootVolume.kmsKeyARN` | KMS Key ARN | `string` | KMS / Disk Encryption | AT |
+| `.<pool>.platform.aws.iamRole` | IAM Role | `string` | IPI Install | AT |
+| `.<pool>.platform.aws.iamProfile` | IAM Instance Profile | `string` | IPI Install | NT |
+| `.<pool>.platform.aws.additionalSecurityGroupIDs` | Additional Security Groups | `[]string` | Existing VPC | AT |
+| `.<pool>.platform.aws.cpuOptions` | CPU Options | `object` | Confidential Compute | AT |
+| `.<pool>.platform.aws.hostPlacement` | Host Placement | `object` | Dedicated Hosts | AT |
+| `.<pool>.platform.aws.metadataService` | Metadata Service | `object` | IPI Install | NT |
+
+## Azure
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.azure.region` | Region | `string` | IPI Install | AT |
+| `.platform.azure.baseDomainResourceGroupName` | DNS Resource Group | `string` | IPI Install | AT |
+| `.platform.azure.networkResourceGroupName` | Network Resource Group | `string` | Existing VPC / VNet | AT |
+| `.platform.azure.virtualNetwork` | Virtual Network | `string` | Existing VPC / VNet | AT |
+| `.platform.azure.subnets` | Subnets | `[]SubnetSpec` | Existing VPC / VNet | AT |
+| `.platform.azure.resourceGroupName` | Resource Group | `string` | IPI Install | AT |
+| `.platform.azure.cloudName` | Cloud Name | `string` | Sovereign Cloud Support | NT |
+| `.platform.azure.outboundType` | Outbound Type | `string` | IPI Install | AT |
+| `.platform.azure.userTags` | User Tags | `map[string]string` | User Tags / Labels | AT |
+| `.platform.azure.customerManagedKey` | Customer Managed Key | `object` | KMS / Disk Encryption | AT |
+| `.platform.azure.userProvisionedDNS` | User-Provisioned DNS | `Enabled` / `Disabled` | User-Provisioned DNS | AT |
+| `.platform.azure.ipFamily` | IP Family | `IPv4` / `DualStack` | Dual Stack | AT |
+| `.platform.azure.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.azure.type` | VM Size | `string` | Default Machine Types | AT |
+| `.<pool>.platform.azure.zones` | Availability Zones | `[]string` | Failure Domains / Zones | AT |
+| `.<pool>.platform.azure.osDisk.diskSizeGB` | OS Disk Size | `int32` | Custom Disk Types | AT |
+| `.<pool>.platform.azure.osDisk.diskType` | OS Disk Type | `string` | Custom Disk Types | AT |
+| `.<pool>.platform.azure.osDisk.diskEncryptionSet` | Disk Encryption Set | `object` | KMS / Disk Encryption | AT |
+| `.<pool>.platform.azure.osDisk.securityProfile` | Disk Security Profile | `object` | Confidential Compute | AT |
+| `.<pool>.platform.azure.encryptionAtHost` | Encryption at Host | `bool` | KMS / Disk Encryption | AT |
+| `.<pool>.platform.azure.osImage` | Custom OS Image | `object` | Custom OS Image | NT |
+| `.<pool>.platform.azure.settings` | Security Settings | `object` | Secure Boot / UEFI, Confidential Compute | AT |
+| `.<pool>.platform.azure.ultraSSDCapability` | Ultra SSD | `Enabled` / `Disabled` | Custom Disk Types | AT |
+| `.<pool>.platform.azure.vmNetworkingType` | Accelerated Networking | `string` | IPI Install | NT |
+| `.<pool>.platform.azure.identity` | VM Identity | `object` | IPI Install | NT |
+| `.<pool>.platform.azure.dataDisks` | Data Disks | `[]DataDisk` | Custom Disk Types | NT |
+| `.<pool>.platform.azure.bootDiagnostics` | Boot Diagnostics | `object` | IPI Install | NT |
+
+## GCP
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.gcp.projectID` | Project ID | `string` | IPI Install, Sovereign Cloud Support | AT |
+| `.platform.gcp.region` | Region | `string` | IPI Install, Sovereign Cloud Support | AT |
+| `.platform.gcp.network` | VPC Network | `string` | Existing VPC | AT |
+| `.platform.gcp.networkProjectID` | Network Project ID | `string` | Shared VPC / XPN | AT |
+| `.platform.gcp.controlPlaneSubnet` | Control Plane Subnet | `string` | Existing VPC | AT |
+| `.platform.gcp.computeSubnet` | Compute Subnet | `string` | Existing VPC | AT |
+| `.platform.gcp.userLabels` | User Labels | `[]UserLabel` | User Tags / Labels | AT |
+| `.platform.gcp.userTags` | User Tags | `[]UserTag` | User Tags / Labels | AT |
+| `.platform.gcp.userProvisionedDNS` | User-Provisioned DNS | `Enabled` / `Disabled` | User-Provisioned DNS | AT |
+| `.platform.gcp.endpoint` | PSC Endpoint | `object` | Service Endpoints / PSC | AT |
+| `.platform.gcp.dns.privateZone` | Private DNS Zone | `object` | Shared VPC / XPN | AT |
+| `.platform.gcp.firewallRulesManagement` | Firewall Rules | `Managed` / `Unmanaged` | IPI Install | NT |
+| `.platform.gcp.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.gcp.type` | Instance Type | `string` | Default Machine Types | AT |
+| `.<pool>.platform.gcp.zones` | Availability Zones | `[]string` | Failure Domains / Zones | AT |
+| `.<pool>.platform.gcp.osDisk.diskType` | Disk Type | `string` | Custom Disk Types | AT |
+| `.<pool>.platform.gcp.osDisk.DiskSizeGB` | Disk Size | `int64` | Custom Disk Types | AT |
+| `.<pool>.platform.gcp.osDisk.encryptionKey` | KMS Encryption Key | `object` | KMS / Disk Encryption | AT |
+| `.<pool>.platform.gcp.osImage` | Custom OS Image | `object` | Custom OS Image | AT |
+| `.<pool>.platform.gcp.tags` | Network Tags | `[]string` | IPI Install | NT |
+| `.<pool>.platform.gcp.secureBoot` | Secure Boot | `Enabled` / `Disabled` | Secure Boot / UEFI | NT |
+| `.<pool>.platform.gcp.confidentialCompute` | Confidential Compute | `string` | Confidential Compute | AT |
+| `.<pool>.platform.gcp.onHostMaintenance` | On Host Maintenance | `Migrate` / `Terminate` | Confidential Compute | AT |
+| `.<pool>.platform.gcp.serviceAccount` | Service Account | `string` | Sovereign Cloud Support | AT |
+
+## GCD (Google Cloud Dedicated)
+
+GCD uses the same Go types as GCP (`pkg/types/gcp/`). The fields below
+highlight sovereign-specific behavior: different defaults, additional
+requirements, or restrictions that do not apply to public GCP. See the
+[GCP section](#gcp) for the full field list.
+
+### Platform fields with sovereign-specific behavior
+
+| JSON Path | Field | Sovereign Behavior | Feature(s) | Test Coverage |
+|-----------|-------|--------------------|------------|---------------|
+| `.platform.gcp.projectID` | Project ID | Must be domain-scoped (contains `:`) | Sovereign Cloud Support | AT/MT |
+| `.platform.gcp.region` | Region | Must have `u-` prefix | Sovereign Cloud Support | AT/MT |
+| `.platform.gcp.endpoint` | PSC Endpoint | Forbidden (rejected by validation) | Service Endpoints / PSC | AT |
+
+### Machine pool fields with sovereign-specific behavior
+
+| JSON Path | Field | Sovereign Behavior | Feature(s) | Test Coverage |
+|-----------|-------|--------------------|------------|---------------|
+| `.<pool>.platform.gcp.type` | Instance Type | Defaults to `c3-standard-4` (C3 only) | Default Machine Types | AT/MT |
+| `.<pool>.platform.gcp.osDisk.diskType` | Disk Type | Defaults to `hyperdisk-balanced` | Custom Disk Types | AT |
+| `.<pool>.platform.gcp.osImage` | Custom OS Image | Required (name + project must be set) | Custom OS Image | AT/MT |
+| `.<pool>.platform.gcp.serviceAccount` | Service Account | Domain-scoped email format | Sovereign Cloud Support | AT |
+
+## Bare Metal
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.baremetal.hosts` | Host Definitions | `[]Host` | IPI Install, Agent-based Install | AT |
+| `.platform.baremetal.apiVIPs` | API VIPs | `[]string` | IPI Install | AT |
+| `.platform.baremetal.ingressVIPs` | Ingress VIPs | `[]string` | IPI Install | AT |
+| `.platform.baremetal.provisioningNetwork` | Provisioning Network | `string` | IPI Install | AT |
+| `.platform.baremetal.clusterProvisioningIP` | Cluster Provisioning IP | `string` | IPI Install | AT |
+| `.platform.baremetal.bootstrapProvisioningIP` | Bootstrap Provisioning IP | `string` | IPI Install | AT |
+| `.platform.baremetal.externalBridge` | External Bridge | `string` | IPI Install | AT |
+| `.platform.baremetal.provisioningBridge` | Provisioning Bridge | `string` | IPI Install | NT |
+| `.platform.baremetal.provisioningNetworkCIDR` | Provisioning CIDR | `IPNet` | IPI Install | AT |
+| `.platform.baremetal.provisioningDHCPRange` | Provisioning DHCP Range | `string` | IPI Install | NT |
+| `.platform.baremetal.provisioningNetworkInterface` | Provisioning NIC | `string` | IPI Install | NT |
+| `.platform.baremetal.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.baremetal.dnsRecordsType` | DNS Records Type | `Internal` / `External` | IPI Install | NT |
+| `.platform.baremetal.additionalNTPServers` | NTP Servers | `[]string` | IPI Install | NT |
+| `.platform.baremetal.bmcVerifyCA` | BMC CA Verify | `string` | IPI Install | NT |
+| `.platform.baremetal.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | IPI Install | NA |
+
+Bare metal MachinePool has no platform-specific fields.
+
+## IBM Cloud
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.ibmcloud.region` | Region | `string` | IPI Install | AT |
+| `.platform.ibmcloud.resourceGroupName` | Resource Group | `string` | IPI Install | AT |
+| `.platform.ibmcloud.networkResourceGroupName` | Network Resource Group | `string` | Existing VPC | AT |
+| `.platform.ibmcloud.vpcName` | VPC Name | `string` | Existing VPC | AT |
+| `.platform.ibmcloud.controlPlaneSubnets` | Control Plane Subnets | `[]string` | Existing VPC | AT |
+| `.platform.ibmcloud.computeSubnets` | Compute Subnets | `[]string` | Existing VPC | AT |
+| `.platform.ibmcloud.serviceEndpoints` | Service Endpoints | `[]ServiceEndpoint` | Service Endpoints / PSC | AT |
+| `.platform.ibmcloud.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.ibmcloud.type` | Machine Profile | `string` | Default Machine Types | AT |
+| `.<pool>.platform.ibmcloud.zones` | Availability Zones | `[]string` | IPI Install | AT |
+| `.<pool>.platform.ibmcloud.bootVolume.encryptionKey` | Boot Encryption Key | `string` | KMS / Disk Encryption | AT |
+| `.<pool>.platform.ibmcloud.dedicatedHosts` | Dedicated Hosts | `[]DedicatedHost` | Dedicated Hosts | AT |
+
+## Nutanix
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.nutanix.prismCentral` | Prism Central | `object` | IPI Install | AT |
+| `.platform.nutanix.prismElements` | Prism Elements | `[]PrismElement` | IPI Install | AT |
+| `.platform.nutanix.subnetUUIDs` | Subnet UUIDs | `[]string` | Existing VPC | AT |
+| `.platform.nutanix.apiVIPs` | API VIPs | `[]string` | IPI Install | AT |
+| `.platform.nutanix.ingressVIPs` | Ingress VIPs | `[]string` | IPI Install | AT |
+| `.platform.nutanix.failureDomains` | Failure Domains | `[]FailureDomain` | Failure Domains / Zones | AT |
+| `.platform.nutanix.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.nutanix.dnsRecordsType` | DNS Records Type | `Internal` / `External` | IPI Install | NT |
+| `.platform.nutanix.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | NT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.nutanix.cpus` | vCPU Count | `int64` | Default Machine Types | NT |
+| `.<pool>.platform.nutanix.coresPerSocket` | Cores per Socket | `int64` | Default Machine Types | NT |
+| `.<pool>.platform.nutanix.memoryMiB` | Memory (MiB) | `int64` | Default Machine Types | NT |
+| `.<pool>.platform.nutanix.osDisk.diskSizeGiB` | OS Disk Size (GiB) | `int64` | Custom Disk Types | NT |
+| `.<pool>.platform.nutanix.bootType` | Boot Type | `Legacy` / `UEFI` / `SecureBoot` | Secure Boot / UEFI | AT |
+| `.<pool>.platform.nutanix.categories` | Prism Categories | `[]Category` | User Tags / Labels | NT |
+| `.<pool>.platform.nutanix.project` | Prism Project | `object` | IPI Install | NT |
+| `.<pool>.platform.nutanix.failureDomains` | Failure Domains | `[]string` | Failure Domains / Zones | AT |
+| `.<pool>.platform.nutanix.gpus` | GPU Devices | `[]GPU` | IPI Install | NT |
+| `.<pool>.platform.nutanix.dataDisks` | Data Disks | `[]DataDisk` | Custom Disk Types | NT |
+
+## OpenStack
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.openstack.cloud` | Cloud Name | `string` | IPI Install | AT |
+| `.platform.openstack.externalNetwork` | External Network | `string` | IPI Install | AT |
+| `.platform.openstack.apiFloatingIP` | API Floating IP | `string` | IPI Install | AT |
+| `.platform.openstack.ingressFloatingIP` | Ingress Floating IP | `string` | IPI Install | AT |
+| `.platform.openstack.externalDNS` | External DNS Servers | `[]string` | IPI Install | NT |
+| `.platform.openstack.clusterOSImage` | Custom OS Image | `string` | Custom OS Image | NT |
+| `.platform.openstack.clusterOSImageProperties` | OS Image Properties | `map[string]string` | Custom OS Image | NT |
+| `.platform.openstack.apiVIPs` | API VIPs | `[]string` | IPI Install | AT |
+| `.platform.openstack.ingressVIPs` | Ingress VIPs | `[]string` | IPI Install | AT |
+| `.platform.openstack.controlPlanePort` | Control Plane Port | `object` | Existing VPC | AT |
+| `.platform.openstack.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.openstack.dnsRecordsType` | DNS Records Type | `Internal` / `External` | IPI Install | NT |
+| `.platform.openstack.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.openstack.type` | Flavor | `string` | Default Machine Types | AT |
+| `.<pool>.platform.openstack.zones` | Availability Zones | `[]string` | IPI Install | AT |
+| `.<pool>.platform.openstack.rootVolume` | Root Volume | `object` | Custom Disk Types | NT |
+| `.<pool>.platform.openstack.additionalNetworkIDs` | Additional Networks | `[]string` | Existing VPC | AT |
+| `.<pool>.platform.openstack.additionalSecurityGroupIDs` | Additional Security Groups | `[]string` | Existing VPC | AT |
+| `.<pool>.platform.openstack.serverGroupPolicy` | Server Group Policy | `string` | IPI Install | NT |
+
+## PowerVC
+
+PowerVC shares much of its type structure with OpenStack. It uses the same
+CAPI provider.
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.powervc.cloud` | Cloud Name | `string` | IPI Install | AT |
+| `.platform.powervc.externalNetwork` | External Network | `string` | IPI Install | NT |
+| `.platform.powervc.apiFloatingIP` | API Floating IP | `string` | IPI Install | NT |
+| `.platform.powervc.ingressFloatingIP` | Ingress Floating IP | `string` | IPI Install | NT |
+| `.platform.powervc.externalDNS` | External DNS Servers | `[]string` | IPI Install | NT |
+| `.platform.powervc.clusterOSImage` | Custom OS Image | `string` | Custom OS Image | NT |
+| `.platform.powervc.apiVIPs` | API VIPs | `[]string` | IPI Install | NT |
+| `.platform.powervc.ingressVIPs` | Ingress VIPs | `[]string` | IPI Install | NT |
+| `.platform.powervc.controlPlanePort` | Control Plane Port | `object` | Existing VPC | NT |
+| `.platform.powervc.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.powervc.imageName` | Image Name | `string` | Custom OS Image | NT |
+| `.platform.powervc.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | NT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.powervc.type` | Flavor | `string` | Default Machine Types | NT |
+| `.<pool>.platform.powervc.zones` | Availability Zones | `[]string` | IPI Install | NT |
+| `.<pool>.platform.powervc.rootVolume` | Root Volume | `object` | Custom Disk Types | NT |
+| `.<pool>.platform.powervc.additionalNetworkIDs` | Additional Networks | `[]string` | Existing VPC | NT |
+| `.<pool>.platform.powervc.additionalSecurityGroupIDs` | Additional Security Groups | `[]string` | Existing VPC | NT |
+| `.<pool>.platform.powervc.serverGroupPolicy` | Server Group Policy | `string` | IPI Install | NT |
+
+## Power VS
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.powervs.powervsResourceGroup` | Resource Group | `string` | IPI Install | AT |
+| `.platform.powervs.region` | Region | `string` | IPI Install | AT |
+| `.platform.powervs.zone` | Zone | `string` | IPI Install | AT |
+| `.platform.powervs.vpcRegion` | VPC Region | `string` | IPI Install | AT |
+| `.platform.powervs.vpcName` | VPC Name | `string` | Existing VPC | AT |
+| `.platform.powervs.vpcSubnets` | VPC Subnets | `[]string` | Existing VPC | AT |
+| `.platform.powervs.clusterOSImage` | Custom OS Image | `string` | Custom OS Image | NT |
+| `.platform.powervs.serviceInstanceGUID` | Service Instance GUID | `string` | IPI Install | AT |
+| `.platform.powervs.serviceEndpoints` | Service Endpoints | `[]ServiceEndpoint` | Service Endpoints / PSC | AT |
+| `.platform.powervs.tgName` | Transit Gateway | `string` | IPI Install | NT |
+| `.platform.powervs.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.powervs.sysType` | System Type | `string` | Default Machine Types | AT |
+| `.<pool>.platform.powervs.procType` | Processor Type | `string` | Default Machine Types | AT |
+| `.<pool>.platform.powervs.processors` | Processors | `IntOrString` | Default Machine Types | AT |
+| `.<pool>.platform.powervs.memoryGiB` | Memory (GiB) | `int32` | Default Machine Types | AT |
+| `.<pool>.platform.powervs.smtLevel` | SMT Level | `string` | Default Machine Types | NT |
+
+## vSphere
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.vsphere.vcenters` | vCenter Connections | `[]VCenter` | IPI Install | AT |
+| `.platform.vsphere.failureDomains` | Failure Domains | `[]FailureDomain` | Failure Domains / Zones | AT |
+| `.platform.vsphere.apiVIPs` | API VIPs | `[]string` | IPI Install | AT |
+| `.platform.vsphere.ingressVIPs` | Ingress VIPs | `[]string` | IPI Install | AT |
+| `.platform.vsphere.diskType` | Disk Provisioning | `thin` / `thick` / `eagerZeroedThick` | Custom Disk Types | NT |
+| `.platform.vsphere.clusterOSImage` | Custom OS Image | `string` | Custom OS Image | NT |
+| `.platform.vsphere.nodeNetworking` | Node Networking | `object` | IPI Install | AT |
+| `.platform.vsphere.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.vsphere.dnsRecordsType` | DNS Records Type | `Internal` / `External` | IPI Install | NT |
+| `.platform.vsphere.hosts` | Static IP Hosts | `[]Host` | IPI Install | AT |
+| `.platform.vsphere.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | NT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.vsphere.cpus` | vCPU Count | `int32` | Default Machine Types | NT |
+| `.<pool>.platform.vsphere.coresPerSocket` | Cores per Socket | `int32` | Default Machine Types | NT |
+| `.<pool>.platform.vsphere.memoryMB` | Memory (MB) | `int64` | Default Machine Types | NT |
+| `.<pool>.platform.vsphere.osDisk.diskSizeGB` | OS Disk Size (GB) | `int32` | Custom Disk Types | NT |
+| `.<pool>.platform.vsphere.zones` | Failure Domain Zones | `[]string` | Failure Domains / Zones | AT |
+| `.<pool>.platform.vsphere.dataDisks` | Data Disks | `[]DataDisk` | Custom Disk Types | NT |
+
+## oVirt
+
+oVirt is a legacy platform with destroy-only support. Fields are listed for
+completeness.
+
+### Platform fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.platform.ovirt.ovirt_cluster_id` | Cluster ID | `string` | IPI Install | NT |
+| `.platform.ovirt.ovirt_storage_domain_id` | Storage Domain ID | `string` | IPI Install | NT |
+| `.platform.ovirt.ovirt_network_name` | Network Name | `string` | IPI Install | NT |
+| `.platform.ovirt.vnicProfileID` | VNIC Profile ID | `string` | IPI Install | NT |
+| `.platform.ovirt.api_vips` | API VIPs | `[]string` | IPI Install | NT |
+| `.platform.ovirt.ingress_vips` | Ingress VIPs | `[]string` | IPI Install | NT |
+| `.platform.ovirt.affinityGroups` | Affinity Groups | `[]AffinityGroup` | IPI Install | NT |
+| `.platform.ovirt.loadBalancer` | Load Balancer | `object` | Load Balancer Config | NT |
+| `.platform.ovirt.defaultMachinePlatform` | Default Machine Platform | `MachinePool` | Default Machine Types | AT |
+
+### Machine pool fields
+
+| JSON Path | Field | Type | Feature(s) | Test Coverage |
+|-----------|-------|------|------------|---------------|
+| `.<pool>.platform.ovirt.instanceTypeID` | Instance Type ID | `string` | Default Machine Types | AT |
+| `.<pool>.platform.ovirt.cpu` | CPU Config | `object` | Default Machine Types | AT |
+| `.<pool>.platform.ovirt.memoryMB` | Memory (MB) | `int32` | Default Machine Types | AT |
+| `.<pool>.platform.ovirt.osDisk.sizeGB` | OS Disk Size (GB) | `int64` | Custom Disk Types | NT |
+| `.<pool>.platform.ovirt.vmType` | VM Type | `desktop` / `server` / `high_performance` | Default Machine Types | AT |
+| `.<pool>.platform.ovirt.clone` | Clone Disks | `bool` | IPI Install | NT |
+| `.<pool>.platform.ovirt.sparse` | Sparse Provisioning | `bool` | IPI Install | NT |
+
+## Cross-Reference: Features to Fields
+
+This section provides a reverse index from each feature in the
+[Platform Feature Matrix](platform_feature_matrix.md) to the install-config
+fields that drive it. Only features with direct field mappings are listed.
+
+**IPI Install** - `.baseDomain`, `.sshKey`, `.pullSecret`, `.credentialsMode`,
+`.platform.<name>.region`, `.platform.<name>.defaultMachinePlatform`, plus
+platform-specific fields (VIPs, project IDs, cloud names, etc.)
+
+**UPI Install** - `.baseDomain`, `.platform.<name>.region`, plus UPI templates
+consume the generated install-config
+
+**Agent-based Install** - `.platform.baremetal.hosts`,
+`.platform.<name>.apiVIPs`, `.platform.<name>.ingressVIPs`
+
+**Single Node (SNO)** - `.controlPlane.replicas` (set to 1),
+`.compute[].replicas` (set to 0)
+
+**Existing VPC / VNet** - `.platform.aws.vpc`, `.platform.azure.virtualNetwork`,
+`.platform.azure.networkResourceGroupName`, `.platform.gcp.network`,
+`.platform.gcp.controlPlaneSubnet`, `.platform.gcp.computeSubnet`,
+`.platform.ibmcloud.vpcName`, `.platform.ibmcloud.controlPlaneSubnets`,
+`.platform.ibmcloud.computeSubnets`, `.platform.openstack.controlPlanePort`,
+`.platform.powervs.vpcName`, `.platform.powervs.vpcSubnets`,
+`.platform.nutanix.subnetUUIDs`
+
+**Shared VPC / XPN** - `.platform.gcp.networkProjectID`,
+`.platform.gcp.dns.privateZone`
+
+**Private Cluster** - `.publish` (set to `Internal`)
+
+**Proxy Support** - `.proxy.httpProxy`, `.proxy.httpsProxy`, `.proxy.noProxy`,
+`.additionalTrustBundle`
+
+**Dual Stack (IPv4+IPv6)** - `.networking.machineNetwork`,
+`.networking.clusterNetwork`, `.networking.serviceNetwork`,
+`.platform.aws.ipFamily`, `.platform.azure.ipFamily`
+
+**User-Provisioned DNS** - `.platform.<name>.userProvisionedDNS`,
+`.platform.aws.hostedZone`, `.platform.aws.hostedZoneRole`
+
+**Default Machine Types** - `.<pool>.platform.<name>.type` (or equivalent:
+`.cpus`, `.memoryMiB` for Nutanix/vSphere; `.sysType`, `.procType` for Power VS)
+
+**Custom Disk Types** - `.<pool>.platform.<name>.osDisk` (or `.rootVolume` for
+AWS/OpenStack)
+
+**Confidential Compute** - `.<pool>.platform.aws.cpuOptions`,
+`.<pool>.platform.azure.settings`, `.<pool>.platform.azure.osDisk.securityProfile`,
+`.<pool>.platform.gcp.confidentialCompute`,
+`.<pool>.platform.gcp.onHostMaintenance`
+
+**Secure Boot / UEFI** - `.<pool>.platform.azure.settings`,
+`.<pool>.platform.gcp.secureBoot`, `.<pool>.platform.nutanix.bootType`
+
+**Dedicated Hosts** - `.<pool>.platform.aws.hostPlacement`,
+`.<pool>.platform.ibmcloud.dedicatedHosts`
+
+**Custom OS Image** - `.<pool>.platform.aws.amiID`,
+`.<pool>.platform.azure.osImage`, `.<pool>.platform.gcp.osImage`,
+`.platform.openstack.clusterOSImage`, `.platform.powervs.clusterOSImage`,
+`.platform.vsphere.clusterOSImage`
+
+**KMS / Disk Encryption** - `.<pool>.platform.aws.rootVolume.kmsKeyARN`,
+`.<pool>.platform.azure.osDisk.diskEncryptionSet`,
+`.<pool>.platform.azure.encryptionAtHost`,
+`.<pool>.platform.gcp.osDisk.encryptionKey`,
+`.<pool>.platform.ibmcloud.bootVolume.encryptionKey`
+
+**User Tags / Labels** - `.platform.aws.userTags`,
+`.platform.azure.userTags`, `.platform.gcp.userLabels`,
+`.platform.gcp.userTags`
+
+**Service Endpoints / PSC** - `.platform.aws.serviceEndpoints`,
+`.platform.gcp.endpoint`, `.platform.ibmcloud.serviceEndpoints`,
+`.platform.powervs.serviceEndpoints`
+
+**FIPS Mode** - `.fips`
+
+**Load Balancer Config** - `.platform.<name>.loadBalancer` (available on
+baremetal, nutanix, openstack, powervc, vsphere, ovirt)
+
+**Failure Domains / Zones** - `.<pool>.platform.<name>.zones`,
+`.platform.nutanix.failureDomains`, `.platform.vsphere.failureDomains`
+
+**Feature Gates** - `.featureSet`, `.featureGates`
+
+**Sovereign Cloud Support** - `.platform.gcp.projectID` (domain-scoped),
+`.platform.gcp.region` (`u-` prefix), `.platform.azure.cloudName`,
+plus GCD-specific defaults and restrictions on `.platform.gcp.endpoint`,
+`.<pool>.platform.gcp.osImage`, `.<pool>.platform.gcp.type`
+
+## References
+
+- [Platform Feature Matrix](platform_feature_matrix.md)
+- [Test documentation structure and conventions](README.md)
+- [Install-config CRD definition](../../data/data/install.openshift.io_installconfigs.yaml)
+- [InstallConfig Go type](../../pkg/types/installconfig.go)

--- a/test/docs/platform_feature_matrix.md
+++ b/test/docs/platform_feature_matrix.md
@@ -1,0 +1,169 @@
+# Platform Feature Matrix
+
+This matrix shows which installer features are tested for each platform and
+how they are tested. Use it to identify coverage gaps and prioritize new test
+documentation. The matrix is maintained manually and should be updated when
+features, tests, or CI jobs change.
+
+## Platform Key
+
+| Abbr | Full Name | Notes |
+|------|-----------|-------|
+| AWS | Amazon Web Services | |
+| AZ | Microsoft Azure | Includes Azure Stack |
+| GCP | Google Cloud Platform | Public cloud |
+| GCD | Google Cloud Dedicated | Sovereign cloud (Trusted Partner Cloud) |
+| BM | Bare Metal | IPI and Agent-based |
+| IBM | IBM Cloud | |
+| NTX | Nutanix | |
+| OST | Red Hat OpenStack Platform | |
+| PVC | IBM PowerVC | Shares OpenStack CAPI provider |
+| PVS | IBM Power Virtual Server | |
+| VSP | VMware vSphere | |
+| OVT | oVirt / RHV | Legacy, destroy-only |
+
+## Legend
+
+| Code | Meaning |
+|------|---------|
+| AT | Automatically Tested - covered by unit tests or CI e2e jobs |
+| MT | Manually Tested - manual test procedures documented |
+| AT/MT | Both automatic and manual tests exist |
+| PT | Partially Tested - some paths tested, gaps remain |
+| NT | Not Tested - feature is implemented but no test coverage found |
+| NA | Not Applicable - feature not implemented for this platform |
+
+## Feature Matrix
+
+| Feature | AWS | AZ | GCP | GCD | BM | IBM | NTX | OST | PVC | PVS | VSP | OVT |
+|---------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+| **Core Installation** | | | | | | | | | | | | |
+| IPI Install | AT[1] | AT[2] | AT[3] | AT[4] | AT[5] | AT[6] | AT[6] | AT[7] | AT[6] | AT[6] | AT[8] | NA |
+| UPI Install | AT[9] | AT[9] | AT[9] | NA | NA | NA | NA | AT[9] | NA | NA | AT[9] | NT[10] |
+| Agent-based Install | AT[11] | AT[11] | AT[11] | NA | AT[11] | NA | AT[11] | AT[11] | NA | NA | AT[11] | NA |
+| Single Node (SNO) | AT | NT | NT | NA | AT | NA | NT | NT | NA | NA | NT | NA |
+| Cluster Destroy | NT[12] | NT | AT[13] | NT[14] | NT | NT | NT | NT | NT | AT | AT | NT |
+| **Networking** | | | | | | | | | | | | |
+| Existing VPC / VNet | AT | AT | AT | NT | NA | AT | AT | AT | NT | AT | AT | NA |
+| Shared VPC / XPN | AT | AT | AT[15] | NA | NA | NA | NA | NA | NA | NA | NA | NA |
+| Private Cluster | AT | AT | AT | AT[16] | NA | NT | NA | NT | NA | NT | NA | NA |
+| Proxy Support | NT[17] | NT[17] | NT[17] | NT[17] | NT[17] | NT[17] | NT[17] | AT | NT[17] | NT[17] | NT[17] | NA |
+| Dual Stack (IPv4+IPv6) | AT | AT | NA | NA | AT | NA | AT | AT | NT | NA | AT | NA |
+| User-Provisioned DNS | AT | AT | AT | NA | NA | NA | NA | NA | NA | NA | NA | NA |
+| **Compute** | | | | | | | | | | | | |
+| Default Machine Types | AT | AT | AT | AT/MT[18] | NA | AT | NT | AT | NT | AT | NA | AT |
+| Custom Disk Types | AT | AT | AT | AT[19] | NA | NT | NA | NA | NA | NA | NT | NA |
+| Confidential Compute | AT | AT | AT | NA | NA | NA | NA | NA | NA | NA | NA | NA |
+| Secure Boot / UEFI | NA | AT | NT[20] | NA | AT | NA | AT | NA | NA | NA | NA | NA |
+| Dedicated Hosts | AT[21] | NA | NA | NA | NA | AT | NA | NA | NA | NA | NA | NA |
+| Custom OS Image | NT | NT | AT[22] | AT/MT[22] | AT | NA | NT | NT | NT | NT | NT | NA |
+| **Storage and Security** | | | | | | | | | | | | |
+| KMS / Disk Encryption | AT | AT | AT | NA | NA | AT | NA | NA | NA | NA | NA | NA |
+| User Tags / Labels | AT | AT | AT | NA | NA | NA | NA | NA | NA | NA | NT[23] | NA |
+| Service Endpoints / PSC | AT | NA | AT[24] | NA[25] | NA | AT | NA | NA | NA | AT | NA | NA |
+| FIPS Mode | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NT[26] | NA |
+| **Infrastructure** | | | | | | | | | | | | |
+| CAPI Provisioning | AT | AT | AT | AT | NA[27] | AT | AT | AT | AT[28] | AT | AT | NA |
+| Load Balancer Config | NT | NA | NA | NA | NT | NA | NT | NT | NT | NA | NT | NT |
+| Failure Domains / Zones | AT | AT | AT | NA | NA | NA | AT | NA | NA | NA | AT | NA |
+| Feature Gates | AT | NT | NT | NA | NT | NA | NT | NT | NA | NA | NT | NA |
+| **Sovereign / Gov Cloud** | | | | | | | | | | | | |
+| Sovereign Cloud Support | AT[29] | NT[30] | AT[31] | AT/MT[32] | NA | NA | NA | NA | NA | NA | NA | NA |
+| **Test Documentation** | | | | | | | | | | | | |
+| Test Plan | No | No | No | Yes[33] | No | No | No | No | No | No | No | No |
+| Test Cases | No | No | No | Yes[33] | No | No | No | No | No | No | No | No |
+
+## Footnotes
+
+1. 29 e2e CI jobs in openshift/release
+2. 15 e2e CI jobs including Azure Stack
+3. 16 e2e CI jobs covering IPI, UPI, shared VPC, KMS, custom DNS, and more
+4. 1 e2e CI job: `e2e-gcd-ovn-private-techpreview`
+5. 10 e2e CI jobs for bare metal IPI
+6. 1 e2e CI job
+7. 8 e2e CI jobs including dual-stack, proxy, and external LB
+8. 16 e2e CI jobs including multi-vCenter, static IPs, and host groups
+9. UPI templates in `upi/<platform>/` with corresponding e2e UPI CI jobs
+10. UPI templates exist in `upi/ovirt/` but no CI coverage found
+11. 11 agent-based CI jobs covering compact, HA, SNO, dual-stack, and PXE
+    configurations across multiple platforms
+12. AWS destroy has 9 source files in `pkg/destroy/aws/` with 0 test files
+13. GCP destroy has unit tests: `gcp_test.go`, `policybinding_test.go`,
+    `quota_test.go`
+14. GCD shares GCP destroy code in `pkg/destroy/gcp/`; no GCD-specific
+    destroy tests
+15. GCP shared VPC via `NetworkProjectID`; dedicated CI jobs
+    (`e2e-gcp-ovn-xpn`, `e2e-gcp-xpn-dedicated-dns-project`, etc.)
+16. GCD is private-only (no public DNS zones in sovereign cloud); the e2e
+    job uses `Publish: Internal`
+17. Proxy is configured at the platform-agnostic `installconfig.Proxy`
+    level; no platform-specific proxy validation tests found. OpenStack is
+    the exception with a dedicated `e2e-openstack-proxy` CI job.
+18. GCD defaults to C3 machine types (only series available in sovereign
+    regions); covered by unit tests in `machinepools_test.go` and manual
+    verification scenario in test docs
+19. GCD defaults to `hyperdisk-balanced` (only disk type available in
+    sovereign regions); covered by `machinepools_test.go`
+20. GCP has a `SecureBoot` field in machine pool but no validation tests
+    for it
+21. AWS `DedicatedHost` placement behind `AWSDedicatedHosts` feature gate;
+    IBM Cloud also supports dedicated hosts with `DedicatedHosts` field
+22. GCP/GCD `OSImage` (name + project) is required for sovereign cloud and
+    optional for public GCP; validated in `machinepool_test.go`. GCD test
+    docs include manual verification of OS image on deployed nodes.
+23. vSphere supports `tagIDs` in failure domain topology but has no
+    dedicated tag validation tests
+24. GCP uses `PSCEndpoint` (Private Service Connect); IBM Cloud and Power VS
+    use `ServiceEndpoints` for API endpoint overrides
+25. GCD forbids PSC endpoint overrides; this constraint is validated in unit
+    tests (reflected in the Sovereign Cloud Support row)
+26. FIPS is a platform-agnostic boolean in install-config; no
+    platform-specific FIPS validation tests exist in the installer
+27. Bare Metal uses custom infrastructure provisioning (not Cluster API)
+28. PowerVC shares the OpenStack CAPI provider
+29. AWS GovCloud regions are supported; European Sovereign Cloud is behind
+    the `AWSEuropeanSovereignCloudInstall` feature gate with test coverage
+    in `featuregates_test.go`
+30. Azure supports `AzureUSGovernmentCloud`, `AzureChinaCloud`, and
+    `AzureGermanCloud` cloud names but has no dedicated sovereign/gov cloud
+    test coverage
+31. GCP sovereign cloud detection (`GetCloudEnvironment`) tested in
+    `pkg/types/gcp/platform_test.go`
+32. GCD has full sovereign cloud test coverage: unit tests for detection,
+    defaults, validation, and config generation, plus manual test
+    procedures documented in `test/docs/gcd/cases/gcd_sovereign_install.md`
+33. Test plan at `test/docs/gcd/plans/gcd-feature.md` and test cases at
+    `test/docs/gcd/cases/gcd_sovereign_install.md` covering 17 scenarios
+    (13 automated, 4 manual)
+
+## How to Update This Matrix
+
+Update this matrix when:
+
+- A new platform is added to the installer
+- A feature gains or loses test coverage
+- New test documentation is added under `test/docs/`
+- CI jobs are added, removed, or renamed in openshift/release
+
+To determine the correct status code for a cell:
+
+1. Check for unit tests: look for `_test.go` files in
+   `pkg/types/<platform>/validation/`, `pkg/asset/installconfig/<platform>/`,
+   `pkg/destroy/<platform>/`, and `pkg/infrastructure/<platform>/`
+2. Check for e2e CI jobs: search the openshift/release repo for job
+   definitions referencing the platform
+3. Check for manual test docs: look for files under
+   `test/docs/<platform>/cases/` with `MANUAL_TESTS_START` markers
+4. If the feature has code but no tests of any kind, use NT
+5. If the feature is not implemented for the platform, use NA
+
+When adding a footnote, use the next available number and add the
+explanation to the Footnotes section. Keep footnotes factual and brief.
+
+## References
+
+- [Test documentation structure and conventions](README.md)
+- [GCD feature test plan](gcd/plans/gcd-feature.md)
+- [GCD sovereign install test cases](gcd/cases/gcd_sovereign_install.md)
+- CI job definitions: openshift/release repo, branch config for
+  `openshift-installer-main`

--- a/test/docs/platform_feature_matrix.md
+++ b/test/docs/platform_feature_matrix.md
@@ -2,8 +2,10 @@
 
 This matrix shows which installer features are tested for each platform and
 how they are tested. Use it to identify coverage gaps and prioritize new test
-documentation. The matrix is maintained manually and should be updated when
-features, tests, or CI jobs change.
+documentation. For a field-level view of which install-config fields drive each
+feature, see the [Install Config Field Index](install_config_field_index.md).
+The matrix is maintained manually and should be updated when features, tests,
+or CI jobs change.
 
 ## Platform Key
 
@@ -162,6 +164,7 @@ explanation to the Footnotes section. Keep footnotes factual and brief.
 
 ## References
 
+- [Install config field index](install_config_field_index.md)
 - [Test documentation structure and conventions](README.md)
 - [GCD feature test plan](gcd/plans/gcd-feature.md)
 - [GCD sovereign install test cases](gcd/cases/gcd_sovereign_install.md)


### PR DESCRIPTION
Add `test/docs/` directory establishing a standard structure for test
documentation in the installer repo, with GCD (Google Cloud Dedicated) as
the first reference implementation.

Structure uses platform-first organization (`test/docs/<platform>/plans/`
and `test/docs/<platform>/cases/`) so all testing docs for a given
platform live together. Extensible to `gcp/`, `aws/`, `azure/`, `bugs/`,
etc.

Contents:
- `test/docs/README.md` - documents the structure, conventions, templates
  for adding new plans and cases, and commands for discovering manual tests
- `test/docs/gcd/plans/gcd-feature.md` - feature test plan for
  [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006) (GCD support) covering scope, strategy, unit test coverage
  map, E2E CI job breakdown, risks, and exit criteria
- `test/docs/gcd/cases/gcd_sovereign_install.md` - 17 test scenarios (13
  automated, 4 manual) covering sovereign cloud detection, defaults,
  validation, configuration generation, and end-to-end installation

Manual test scenarios include step-by-step commands and a checkbox
checklist section with grep-friendly `MANUAL_TESTS_START`/`MANUAL_TESTS_END`
markers so manual tests can be discovered across the repo with:
`grep -rl "MANUAL_TESTS_START" test/docs/*/cases/`

Reference examples used:
- openshift/kueue-operator#1994
- openshift/origin test/extended/node/runcdeprecationcases.md

Ref: [OCPQUAL-24](https://redhat.atlassian.net/browse/OCPQUAL-24), [OCPSTRAT-3006](https://redhat.atlassian.net/browse/OCPSTRAT-3006)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for organizing, creating, linking, and maintaining installer test documentation.
  * Added comprehensive test plans for GCD sovereign-cloud installation and OpenShift IPI support, covering validation, configuration, deployment, verification, constraints, and cleanup.
  * Added a platform feature matrix documenting installer coverage across 13 platforms, including feature areas, test statuses, and maintenance guidance.

* **New Features**
  * Added a command-line validator for checking test documentation structure, metadata, links, scenarios, and coverage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->