### PR TITLE
OCPBUGS-122133: gcp: skip disk type check when the permission is denied

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -201,8 +202,12 @@ func validateDiskTypeAvailability(client API, fieldPath *field.Path, project, re
 
 	dt, dtZones, err := client.GetDiskTypeWithZones(context.TODO(), project, region, diskType)
 	if err != nil {
+		// Reading a disk type is not required to install, so a service account
+		// holding only the minimum set of install permissions is denied here. That
+		// says nothing about the configured disk type, so skip the check rather
+		// than report a bad value.
 		var gerr *googleapi.Error
-		if errors.As(err, &gerr) && gerr.Code < 500 {
+		if errors.As(err, &gerr) && gerr.Code < 500 && gerr.Code != http.StatusForbidden {
 			return append(allErrs, field.Invalid(fieldPath.Child("diskType"), diskType, err.Error()))
 		}
 		logrus.Warnf("could not verify disk type %s availability in %s, skipping API check: %v", diskType, region, err)

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -202,10 +202,11 @@ func validateDiskTypeAvailability(client API, fieldPath *field.Path, project, re
 	dt, dtZones, err := client.GetDiskTypeWithZones(context.TODO(), project, region, diskType)
 	if err != nil {
 		var gerr *googleapi.Error
-		if errors.As(err, &gerr) {
+		if errors.As(err, &gerr) && gerr.Code < 500 {
 			return append(allErrs, field.Invalid(fieldPath.Child("diskType"), diskType, err.Error()))
 		}
-		return append(allErrs, field.InternalError(fieldPath.Child("diskType"), err))
+		logrus.Warnf("could not verify disk type %s availability in %s, skipping API check: %v", diskType, region, err)
+		return allErrs
 	}
 
 	if dt == nil {

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1465,6 +1465,7 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 		mockErr        error
 		expectedError  bool
 		expectedErrMsg string
+		expectedWarn   string
 	}{
 		{
 			name:          "Empty disk type is a no-op",
@@ -1514,16 +1515,22 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 			expectedErrMsg: `forbidden`,
 		},
 		{
-			name:           "Non-API error returns internal error",
-			diskType:       "pd-ssd",
-			mockErr:        fmt.Errorf("network timeout"),
-			expectedError:  true,
-			expectedErrMsg: `network timeout`,
+			name:         "GCP 503 server error degrades gracefully",
+			diskType:     "pd-ssd",
+			mockErr:      &googleapi.Error{Code: http.StatusServiceUnavailable, Message: "backend error"},
+			expectedWarn: `could not verify disk type pd-ssd availability`,
+		},
+		{
+			name:         "Non-API error degrades gracefully",
+			diskType:     "pd-ssd",
+			mockErr:      fmt.Errorf("network timeout"),
+			expectedWarn: `could not verify disk type pd-ssd availability`,
 		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			hook := logrusTest.NewGlobal()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			gcpClient := mock.NewMockAPI(mockCtrl)
@@ -1538,6 +1545,10 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 				assert.Regexp(t, test.expectedErrMsg, errs.ToAggregate().Error())
 			} else {
 				assert.Empty(t, errs)
+			}
+			if test.expectedWarn != "" {
+				assert.NotEmpty(t, hook.Entries)
+				assert.Regexp(t, test.expectedWarn, hook.LastEntry().Message)
 			}
 		})
 	}

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1510,9 +1510,15 @@ func TestValidateDiskTypeAvailability(t *testing.T) {
 		{
 			name:           "GCP API error returns field error",
 			diskType:       "pd-ssd",
-			mockErr:        &googleapi.Error{Code: http.StatusForbidden, Message: "forbidden"},
+			mockErr:        &googleapi.Error{Code: http.StatusBadRequest, Message: "bad request"},
 			expectedError:  true,
-			expectedErrMsg: `forbidden`,
+			expectedErrMsg: `bad request`,
+		},
+		{
+			name:         "GCP 403 permission denied degrades gracefully",
+			diskType:     "pd-ssd",
+			mockErr:      &googleapi.Error{Code: http.StatusForbidden, Message: "Required 'compute.diskTypes.get' permission"},
+			expectedWarn: `could not verify disk type pd-ssd availability`,
 		},
 		{
 			name:         "GCP 503 server error degrades gracefully",


### PR DESCRIPTION
 The disk type availability check queries compute.diskTypes.get once per
zone. Service accounts holding only the documented minimum install
permissions do not have that permission, so the lookup returns 403 and
the install fails before any resource is created:
    
      platform.gcp.defaultMachinePlatform.diskType: Invalid value: "pd-ssd":
      googleapi: Error 403: Required 'compute.diskTypes.get' permission
    
The disk type is valid; only the check is unavailable. Reading a disk
 type is not needed to install, so treat a denial the same way as a
 backend error and skip the check rather than report a bad value.


This PR also includes the backport for 9fb3564b853d75837f5bca6c126b6b9f79c48758.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disk type validation now continues when Google Cloud verification encounters permission-related, service-unavailable, or other server-side failures.
  - These recoverable issues are reported as warnings instead of blocking validation.
  - Invalid disk type requests continue to produce validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->