### PR TITLE
CORS-4308: networking: enforce NetworkObservabilityInstall feature gate

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -22,6 +22,7 @@ import (
 	utilsnet "k8s.io/utils/net"
 
 	configv1 "github.com/openshift/api/config/v1"
+	features "github.com/openshift/api/features"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/hostcrypt"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -1693,6 +1694,12 @@ func validateGatedFeatures(c *types.InstallConfig) field.ErrorList {
 	}
 
 	gatedFeatures = append(gatedFeatures, validateMachinePoolFeatureGates(c)...)
+
+	gatedFeatures = append(gatedFeatures, featuregates.GatedInstallConfigFeature{
+		FeatureGateName: features.FeatureGateNetworkObservabilityInstall,
+		Condition:       c.Networking != nil && c.Networking.NetworkObservability != nil,
+		Field:           field.NewPath("networking", "networkObservability"),
+	})
 
 	fg := c.EnabledFeatureGates()
 	errMsgTemplate := "this field is protected by the %s feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set"

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -410,6 +410,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid networkObservability installationPolicy",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
 				invalidPolicy := types.NetworkObservabilityInstallationPolicy("test")
 				c.Networking.NetworkObservability = &types.NetworkObservability{
 					InstallationPolicy: &invalidPolicy,
@@ -422,6 +423,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "missing networkObservability installationPolicy",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
 				c.Networking.NetworkObservability = &types.NetworkObservability{}
 				return c
 			}(),
@@ -431,6 +433,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "blank networkObservability installationPolicy",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
 				blankPolicy := types.NetworkObservabilityInstallationPolicy("")
 				c.Networking.NetworkObservability = &types.NetworkObservability{
 					InstallationPolicy: &blankPolicy,
@@ -443,6 +446,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "valid networkObservability InstallAndEnable",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
 				policy := types.NetworkObservabilityInstallAndEnable
 				c.Networking.NetworkObservability = &types.NetworkObservability{
 					InstallationPolicy: &policy,
@@ -454,6 +458,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "valid networkObservability NoAction",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
+				c.FeatureSet = configv1.TechPreviewNoUpgrade
 				policy := types.NetworkObservabilityNoAction
 				c.Networking.NetworkObservability = &types.NetworkObservability{
 					InstallationPolicy: &policy,
@@ -468,6 +473,18 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Networking.NetworkObservability = nil
 				return c
 			}(),
+		},
+		{
+			name: "networkObservability feature gate disabled",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				policy := types.NetworkObservabilityInstallAndEnable
+				c.Networking.NetworkObservability = &types.NetworkObservability{
+					InstallationPolicy: &policy,
+				}
+				return c
+			}(),
+			expectedError: `^networking\.networkObservability: Forbidden: this field is protected by the NetworkObservabilityInstall feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
 		},
 		{
 			name: "missing service network",


### PR DESCRIPTION
When running `openshift-install`, this checks that the `NetworkObservabilityInstall` feature gate is enabled before allowing the `networkObservability` field in install-config.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature-gate validation for Network Observability configuration.
  * Network Observability can now be enabled when the required TechPreview feature set is active.

* **Bug Fixes**
  * Installation configurations that enable Network Observability without the required feature gate are now rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->