### PR TITLE
[release-4.22] AGENT-1571: Backport NoRegistryClusterInstall feature cleanup post feature promotion - Remove feature gate

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -384,10 +384,9 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 	pullSecret := installConfig.Config.PullSecret
 
 	// Merge IRI registry credentials into pull secret if available.
-	// IRIRegistryCredentials generates credentials only when the NoRegistryClusterInstall
-	// feature gate is enabled and an InternalReleaseImage manifest is present.
-	// This ensures kubelet/CRI-O on bootstrap and cluster nodes can
-	// authenticate to the IRI registry on master nodes.
+	// IRIRegistryCredentials generates credentials when an InternalReleaseImage
+	// manifest is present. This ensures kubelet/CRI-O on bootstrap and cluster
+	// nodes can authenticate to the IRI registry on master nodes.
 	iriAuth := &tls.IRIRegistryCredentials{}
 	dependencies.Get(iriAuth)
 	if iriAuth.Password != "" {

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
-	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/rhcos"
@@ -229,15 +228,13 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		}
 	}
 
-	if installConfig.Config.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		iri := &manifests.InternalReleaseImage{}
-		dependencies.Get(iri)
+	iri := &manifests.InternalReleaseImage{}
+	dependencies.Get(iri)
 
-		// Skip if InternalReleaseImage manifest wasn't found.
-		if len(iri.FileList) > 0 {
-			files = append(files, appendIRIcerts(dependencies))
-			files = append(files, appendIRIRegistryCredentials(dependencies))
-		}
+	// Skip if InternalReleaseImage manifest wasn't found.
+	if len(iri.FileList) > 0 {
+		files = append(files, appendIRIcerts(dependencies))
+		files = append(files, appendIRIRegistryCredentials(dependencies))
 	}
 
 	return files

--- a/pkg/asset/templates/content/bootkube/internal-release-image-registry-auth-secret.go
+++ b/pkg/asset/templates/content/bootkube/internal-release-image-registry-auth-secret.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/templates/content"
@@ -42,10 +41,6 @@ func (t *InternalReleaseImageRegistryAuthSecret) Generate(_ context.Context, dep
 	iri := &manifests.InternalReleaseImage{}
 
 	dependencies.Get(installConfig, iri)
-
-	if !installConfig.Config.EnabledFeatureGates().Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		return nil
-	}
 
 	// Skip if InternalReleaseImage manifest wasn't found.
 	if len(iri.FileList) == 0 {

--- a/pkg/asset/templates/content/bootkube/internal-release-image-server-tls-secret.go
+++ b/pkg/asset/templates/content/bootkube/internal-release-image-server-tls-secret.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/templates/content"
@@ -42,10 +41,6 @@ func (t *InternalReleaseImageTLSSecret) Generate(_ context.Context, dependencies
 	iri := &manifests.InternalReleaseImage{}
 
 	dependencies.Get(installConfig, iri)
-
-	if !installConfig.Config.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		return nil
-	}
 
 	// Skip if InternalReleaseImage manifest wasn't found.
 	if len(iri.FileList) == 0 {

--- a/pkg/asset/tls/iricertkey.go
+++ b/pkg/asset/tls/iricertkey.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"net"
 
-	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/templates/content/manifests"
@@ -39,10 +38,6 @@ func (a *IRICertKey) Generate(ctx context.Context, dependencies asset.Parents) e
 	installConfig := &installconfig.InstallConfig{}
 	iri := &manifests.InternalReleaseImage{}
 	dependencies.Get(ca, installConfig, iri)
-
-	if !installConfig.Config.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		return nil
-	}
 
 	// Skip if InternalReleaseImage manifest wasn't found.
 	if len(iri.FileList) == 0 {

--- a/pkg/asset/tls/iriregistryauth.go
+++ b/pkg/asset/tls/iriregistryauth.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	features "github.com/openshift/api/features"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/templates/content/manifests"
@@ -51,11 +50,6 @@ func (a *IRIRegistryCredentials) Generate(ctx context.Context, dependencies asse
 	installConfig := &installconfig.InstallConfig{}
 	iri := &manifests.InternalReleaseImage{}
 	dependencies.Get(installConfig, iri)
-
-	// Only generate if NoRegistryClusterInstall feature is enabled
-	if !installConfig.Config.EnabledFeatureGates().Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		return nil
-	}
 
 	// Skip if InternalReleaseImage manifest wasn't found
 	if len(iri.FileList) == 0 {

--- a/pkg/asset/tls/iriregistryauth_test.go
+++ b/pkg/asset/tls/iriregistryauth_test.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/templates/content/manifests"
@@ -23,25 +22,16 @@ import (
 func TestIRIRegistryCredentialsGenerate(t *testing.T) {
 	tests := []struct {
 		name           string
-		featureGate    string
 		iriManifest    bool
 		shouldGenerate bool
 	}{
 		{
-			name:           "Generate with feature gate enabled and IRI manifest present",
-			featureGate:    "TechPreviewNoUpgrade",
+			name:           "Generate with IRI manifest present",
 			iriManifest:    true,
 			shouldGenerate: true,
 		},
 		{
-			name:           "Skip without feature gate",
-			featureGate:    "",
-			iriManifest:    true,
-			shouldGenerate: false,
-		},
-		{
 			name:           "Skip without IRI manifest",
-			featureGate:    "TechPreviewNoUpgrade",
 			iriManifest:    false,
 			shouldGenerate: false,
 		},
@@ -82,10 +72,6 @@ func TestIRIRegistryCredentialsGenerate(t *testing.T) {
 						},
 					},
 				},
-			}
-
-			if tt.featureGate != "" {
-				ic.Config.FeatureSet = configv1.FeatureSet(tt.featureGate)
 			}
 
 			// Create IRI manifest asset


### PR DESCRIPTION
NoRegistryClusterInstall feature is now enabled for default installs.

This patch is part of the NoRegistryClusterInstall feature cleanup post feature promotion and backport to 4.22. It contains the following PR:

https://github.com/openshift/installer/pull/10746

The commit backported is https://github.com/openshift/installer/pull/10746/changes/a68c36c93db34e801957f014045e2f30362343e0
