### PR TITLE
OCPBUGS-115187: Gather master only from primary IP on baremetal

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -146,10 +146,10 @@ fi
 for master in "${MASTERS[@]}"
 do
     echo "Collecting info from ${master}"
-    scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -q /usr/local/bin/installer-masters-gather.sh "core@[${master}]:"
+    scp -o ConnectTimeout=30 -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -q /usr/local/bin/installer-masters-gather.sh "core@[${master}]:"
     mkdir -p "${ARTIFACTS}/control-plane/${master}"
-    ssh -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C "sudo ./installer-masters-gather.sh --id '${MASTER_GATHER_ID}'" </dev/null
-    scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@[${master}]:/tmp/artifacts-${MASTER_GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
+    ssh -o ConnectTimeout=30 -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C "sudo ./installer-masters-gather.sh --id '${MASTER_GATHER_ID}'" </dev/null
+    scp -o ConnectTimeout=30 -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@[${master}]:/tmp/artifacts-${MASTER_GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
 done
 
 TAR_FILE="${TAR_FILE:-${HOME}/log-bundle-${GATHER_ID}.tar.gz}"

--- a/data/unpack_test.go
+++ b/data/unpack_test.go
@@ -2,8 +2,10 @@ package data
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -25,4 +27,39 @@ func TestUnpack(t *testing.T) {
 	if firstLine != expected {
 		t.Fatalf("%q != %q", firstLine, expected)
 	}
+}
+
+func TestInstallerGatherSSHConnectTimeout(t *testing.T) {
+	content := installerGatherContent(t)
+
+	commandCount := 0
+	for _, line := range strings.Split(content, "\n") {
+		command := strings.TrimSpace(line)
+		if !strings.HasPrefix(command, "scp ") && !strings.HasPrefix(command, "ssh ") {
+			continue
+		}
+		commandCount++
+		if !strings.Contains(command, "-o ConnectTimeout=30") {
+			t.Errorf("SSH command does not set ConnectTimeout=30: %s", command)
+		}
+	}
+	if commandCount != 3 {
+		t.Errorf("expected 3 SSH commands, found %d", commandCount)
+	}
+}
+
+func installerGatherContent(t *testing.T) string {
+	t.Helper()
+	file, err := Assets.Open("bootstrap/files/usr/local/bin/installer-gather.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(content)
 }

--- a/pkg/infrastructure/baremetal/baremetal.go
+++ b/pkg/infrastructure/baremetal/baremetal.go
@@ -61,7 +61,11 @@ func (a Provider) ExtractHostAddresses(dir string, ic *types.InstallConfig, ha *
 		ha.Bootstrap = ic.Platform.BareMetal.APIVIPs[0]
 	}
 
-	masters, err := getMasterAddresses(dir)
+	machineNetworks := []types.MachineNetworkEntry{}
+	if ic.Networking != nil {
+		machineNetworks = ic.Networking.MachineNetwork
+	}
+	masters, err := getMasterAddresses(dir, machineNetworks)
 	if err != nil {
 		return err
 	}

--- a/pkg/infrastructure/baremetal/baremetal_test.go
+++ b/pkg/infrastructure/baremetal/baremetal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/infrastructure"
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 )
@@ -28,6 +29,7 @@ func TestExtractHostAddresses(t *testing.T) {
 	tests := []struct {
 		name              string
 		platform          *baremetal.Platform
+		machineNetworks   []string
 		writeMastersJSON  bool
 		expectedBootstrap string
 		expectedMasters   []string
@@ -39,6 +41,7 @@ func TestExtractHostAddresses(t *testing.T) {
 				BootstrapProvisioningIP: "172.22.0.2",
 				APIVIPs:                 []string{"192.168.111.5"},
 			},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  true,
 			expectedBootstrap: "172.22.0.2",
 			expectedMasters:   []string{"192.168.111.20"},
@@ -49,6 +52,7 @@ func TestExtractHostAddresses(t *testing.T) {
 				BootstrapExternalStaticIP: "192.168.111.10",
 				APIVIPs:                   []string{"192.168.111.5"},
 			},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  true,
 			expectedBootstrap: "192.168.111.10",
 			expectedMasters:   []string{"192.168.111.20"},
@@ -58,6 +62,7 @@ func TestExtractHostAddresses(t *testing.T) {
 			platform: &baremetal.Platform{
 				APIVIPs: []string{"192.168.111.5"},
 			},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  true,
 			expectedBootstrap: "192.168.111.5",
 			expectedMasters:   []string{"192.168.111.20"},
@@ -69,6 +74,7 @@ func TestExtractHostAddresses(t *testing.T) {
 				BootstrapExternalStaticIP: "192.168.111.10",
 				APIVIPs:                   []string{"192.168.111.5"},
 			},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  true,
 			expectedBootstrap: "172.22.0.2",
 			expectedMasters:   []string{"192.168.111.20"},
@@ -79,6 +85,7 @@ func TestExtractHostAddresses(t *testing.T) {
 				BootstrapExternalStaticIP: "192.168.111.10",
 				APIVIPs:                   []string{"192.168.111.5"},
 			},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  true,
 			expectedBootstrap: "192.168.111.10",
 			expectedMasters:   []string{"192.168.111.20"},
@@ -86,7 +93,15 @@ func TestExtractHostAddresses(t *testing.T) {
 		{
 			name:              "missing masters.json returns error",
 			platform:          &baremetal.Platform{APIVIPs: []string{"192.168.111.5"}},
+			machineNetworks:   []string{"192.168.111.0/24"},
 			writeMastersJSON:  false,
+			expectedBootstrap: "192.168.111.5",
+			expectErr:         true,
+		},
+		{
+			name:              "missing machine network returns error",
+			platform:          &baremetal.Platform{APIVIPs: []string{"192.168.111.5"}},
+			writeMastersJSON:  true,
 			expectedBootstrap: "192.168.111.5",
 			expectErr:         true,
 		},
@@ -104,6 +119,10 @@ func TestExtractHostAddresses(t *testing.T) {
 				Platform: types.Platform{
 					BareMetal: tc.platform,
 				},
+				Networking: &types.Networking{},
+			}
+			for _, cidr := range tc.machineNetworks {
+				ic.Networking.MachineNetwork = append(ic.Networking.MachineNetwork, types.MachineNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
 			}
 
 			ha := &infrastructure.HostAddresses{}
@@ -116,6 +135,57 @@ func TestExtractHostAddresses(t *testing.T) {
 				assert.Equal(t, tc.expectedMasters, ha.Masters)
 			}
 			assert.Equal(t, tc.expectedBootstrap, ha.Bootstrap)
+		})
+	}
+}
+
+func TestExtractHostAddressesSelectsPrimaryMachineNetwork(t *testing.T) {
+	mastersJSON := `{
+		"master-1": {"metadata":{"name":"master-1"},"status":{"hardware":{"nics":[
+			{"ip":"172.22.0.21"},{"ip":"fe80::21"},{"ip":"192.168.12.21"},{"ip":"fd2e::21"},{"ip":"192.168.111.21"}
+		]}}},
+		"master-0": {"metadata":{"name":"master-0"},"status":{"hardware":{"nics":[
+			{"ip":"not-an-ip"},{"ip":"192.168.11.20"},{"ip":"fd2e::20"},{"ip":"192.168.111.20"},{"ip":"192.168.111.25"}
+		]}}},
+		"master-2": {"metadata":{"name":"master-2"},"status":{}},
+		"master-3": {"metadata":{"name":"master-3"},"status":{"hardware":{"nics":[{"ip":"192.168.12.23"}]}}}
+	}`
+
+	tests := []struct {
+		name            string
+		machineNetworks []string
+		expected        []string
+		expectErr       bool
+	}{
+		{name: "IPv4 single-stack", machineNetworks: []string{"192.168.111.0/24"}, expected: []string{"192.168.111.20", "192.168.111.21"}},
+		{name: "IPv6 single-stack", machineNetworks: []string{"fd2e::/64"}, expected: []string{"fd2e::20", "fd2e::21"}},
+		{name: "IPv4-primary dual-stack", machineNetworks: []string{"192.168.111.0/24", "fd2e::/64"}, expected: []string{"192.168.111.20", "192.168.111.21"}},
+		{name: "IPv6-primary dual-stack", machineNetworks: []string{"fd2e::/64", "192.168.111.0/24"}, expected: []string{"fd2e::20", "fd2e::21"}},
+		{name: "missing machine network", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, MastersFileName), []byte(mastersJSON), 0o600)
+			assert.NoError(t, err)
+
+			ic := &types.InstallConfig{
+				Platform:   types.Platform{BareMetal: &baremetal.Platform{APIVIPs: []string{"192.168.111.5"}}},
+				Networking: &types.Networking{},
+			}
+			for _, cidr := range tc.machineNetworks {
+				ic.Networking.MachineNetwork = append(ic.Networking.MachineNetwork, types.MachineNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
+			}
+
+			ha := &infrastructure.HostAddresses{}
+			err = Provider{}.ExtractHostAddresses(dir, ic, ha)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expected, ha.Masters)
 		})
 	}
 }

--- a/pkg/infrastructure/baremetal/variables.go
+++ b/pkg/infrastructure/baremetal/variables.go
@@ -3,6 +3,7 @@ package baremetal
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/openshift/installer/pkg/tfvars"
 	baremetaltfvars "github.com/openshift/installer/pkg/tfvars/baremetal"
+	"github.com/openshift/installer/pkg/types"
 )
 
 const (
@@ -55,9 +57,20 @@ func getConfig(dir string) (baremetalConfig, error) {
 	return config, nil
 }
 
-func getMasterAddresses(dir string) ([]string, error) {
+func getMasterAddresses(dir string, machineNetworks []types.MachineNetworkEntry) ([]string, error) {
 	logrus.Debug("baremetal: getting master addresses")
 	masters := []string{}
+	if len(machineNetworks) == 0 {
+		return masters, fmt.Errorf("failed to get master addresses: machine network is not configured")
+	}
+
+	primaryIsIPv4 := isIPv4(machineNetworks[0].CIDR.IP)
+	primaryNetworks := make([]types.MachineNetworkEntry, 0, len(machineNetworks))
+	for _, machineNetwork := range machineNetworks {
+		if isIPv4(machineNetwork.CIDR.IP) == primaryIsIPv4 {
+			primaryNetworks = append(primaryNetworks, machineNetwork)
+		}
+	}
 
 	data, err := os.ReadFile(filepath.Join(dir, MastersFileName))
 	if err != nil {
@@ -75,14 +88,37 @@ func getMasterAddresses(dir string) ([]string, error) {
 		logrus.Debug("  bmh:", bmh.Name)
 
 		if bmh.Status.HardwareDetails == nil {
-			logrus.Debug("    HardwareDetails nil, skipping")
+			logrus.Warnf("baremetal: no hardware details found for master %q, skipping", bmh.Name)
 			continue
 		}
 
-		for _, nic := range bmh.Status.HardwareDetails.NIC {
-			masters = append(masters, nic.IP)
+		address, err := addressForMaster(primaryIsIPv4, bmh.Status.HardwareDetails.NIC, primaryNetworks)
+		if err != nil {
+			logrus.Warnf("baremetal: primary network error %v, %q, skipping", err, bmh.Name)
+			continue
 		}
+		masters = append(masters, address)
 	}
 
 	return masters, nil
+}
+
+func addressForMaster(primaryIsIPv4 bool, nics []baremetalhost.NIC, machineNetworks []types.MachineNetworkEntry) (string, error) {
+	for _, nic := range nics {
+		ip := net.ParseIP(nic.IP)
+		if ip == nil || ip.IsLinkLocalUnicast() || isIPv4(ip) != primaryIsIPv4 {
+			continue
+		}
+
+		for _, machineNetwork := range machineNetworks {
+			if machineNetwork.CIDR.Contains(ip) {
+				return nic.IP, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no primary machine network found")
+}
+
+func isIPv4(ip net.IP) bool {
+	return ip.To4() != nil
 }


### PR DESCRIPTION
The current implementation iterates over all the interfaces and all the
ips of those interfaces when collecting informations from masters. This
has the result of fetching the same data multiple times and making the
process longer in case of failures (one real example is the scenario
where the master has multiple interfaces but sshd is listening only on
the primary one).

Here we match the ip of the interface with the primary ip of the machine
network (to take into account dual stack clusters) and we use only that
to gather the information.

Additionally, add a timeout to the ssh / scp commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote log collection now stops waiting after 30 seconds when connecting to a host.
  * Bare-metal provisioning more reliably identifies master IP addresses using configured machine networks.
  * Improved support for IPv4, IPv6, and dual-stack network configurations.
  * Excludes unsuitable link-local addresses and safely handles missing network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->