### PR TITLE
OCPBUGS-114718: Only set insecure flag when accessing mirror for oc adm

### DIFF
--- a/pkg/asset/rhcos/releaseextract.go
+++ b/pkg/asset/rhcos/releaseextract.go
@@ -203,28 +203,20 @@ func (r *releasePayload) getImageFromRelease(imageName string, architecture stri
 	archName := arch.GoArch(architecture)
 	imagefor := "--image-for=" + imageName
 	filterbyos := "--filter-by-os=linux/" + archName
-	insecure := "--insecure=true"
 
-	var cmd = []string{
+	cmd := []string{
 		"oc",
 		"adm",
 		"release",
 		"info",
 		imagefor,
 		filterbyos,
-		insecure,
 	}
-	if r.mirrorConfig.HasMirrors() {
-		logrus.Debugf("Using mirror configuration")
-		mirrorArg, cleanup, err := getMirrorArg(r.mirrorConfig)
-		if err != nil {
-			return "", err
-		}
-		if mirrorArg != "" {
-			defer cleanup()
-			cmd = append(cmd, mirrorArg)
-		}
+	cmd, cleanup, err := r.appendMirrorArgs(cmd)
+	if err != nil {
+		return "", err
 	}
+	defer cleanup()
 	cmd = append(cmd, r.releaseImage)
 	logrus.Debugf("Fetching image from OCP release (%s)", cmd)
 	image, err := agent.ExecuteOC(r.pullSecret, cmd)
@@ -242,28 +234,21 @@ func (r *releasePayload) extractFileFromImage(image, file, cacheDir string, arch
 	archName := arch.GoArch(architecture)
 	extractpath := "--path=" + file + ":" + cacheDir
 	filterbyos := "--filter-by-os=linux/" + archName
-	insecure := "--insecure=true"
 
-	var cmd = []string{
+	cmd := []string{
 		"oc",
 		"image",
 		"extract",
 		extractpath,
 		filterbyos,
-		insecure,
 		"--confirm",
 	}
-
-	if r.mirrorConfig.HasMirrors() {
-		mirrorArg, cleanup, err := getMirrorArg(r.mirrorConfig)
-		if err != nil {
-			return nil, err
-		}
-		if mirrorArg != "" {
-			defer cleanup()
-			cmd = append(cmd, mirrorArg)
-		}
+	cmd, cleanup, err := r.appendMirrorArgs(cmd)
+	if err != nil {
+		return nil, err
 	}
+	defer cleanup()
+
 	path := filepath.Join(cacheDir, path.Base(file))
 	// Remove file if it exists
 	if err := removeCacheFile(path); err != nil {
@@ -271,7 +256,7 @@ func (r *releasePayload) extractFileFromImage(image, file, cacheDir string, arch
 	}
 	cmd = append(cmd, image)
 	logrus.Debugf("extracting %s to %s, %s", file, cacheDir, cmd)
-	_, err := retry.Do(r.config.MaxTries, r.config.RetryDelay, agent.ExecuteOC, r.pullSecret, cmd)
+	_, err = retry.Do(r.config.MaxTries, r.config.RetryDelay, agent.ExecuteOC, r.pullSecret, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -384,6 +369,33 @@ func removeCacheFile(path string) error {
 		logrus.Debugf("Removed file %s", file)
 	}
 	return nil
+}
+
+// appendMirrorArgs appends the mirror-related oc arguments to cmd when a mirror
+// configuration is present, returning the updated command and a cleanup function
+// (which the caller must invoke) that removes any temporary ICSP file.
+//
+// A mirror registry may serve over HTTP or present a self-signed certificate, so
+// TLS verification is relaxed with --insecure only for mirrored installs;
+// connected installs keep full TLS verification against trusted registries.
+func (r *releasePayload) appendMirrorArgs(cmd []string) ([]string, func(), error) {
+	cleanup := func() {}
+	if !r.mirrorConfig.HasMirrors() {
+		return cmd, cleanup, nil
+	}
+
+	logrus.Debugf("Using mirror configuration")
+	cmd = append(cmd, "--insecure=true")
+
+	mirrorArg, mirrorCleanup, err := getMirrorArg(r.mirrorConfig)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	if mirrorArg != "" {
+		cleanup = mirrorCleanup
+		cmd = append(cmd, mirrorArg)
+	}
+	return cmd, cleanup, nil
 }
 
 // Create a temporary file containing the ImageContentPolicySources.

--- a/pkg/asset/rhcos/releaseextract_test.go
+++ b/pkg/asset/rhcos/releaseextract_test.go
@@ -1,0 +1,132 @@
+package rhcos
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// mirrorConfig returns a MirrorConfig with a single mirror entry.
+func mirrorConfig() types.MirrorConfig {
+	return types.MirrorConfig{
+		{
+			Location: "registry.example.com/ocp/release",
+			Mirrors:  []string{"mirror.example.com/ocp/release"},
+		},
+	}
+}
+
+// hasArgWithPrefix reports whether any argument in cmd starts with prefix.
+func hasArgWithPrefix(cmd []string, prefix string) bool {
+	for _, arg := range cmd {
+		if strings.HasPrefix(arg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAppendMirrorArgs(t *testing.T) {
+	cases := []struct {
+		name           string
+		mirrorConfig   types.MirrorConfig
+		expectInsecure bool
+		expectICSP     bool
+	}{
+		{
+			name:           "no mirror omits --insecure",
+			mirrorConfig:   nil,
+			expectInsecure: false,
+			expectICSP:     false,
+		},
+		{
+			name:           "mirror includes --insecure and icsp file",
+			mirrorConfig:   mirrorConfig(),
+			expectInsecure: true,
+			expectICSP:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &releasePayload{mirrorConfig: tc.mirrorConfig}
+			base := []string{"oc", "adm", "release", "info"}
+
+			cmd, cleanup, err := r.appendMirrorArgs(base)
+			assert.NoError(t, err)
+			assert.NotNil(t, cleanup)
+			defer cleanup()
+
+			assert.Equal(t, tc.expectInsecure, assertContains(cmd, "--insecure=true"),
+				"unexpected --insecure=true presence in %v", cmd)
+			assert.Equal(t, tc.expectICSP, hasArgWithPrefix(cmd, "--icsp-file="),
+				"unexpected --icsp-file presence in %v", cmd)
+		})
+	}
+}
+
+// The release-info command must only carry --insecure when mirrors are set.
+func TestGetImageFromReleaseCmd(t *testing.T) {
+	cases := []struct {
+		name           string
+		mirrorConfig   types.MirrorConfig
+		expectInsecure bool
+	}{
+		{name: "connected install", mirrorConfig: nil, expectInsecure: false},
+		{name: "mirrored install", mirrorConfig: mirrorConfig(), expectInsecure: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &releasePayload{
+				releaseImage: "registry.example.com/ocp/release:latest",
+				mirrorConfig: tc.mirrorConfig,
+			}
+
+			cmd := []string{"oc", "adm", "release", "info", "--image-for=machine-os-images", "--filter-by-os=linux/amd64"}
+			cmd, cleanup, err := r.appendMirrorArgs(cmd)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			assert.Equal(t, tc.expectInsecure, assertContains(cmd, "--insecure=true"))
+		})
+	}
+}
+
+// The image-extract command must only carry --insecure when mirrors are set.
+func TestExtractFileFromImageCmd(t *testing.T) {
+	cases := []struct {
+		name           string
+		mirrorConfig   types.MirrorConfig
+		expectInsecure bool
+	}{
+		{name: "connected install", mirrorConfig: nil, expectInsecure: false},
+		{name: "mirrored install", mirrorConfig: mirrorConfig(), expectInsecure: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &releasePayload{mirrorConfig: tc.mirrorConfig}
+
+			cmd := []string{"oc", "image", "extract", "--path=/coreos/coreos-x86_64.iso:/tmp", "--filter-by-os=linux/amd64", "--confirm"}
+			cmd, cleanup, err := r.appendMirrorArgs(cmd)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			assert.Equal(t, tc.expectInsecure, assertContains(cmd, "--insecure=true"))
+		})
+	}
+}
+
+// assertContains reports whether cmd contains an exact match for arg.
+func assertContains(cmd []string, arg string) bool {
+	for _, a := range cmd {
+		if a == arg {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Gate the oc adm `--insecure` flag behind mirror configuration so its only added to the command when a mirror is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for release information and image extraction commands by preserving TLS verification when no mirror configuration is present.
  * Mirror-specific insecure mode is now enabled only when required by configured mirrors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->