### PR TITLE
OCPBUGS-59520: azure: require storageAccountType when managedDisk is specified

### DIFF
--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -354,11 +354,19 @@ func validateDataDisk(p *azure.MachinePool, poolName string, fldPath *field.Path
 	switch poolName {
 	case types.MachinePoolControlPlaneRoleName, types.MachinePoolComputeRoleName:
 		for i, dataDisk := range p.DataDisks {
-			if dataDisk.ManagedDisk != nil && dataDisk.ManagedDisk.SecurityProfile != nil {
-				allErrs = append(allErrs, field.Forbidden(
-					fldPath.Index(i).Child("managedDisk", "securityProfile"),
-					"data disk security profiles are not yet supported by the Machine API and would be silently ignored",
-				))
+			if dataDisk.ManagedDisk != nil {
+				if dataDisk.ManagedDisk.StorageAccountType == "" {
+					allErrs = append(allErrs, field.Required(
+						fldPath.Index(i).Child("managedDisk", "storageAccountType"),
+						"storageAccountType is required when managedDisk is specified",
+					))
+				}
+				if dataDisk.ManagedDisk.SecurityProfile != nil {
+					allErrs = append(allErrs, field.Forbidden(
+						fldPath.Index(i).Child("managedDisk", "securityProfile"),
+						"data disk security profiles are not yet supported by the Machine API and would be silently ignored",
+					))
+				}
 			}
 		}
 	default:

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -916,6 +916,62 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `test-path\.dataDisks\[0\]\.managedDisk\.securityProfile: Forbidden: data disk security profiles are not yet supported by the Machine API and would be silently ignored`,
 		},
 		{
+			name:          "master data disk with managedDisk but missing storageAccountType is rejected",
+			azurePlatform: azure.PublicCloud,
+			pool: &types.MachinePool{
+				Name: "master",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						DataDisks: []capz.DataDisk{{
+							NameSuffix:  "etcd",
+							DiskSizeGB:  128,
+							ManagedDisk: &capz.ManagedDiskParameters{},
+							Lun:         ptr.To(int32(0)),
+						}},
+					},
+				},
+			},
+			expected: `test-path\.dataDisks\[0\]\.managedDisk\.storageAccountType: Required value: storageAccountType is required when managedDisk is specified`,
+		},
+		{
+			name:          "worker data disk with managedDisk but missing storageAccountType is rejected",
+			azurePlatform: azure.PublicCloud,
+			pool: &types.MachinePool{
+				Name: "worker",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						DataDisks: []capz.DataDisk{{
+							NameSuffix: "data",
+							DiskSizeGB: 128,
+							ManagedDisk: &capz.ManagedDiskParameters{
+								DiskEncryptionSet: &capz.DiskEncryptionSetParameters{
+									ID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/des",
+								},
+							},
+							Lun: ptr.To(int32(0)),
+						}},
+					},
+				},
+			},
+			expected: `test-path\.dataDisks\[0\]\.managedDisk\.storageAccountType: Required value: storageAccountType is required when managedDisk is specified`,
+		},
+		{
+			name:          "data disk without managedDisk passes without storageAccountType",
+			azurePlatform: azure.PublicCloud,
+			pool: &types.MachinePool{
+				Name: "master",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						DataDisks: []capz.DataDisk{{
+							NameSuffix: "etcd",
+							DiskSizeGB: 128,
+							Lun:        ptr.To(int32(0)),
+						}},
+					},
+				},
+			},
+		},
+		{
 			name:          "data disks with no security settings pass validation",
 			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{


### PR DESCRIPTION
## Bug

[OCPBUGS-59520](https://redhat.atlassian.net/browse/OCPBUGS-59520)

## Changes

**`pkg/types/azure/validation/machinepool.go`**
- Add `storageAccountType` presence check inside `validateDataDisk` — returns `field.Required` when `managedDisk` is non-nil but `storageAccountType` is empty

**`pkg/types/azure/validation/machinepool_test.go`**
- Master data disk with empty `managedDisk` → rejected
- Worker data disk with `managedDisk.diskEncryptionSet` but no `storageAccountType` → rejected
- Data disk with no `managedDisk` at all → passes (no regression)

## Related

Part of [SPLAT-2352](https://redhat.atlassian.net/browse/SPLAT-2352) — Azure multi-disk GA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for managed data disks by requiring a storage account type.
  * Continued rejecting unsupported managed-disk security profiles.
  * Preserved support for unmanaged data disks without a storage account type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->