### PR TITLE
OCPBUGS-105407: Remove VSphereMultiNetworks feature gate

### DIFF
--- a/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
@@ -102,8 +102,7 @@ vcenter:
 `
 
 	// expectedYamlConfigWithNodes is used by tests that exercise the yaml path
-	// with the VSphereMultiNetworks feature gate enabled and a machine network
-	// CIDR of 10.0.0.0/24 (the fallback path).
+	// with a machine network CIDR of 10.0.0.0/24 (the fallback path).
 	expectedYamlConfigWithNodes = `global:
   insecureFlag: true
   secretName: vsphere-creds
@@ -260,9 +259,8 @@ func TestCloudProviderConfig(t *testing.T) {
 			}(),
 		},
 		{
-			// VSphereMultiNetworks is enabled in inDefault() so the nodes
-			// section is always populated from the machine network CIDR when
-			// nodeNetworking is not explicitly set.
+			// The nodes section is always populated from the machine network
+			// CIDR when nodeNetworking is not explicitly set.
 			name:                "valid out of tree yaml cloud provider config",
 			platform:            validPlatform(),
 			installConfig:       makeInstallConfig(validPlatform(), "", "10.0.0.0/24"),
@@ -270,8 +268,7 @@ func TestCloudProviderConfig(t *testing.T) {
 			expectedCloudConfig: expectedYamlConfig,
 		},
 		{
-			// TechPreviewNoUpgrade also enables VSphereMultiNetworks – same
-			// result as the default case above.
+			// TechPreviewNoUpgrade – same result as the default case above.
 			name:                "valid out of tree yaml cloud provider config with node networking from machine network",
 			platform:            validPlatform(),
 			installConfig:       makeInstallConfig(validPlatform(), configv1.TechPreviewNoUpgrade, "10.0.0.0/24"),
@@ -279,8 +276,8 @@ func TestCloudProviderConfig(t *testing.T) {
 			expectedCloudConfig: expectedYamlConfigWithNodes,
 		},
 		{
-			// With VSphereMultiNetworks enabled and explicit nodeNetworking set
-			// in the install-config, the explicit values take precedence.
+			// With explicit nodeNetworking set in the install-config, the
+			// explicit values take precedence.
 			name: "valid out of tree yaml cloud provider config with explicit node networking",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()

--- a/pkg/types/vsphere/validation/featuregates.go
+++ b/pkg/types/vsphere/validation/featuregates.go
@@ -14,26 +14,7 @@ import (
 func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
 	v := c.VSphere
 
-	multiNetworksFound := false
-	nodeNetworkingDefined := v.NodeNetworking != nil
-
-	for _, fd := range v.FailureDomains {
-		if len(fd.Topology.Networks) > 1 {
-			multiNetworksFound = true
-		}
-	}
-
 	return []featuregates.GatedInstallConfigFeature{
-		{
-			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
-			Condition:       multiNetworksFound,
-			Field:           field.NewPath("platform", "vsphere", "failureDomains", "topology", "networks"),
-		},
-		{
-			FeatureGateName: features.FeatureGateVSphereMultiNetworks,
-			Condition:       nodeNetworkingDefined,
-			Field:           field.NewPath("platform", "vsphere", "nodeNetworking"),
-		},
 		{
 			FeatureGateName: features.FeatureGateOnPremDNSRecords,
 			Condition:       v.DNSRecordsType == configv1.DNSRecordsTypeExternal,


### PR DESCRIPTION
OCPBUGS-105407

### Changes
- Removed usages of VSphereMultiNetworks feature gate

### Notes
VSphereMultiNetworks has been GA for several releases. Remove the feature gate checks from the installer so that multi-network topology and nodeNetworking fields are accepted unconditionally.

Also, some of the feature gate checks were removed in past PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - vSphere network configuration validation no longer depends on the multi-network feature gate.
  - Failure-domain and node-network validation entries have been removed from gated checks.
  - Machine-network CIDR fallback and explicit node-network precedence remain unchanged.

- **Tests**
  - Updated vSphere configuration test descriptions to reflect the current network behavior.
  - Existing test scenarios and expected results remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->