### PR TITLE
OCPBUGS-59743: azure: reject data disks on Azure Stack Hub

### DIFF
--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -124,7 +124,12 @@ func ValidateMachinePool(p *azure.MachinePool, poolName string, platform *azure.
 	}
 
 	if len(p.DataDisks) > 0 {
-		allErrs = append(allErrs, validateDataDisk(p, poolName, fldPath.Child("dataDisks"))...)
+		if platform.CloudName == azure.StackCloud {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("dataDisks"),
+				fmt.Sprintf("data disks are not supported on %s", azure.StackCloud)))
+		} else {
+			allErrs = append(allErrs, validateDataDisk(p, poolName, fldPath.Child("dataDisks"))...)
+		}
 	}
 
 	if pool != nil {

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -989,6 +989,26 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
+			name:          "data disks on Azure Stack Hub are rejected",
+			azurePlatform: azure.StackCloud,
+			pool: &types.MachinePool{
+				Name: "master",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						DataDisks: []capz.DataDisk{{
+							NameSuffix: "etcd",
+							DiskSizeGB: 128,
+							ManagedDisk: &capz.ManagedDiskParameters{
+								StorageAccountType: "Premium_LRS",
+							},
+							Lun: ptr.To(int32(0)),
+						}},
+					},
+				},
+			},
+			expected: `test-path\.dataDisks: Forbidden: data disks are not supported on AzureStackCloud`,
+		},
+		{
 			name:          "azure VM Identity is unrecognized type",
 			azurePlatform: azure.PublicCloud,
 			pool: &types.MachinePool{


### PR DESCRIPTION
## Summary

Data disks are not currently supported or tested on Azure Stack Hub. When configured, the MAPI machineset spec serializes a zero-value `managedDisk` struct with an empty `storageAccountType`, which Azure rejects at provisioning time.

Rather than failing at provisioning time, this PR adds install-config validation to reject `dataDisks` on Azure Stack Hub upfront with a clear error message, consistent with how other unsupported features (security profiles, managed boot diagnostics) are already blocked on that platform.

## Changes

- **`pkg/types/azure/validation/machinepool.go`**: Add `field.Forbidden` guard for `dataDisks` when `platform.CloudName == azure.StackCloud`
- **`pkg/types/azure/validation/machinepool_test.go`**: Add test case verifying data disks on Azure Stack Hub are rejected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Azure Stack now clearly rejects machine pool configurations that include data disks.
  - Other Azure cloud environments continue to validate data disks as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->