### PR TITLE
Update OpenStack base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Local build output; each build stage generates its own binary
+bin
+
+# Pre-built CAPI provider binaries from local development; the Dockerfile
+# replaces these from the kas-artifacts and etcd-artifacts stages
+cluster-api/bin

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -3,8 +3,8 @@
 # oc for getting assets from an existing cluster to spin up multi-architecture compute clusters on libvirt.
 
 # The binaries in these images are dynamically linked
-FROM registry.ci.openshift.org/ocp/4.17:etcd AS etcd
-FROM registry.ci.openshift.org/ocp/4.17:hyperkube AS kas
+FROM registry.ci.openshift.org/ocp/4.22:etcd AS etcd
+FROM registry.ci.openshift.org/ocp/4.22:hyperkube AS kas
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 ARG TAGS="libvirt fipscapable"
@@ -17,7 +17,7 @@ RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
 	mv /usr/bin/etcd /usr/bin/kube-apiserver -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.17:cli as cli
+FROM registry.ci.openshift.org/ocp/4.22:cli as cli
 FROM quay.io/multi-arch/yq:3.3.0 as yq3
 FROM quay.io/multi-arch/yq:4.30.5 as yq4
 

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -2,8 +2,8 @@
 # It builds an image containing the openshift-install command as well as the openstack cli.
 
 # We copy from the -artifacts images because they are statically linked
-FROM registry.ci.openshift.org/ocp/4.17:installer-kube-apiserver-artifacts AS kas-artifacts
-FROM registry.ci.openshift.org/ocp/4.17:installer-etcd-artifacts AS etcd-artifacts
+FROM registry.ci.openshift.org/ocp/4.22:installer-kube-apiserver-artifacts AS kas-artifacts
+FROM registry.ci.openshift.org/ocp/4.22:installer-etcd-artifacts AS etcd-artifacts
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 # FIPS support is offered via the baremetal-installer image
@@ -18,9 +18,9 @@ RUN mkdir -p cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH) && \
 	mv cluster-api/bin/$(go env GOOS)/$(go env GOHOSTARCH)/* -t cluster-api/bin/$(go env GOOS)_$(go env GOHOSTARCH)/
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.17:cli AS cli
+FROM registry.ci.openshift.org/ocp/4.22:cli AS cli
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi/openstack /var/lib/openshift-install/upi

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -70,4 +70,4 @@ USER 1000:1000
 ENV HOME /output
 ENV LC_ALL en_US.UTF-8
 WORKDIR /output
-ENTRYPOINT ["/bin/openshift-install"]
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
- **images: bump openstack images to 4.22**
- **images: bump libvirt images to 4.22**
- **Add dockerignore**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI container images to use OpenShift 4.22 components.
  * Refreshed supporting artifact, CLI, and base operating system images.
  * Updated the OpenStack CI image entrypoint for improved command-line compatibility.
  * Excluded local build artifacts from Docker build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->