### PR TITLE
SPLAT-2923: vsphere: retry and throttle vCenter lookups during UPI VM creation

### DIFF
--- a/upi/vsphere/powercli/upi-functions.ps1
+++ b/upi/vsphere/powercli/upi-functions.ps1
@@ -1,5 +1,37 @@
 #!/usr/bin/pwsh
 
+# vCenter calls occasionally fail transiently (session hiccups, timeouts, or
+# API overload when many VM-creation jobs query vCenter concurrently), which
+# some PowerCLI cmdlets surface as a terminating "Value cannot be null"
+# exception rather than a retryable error. Wrap vCenter lookups that must
+# already exist (i.e. not a find-or-create check) with this helper so a
+# transient hiccup doesn't abort the whole install.
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory=$true)]
+        [scriptblock]$ScriptBlock,
+        [string]$OperationName = "vCenter operation",
+        [int]$MaxAttempts = 5,
+        [int]$InitialDelaySeconds = 5
+    )
+
+    $delay = $InitialDelaySeconds
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            return & $ScriptBlock
+        }
+        catch {
+            if ($attempt -ge $MaxAttempts) {
+                Write-Warning "Giving up on '$($OperationName)' after $($attempt) attempts: $($_.Exception.Message)"
+                throw
+            }
+            Write-Warning "Attempt $($attempt)/$($MaxAttempts) for '$($OperationName)' failed: $($_.Exception.Message). Retrying in $($delay)s..."
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2
+        }
+    }
+}
+
 function New-OpenShiftVM {
     param(
         [int]$CoresPerSocket = 1, # Default is 1 due to not knowing how many may come in via NumCpu variable
@@ -259,6 +291,16 @@ function New-OpenshiftVMs {
 
     Write-Output "Creating $($NodeType) VMs"
 
+    # Creating VMs fires one thread job per VM, each issuing several vCenter
+    # lookups. Left unthrottled, a serial cluster's 3 control-plane (or more
+    # worker) jobs hit vCenter with the same lookup burst simultaneously,
+    # which increases the odds of a transient vCenter API failure. Cap
+    # concurrency unless the caller has set $vmCreationThrottleLimit.
+    $throttleLimit = 5
+    if ($NULL -ne $vmCreationThrottleLimit -and $vmCreationThrottleLimit -gt 0) {
+        $throttleLimit = $vmCreationThrottleLimit
+    }
+
     $jobs = @()
     $vmStep = (100 / $vmHash.virtualmachines.Count)
     $vmCount = 1
@@ -269,7 +311,7 @@ function New-OpenshiftVMs {
             continue
         }
 
-        $jobs += Start-ThreadJob -n "create-vm-$($metadata.infraID)-$($key)" -ScriptBlock {
+        $jobs += Start-ThreadJob -n "create-vm-$($metadata.infraID)-$($key)" -ThrottleLimit $throttleLimit -ScriptBlock {
             param($key,$node,$vm_template,$metadata,$tag,$scriptdir,$cliContext)
             . .\variables.ps1
             . ${scriptdir}\upi-functions.ps1
@@ -278,9 +320,13 @@ function New-OpenshiftVMs {
             $name = "$($metadata.infraID)-$($key)"
             Write-Output "Creating $($name)"
 
-            $rp = Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Name $($node.cluster)) -Server $node.server
+            $rp = Invoke-WithRetry -OperationName "Get-ResourcePool $($metadata.infraID)" -ScriptBlock {
+                Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Name $($node.cluster) -Server $node.server -ErrorAction Stop) -Server $node.server -ErrorAction Stop
+            }
             ##$datastore = Get-Datastore -Name $node.datastore -Server $node.server
-            $datastoreInfo = Get-Datastore -Name $node.datastore -Location $node.datacenter -Server $node.server
+            $datastoreInfo = Invoke-WithRetry -OperationName "Get-Datastore $($node.datastore)" -ScriptBlock {
+                Get-Datastore -Name $node.datastore -Location $node.datacenter -Server $node.server -ErrorAction Stop
+            }
 
             # Pull network config for each node
             if ($node.type -eq "master") {
@@ -315,8 +361,12 @@ function New-OpenshiftVMs {
             $tag = Get-Tag -Server $node.server -Category $tagCategory -Name "$($metadata.infraID)" -ErrorAction continue 2>$null
 
             # Get correct template / folder
-            $folder = Get-Folder -Server $node.server -Name $metadata.infraID -Location $node.datacenter
-            $template = Get-VM -Server $node.server -Name $vm_template -Location $($node.datacenter)
+            $folder = Invoke-WithRetry -OperationName "Get-Folder $($metadata.infraID)" -ScriptBlock {
+                Get-Folder -Server $node.server -Name $metadata.infraID -Location $node.datacenter -ErrorAction Stop
+            }
+            $template = Invoke-WithRetry -OperationName "Get-VM $($vm_template)" -ScriptBlock {
+                Get-VM -Server $node.server -Name $vm_template -Location $($node.datacenter) -ErrorAction Stop
+            }
 
             # Clone the virtual machine from the imported template
             #$vm = New-OpenShiftVM -Template $template -Name $name -ResourcePool $rp -Datastore $datastoreInfo -Location $folder -LinkedClone -ReferenceSnapshot $snapshot -IgnitionData $ignition -Tag $tag -Networking $network -NumCPU $numCPU -MemoryMB $memory

--- a/upi/vsphere/powercli/upi.ps1
+++ b/upi/vsphere/powercli/upi.ps1
@@ -169,7 +169,9 @@ foreach ($fd in $fds)
 {
     Write-Output "Getting viserver for $($fd.server)"
     $viserver = $viservers[$fd.server]
-    $datastoreInfo = Get-Datastore -Server $viserver -Name $fd.datastore -Location $fd.datacenter
+    $datastoreInfo = Invoke-WithRetry -OperationName "Get-Datastore $($fd.datastore)" -ScriptBlock {
+        Get-Datastore -Server $viserver -Name $fd.datastore -Location $fd.datacenter -ErrorAction Stop
+    }
 
     # Load tags for this FD.
     $tagCategory = Get-TagCategory -Server $viserver -Name "openshift-$($metadata.infraID)" -ErrorAction continue 2>$null
@@ -255,10 +257,18 @@ Write-Output "Creating LB"
 # Data needed for LB VM creation
 $tagCategory = Get-TagCategory -Server $fds[0].server -Name "openshift-$($metadata.infraID)" -ErrorAction continue 2>$null
 $tag = Get-Tag -Server $fds[0].server -Category $tagCategory -Name "$($metadata.infraID)" -ErrorAction continue 2>$null
-$rp = Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Server $fds[0].server -Name $($fds[0].cluster))
-$datastoreInfo = Get-Datastore -Name $fds[0].datastore -Server $fds[0].server -Location $fds[0].datacenter
-$folder = Get-Folder -Server $fds[0].server -Name $metadata.infraID -Location $fds[0].datacenter
-$template = Get-VM -Server $fds[0].server -Name $vm_template -Location $fds[0].datacenter
+$rp = Invoke-WithRetry -OperationName "Get-ResourcePool $($metadata.infraID)" -ScriptBlock {
+    Get-ResourcePool -Name $($metadata.infraID) -Location $(Get-Cluster -Server $fds[0].server -Name $($fds[0].cluster) -ErrorAction Stop) -Server $fds[0].server -ErrorAction Stop
+}
+$datastoreInfo = Invoke-WithRetry -OperationName "Get-Datastore $($fds[0].datastore)" -ScriptBlock {
+    Get-Datastore -Name $fds[0].datastore -Server $fds[0].server -Location $fds[0].datacenter -ErrorAction Stop
+}
+$folder = Invoke-WithRetry -OperationName "Get-Folder $($metadata.infraID)" -ScriptBlock {
+    Get-Folder -Server $fds[0].server -Name $metadata.infraID -Location $fds[0].datacenter -ErrorAction Stop
+}
+$template = Invoke-WithRetry -OperationName "Get-VM $($vm_template)" -ScriptBlock {
+    Get-VM -Server $fds[0].server -Name $vm_template -Location $fds[0].datacenter -ErrorAction Stop
+}
 
 # Create LB for Cluster
 $ignition = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((New-LoadBalancerIgnition $sshKey)))

--- a/upi/vsphere/variables.ps1.example
+++ b/upi/vsphere/variables.ps1.example
@@ -63,6 +63,11 @@ $compute_hostnames = "compute-0", "compute-1", "compute-2"
 # You can also set this if you want to change the default name of template when its uploaded.
 $vm_template = ""
 
+# Maximum number of VM-creation jobs to run concurrently against vCenter.
+# Lower this if you see transient vCenter API failures during VM creation.
+# Defaults to 5 if unset.
+$vmCreationThrottleLimit = 5
+
 $failure_domains = @"
 [
     {


### PR DESCRIPTION
[SPLAT-2923](https://redhat.atlassian.net/browse/SPLAT-2923)

### Changes
- Added retries to Get-* calls
- Added throttle limit to VM creation

### Notes
We were seeing periodic UPI CI failures where VM creation aborted with "Value cannot be null" from PowerCLI Get-Datastore/Get-VM/Get-Folder/ Get-ResourcePool calls. These lookups target resources that should already exist, so a failure there is a transient vCenter API hiccup rather than a real "not found" condition, made more likely by multiple VM-creation thread jobs querying vCenter concurrently with no limit.

Add a retry-with-backoff helper around these lookups and cap the number of concurrent VM-creation thread jobs (configurable via vmCreationThrottleLimit, default 5) to reduce load on vCenter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * vCenter operations now automatically retry temporary failures before reporting an error.
  * Improved error handling and clearer operation-specific failure reporting for infrastructure lookups.

* **Performance**
  * VM creation supports configurable concurrency, with a default limit of five simultaneous jobs.

* **Configuration**
  * Added an example setting to adjust the VM creation concurrency limit for different environments.
  * The concurrency limit can be tuned to help manage transient vCenter API failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->