### PR TITLE
OKD-194: Add OKD cincinnati as the default update service for OKD

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,12 +4,7 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-{{- if .IsSCOS }}
-  upstream: https://amd64.origin.releases.ci.openshift.org/graph
-  channel: stable-scos-4
-{{- else }}
   channel: {{.CVOChannel}}
-{{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}
   capabilities:

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -91,7 +91,6 @@ type bootstrapTemplateData struct {
 	BootstrapInPlace      *types.BootstrapInPlace
 	UseIPv6ForNodeIP      bool
 	UseDualForNodeIP      bool
-	IsSCOS                bool
 	IsOKD                 bool
 	BootstrapNodeIP       string
 	APIServerURL          string
@@ -416,7 +415,6 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		BootstrapInPlace:      bootstrapInPlaceConfig,
 		UseIPv6ForNodeIP:      ipv6Primary,
 		UseDualForNodeIP:      hasIPv4 && hasIPv6,
-		IsSCOS:                installConfig.Config.IsSCOS(),
 		IsOKD:                 installConfig.Config.IsOKD(),
 		BootstrapNodeIP:       bootstrapNodeIP,
 		APIServerURL:          apiURL,

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -190,7 +190,6 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		RootCaCert:            string(rootCA.Cert()),
 		RootCACertBase64:      base64.StdEncoding.EncodeToString(rootCA.Cert()),
 		RootCASignerKeyBase64: base64.StdEncoding.EncodeToString(rootCA.Key()),
-		IsSCOS:                installConfig.Config.IsSCOS(),
 		IsOKD:                 installConfig.Config.IsOKD(),
 	}
 

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -79,7 +79,6 @@ type bootkubeTemplateData struct {
 	EtcdSignerClientCert       string
 	EtcdSignerClientKey        string
 	EtcdSignerKey              string
-	IsSCOS                     bool
 	IsOKD                      bool
 	McsTLSCert                 string
 	McsTLSKey                  string


### PR DESCRIPTION
As of https://github.com/openshift/cluster-version-operator/pull/1466, the cvo will already have a default update service url, so we need to remove the override for OKD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Standardized ClusterVersion channel configuration across all deployments.
  * Removed SCOS-specific update graph and channel settings.
  * ClusterVersion updates now consistently use the configured release channel, providing uniform update behavior across supported deployment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->