### PR TITLE
NO-JIRA: openstack: pin argcomplete for yq on Python 3.9

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -57,8 +57,8 @@ RUN yum update -y && \
     git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
-# Pin argcomplete: 3.7.1+ breaks on Python 3.9 (PEP604 annotations).
-RUN python3 -m pip install 'yq' 'argcomplete<3.7.1'
+# Exclude argcomplete 3.7.1: PEP604 annotations crash on Python 3.9.
+RUN python3 -m pip install 'yq' 'argcomplete!=3.7.1'
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -57,7 +57,8 @@ RUN yum update -y && \
     git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
-RUN python3 -m pip install yq
+# Pin argcomplete: 3.7.1+ breaks on Python 3.9 (PEP604 annotations).
+RUN python3 -m pip install 'yq' 'argcomplete<3.7.1'
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Unpinned `pip install yq` in the openstack-installer CI image pulled argcomplete 3.7.1, which uses PEP 604 `str | bytes` annotations that crash on Python 3.9 and break openstack-conf-* steps. Pin argcomplete below 3.7.1.

### Test plan

Before the fix. Test on the "bad" image which is running on the CI:
```
$ podman run --rm -it --entrypoint bash quay-proxy.ci.openshift.org/openshift/ci@sha256:90c06669d96c1d38d9a1991e6f13fa1c7f2995bd8ef38c96de24cd5a8f15153a
Trying to pull quay-proxy.ci.openshift.org/openshift/ci@sha256:90c06669d96c1d38d9a1991e6f13fa1c7f2995bd8ef38c96de24cd5a8f15153a...
Getting image source signatures
Copying blob 4ab8fcecd990 done   | 
Copying blob 447d0b6228cd done   | 
Copying blob 93e9325d46c6 done   | 
Copying blob 7599161f48c3 done   | 
Copying blob 40e928b893e8 done   | 
Copying blob 7405f1fed259 done   | 
Copying config 74f79682df done   | 
Writing manifest to image destination
bash-5.1$ python3 -m pip show argcomplete
Name: argcomplete
Version: 3.7.1
Summary: Bash tab completion for argparse
Home-page: 
Author: Andrey Kislyuk
Author-email: kislyuk@gmail.com
License: Apache Software License
Location: /usr/local/lib/python3.9/site-packages
Requires: 
Required-by: yq
bash-5.1$ yq --version
Traceback (most recent call last):
  File "/usr/local/bin/yq", line 5, in <module>
    from yq import cli
  File "/usr/local/lib/python3.9/site-packages/yq/__init__.py", line 18, in <module>
    import argcomplete
  File "/usr/local/lib/python3.9/site-packages/argcomplete/__init__.py", line 4, in <module>
    from . import completers
  File "/usr/local/lib/python3.9/site-packages/argcomplete/completers.py", line 34, in <module>
    class ChoicesCompleter(BaseCompleter):
  File "/usr/local/lib/python3.9/site-packages/argcomplete/completers.py", line 35, in ChoicesCompleter
    choices: Final[Mapping[str, str | bytes]]
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

After the fix:

Local image build and smoke test:
```
podman build -t openstack-installer:argcomplete-ne -f images/openstack/Dockerfile.ci .
podman run --rm -it --entrypoint /bin/bash openstack-installer:argcomplete-ne
```

Inside the container:
```
bash-5.1$ python3 -m pip show argcomplete
Name: argcomplete
Version: 3.7.0
Summary: Bash tab completion for argparse
Home-page: 
Author: Andrey Kislyuk
Author-email: kislyuk@gmail.com
License: Apache Software License
Location: /usr/local/lib/python3.9/site-packages
Requires: 
Required-by: yq
bash-5.1$ 
bash-5.1$ 
bash-5.1$ yq --version
yq 4.1.2
jq-1.6
bash-5.1$ 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI environment to install a compatible `yq` dependency.
  * Documented the Python 3.9 compatibility consideration for this dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->