### PR TITLE
OCPBUGS-112028, OCPBUGS-111885: [release-4.22] pin argcomplete for yq on Python 3.9 and bump google-cloud-cli to 563.0.0-1

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -53,7 +53,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \      
       gettext \
-      google-cloud-cli-447.0.0-1 \
+      google-cloud-cli-563.0.0-1 \
       gzip \
       jq \
       unzip \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -51,7 +51,8 @@ RUN yum update -y && \
     git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
-RUN python3 -m pip install yq
+# Exclude argcomplete 3.7.1: PEP604 annotations crash on Python 3.9.
+RUN python3 -m pip install 'yq' 'argcomplete!=3.7.1'
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Following #10757 on `main`, the same errors are happening in `release-4.22`, so the 
fix needs to be backported.