### PR TITLE
OCPBUGS-61892: fix swap disk nil-panic and block swap on control plane

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -625,18 +625,10 @@ func (m *Master) Generate(ctx context.Context, dependencies asset.Parents) error
 	if installConfig.Config.Enabled(features.FeatureGateMultiDiskSetup) {
 		for i, diskSetup := range installConfig.Config.ControlPlane.DiskSetup {
 			var dataDisk any
-			var diskName string
 
-			switch diskSetup.Type {
-			case types.Etcd:
-				diskName = diskSetup.Etcd.PlatformDiskID
-			case types.Swap:
-				diskName = diskSetup.Etcd.PlatformDiskID
-			case types.UserDefined:
-				diskName = diskSetup.UserDefined.PlatformDiskID
-			default:
-				// We shouldn't get here, but just in case
-				return errors.Errorf("disk setup type %s is not supported", diskSetup.Type)
+			diskName, err := DiskName(diskSetup)
+			if err != nil {
+				return err
 			}
 
 			switch ic.Platform.Name() {

--- a/pkg/asset/machines/util.go
+++ b/pkg/asset/machines/util.go
@@ -21,6 +21,20 @@ const (
 	VsphereScsiByPath = "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:%d:0"
 )
 
+// DiskName returns the platform disk ID for the given disk setup entry.
+func DiskName(diskSetup types.Disk) (string, error) {
+	switch diskSetup.Type {
+	case types.Etcd:
+		return diskSetup.Etcd.PlatformDiskID, nil
+	case types.Swap:
+		return diskSetup.Swap.PlatformDiskID, nil
+	case types.UserDefined:
+		return diskSetup.UserDefined.PlatformDiskID, nil
+	default:
+		return "", errors.Errorf("disk setup type %s is not supported", diskSetup.Type)
+	}
+}
+
 // NodeDiskSetup determines the path per disk type, and per platform and role, runs ForDiskSetup.
 func NodeDiskSetup(installConfig *installconfig.InstallConfig, role string, diskSetup types.Disk, dataDisk any) (*v1.MachineConfig, error) {
 	var path string

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -407,18 +407,10 @@ func (w *Worker) Generate(ctx context.Context, dependencies asset.Parents) error
 		if installConfig.Config.Enabled(features.FeatureGateMultiDiskSetup) {
 			for i, diskSetup := range pool.DiskSetup {
 				var dataDisk any
-				var diskName string
 
-				switch diskSetup.Type {
-				case types.Etcd:
-					diskName = diskSetup.Etcd.PlatformDiskID
-				case types.Swap:
-					diskName = diskSetup.Etcd.PlatformDiskID
-				case types.UserDefined:
-					diskName = diskSetup.UserDefined.PlatformDiskID
-				default:
-					// We shouldn't get here, but just in case
-					return errors.Errorf("disk setup type %s is not supported", diskSetup.Type)
+				diskName, err := DiskName(diskSetup)
+				if err != nil {
+					return err
 				}
 
 				switch ic.Platform.Name() {

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -123,6 +123,10 @@ func validateDiskSetup(p *types.MachinePool, fldPath *field.Path) field.ErrorLis
 			}
 			foundEtcd = true
 		case types.Swap:
+			if p.Name == "master" {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("swap"), dsYaml, "swap is unsupported on control plane nodes"))
+				continue
+			}
 			if foundSwap {
 				allErrs = append(allErrs, field.TooMany(fldPath.Child("swap"), 2, 1))
 				continue

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -364,6 +364,22 @@ func TestValidateMachinePool(t *testing.T) {
 			expectedError: `^test-path\.diskSetup\.etcd: Invalid value: "type: etcd\\n": etcd configuration must be created$`,
 		},
 		{
+			name:     "invalid swap disk on master machine pool",
+			platform: &types.Platform{Azure: &azure.Platform{Region: "eastus"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("master")
+				p.DiskSetup = append(p.DiskSetup, types.Disk{
+					Type: "swap",
+					Swap: &types.DiskSwap{PlatformDiskID: "swap"},
+				})
+				p.Platform = types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{},
+				}
+				return p
+			}(),
+			expectedError: `^test-path\.diskSetup\.swap: Invalid value: "swap:\\n  platformDiskID: swap\\ntype: swap\\n": swap is unsupported on control plane nodes$`,
+		},
+		{
 			name:     "valid swap disk",
 			platform: &types.Platform{Azure: &azure.Platform{Region: "eastus"}},
 			pool: func() *types.MachinePool {


### PR DESCRIPTION
## Summary

- Fix nil-pointer dereference in swap disk setup where `diskSetup.Etcd.PlatformDiskID` was incorrectly referenced instead of `diskSetup.Swap.PlatformDiskID` in both master.go and worker.go
- Add validation to reject swap disks on control plane nodes — the MCO hardcodes `failSwapOn: true` for masters ([kubelet.yaml](https://github.com/openshift/machine-config-operator/blob/main/templates/master/01-master-kubelet/_base/files/kubelet.yaml#L19)) and [actively blocks](https://github.com/openshift/machine-config-operator/blob/main/pkg/controller/kubelet-config/helpers.go#L381-L386) KubeletConfig CRs that attempt to override it, so swap cannot function on control plane



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected swap disk identification during multi-disk setup for worker and control plane machines, ensuring the configured swap disk is used.
  - Swap disk configuration on control plane nodes is now rejected with a clear validation error.
  - Improved validation handling for unsupported disk setup types, providing consistent error reporting during machine configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->