### PR TITLE
Bug: fix NetworkDeviceSpec CRD rejecting valid IPv4 addresses

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -8648,7 +8648,7 @@ spec:
                               description: |-
                                 gateway is an IPv4 or IPv6 address which represents the subnet gateway,
                                 for example, 192.168.1.1.
-                              format: ipv6
+                              format: ip
                               type: string
                             ipAddrs:
                               description: |-
@@ -8656,7 +8656,6 @@ spec:
                                 this device, for example, 192.168.1.100/24. IP addresses provided via ipAddrs are
                                 intended to allow explicit assignment of a machine's IP address.
                               example: 2001:DB8:0000:0000:244:17FF:FEB6:D37D/64
-                              format: ipv6
                               items:
                                 type: string
                               type: array
@@ -8666,7 +8665,7 @@ spec:
                                 8.8.8.8. a nameserver is not provided by a fulfilled IPAddressClaim. If DHCP is not the
                                 source of IP addresses for this network device, nameservers should include a valid nameserver.
                               example: 8.8.8.8
-                              format: ipv6
+                              format: ip
                               items:
                                 type: string
                               type: array

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -331,15 +331,12 @@ type Host struct {
 type NetworkDeviceSpec struct {
 	// gateway is an IPv4 or IPv6 address which represents the subnet gateway,
 	// for example, 192.168.1.1.
-	// +kubebuilder:validation:Format=ipv4
-	// +kubebuilder:validation:Format=ipv6
+	// +kubebuilder:validation:Format=ip
 	Gateway string `json:"gateway,omitempty"`
 
 	// ipAddrs is a list of one or more IPv4 and/or IPv6 addresses and CIDR to assign to
 	// this device, for example, 192.168.1.100/24. IP addresses provided via ipAddrs are
 	// intended to allow explicit assignment of a machine's IP address.
-	// +kubebuilder:validation:Format=ipv4
-	// +kubebuilder:validation:Format=ipv6
 	// +kubebuilder:example=`192.168.1.100/24`
 	// +kubebuilder:example=`2001:DB8:0000:0000:244:17FF:FEB6:D37D/64`
 	// +kubebuilder:validation:Required
@@ -348,8 +345,7 @@ type NetworkDeviceSpec struct {
 	// nameservers is a list of IPv4 and/or IPv6 addresses used as DNS nameservers, for example,
 	// 8.8.8.8. a nameserver is not provided by a fulfilled IPAddressClaim. If DHCP is not the
 	// source of IP addresses for this network device, nameservers should include a valid nameserver.
-	// +kubebuilder:validation:Format=ipv4
-	// +kubebuilder:validation:Format=ipv6
+	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:example=`8.8.8.8`
 	Nameservers []string `json:"nameservers,omitempty"`
 }

--- a/pkg/types/vsphere/validation/crd_networkdevice_test.go
+++ b/pkg/types/vsphere/validation/crd_networkdevice_test.go
@@ -1,0 +1,84 @@
+package validation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func loadInstallConfigCRD(t *testing.T) *apiextensionsv1.CustomResourceDefinition {
+	t.Helper()
+	data, err := os.ReadFile("../../../../data/data/install.openshift.io_installconfigs.yaml")
+	if err != nil {
+		t.Fatalf("failed to load CRD: %v", err)
+	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.Unmarshal(data, &crd); err != nil {
+		t.Fatalf("failed to unmarshal CRD: %v", err)
+	}
+	return &crd
+}
+
+func networkDeviceSchemaProps(t *testing.T, crd *apiextensionsv1.CustomResourceDefinition) map[string]apiextensionsv1.JSONSchemaProps {
+	t.Helper()
+
+	if len(crd.Spec.Versions) == 0 || crd.Spec.Versions[0].Schema == nil || crd.Spec.Versions[0].Schema.OpenAPIV3Schema == nil {
+		t.Fatal("CRD OpenAPI schema is missing")
+	}
+	schema := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	platform, ok := schema.Properties["platform"]
+	if !ok {
+		t.Fatal("missing platform property in CRD schema")
+	}
+	vsphere, ok := platform.Properties["vsphere"]
+	if !ok {
+		t.Fatal("missing vsphere property in CRD schema")
+	}
+	hosts, ok := vsphere.Properties["hosts"]
+	if !ok {
+		t.Fatal("missing hosts property in CRD schema")
+	}
+	if hosts.Items == nil || hosts.Items.Schema == nil {
+		t.Fatal("hosts items schema is nil")
+	}
+	netDev, ok := hosts.Items.Schema.Properties["networkDevice"]
+	if !ok {
+		t.Fatal("missing networkDevice property in CRD schema")
+	}
+	return netDev.Properties
+}
+
+// TestCRDNetworkDeviceSpecFormats guards against controller-gen collapsing dual
+// Format=ipv4/Format=ipv6 markers into format: ipv6 (openshift/installer#10377).
+// gateway and nameservers must use format: ip; ipAddrs must not use an IP format
+// because entries are CIDRs.
+func TestCRDNetworkDeviceSpecFormats(t *testing.T) {
+	props := networkDeviceSchemaProps(t, loadInstallConfigCRD(t))
+
+	t.Run("gateway", func(t *testing.T) {
+		gw, ok := props["gateway"]
+		if !assert.True(t, ok, "gateway property must exist") {
+			return
+		}
+		assert.Equal(t, "ip", gw.Format, "gateway must use format: ip to accept IPv4 and IPv6")
+	})
+
+	t.Run("ipAddrs", func(t *testing.T) {
+		ip, ok := props["ipAddrs"]
+		if !assert.True(t, ok, "ipAddrs property must exist") {
+			return
+		}
+		assert.Empty(t, ip.Format, "ipAddrs must not set format; values are CIDRs not bare IPs")
+	})
+
+	t.Run("nameservers", func(t *testing.T) {
+		ns, ok := props["nameservers"]
+		if !assert.True(t, ok, "nameservers property must exist") {
+			return
+		}
+		assert.Equal(t, "ip", ns.Format, "nameservers must use format: ip to accept IPv4 and IPv6")
+	})
+}

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -888,6 +888,48 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path.hosts.gateway: Invalid value: "8888:666:7777:5555:3333:0000:9999:JENNY": "8888:666:7777:5555:3333:0000:9999:JENNY" is not a valid IP$`,
 		},
 		{
+			name: "Static IP - valid IPAddrs IPv6 CIDR",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Hosts = validHosts()
+				p.Hosts[1].NetworkDevice.IPAddrs = []string{"2001:db8:3333:4444::1/64"}
+				p.Hosts[1].NetworkDevice.Gateway = "2001:db8:3333:4444::ffff"
+				return p
+			}(),
+			config: validStaticIPInstallConfig(),
+		},
+		{
+			name: "Static IP - valid Nameservers IPv4",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Hosts = validHosts()
+				p.Hosts[1].NetworkDevice.Nameservers = []string{"8.8.8.8", "1.1.1.1"}
+				return p
+			}(),
+			config: validStaticIPInstallConfig(),
+		},
+		{
+			name: "Static IP - valid Nameservers IPv6",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Hosts = validHosts()
+				p.Hosts[1].NetworkDevice.Nameservers = []string{"2001:4860:4860::8888"}
+				return p
+			}(),
+			config: validStaticIPInstallConfig(),
+		},
+		{
+			name: "Static IP - invalid Nameserver",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Hosts = validHosts()
+				p.Hosts[1].NetworkDevice.Nameservers = []string{"not-an-ip"}
+				return p
+			}(),
+			config:        validStaticIPInstallConfig(),
+			expectedError: `^test-path.hosts.nameservers: Invalid value: "not-an-ip": "not-an-ip" is not a valid IP$`,
+		},
+		{
 			name: "Static IP - More than 3 nameservers",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()


### PR DESCRIPTION
## Summary
- Fix vSphere `NetworkDeviceSpec` CRD schema incorrectly using `format: ipv6` for fields that must accept both IPv4 and IPv6 (`gateway`, `ipAddrs`, `nameservers`).
- Use the repository's existing `Format=ip` convention for `gateway` and `nameservers`; remove Format markers from `ipAddrs` because entries are CIDRs (e.g. `192.168.1.100/24`), which `Format=ip` would reject.
- Regenerate `install.openshift.io_installconfigs.yaml` and add regression coverage so dual `Format=ipv4`/`Format=ipv6` markers cannot silently collapse back to `format: ipv6`.

Fixes https://github.com/openshift/installer/issues/10377

## Test plan
- [x] `go generate ./pkg/types/installconfig.go` (idempotent)
- [x] `go test ./pkg/types/vsphere/validation/ -run 'TestCRDNetworkDeviceSpecFormats|TestValidatePlatform'`
- [ ] Confirm generated CRD shows `format: ip` for `gateway`/`nameservers` and no format on `ipAddrs`
- [ ] Confirm valid IPv4 gateway/nameserver values are accepted by schema consumers (e.g. hive)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for vSphere network settings to support IPv4 and IPv6 gateway and nameserver addresses.
  * Corrected handling of IP address ranges, including IPv6 host addresses and CIDR notation.
  * Added validation coverage for invalid nameserver values.

* **Tests**
  * Added coverage to verify network-related schema formats and static IP validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->