### PR TITLE
OCPBUGS-105510: images: add BUILD_VERSION arg

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -8,6 +8,7 @@ FROM registry.ci.openshift.org/ocp/5.0:hyperkube AS kas
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 ARG TAGS="baremetal fipscapable"
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=etcd /usr/bin/etcd /usr/bin/etcd

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -10,6 +10,7 @@ FROM registry.ci.openshift.org/ocp/5.0:installer-etcd-artifacts AS etcd-artifact
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS macbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/darwin/amd64 cluster-api/bin/darwin_amd64
@@ -19,6 +20,7 @@ RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS macarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/darwin/arm64 cluster-api/bin/darwin_arm64
@@ -28,6 +30,7 @@ RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS linuxbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/linux/amd64 cluster-api/bin/linux_amd64
@@ -38,6 +41,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS l
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/linux/arm64 cluster-api/bin/linux_arm64

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -10,6 +10,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS b
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -11,6 +11,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS b
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -9,6 +9,7 @@ FROM registry.ci.openshift.org/ocp/4.17:hyperkube AS kas
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 ARG TAGS="libvirt fipscapable"
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=etcd /usr/bin/etcd /usr/bin/etcd

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -10,6 +10,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS b
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 ARG TAGS=""
 ARG SKIP_ENVTEST="y"
+ARG BUILD_VERSION=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 COPY --from=kas-artifacts /usr/share/openshift/ cluster-api/bin/


### PR DESCRIPTION
Add a BUILD_VERSION arg to our CI images, which will be set in the CI environment and then set that as an environment variable to pass to the build scripts. This is similar to the pattern of ART/OSBS.

Currently, with BUILD_VERSION unset in CI, we fall back to the git tags. But with 5.0 & 4.23 having identical commits, we need a way to distinguish between the two different builds, in which case we can just adopt the same pattern used by ART/OSBS.

The images can be built in three modes:
1. Outside ART but without build arg passed. Build arg `BUILD_VERSION` has a `""` default value, this gets exposed to the `hack/build.sh` as an envvar and the script falls back to using git tags, like before this change.
2. Outside ART, with build arg passed. The passed value will be exposed to the `hack/build.sh` as `BUILD_VERSION` envvar and will prevent the git tag fallback. We will use this mode in selected CI configs to force using a certain version when needed.
3. ART tooling [injects](https://redhat-internal.slack.com/archives/CB95J6R4N/p1787048866797949?thread_ts=1787048655.916969&cid=CB95J6R4N) `ENV BUILD_VERSION <value>` into Dockerfiles. ENV instructions override ARG ones[1], so ART-built images will correctly use whatever ART injects, no matter if anything passes a value for the build arg or not.

[1] https://docs.docker.com/reference/dockerfile/#using-arg-variables

Co-authored-by: Petr Muller <muller@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional build version metadata support across CI container images and installer build environments.
  * Standardized version handling for bare-metal, libvirt, OpenStack, and installer image builds.
  * Existing build workflows remain compatible when no version is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->