### PR TITLE
[release-4.22] OCPBUGS-105364: Azure: delete bootstrap ignition storage during bootstrap destroy

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -53,7 +53,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \      
       gettext \
-      google-cloud-cli-447.0.0-1 \
+      google-cloud-cli-563.0.0-1 \
       gzip \
       jq \
       unzip \

--- a/pkg/infrastructure/azure/azure.go
+++ b/pkg/infrastructure/azure/azure.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -735,6 +736,15 @@ func (p *Provider) PostDestroy(ctx context.Context, in clusterapi.PostDestroyerI
 			return fmt.Errorf("failed to delete inbound nat rule: %w", err)
 		}
 	}
+
+	// Clean up bootstrap storage account (ignition container and optionally
+	// the entire account if no image gallery containers remain).
+	if in.Metadata.Azure.CloudName != aztypes.StackCloud {
+		if err := deleteBootstrapIgnition(ctx, session, opts, resourceGroupName, in.Metadata.InfraID); err != nil {
+			logrus.Warnf("Failed to clean up bootstrap storage: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -789,6 +799,71 @@ func randomString(length int) string {
 	}
 
 	return string(s)
+}
+
+// deleteBootstrapIgnition removes the ignition container and, if no other
+// containers remain, deletes the storage account created for bootstrap.
+func deleteBootstrapIgnition(ctx context.Context, session *azconfig.Session, opts *arm.ClientOptions, resourceGroupName, infraID string) error {
+	storageAccountName := aztypes.GetStorageAccountName(infraID)
+
+	storageClientFactory, err := armstorage.NewClientFactory(
+		session.Credentials.SubscriptionID,
+		session.TokenCreds,
+		opts,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client factory: %w", err)
+	}
+
+	blobContainersClient := storageClientFactory.NewBlobContainersClient()
+	_, err = blobContainersClient.Delete(ctx, resourceGroupName, storageAccountName, "ignition", nil)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return fmt.Errorf("failed to delete ignition container: %w", err)
+		}
+		logrus.Debugf("Ignition container already deleted from storage account %s", storageAccountName)
+	} else {
+		logrus.Infof("Deleted bootstrap ignition container from storage account %s", storageAccountName)
+	}
+
+	pager := blobContainersClient.NewListPager(resourceGroupName, storageAccountName, nil)
+	hasContainers := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if isNotFoundError(err) {
+				break
+			}
+			logrus.Warnf("Failed to list containers in storage account %s, skipping account deletion: %v", storageAccountName, err)
+			return nil
+		}
+		if len(page.Value) > 0 {
+			hasContainers = true
+			break
+		}
+	}
+
+	accountsClient := storageClientFactory.NewAccountsClient()
+	if !hasContainers {
+		_, err = accountsClient.Delete(ctx, resourceGroupName, storageAccountName, nil)
+		if err != nil {
+			if isNotFoundError(err) {
+				logrus.Debugf("Storage account %s already deleted", storageAccountName)
+				return nil
+			}
+			return fmt.Errorf("failed to delete storage account %s: %w", storageAccountName, err)
+		}
+		logrus.Infof("Deleted bootstrap storage account %s", storageAccountName)
+	} else {
+		logrus.Infof("Storage account %s has remaining containers, skipping deletion (will be removed with resource group)", storageAccountName)
+	}
+
+	return nil
+}
+
+func isNotFoundError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 // Ignition provisions the Azure container that holds the bootstrap ignition


### PR DESCRIPTION
## Summary
- Cherry-pick of #10701 / OCPBUGS-98700 to `release-4.22` (clone: OCPBUGS-105364).
- Replaces #10747: the cherry-pick-robot branch is not writable, so this fork PR adds the CI unblocker requested there.
- Cherry-pick of `19f9d3fd80c9` from main (`update gcloud sdk to 563` in `images/installer/Dockerfile.upi.ci`) so `ci/prow/e2e-aws-ovn` can pass, per @IlanZuckerman on #10747.

Fixes: https://issues.redhat.com/browse/OCPBUGS-105364

## Test plan
- [x] Cherry-pick of `19f9d3fd` applied cleanly onto #10747 HEAD
- [ ] `ci/prow/e2e-aws-ovn` green (the gcloud 563 pin)
- [ ] `ci/prow/e2e-azure-ovn` / `ci/prow/images` / `ci/prow/okd-scos-images` re-run on this HEAD
- [ ] Re-apply `/lgtm`, `/approve`, `/label backport-risk-assessed`, `/verified` (labels do not carry over from #10747)


Made with [Cursor](https://cursor.com)