### PR TITLE
OCPBUGS-45804: Update timeout in GetMarketplaceImage to 5 minutes

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -14,6 +14,7 @@ import (
 	azmarketplace "github.com/Azure/azure-sdk-for-go/profiles/latest/marketplaceordering/mgmt/marketplaceordering"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -39,7 +40,7 @@ type API interface {
 	ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error)
 	GetStorageEndpointSuffix(ctx context.Context) (string, error)
 	GetDiskEncryptionSet(ctx context.Context, subscriptionID, groupName string, diskEncryptionSetName string) (*azenc.DiskEncryptionSet, error)
-	GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (azenc.VirtualMachineImage, error)
+	GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (armcompute.VirtualMachineImage, error)
 	AreMarketplaceImageTermsAccepted(ctx context.Context, publisher, offer, sku string) (bool, error)
 	GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error)
 	GetAvailabilityZones(ctx context.Context, region string, instanceType string) ([]string, error)
@@ -368,17 +369,29 @@ func (c *Client) GetVMCapabilities(ctx context.Context, instanceType, region str
 }
 
 // GetMarketplaceImage get the specified marketplace VM image.
-func (c *Client) GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (azenc.VirtualMachineImage, error) {
-	client := azenc.NewVirtualMachineImagesClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
-	client.Authorizer = c.ssn.Authorizer
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+func (c *Client) GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (armcompute.VirtualMachineImage, error) {
+	clientOptions := arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Retry: policy.RetryOptions{
+				MaxRetries: 5,
+				TryTimeout: 1 * time.Minute,
+			},
+			Cloud: c.ssn.CloudConfig,
+		},
+	}
+	client, err := armcompute.NewVirtualMachineImagesClient(c.ssn.Credentials.SubscriptionID, c.ssn.TokenCreds, &clientOptions)
+	if err != nil {
+		return armcompute.VirtualMachineImage{}, fmt.Errorf("error creating virtual machine images client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	image, err := client.Get(ctx, region, publisher, offer, sku, version)
+	resp, err := client.Get(ctx, region, publisher, offer, sku, version, nil)
 	if err != nil {
-		return image, fmt.Errorf("could not get marketplace image: %w", err)
+		return armcompute.VirtualMachineImage{}, fmt.Errorf("could not get marketplace image: %w", err)
 	}
-	return image, nil
+	return resp.VirtualMachineImage, nil
 }
 
 // AreMarketplaceImageTermsAccepted tests whether the terms have been accepted for the specified marketplace VM image.

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -17,6 +17,7 @@ import (
 	subscriptions "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/resources/mgmt/subscriptions"
 	network "github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"
 	compute "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -209,10 +210,10 @@ func (mr *MockAPIMockRecorder) GetLocationInfo(ctx, region, instanceType any) *g
 }
 
 // GetMarketplaceImage mocks base method.
-func (m *MockAPI) GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (compute.VirtualMachineImage, error) {
+func (m *MockAPI) GetMarketplaceImage(ctx context.Context, region, publisher, offer, sku, version string) (armcompute.VirtualMachineImage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMarketplaceImage", ctx, region, publisher, offer, sku, version)
-	ret0, _ := ret[0].(compute.VirtualMachineImage)
+	ret0, _ := ret[0].(armcompute.VirtualMachineImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -943,7 +943,10 @@ func validateMarketplaceImage(client API, region string, instanceHyperVGenSet se
 	if err != nil {
 		return field.Invalid(osImageFieldPath, osImage, err.Error())
 	}
-	imageHyperVGen := string(vmImage.HyperVGeneration)
+	imageHyperVGen := ""
+	if vmImage.Properties != nil && vmImage.Properties.HyperVGeneration != nil {
+		imageHyperVGen = string(*vmImage.Properties.HyperVGeneration)
+	}
 	if !instanceHyperVGenSet.Has(imageHyperVGen) {
 		errMsg := fmt.Sprintf("instance type supports HyperVGenerations %v but the specified image is for HyperVGeneration %s; to correct this issue either specify a compatible instance type or change the HyperVGeneration for the image by using a different SKU", instanceHyperVGenSet.UnsortedList(), imageHyperVGen)
 		return field.Invalid(osImageFieldPath, osImage.SKU, errMsg)
@@ -955,7 +958,7 @@ func validateMarketplaceImage(client API, region string, instanceHyperVGenSet se
 		// Use the default if not set in the install-config
 		osImagePlan = aztypes.ImageWithPurchasePlan
 	}
-	if plan := vmImage.Plan; plan != nil {
+	if vmImage.Properties != nil && vmImage.Properties.Plan != nil {
 		if osImagePlan == aztypes.ImageNoPurchasePlan {
 			return field.Invalid(osImageFieldPath, osImage, "marketplace image requires license terms to be accepted")
 		}

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -9,11 +9,13 @@ import (
 	azsubs "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/resources/mgmt/subscriptions"
 	aznetwork "github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"
 	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/azure/mock"
@@ -261,18 +263,18 @@ var (
 		return &r
 	}()
 
-	marketplaceImageAPIResult = azenc.VirtualMachineImage{
+	marketplaceImageAPIResult = armcompute.VirtualMachineImage{
 		Name: to.StringPtr("VMImage"),
-		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
-			HyperVGeneration: azenc.HyperVGenerationTypesV1,
-			Plan:             &azenc.PurchasePlan{},
+		Properties: &armcompute.VirtualMachineImageProperties{
+			HyperVGeneration: ptr.To(armcompute.HyperVGenerationTypesV1),
+			Plan:             &armcompute.PurchasePlan{},
 		},
 	}
 
-	marketplaceImageAPIResultNoPlan = azenc.VirtualMachineImage{
+	marketplaceImageAPIResultNoPlan = armcompute.VirtualMachineImage{
 		Name: to.StringPtr("VMImage"),
-		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
-			HyperVGeneration: azenc.HyperVGenerationTypesV1,
+		Properties: &armcompute.VirtualMachineImageProperties{
+			HyperVGeneration: ptr.To(armcompute.HyperVGenerationTypesV1),
 		},
 	}
 
@@ -1537,9 +1539,9 @@ func TestAzureMarketplaceImage(t *testing.T) {
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU).Return(false, fmt.Errorf("error")).AnyTimes()
 	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU).Return(false, nil).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(azenc.VirtualMachineImage{
-		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
-			HyperVGeneration: azenc.HyperVGenerationTypesV2,
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(armcompute.VirtualMachineImage{
+		Properties: &armcompute.VirtualMachineImageProperties{
+			HyperVGeneration: ptr.To(armcompute.HyperVGenerationTypesV2),
 		},
 	}, nil).AnyTimes()
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringOSImageSKU).Return(true, nil).AnyTimes()
@@ -1727,9 +1729,9 @@ func TestAzureMarketplaceImages(t *testing.T) {
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU).Return(false, fmt.Errorf("error")).AnyTimes()
 	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU).Return(false, nil).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(azenc.VirtualMachineImage{
-		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
-			HyperVGeneration: azenc.HyperVGenerationTypesV2,
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(armcompute.VirtualMachineImage{
+		Properties: &armcompute.VirtualMachineImageProperties{
+			HyperVGeneration: ptr.To(armcompute.HyperVGenerationTypesV2),
 		},
 	}, nil).AnyTimes()
 	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringOSImageSKU).Return(true, nil).AnyTimes()

--- a/pkg/asset/machines/clusterapi.go
+++ b/pkg/asset/machines/clusterapi.go
@@ -266,8 +266,8 @@ func (c *ClusterAPI) Generate(ctx context.Context, dependencies asset.Parents) e
 			// Publisher is case-sensitive and matched against exactly. Also the
 			// Plan's publisher might not be exactly the same as the Image's
 			// publisher
-			if img.Plan != nil && img.Plan.Publisher != nil {
-				mpool.OSImage.Publisher = *img.Plan.Publisher
+			if img.Properties != nil && img.Properties.Plan != nil && img.Properties.Plan.Publisher != nil {
+				mpool.OSImage.Publisher = *img.Properties.Plan.Publisher
 			}
 		}
 		capabilities, err := installConfig.Azure.ControlPlaneCapabilities()

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -398,8 +398,8 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 			// Publisher is case-sensitive and matched against exactly. Also the
 			// Plan's publisher might not be exactly the same as the Image's
 			// publisher
-			if img.Plan != nil && img.Plan.Publisher != nil {
-				mpool.OSImage.Publisher = *img.Plan.Publisher
+			if img.Properties != nil && img.Properties.Plan != nil && img.Properties.Plan.Publisher != nil {
+				mpool.OSImage.Publisher = *img.Properties.Plan.Publisher
 			}
 		}
 		pool.Platform.Azure = &mpool

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -646,8 +646,8 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 				// Publisher is case-sensitive and matched against exactly. Also
 				// the Plan's publisher might not be exactly the same as the
 				// Image's publisher
-				if img.Plan != nil && img.Plan.Publisher != nil {
-					mpool.OSImage.Publisher = *img.Plan.Publisher
+				if img.Properties != nil && img.Properties.Plan != nil && img.Properties.Plan.Publisher != nil {
+					mpool.OSImage.Publisher = *img.Properties.Plan.Publisher
 				}
 			}
 			pool.Platform.Azure = &mpool


### PR DESCRIPTION
Update timeout GetMarketplaceImage() to 5 minutes
If a failure occurs during this 5 minute window, retry up to 5 times
While here, also update to use v2 functions and structures for just this function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure marketplace image retrieval to use the current Azure API.
  * Improved compatibility when reading image generation and purchase-plan details.
  * Preserved validation and publisher detection across cluster, master, and worker configurations.
  * Added clearer handling for Azure client creation and image retrieval errors.
  * Improved resilience when marketplace image metadata is unavailable or incomplete.
  * Increased reliability of image requests through improved retry and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->