### PR TITLE
OCPBUGS-114375: azure: skip AppendVarPartition when DiskSetup provides a user-defined /var mount

### DIFF
--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -45,9 +46,20 @@ func (a *Master) Generate(_ context.Context, dependencies asset.Parents) error {
 	a.Config = pointerIgnitionConfig(installConfig.Config, rootCA.Cert(), "master")
 
 	if installConfig.Config.Platform.Name() == azure.Name {
-		logrus.Debugf("Adding /var partition to skip CoreOS growfs step")
-		// See https://issues.redhat.com/browse/OCPBUGS-43625
-		ignition.AppendVarPartition(a.Config)
+		varClaimed := false
+		if installConfig.Config.ControlPlane != nil {
+			for _, ds := range installConfig.Config.ControlPlane.DiskSetup {
+				if ds.Type == types.UserDefined && ds.UserDefined != nil && ds.UserDefined.MountPath == "/var" {
+					varClaimed = true
+					break
+				}
+			}
+		}
+		if !varClaimed {
+			logrus.Debugf("Adding /var partition to skip CoreOS growfs step")
+			// See https://issues.redhat.com/browse/OCPBUGS-43625
+			ignition.AppendVarPartition(a.Config)
+		}
 	}
 
 	data, err := ignition.Marshal(a.Config)

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
 )
 
 // TestMasterGenerate tests generating the master asset.
@@ -34,7 +35,7 @@ func TestMasterGenerate(t *testing.T) {
 			},
 			ControlPlane: &types.MachinePool{
 				Name:     "master",
-				Replicas: pointer.Int64Ptr(3),
+				Replicas: ptr.To[int64](3),
 			},
 		})
 
@@ -59,4 +60,109 @@ func TestMasterGenerate(t *testing.T) {
 		actualIgnitionConfigNames[i] = f.Filename
 	}
 	assert.Equal(t, expectedIgnitionConfigNames, actualIgnitionConfigNames, "unexpected names for master ignition configs")
+}
+
+func TestMasterGenerateAzureVarPartition(t *testing.T) {
+	rootCAParents := asset.Parents{}
+	rootCAParents.Add(&tls.SignerKeyParams{})
+	rootCA := &tls.RootCA{}
+	err := rootCA.Generate(context.Background(), rootCAParents)
+	assert.NoError(t, err)
+
+	hasVarPartition := func(m *Master) bool {
+		for _, disk := range m.Config.Storage.Disks {
+			for _, p := range disk.Partitions {
+				if p.Label != nil && *p.Label == "var" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	t.Run("Azure without /var DiskSetup appends var partition", func(t *testing.T) {
+		ic := installconfig.MakeAsset(&types.InstallConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			BaseDomain: "test.com",
+			Networking: &types.Networking{
+				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
+			},
+			Platform: types.Platform{
+				Azure: &azure.Platform{Region: "eastus", CloudName: azure.PublicCloud},
+			},
+			ControlPlane: &types.MachinePool{
+				Name:     "master",
+				Replicas: ptr.To[int64](3),
+			},
+		})
+		parents := asset.Parents{}
+		parents.Add(ic, rootCA)
+		master := &Master{}
+		err := master.Generate(context.Background(), parents)
+		assert.NoError(t, err)
+		assert.True(t, hasVarPartition(master), "expected /var partition on Azure without DiskSetup")
+	})
+
+	t.Run("Azure with /var UserDefined DiskSetup skips var partition", func(t *testing.T) {
+		ic := installconfig.MakeAsset(&types.InstallConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			BaseDomain: "test.com",
+			Networking: &types.Networking{
+				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
+			},
+			Platform: types.Platform{
+				Azure: &azure.Platform{Region: "eastus", CloudName: azure.PublicCloud},
+			},
+			ControlPlane: &types.MachinePool{
+				Name:     "master",
+				Replicas: ptr.To[int64](3),
+				DiskSetup: []types.Disk{
+					{
+						Type: types.UserDefined,
+						UserDefined: &types.DiskUserDefined{
+							PlatformDiskID: "var-disk",
+							MountPath:      "/var",
+						},
+					},
+				},
+			},
+		})
+		parents := asset.Parents{}
+		parents.Add(ic, rootCA)
+		master := &Master{}
+		err := master.Generate(context.Background(), parents)
+		assert.NoError(t, err)
+		assert.False(t, hasVarPartition(master), "expected no /var partition when DiskSetup claims /var")
+	})
+
+	t.Run("Azure with non-var DiskSetup still appends var partition", func(t *testing.T) {
+		ic := installconfig.MakeAsset(&types.InstallConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			BaseDomain: "test.com",
+			Networking: &types.Networking{
+				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
+			},
+			Platform: types.Platform{
+				Azure: &azure.Platform{Region: "eastus", CloudName: azure.PublicCloud},
+			},
+			ControlPlane: &types.MachinePool{
+				Name:     "master",
+				Replicas: ptr.To[int64](3),
+				DiskSetup: []types.Disk{
+					{
+						Type: types.Etcd,
+						Etcd: &types.DiskEtcd{
+							PlatformDiskID: "etcd-disk",
+						},
+					},
+				},
+			},
+		})
+		parents := asset.Parents{}
+		parents.Add(ic, rootCA)
+		master := &Master{}
+		err := master.Generate(context.Background(), parents)
+		assert.NoError(t, err)
+		assert.True(t, hasVarPartition(master), "expected /var partition when DiskSetup does not claim /var")
+	})
 }


### PR DESCRIPTION
## Summary

On Azure, the installer unconditionally creates a `/var` partition on the boot disk. When a user configures a `UserDefined` DiskSetup entry with `mountPath: /var`, this collides with the auto-generated partition, causing ignition to fail with conflicting partition.

This PR adds a guard in `Master.Generate()` that checks whether any control plane `DiskSetup` entry of type `UserDefined` already claims `/var` as its mount path. If so, `AppendVarPartition` is skipped.

## Changes

- **`pkg/asset/ignition/machine/master.go`**: Check `ControlPlane.DiskSetup` for a `UserDefined` entry with `MountPath == "/var"` before calling `AppendVarPartition`
- **`pkg/asset/ignition/machine/master_test.go`**: Add 3 test cases covering: Azure without DiskSetup (appends `/var`), Azure with `/var` UserDefined DiskSetup (skips), Azure with non-`/var` DiskSetup like etcd (still appends). Also migrated deprecated `k8s.io/utils/pointer` → `k8s.io/utils/ptr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Azure control-plane disk configuration to respect user-defined `/var` mounts.
  - Automatically adds a `/var` partition when no user-managed `/var` disk is configured.
  - Preserves automatic `/var` setup when only other disks, such as an etcd disk, are defined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->